### PR TITLE
tests/net_hosted: Only run network loopback test on supported targets.

### DIFF
--- a/tests/net_hosted/asyncio_loopback.py
+++ b/tests/net_hosted/asyncio_loopback.py
@@ -1,5 +1,12 @@
 # Test network loopback behaviour
 
+import sys
+
+# Only certain platforms can do TCP/IP loopback.
+if sys.platform not in ("darwin", "esp32", "linux"):
+    print("SKIP")
+    raise SystemExit
+
 try:
     import asyncio
 except ImportError:


### PR DESCRIPTION
### Summary

Only a few ports have TCP/IP loopback enabled in their network stack, and this test will only pass on those ports.  There's not really any good way to do a feature check for loopback mode without actually running the test and seeing if it passes/fails, so add an explicit check that the test is running on a port known to support loopback.

(Enabling loopback on lwIP, eg RPI_PICO_W, costs +568 code and +272 bss and is a rarely used feature, so not worth unconditionally enabling.)

### Testing

Tested on RPI_PICO2_W, this test now skips.

Tested on unix port and ESP32_GENERIC, this test still runs and passes.

