### PR TITLE
Add `mpremote fs tree` command to show a tree of the device's files.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -234,6 +234,7 @@ The full list of supported commands are:
   - ``rmdir <dirs...>`` to remove directories on the device
   - ``touch <file..>`` to create the files (if they don't already exist)
   - ``sha256sum <file..>`` to calculate the SHA256 sum of files
+  - ``tree [-vsh] <dirs...>`` to print a tree of the given directories
 
   The ``cp`` command uses a convention where a leading ``:`` represents a remote
   path. Without a leading ``:`` means a local path. This is based on the
@@ -263,6 +264,13 @@ The full list of supported commands are:
   .. warning::
     There is no supported way to undelete files removed by ``mpremote rm -r :``.
     Please use with caution.
+
+  The ``tree`` command will print a tree of the given directories.
+  Using the ``--size/-s`` option will print the size of each file, or use
+  ``--human/-h`` to use a more human readable format.
+  Note: Directory size is only printed when a non-zero size is reported by the device's filesystem.
+  The ``-v`` option  can be used to include the name of the serial device in
+  the output.
 
   All other commands implicitly assume the path is a remote path, but the ``:``
   can be optionally used for clarity.

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -237,3 +237,6 @@ echo -----
 # try to delete existing folder in mounted filesystem
 $MPREMOTE mount "${TMP}" + rm -rv :package || echo "expect error"
 echo -----
+# fs without command should raise error
+$MPREMOTE fs 2>/dev/null || echo "expect error: $?"
+echo -----

--- a/tools/mpremote/tests/test_filesystem.sh.exp
+++ b/tools/mpremote/tests/test_filesystem.sh.exp
@@ -272,3 +272,5 @@ rm :package
 mpremote: rm -r not permitted on /remote directory
 expect error
 -----
+expect error: 2
+-----

--- a/tools/mpremote/tests/test_fs_tree.sh
+++ b/tools/mpremote/tests/test_fs_tree.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+# Creates a RAM disk big enough to hold two copies of the test directory
+# structure.
+cat << EOF > "${TMP}/ramdisk.py"
+class RAMBlockDev:
+    def __init__(self, block_size, num_blocks):
+        self.block_size = block_size
+        self.data = bytearray(block_size * num_blocks)
+
+    def readblocks(self, block_num, buf):
+        for i in range(len(buf)):
+            buf[i] = self.data[block_num * self.block_size + i]
+
+    def writeblocks(self, block_num, buf):
+        for i in range(len(buf)):
+            self.data[block_num * self.block_size + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        if op == 4: # get number of blocks
+            return len(self.data) // self.block_size
+        if op == 5: # get block size
+            return self.block_size
+
+import os
+
+bdev = RAMBlockDev(512, 50)
+os.VfsFat.mkfs(bdev)
+os.mount(bdev, '/ramdisk')
+os.chdir('/ramdisk')
+EOF
+
+# setup 
+echo -----
+$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE resume ls
+
+echo -----
+echo "empty tree"
+$MPREMOTE resume tree :
+
+echo -----
+$MPREMOTE resume touch :a.py + touch :b.py  
+$MPREMOTE resume mkdir :foo + touch :foo/aa.py + touch :foo/ba.py
+
+echo "small tree - :" 
+$MPREMOTE resume tree :
+
+echo -----
+echo "no path" 
+$MPREMOTE resume tree 
+
+echo -----
+echo "path = '.'" 
+$MPREMOTE resume tree .
+
+echo -----
+echo "path = ':.'" 
+$MPREMOTE resume tree :.
+
+
+echo -----
+echo "multiple trees" 
+$MPREMOTE resume mkdir :bar + touch :bar/aaa.py + touch :bar/bbbb.py
+$MPREMOTE resume mkdir :bar/baz + touch :bar/baz/aaa.py + touch :bar/baz/bbbb.py
+$MPREMOTE resume mkdir :bar/baz/quux + touch :bar/baz/quux/aaa.py + touch :bar/baz/quux/bbbb.py
+$MPREMOTE resume mkdir :bar/baz/quux/xen + touch :bar/baz/quux/xen/aaa.py
+
+$MPREMOTE resume tree
+
+echo -----
+echo single path
+$MPREMOTE resume tree :foo
+
+echo -----
+echo "multiple paths" 
+$MPREMOTE resume tree :foo :bar
+
+echo -----
+echo "subtree" 
+$MPREMOTE resume tree bar/baz
+
+echo -----
+echo mountpoint
+$MPREMOTE resume tree :/ramdisk
+
+echo -----
+echo non-existent folder : error
+$MPREMOTE resume tree :not_there || echo "expect error: $?"
+
+echo -----
+echo file : error 
+$MPREMOTE resume tree :a.py || echo "expect error: $?"
+
+echo -----
+echo "tree -s :"
+mkdir -p "${TMP}/data"
+dd if=/dev/zero of="${TMP}/data/file1.txt" bs=1 count=20 > /dev/null 2>&1
+dd if=/dev/zero of="${TMP}/data/file2.txt" bs=1 count=204 > /dev/null 2>&1
+dd if=/dev/zero of="${TMP}/data/file3.txt" bs=1 count=1096 > /dev/null 2>&1
+dd if=/dev/zero of="${TMP}/data/file4.txt" bs=1 count=2192 > /dev/null 2>&1
+
+$MPREMOTE resume cp -r "${TMP}/data" :
+$MPREMOTE resume tree -s :
+echo -----
+echo "tree -s"
+$MPREMOTE resume tree -s
+echo -----
+$MPREMOTE resume tree --human :
+echo -----
+$MPREMOTE resume tree -s --human : || echo "expect error: $?"
+echo -----
+

--- a/tools/mpremote/tests/test_fs_tree.sh.exp
+++ b/tools/mpremote/tests/test_fs_tree.sh.exp
@@ -1,0 +1,225 @@
+-----
+ls :
+-----
+empty tree
+tree :
+:/ramdisk
+-----
+touch :a.py
+touch :b.py
+mkdir :foo
+touch :foo/aa.py
+touch :foo/ba.py
+small tree - :
+tree :
+:/ramdisk
+├── a.py
+├── b.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+no path
+tree :
+:/ramdisk
+├── a.py
+├── b.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+path = '.'
+tree :.
+:/ramdisk
+├── a.py
+├── b.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+path = ':.'
+tree :.
+:/ramdisk
+├── a.py
+├── b.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+multiple trees
+mkdir :bar
+touch :bar/aaa.py
+touch :bar/bbbb.py
+mkdir :bar/baz
+touch :bar/baz/aaa.py
+touch :bar/baz/bbbb.py
+mkdir :bar/baz/quux
+touch :bar/baz/quux/aaa.py
+touch :bar/baz/quux/bbbb.py
+mkdir :bar/baz/quux/xen
+touch :bar/baz/quux/xen/aaa.py
+tree :
+:/ramdisk
+├── a.py
+├── b.py
+├── bar
+│   ├── aaa.py
+│   ├── baz
+│   │   ├── aaa.py
+│   │   ├── bbbb.py
+│   │   └── quux
+│   │       ├── aaa.py
+│   │       ├── bbbb.py
+│   │       └── xen
+│   │           └── aaa.py
+│   └── bbbb.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+single path
+tree :foo
+:foo
+├── aa.py
+└── ba.py
+-----
+multiple paths
+tree :foo
+:foo
+├── aa.py
+└── ba.py
+tree :bar
+:bar
+├── aaa.py
+├── baz
+│   ├── aaa.py
+│   ├── bbbb.py
+│   └── quux
+│       ├── aaa.py
+│       ├── bbbb.py
+│       └── xen
+│           └── aaa.py
+└── bbbb.py
+-----
+subtree
+tree :bar/baz
+:bar/baz
+├── aaa.py
+├── bbbb.py
+└── quux
+    ├── aaa.py
+    ├── bbbb.py
+    └── xen
+        └── aaa.py
+-----
+mountpoint
+tree :/ramdisk
+:/ramdisk
+├── a.py
+├── b.py
+├── bar
+│   ├── aaa.py
+│   ├── baz
+│   │   ├── aaa.py
+│   │   ├── bbbb.py
+│   │   └── quux
+│   │       ├── aaa.py
+│   │       ├── bbbb.py
+│   │       └── xen
+│   │           └── aaa.py
+│   └── bbbb.py
+└── foo
+    ├── aa.py
+    └── ba.py
+-----
+non-existent folder : error
+tree :not_there
+mpremote: tree: 'not_there' is not a directory
+expect error: 1
+-----
+file : error
+tree :a.py
+mpremote: tree: 'a.py' is not a directory
+expect error: 1
+-----
+tree -s :
+cp ${TMP}/data :
+tree :
+:/ramdisk
+├── [        0]  a.py
+├── [        0]  b.py
+├── bar
+│   ├── [        0]  aaa.py
+│   ├── baz
+│   │   ├── [        0]  aaa.py
+│   │   ├── [        0]  bbbb.py
+│   │   └── quux
+│   │       ├── [        0]  aaa.py
+│   │       ├── [        0]  bbbb.py
+│   │       └── xen
+│   │           └── [        0]  aaa.py
+│   └── [        0]  bbbb.py
+├── data
+│   ├── [       20]  file1.txt
+│   ├── [      204]  file2.txt
+│   ├── [     1096]  file3.txt
+│   └── [     2192]  file4.txt
+└── foo
+    ├── [        0]  aa.py
+    └── [        0]  ba.py
+-----
+tree -s
+tree :
+:/ramdisk
+├── [        0]  a.py
+├── [        0]  b.py
+├── bar
+│   ├── [        0]  aaa.py
+│   ├── baz
+│   │   ├── [        0]  aaa.py
+│   │   ├── [        0]  bbbb.py
+│   │   └── quux
+│   │       ├── [        0]  aaa.py
+│   │       ├── [        0]  bbbb.py
+│   │       └── xen
+│   │           └── [        0]  aaa.py
+│   └── [        0]  bbbb.py
+├── data
+│   ├── [       20]  file1.txt
+│   ├── [      204]  file2.txt
+│   ├── [     1096]  file3.txt
+│   └── [     2192]  file4.txt
+└── foo
+    ├── [        0]  aa.py
+    └── [        0]  ba.py
+-----
+tree :
+:/ramdisk
+├── [     0]  a.py
+├── [     0]  b.py
+├── bar
+│   ├── [     0]  aaa.py
+│   ├── baz
+│   │   ├── [     0]  aaa.py
+│   │   ├── [     0]  bbbb.py
+│   │   └── quux
+│   │       ├── [     0]  aaa.py
+│   │       ├── [     0]  bbbb.py
+│   │       └── xen
+│   │           └── [     0]  aaa.py
+│   └── [     0]  bbbb.py
+├── data
+│   ├── [    20]  file1.txt
+│   ├── [   204]  file2.txt
+│   ├── [  1.1K]  file3.txt
+│   └── [  2.1K]  file4.txt
+└── foo
+    ├── [     0]  aa.py
+    └── [     0]  ba.py
+-----
+usage: fs [--help] [--recursive | --no-recursive] [--force | --no-force]
+          [--verbose | --no-verbose] [--size | --human]
+          command path [path ...] ...
+fs: error: argument --human/-h: not allowed with argument --size/-s
+expect error: 2
+-----


### PR DESCRIPTION
### Summary
This PR adds a new command to `mpremote` that displays the file system of a connected device in a tree format.

While working on mpremote rm -r I developed a desire to see a tree-view of files on the device.
I build a PoC for this and [asked for feedback](https://github.com/orgs/micropython/discussions/17104) 
where there appears to be a common need for this.

The  `mpremote fs tree` command :
 - Shows treeview from current path or specified path
 -  uses the graph chars ("├── ", "└── ") ( not configurable)
 - options: 
    - -v/--verbose adds the serial device name to the top of the tree
    - -s/--size add a (human readable) size to the files. ( not using -h as that )

This PR also fixes a limitation where `ls` can be run without specifying a path, but this would result in an error if an option was specified.
As `tree` also uses the same logic I wanted to fix this for both commands.

**Example tree view:**
```
$ mpremote resume tree -sv /
tree :/
:/ on /dev/ttyACM0
├── [  10B] a.py
├── [ 1.9K] b.py
├── backup
│   ├── [  10B] a.py
│   ├── [ 1.9K] b.py
│   ├── foo
│   │   ├── [   0B] aa.py
│   │   └── [   0B] ba.py
│   └── lib
│       ├── [   0B] bar.py
│       └── [   0B] foo.py
├── [   0B] bar.py
├── foo
│   ├── [   0B] aa.py
│   └── [   0B] ba.py
├── [   0B] foo.py
├── lib
│   ├── [   0B] bar.py
│   └── [   0B] foo.py
└── ramdisk
    ├── [   0B] bar.py
    ├── [   0B] foo.py
    └── lib
        ├── [   0B] lib_bar.py
        └── [   0B] lib_foo.py
```

### Testing

Automated tests for valid and error cases have been added, but can only be verified on unix based systems.
The -v option cannot be tested reliably with the `.exp` output approach as devices can,  and will,  be assigned to different port names.  So this has been omitted from automated tests.

Note that there is now 3x duplication of the `ramdisk.py` script across multiple test scripts. 
It would be best to reduce this to a single file and use it in all tests.

Manual testing:
| port | WSL2/ubuntu| Windows|
|--------|--------|--------|
| stm32| PASS | PASS |
| samd | PASS | PASS |
| esp32| PASS | PASS | 

### Documentation

Documentation and samples for the `fs tree` command have been added to the mpremote doc page.
A few _sub sections_ have been added to the **fs section**  to improve readability, 
A few paragraphs have been moved to a more appropriate location to better fit this structure.




