### PR TITLE
pre-commit,ci: Bump the Ruff version.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    # ruff version should be kept in sync with .pre-commit-config.yaml
-    - run: pipx install ruff==0.9.6
+    # ruff version should be kept in sync with .pre-commit-config.yaml & also micropython-lib
+    - run: pipx install ruff==0.11.6
     - run: ruff check --output-format=github .
     - run: ruff format --diff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
         verbose: true
         stages: [commit-msg]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # Version should be kept in sync with .github/workflows/ruff.yml
-    rev: v0.9.6
+    # Version should be kept in sync with .github/workflows/ruff.yml & also micropython-lib
+    rev: v0.11.6
     hooks:
       - id: ruff
       - id: ruff-format

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -1131,7 +1131,7 @@ def load_object_file(env, f, felf):
         elif sym.entry["st_shndx"] == "SHN_UNDEF" and sym["st_info"]["bind"] == "STB_GLOBAL":
             # Undefined global symbol, needs resolving
             env.unresolved_syms.append(sym)
-    if len(dup_errors):
+    if dup_errors:
         raise LinkError("\n".join(dup_errors))
 
 
@@ -1214,7 +1214,7 @@ def link_objects(env, native_qstr_vals_len):
             else:
                 undef_errors.append("{}: undefined symbol: {}".format(sym.filename, sym.name))
 
-    if len(undef_errors):
+    if undef_errors:
         raise LinkError("\n".join(undef_errors))
 
     # Align sections, assign their addresses, and create full_text


### PR DESCRIPTION
### Summary

Brings the Ruff version into sync with https://github.com/micropython/micropython-lib/pull/1001 (as micropython-lib was previously using a much older Ruff version).

Includes one automatically applied fix.
