### PR TITLE
Mpr/fix rm remote

### DIFF
--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -234,3 +234,6 @@ $MPREMOTE resume rm -r -v :/ramdisk
 $MPREMOTE resume ls :/ramdisk
 
 echo -----
+# try to delete existing folder in mounted filesystem
+$MPREMOTE mount "${TMP}" + rm -rv :package || echo "expect error"
+echo -----

--- a/tools/mpremote/tests/test_filesystem.sh.exp
+++ b/tools/mpremote/tests/test_filesystem.sh.exp
@@ -267,3 +267,8 @@ removed directory: '/ramdisk/package'
 skipped: '/ramdisk' (vfs mountpoint)
 ls :/ramdisk
 -----
+Local directory ${TMP} is mounted at /remote
+rm :package
+mpremote: rm -r not permitted on /remote directory
+expect error
+-----


### PR DESCRIPTION
### Summary

Removes the risk of inadvertently deleting files from the host by preventing the deletion of files from the host via `rm -r` on the `/remote` vfs as reported in #17147.

### Testing

The PR adds a test for `rm -r` on the `/remote` vfs to ensure that the deletion of files from the host is prevented.
Tested manually on Windows.

### Trade-offs and Alternatives

The fix only addresses the risk via `rm -r` as that has a potentially large impact, and not with just the `rm` command that has been in use for quite some time.
The same safeguard could be added to the `rm' command.


Fixes: https://github.com/micropython/micropython/issues/17147