### PR TITLE
tools/mpremote: Improve df command to use new no-arg vfs.mount() query.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -379,7 +379,27 @@ _BUILTIN_COMMAND_EXPANSIONS = {
     # Disk used/free.
     "df": [
         "exec",
-        "import os\nprint('mount \\tsize \\tused \\tavail \\tuse%')\nfor _m in [''] + os.listdir('/'):\n _s = os.stat('/' + _m)\n if not _s[0] & 1 << 14: continue\n _s = os.statvfs(_m)\n if _s[0]:\n  _size = _s[0] * _s[2]; _free = _s[0] * _s[3]; print(_m, _size, _size - _free, _free, int(100 * (_size - _free) / _size), sep='\\t')",
+        """
+import os,vfs
+_f = "{:<10}{:>9}{:>9}{:>9}{:>5} {}"
+print(_f.format("filesystem", "size", "used", "avail", "use%", "mounted on"))
+try:
+ _ms = vfs.mount()
+except:
+ _ms = []
+ for _m in [""] + os.listdir("/"):
+  _m = "/" + _m
+  _s = os.stat(_m)
+  if _s[0] & 1 << 14:
+   _ms.append(("<unknown>",_m))
+for _v,_p in _ms:
+ _s = os.statvfs(_p)
+ _sz = _s[0]*_s[2]
+ if _sz:
+  _av = _s[0]*_s[3]
+  _us = 100*(_sz-_av)//_sz
+  print(_f.format(str(_v), _sz, _sz-_av, _av, _us, _p))
+""",
     ],
     # Other shortcuts.
     "reset": {


### PR DESCRIPTION
### Summary

The existing `mpremote df` command is not very good, because it needs to assume that all directories in the root directory are mount points, and also doesn't correctly stat filesystems when the current directory is not the root.  This leads to wrong results, eg on PYBD-SF2:
```
$ mpremote df
mount 	size 	used 	avail 	use%
	2076672	670720	1405952	32
rom	2076672	670720	1405952	32
flash	2076672	670720	1405952	32
```
and on RPI_PICO2:
```
$ mpremote df
mount 	size 	used 	avail 	use%
	3145728	49152	3096576	1
lib	3145728	49152	3096576	1
```

With the introduction of `vfs.mount()` to return a list of mounted filesystems and their path (see #16939), we can implement a much better `df`, as done in this PR.

Now the above examples are:
```
$ mpremote df
filesystem     size     used    avail use% mounted on
<VfsRom>      66010    66010        0  100 /rom
<VfsFat>    2076672   670720  1405952   32 /flash
```
and
```
$ mpremote df
filesystem     size     used    avail use% mounted on
<VfsLfs2>   3145728    49152  3096576    1 /
```

### Testing

Tested on PYBD_SF2 and RPI_PICO2, and also a board without any mount points (to verify that only the heading row is printed).

Also, it now works on boards without floating point because it uses `//` instead of `/` to calculate the percentage used.

### Trade-offs and Alternatives

~~This new `df` wont work with MicroPython versions earlier than v1.25.0 due to the required no-arg `vfs.mount()` function.  I'm not sure it's worth auto-detecting this feature and supporting old versions?~~

EDIT: the new `df` now works with all versions of MicroPython, falling back to `os.listdir("/")` when `vfs.mount()` doesn't work.
