### PR TITLE
ESP32_GENERIC_C3/mpconfigboard.h: Add defaults for I2C pins.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -20,6 +20,6 @@
    Without defining, SDL/SDA default is 19/18 which
    conflict with USB
 **/
-#define I2C pin defaults
+// define I2C pin defaults
 #define MICROPY_HW_I2C0_SCL                 (7)
 #define MICROPY_HW_I2C0_SDA                 (6)

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -20,6 +20,6 @@
    Without defining, SDL/SDA default is 19/18 which
    conflict with USB
 **/
-# define I2C Defaults:
+#define I2C Defaults:
 #define MICROPY_HW_I2C0_SCL                 (7)
 #define MICROPY_HW_I2C0_SDA                 (6)

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -20,6 +20,6 @@
    Without defining, SDL/SDA default is 19/18 which
    conflict with USB
 **/
-#define I2C Defaults
+#define I2C pin defaults
 #define MICROPY_HW_I2C0_SCL                 (7)
 #define MICROPY_HW_I2C0_SDA                 (6)

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -20,6 +20,6 @@
    Without defining, SDL/SDA default is 19/18 which
    conflict with USB
 **/
-#define I2C Defaults:
+#define I2C Defaults
 #define MICROPY_HW_I2C0_SCL                 (7)
 #define MICROPY_HW_I2C0_SDA                 (6)

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.h
@@ -5,3 +5,21 @@
 
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)
+
+/**
+   22 Pins total
+                          SDA      SCL
+   For adafruit qtpy        5        6
+   For xiao c3              6        7
+
+   GPIO 8&9 are strapping (okay to use after start)
+   GPIO 12-17 are typically used for SPI flash/PSRAM
+   GPIO 18&19 are typically used for USB/JTAG
+
+   GPIO 0-7,10-11,20-21 generally possible
+   Without defining, SDL/SDA default is 19/18 which
+   conflict with USB
+**/
+# define I2C Defaults:
+#define MICROPY_HW_I2C0_SCL                 (7)
+#define MICROPY_HW_I2C0_SDA                 (6)


### PR DESCRIPTION
### Summary

For the ESP32C3  (XIAO C3 for example) the default I2C pins conflicted with the
USB pins resulting in REPL hanging after using the new I2C initializer without
parameters. 

Reference:
#17103
#16671


### Testing

I tested on an XIAO ESP32C3 board, using the micropython master development branch.

### Trade-offs and Alternatives

While the values I defaulted to should allow for safe construction of  an I2C object,
they may not be correct for any particular wiring.  
I would suggest the documentation be updated for board configurations to include the 
necessary default pin parameters. 

Another valid approach would be to require the parameters (port id, scl, sda) for every
I2C object creation - my favorite for consistency.

