### PR TITLE
stm32/machine_adc: Enable ADC re-read errata handling for STM32WB55.

### DIFF
--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -445,10 +445,13 @@ static void adc_config_channel(ADC_TypeDef *adc, uint32_t channel, uint32_t samp
 
 static uint32_t adc_read_channel(ADC_TypeDef *adc) {
     uint32_t value;
-    #if defined(STM32G4)
-    // For STM32G4 there is errata 2.7.7, "Wrong ADC result if conversion done late after
-    // calibration or previous conversion".  According to the errata, this can be avoided
-    // by performing two consecutive ADC conversions and keeping the second result.
+    #if defined(STM32G4) || defined(STM32WB)
+    // For STM32G4 errata 2.7.7 / STM32WB errata 2.7.1:
+    // "Wrong ADC result if conversion done late after calibration or previous conversion"
+    // states an incorrect reading is returned if more than 1ms has elapsed since the last
+    // reading or calibration. According to the errata, this can be avoided by performing
+    // two consecutive ADC conversions and keeping the second result.
+    // Note: On STM32WB55 @ 64Mhz each ADC read takes ~ 3us.
     for (uint8_t i = 0; i < 2; i++)
     #endif
     {


### PR DESCRIPTION
### Summary
For STM32WB errata 2.7.1:
"Wrong ADC result if conversion done late after calibration or previous conversion"
states an incorrect reading is returned if more than 1ms has elapsed since the last
reading or calibration. According to the errata, this can be avoided by performing
two consecutive ADC conversions and keeping the second result.

This matches existing handling for a comparable STM32G4 errata 2.7.7 


### Testing

Before this change the first read from an ADC channel often looked wrong, it turns out we'd previously added what was essentially a double-read in our application "to help the adc stabilise". Fixing it here in micropython is far more reliable and efficient.


### Trade-offs and Alternatives

I initially though it would be better to add some timing checks / "how long since last read" and only re-read if needed, however I temporarily added some timing checks with `ticks_us`/`ticks_diff` and on my STM32WB55 @ 64Mhz and each ADC read seemed to take only ~ 3us, certainly not worth the overhead of storing and checking the time of last read.
