### PR TITLE
extmod/modjson: Detect unterminated composite entities.

### DIFF
--- a/extmod/modjson.c
+++ b/extmod/modjson.c
@@ -160,7 +160,8 @@ static mp_obj_t mod_json_load(mp_obj_t stream_obj) {
     for (;;) {
     cont:
         if (S_END(s)) {
-            break;
+            // Input finished abruptly in the middle of a composite entity.
+            goto fail;
         }
         mp_obj_t next = MP_OBJ_NULL;
         bool enter = false;

--- a/tests/extmod/json_loads.py
+++ b/tests/extmod/json_loads.py
@@ -71,3 +71,27 @@ try:
     my_print(json.loads("[null]   a"))
 except ValueError:
     print("ValueError")
+
+# incomplete object declaration
+try:
+    my_print(json.loads('{"a":0,'))
+except ValueError:
+    print("ValueError")
+
+# incomplete nested array declaration
+try:
+    my_print(json.loads('{"a":0, ['))
+except ValueError:
+    print("ValueError")
+
+# incomplete array declaration
+try:
+    my_print(json.loads('[0,'))
+except ValueError:
+    print("ValueError")
+
+# incomplete nested object declaration
+try:
+    my_print(json.loads('[0, {"a":0, '))
+except ValueError:
+    print("ValueError")


### PR DESCRIPTION
### Summary

This PR makes the JSON parser raise an exception when handling objects or arrays whose declaration is incomplete, as in missing the closing marker (brace or bracket) and if the missing marker would have been the last non-whitespace character in the incoming string.

Since CPython's JSON parser would raise an exception in such a case, unlike MicroPython's, this PR aligns MicroPython's behaviour with CPython.

This commit fixes issue #17141.

### Testing

This was tested with the Unix port, passing all JSON-related tests (existing and new).

### Trade-offs and Alternatives

There may be some code out there that relies on this peculiar behaviour, and thus this PR may introduce an incompatibility across MicroPython versions.

On the other hand, the code wouldn't have worked in CPython in the first place as an incomplete JSON object is not meant to be parseable by `json.load` or `json.loads` anyway since they expect a fully formed JSON object to be available (either from a string or from a file descriptor).