### PR TITLE
py/modthread: Initialize thread state nlr_top to NULL.

### DIFF
--- a/py/runtime.h
+++ b/py/runtime.h
@@ -165,6 +165,7 @@ static inline void mp_thread_init_state(mp_state_thread_t *ts, size_t stack_size
     ts->gc_lock_depth = 0;
 
     // There are no pending jump callbacks or exceptions yet
+    ts->nlr_top = NULL;
     ts->nlr_jump_callback_top = NULL;
     ts->mp_pending_exception = MP_OBJ_NULL;
 


### PR DESCRIPTION
### Summary

This ensures the check in [`MP_NLR_JUMP_HEAD`](https://github.com/micropython/micropython/blob/6cb0a4edea1025a1ef88b7cd2bc0a88e007de904/py/nlr.h#L161-L163) works as expected and `nlr_jump_fail` gets called so we get a bit better error message.

### Testing

Made this fix while debugging another issue (a try-catch block not working when using `@micropython.native`, which I have not yet figured out, but when I do there will be a PR for that as well). 

There is not really a way to test this change other than if you already have bug that causes a incomplete NLR stack.

### Trade-offs and Alternatives

The code is likely going to crash anyway, so all this does is make it clear that crash is due to a incomplete NLR stack (instead of following an uninitialized pointer, jumping to some random location and crashing there).