### PR TITLE
rp2/Makefile: Add deploy target that uses picotool load.

### DIFF
--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -67,6 +67,9 @@ all:
 clean:
 	$(RM) -rf $(BUILD)
 
+deploy: all
+	$(Q)picotool load -x $(BUILD)/firmware.elf
+
 # First ensure that pico-sdk is initialised, then run CMake with the
 # UPDATE_SUBMODULES flag to update necessary submodules for this board.
 #

--- a/ports/rp2/README.md
+++ b/ports/rp2/README.md
@@ -47,8 +47,10 @@ pass the board name to the build; e.g. for Raspberry Pi Pico W:
 ## Deploying firmware to the device
 
 Firmware can be deployed to the device by putting it into bootloader mode
-(hold down BOOTSEL while powering on or resetting) and then copying
-`firmware.uf2` to the USB mass storage device that appears.
+(hold down BOOTSEL while powering on or resetting) and then either copying
+`firmware.uf2` to the USB mass storage device that appears, or using
+`picotool load -x firmware.elf`.  The latter command can be accessed
+conveniently via `make deploy`.
 
 If MicroPython is already installed then the bootloader can be entered by
 executing `import machine; machine.bootloader()` at the REPL.


### PR DESCRIPTION
### Summary

This is a convenient way to deploy firmware to an RP2xxx-based board.

### Testing

Tested with RPI_PICO, RPI_PICO2 and RPI_PICO2 in RISCV mode.

### Trade-offs and Alternatives

The user needs to have `picotool` installed in their path, and have relevant udev/usb permissions.
