### PR TITLE
ports: zephyr: beagleconnect_freedom: Enable ADC.

### DIFF
--- a/ports/zephyr/boards/beagleconnect_freedom.conf
+++ b/ports/zephyr/boards/beagleconnect_freedom.conf
@@ -1,4 +1,5 @@
 # Hardware features
+CONFIG_ADC=y
 CONFIG_PWM=y
 CONFIG_I2C=y
 CONFIG_SPI=y


### PR DESCRIPTION
- Enable Analog inputs
- Requires Zephyr >= v3.8.0