### PR TITLE
tests: Improve test skipping for a few tests

### DIFF
--- a/tests/extmod/binascii_hexlify.py
+++ b/tests/extmod/binascii_hexlify.py
@@ -1,5 +1,5 @@
 try:
-    import binascii
+    from binascii import hexlify
 except ImportError:
     print("SKIP")
     raise SystemExit
@@ -10,10 +10,10 @@ for x in (
     b"\x7f\x80\xff",
     b"1234ABCDabcd",
 ):
-    print(binascii.hexlify(x))
+    print(hexlify(x))
 
 # Two-argument version (now supported in CPython)
-print(binascii.hexlify(b"123", ":"))
+print(hexlify(b"123", ":"))
 
 # zero length buffer
-print(binascii.hexlify(b"", b":"))
+print(hexlify(b"", b":"))

--- a/tests/extmod/binascii_unhexlify.py
+++ b/tests/extmod/binascii_unhexlify.py
@@ -1,5 +1,5 @@
 try:
-    import binascii
+    from binascii import unhexlify
 except ImportError:
     print("SKIP")
     raise SystemExit
@@ -10,14 +10,14 @@ for x in (
     b"7f80ff",
     b"313233344142434461626364",
 ):
-    print(binascii.unhexlify(x))
+    print(unhexlify(x))
 
 try:
-    a = binascii.unhexlify(b"0")  # odd buffer length
+    a = unhexlify(b"0")  # odd buffer length
 except ValueError:
     print("ValueError")
 
 try:
-    a = binascii.unhexlify(b"gg")  # digit not hex
+    a = unhexlify(b"gg")  # digit not hex
 except ValueError:
     print("ValueError")

--- a/tests/extmod/vfs_lfs_ilistdir_del.py
+++ b/tests/extmod/vfs_lfs_ilistdir_del.py
@@ -71,5 +71,10 @@ def test(bdev, vfs_class):
         fs.open("/test", "w").close()
 
 
-bdev = RAMBlockDevice(30)
+try:
+    bdev = RAMBlockDevice(30)
+except MemoryError:
+    print("SKIP")
+    raise SystemExit
+
 test(bdev, vfs.VfsLfs2)

--- a/tests/extmod/vfs_mountinfo.py
+++ b/tests/extmod/vfs_mountinfo.py
@@ -5,7 +5,6 @@ try:
 except ImportError:
     print("SKIP")
     raise SystemExit
-import errno
 
 
 class Filesystem:


### PR DESCRIPTION
### Summary

Some tweaks to tests found during testing for v1.25.0.  Allows skipping tests automatically on targets that they can't run on.

### Testing

Tested on an nrf board with lots of features disabled.  The tests properly skip now.

