### PR TITLE
extmod/nimble: Add timeout to deinit.

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -705,12 +705,12 @@ int mp_bluetooth_init(void) {
     return 0;
 }
 
-void mp_bluetooth_deinit(void) {
+int mp_bluetooth_deinit(void) {
     DEBUG_printf("mp_bluetooth_deinit\n");
 
     // Nothing to do if not initialised.
     if (!MP_STATE_PORT(bluetooth_btstack_root_pointers)) {
-        return;
+        return 0;
     }
 
     mp_bluetooth_gap_advertise_stop();
@@ -737,6 +737,9 @@ void mp_bluetooth_deinit(void) {
     deinit_stack();
 
     DEBUG_printf("mp_bluetooth_deinit: complete\n");
+
+    bool timeout = mp_bluetooth_btstack_state == MP_BLUETOOTH_BTSTACK_STATE_TIMEOUT;
+    return timeout ? MP_ETIMEDOUT : 0;
 }
 
 bool mp_bluetooth_is_active(void) {

--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -290,12 +290,13 @@ static mp_obj_t bluetooth_ble_make_new(const mp_obj_type_t *type, size_t n_args,
 static mp_obj_t bluetooth_ble_active(size_t n_args, const mp_obj_t *args) {
     if (n_args == 2) {
         // Boolean enable/disable argument supplied, set current state.
+        int err;
         if (mp_obj_is_true(args[1])) {
-            int err = mp_bluetooth_init();
-            bluetooth_handle_errno(err);
+            err = mp_bluetooth_init();
         } else {
-            mp_bluetooth_deinit();
+            err = mp_bluetooth_deinit();
         }
+        bluetooth_handle_errno(err);
     }
     // Return current state.
     return mp_obj_new_bool(mp_bluetooth_is_active());

--- a/extmod/modbluetooth.h
+++ b/extmod/modbluetooth.h
@@ -295,7 +295,7 @@ extern const mp_obj_type_t mp_type_bluetooth_uuid;
 int mp_bluetooth_init(void);
 
 // Disables the Bluetooth stack. Is a no-op when not enabled.
-void mp_bluetooth_deinit(void);
+int mp_bluetooth_deinit(void);
 
 // Returns true when the Bluetooth stack is active.
 bool mp_bluetooth_is_active(void);

--- a/extmod/nimble/modbluetooth_nimble.h
+++ b/extmod/nimble/modbluetooth_nimble.h
@@ -84,7 +84,7 @@ void mp_bluetooth_nimble_port_hci_deinit(void);
 void mp_bluetooth_nimble_port_start(void);
 
 // Tell the port to stop its background task.
-void mp_bluetooth_nimble_port_shutdown(void);
+int mp_bluetooth_nimble_port_shutdown(void);
 
 // --- Called by the HCI UART layer to let us know when packets have been sent.
 void mp_bluetooth_nimble_sent_hci_packet(void);

--- a/ports/esp32/mpnimbleport.c
+++ b/ports/esp32/mpnimbleport.c
@@ -58,7 +58,7 @@ void mp_bluetooth_nimble_port_start(void) {
     nimble_port_freertos_init(ble_host_task);
 }
 
-void mp_bluetooth_nimble_port_shutdown(void) {
+int mp_bluetooth_nimble_port_shutdown(void) {
     DEBUG_printf("mp_bluetooth_nimble_port_shutdown\n");
 
     #if MICROPY_PY_BLUETOOTH_USE_SYNC_EVENTS_WITH_INTERLOCK
@@ -79,6 +79,8 @@ void mp_bluetooth_nimble_port_shutdown(void) {
 
     // Mark stack as shutdown.
     mp_bluetooth_nimble_ble_state = MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF;
+
+    return 0;
 }
 
 #endif

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -775,7 +775,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #endif
 
     #if MICROPY_PY_BLUETOOTH
-    void mp_bluetooth_deinit(void);
+    int mp_bluetooth_deinit(void);
     mp_bluetooth_deinit();
     #endif
 

--- a/ports/zephyr/modbluetooth_zephyr.c
+++ b/ports/zephyr/modbluetooth_zephyr.c
@@ -305,11 +305,11 @@ int mp_bluetooth_init(void) {
     return 0;
 }
 
-void mp_bluetooth_deinit(void) {
+int mp_bluetooth_deinit(void) {
     DEBUG_printf("mp_bluetooth_deinit %d\n", mp_bluetooth_zephyr_ble_state);
     if (mp_bluetooth_zephyr_ble_state == MP_BLUETOOTH_ZEPHYR_BLE_STATE_OFF
         || mp_bluetooth_zephyr_ble_state == MP_BLUETOOTH_ZEPHYR_BLE_STATE_SUSPENDED) {
-        return;
+        return 0;
     }
 
     mp_bluetooth_gap_advertise_stop();
@@ -332,6 +332,7 @@ void mp_bluetooth_deinit(void) {
 
     MP_STATE_PORT(bluetooth_zephyr_root_pointers) = NULL;
     mp_bt_zephyr_next_conn = NULL;
+    return 0;
 }
 
 bool mp_bluetooth_is_active(void) {


### PR DESCRIPTION
### Summary

If the BLE radio stops responding before deinit is called the function can get stuck waiting for an event that is never received, particularly if the radio is external or on a separate core.

This PR adds a timeout, similar to the timeout already used in the init function. That init function timeout was also
simplified as part of this change.

Relates to https://github.com/micropython/micropython/issues/17246

### Testing

This has been tested on a stm32wb55 where the deinit was intermittently locking up waiting for the state to change.
This happened on a semi-regular basis on an application automated test suite which was running through hundreds of cycles over a number of hours.

### Trade-offs and Alternatives

The main alternative to this is relying on watchdog to break the unit out of the infinite C loop once the failure occurs, but this is not appropriate for all applications.