### PR TITLE
tests/extmod/vfs_posix.py: Fix test on Android.

### DIFF
--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -29,7 +29,21 @@ print(os.getcwd() == curdir)
 print(type(os.stat("/")))
 
 # listdir and ilistdir
-print(type(os.listdir("/")))
+target = "/"
+try:
+    import platform
+
+    # On Android non-root users are permitted full filesystem access only to
+    # selected directories.  To let this test pass on bionic, the internal
+    # user-accessible storage area root is enumerated instead of the
+    # filesystem root.  "/storage/emulated/0" should be there on pretty much
+    # any recent-ish device; querying the proper location requires a JNI
+    # round-trip, not really worth it.
+    if platform.platform().startswith("Android-"):
+        target = "/storage/emulated/0"
+except ImportError:
+    pass
+print(type(os.listdir(target)))
 
 # mkdir
 os.mkdir(temp_dir)


### PR DESCRIPTION
### Summary

This PR makes a slight change to the `vfs_posix` test suite to let it pass on Android.

On Android, non-root processes can perform most filesystem operations only on a restricted set of directories.  The `vfs_posix` test suite attempted to enumerate the filesystem root directory, and said directory happens to be restricted for non-root processes.  This would raise an EACCES OSError and terminate the test with a unexpected failure.

To fix this, rather than enumerating the filesystem root directory the enumeration target is the internal shared storage area root - which doesn't have enumeration restrictions for non-root processes.  The path is hardcoded because it is guaranteed to be there on pretty much any recent-ish device for now (it stayed the same for more than a decade for compatibility reasons).  The proper way would be to query the storage subsystem via a JNI round-trip (that has to be implemented somewhere else), but this introduces too much complexity for something that is unlikely to break going forward.

### Testing

The `vfs_posix` test was executed successfully on a no-name Android 11 tablet under Termux.

### Trade-offs and Alternatives

There's a non-zero possibility Google may either remove `/storage/emulated/0` or restrict its enumeration in the future, but that possibility should be rather low as a lot of native code that is not running as part of an UI application assumes that directory is there and is available.