### PR TITLE
nrf/mpconfigport: Enable IO.IOBase as a core feature.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1469,7 +1469,7 @@ typedef double mp_float_t;
 
 // Whether to provide "io.IOBase" class to support user streams
 #ifndef MICROPY_PY_IO_IOBASE
-#define MICROPY_PY_IO_IOBASE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#define MICROPY_PY_IO_IOBASE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
 #endif
 
 // Whether to provide "io.BytesIO" class


### PR DESCRIPTION
### Summary

IOBase is quite an important building block of other parts of the system, such as `mpremote mount` and running .mpy and native tests.  It's also used by `asyncio` which is enabled by default on all boards.

This feature costs +244 bytes of firmware size, which is worth the cost for the extra features it enables.

### Testing

Tested on PCA10028 and PCA10040, they can now run more tests.