### PR TITLE
py/scheduler: warning about C callbacks scheduling new tasks.

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -184,6 +184,17 @@ static void pairheap_test(size_t nops, int *ops) {
     mp_printf(&mp_plat_print, "\n");
 }
 
+static mp_sched_node_t mp_coverage_sched_node;
+
+static void coverage_sched_function(mp_sched_node_t *node) {
+    (void)node;
+    static mp_uint_t loop = 3;
+    mp_printf(&mp_plat_print, "scheduled function\n");
+    if (--loop) {
+        mp_sched_schedule_node(&mp_coverage_sched_node, coverage_sched_function);
+    }
+}
+
 // function to run extra tests for things that can't be checked by scripts
 static mp_obj_t extra_coverage(void) {
     // mp_printf (used by ports that don't have a native printf)
@@ -621,6 +632,12 @@ static mp_obj_t extra_coverage(void) {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
         }
         mp_handle_pending(true);
+
+        mp_sched_schedule_node(&mp_coverage_sched_node, coverage_sched_function);
+        for (int i = 0; i <= 3; ++i) {
+            mp_printf(&mp_plat_print, "loop\n");
+            mp_handle_pending(true);
+        }
     }
 
     // ringbuf

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -44,6 +44,7 @@
 #undef MICROPY_VFS_ROM_IOCTL
 #define MICROPY_VFS_ROM_IOCTL          (1)
 #define MICROPY_PY_CRYPTOLIB_CTR       (1)
+#define MICROPY_SCHEDULER_STATIC_NODES (1)
 
 // Enable os.uname for attrtuple coverage test
 #define MICROPY_PY_OS_UNAME            (1)

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -88,6 +88,8 @@ static inline void mp_sched_run_pending(void) {
 
     #if MICROPY_SCHEDULER_STATIC_NODES
     // Run all pending C callbacks.
+    // Warning: if C callbacks themserlves schedule new C callbacks this
+    // loop will never exit.
     while (MP_STATE_VM(sched_head) != NULL) {
         mp_sched_node_t *node = MP_STATE_VM(sched_head);
         MP_STATE_VM(sched_head) = node->next;

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -122,6 +122,13 @@ unlocked
 KeyboardInterrupt: 
 KeyboardInterrupt: 
 10
+loop
+scheduled function
+scheduled function
+scheduled function
+loop
+loop
+loop
 # ringbuf
 99 0
 98 1


### PR DESCRIPTION
### Summary

If a `mp_sched_schedule_node` based C scheduler function re-schedules itself then the `mp_sched_run_pending` function can get stuck in an infinite loop re-running the function where ctrl-c cannot break out of it anymore.

~~This change adds a unit test to display the behavior (in a self-limiting fashion) along with a minimal change to auto-break out of `mp_sched_run_pending` if the node is re-scheduled. It will still be run on next run of `mp_sched_run_pending` but other aspects of the application / micropython will be able to run as well in this case.~~

This MR adds a coverage unit test showing the behavior and adds a comment in the scheduler warning developers of this behavior. It should only apply to people working on C code within the micropython codebase.

See https://github.com/micropython/micropython/issues/17246

### Testing

Tested on a STM32WB55 with manually broken rfcore, before this it was stuck in an infinite loop trying to init the radio.

### Trade-offs and Alternatives

If there are two C scheduled functions that continually re-schedule each other this fix won't catch that, but I tried to keep the minimal fix as simple as possible as I believe the goal is to keep `mp_sched_run_pending` as fast as possible as its run in the interpreter core?