### PR TITLE
ports: Fix SparkFun capitalization.

### DIFF
--- a/docs/library/wm8960.rst
+++ b/docs/library/wm8960.rst
@@ -358,13 +358,13 @@ Run WM8960 on a MIMXRT10xx_DEV board in secondary mode (default)::
         sysclk_source=wm8960.SYSCLK_MCLK)
 
 
-Record with a Sparkfun WM8960 breakout board with Teensy in secondary mode (default)::
+Record with a SparkFun WM8960 breakout board with Teensy in secondary mode (default)::
 
     # Micro_python WM8960 Codec driver
     #
     # The breakout board uses a fixed 24MHz MCLK. Therefore the internal
     # PLL must be used as sysclk, which is the master audio clock.
-    # The Sparkfun board has the WS pins for RX and TX connected on the
+    # The SparkFun board has the WS pins for RX and TX connected on the
     # board. Therefore adc_sync must be set to sync_adc, to configure
     # it's ADCLRC pin as input.
     #
@@ -379,11 +379,11 @@ Record with a Sparkfun WM8960 breakout board with Teensy in secondary mode (defa
         right_input=wm8960.INPUT_CLOSED)
 
 
-Play with a Sparkfun WM8960 breakout board with Teensy in secondary mode (default)::
+Play with a SparkFun WM8960 breakout board with Teensy in secondary mode (default)::
 
     # The breakout board uses a fixed 24MHz MCLK. Therefore the internal
     # PLL must be used as sysclk, which is the master audio clock.
-    # The Sparkfun board has the WS pins for RX and TX connected on the
+    # The SparkFun board has the WS pins for RX and TX connected on the
     # board. Therefore adc_sync must be set to sync_adc, to configure
     # it's ADCLRC pin as input.
 

--- a/docs/samd/pinout.rst
+++ b/docs/samd/pinout.rst
@@ -892,7 +892,7 @@ Default pin assignments:
 
 There seems to be no default pin assignment for this board.
 
-Sparkfun SAMD51 Thing Plus pin assignment table
+SparkFun SAMD51 Thing Plus pin assignment table
 ------------------------------------------------
 
 === ==== ============ ==== ==== ==== ====== ====== ===== ===== =====

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/board.json
@@ -13,8 +13,8 @@
         "sparkfun_samd51_thing_plus.jpg"
     ],
     "mcu": "samd51",
-    "product": "Sparkfun SAMD51 Thing Plus",
+    "product": "SparkFun SAMD51 Thing Plus",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/14713",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/mpconfigboard.h
+++ b/ports/samd/boards/SPARKFUN_SAMD51_THING_PLUS/mpconfigboard.h
@@ -1,4 +1,4 @@
-#define MICROPY_HW_BOARD_NAME       "Sparkfun SAMD51 Thing Plus"
+#define MICROPY_HW_BOARD_NAME       "SparkFun SAMD51 Thing Plus"
 #define MICROPY_HW_MCU_NAME         "SAMD51J20A"
 
 #define MICROPY_HW_XOSC32K          (1)

--- a/ports/samd/modmachine.c
+++ b/ports/samd/modmachine.c
@@ -42,7 +42,7 @@
 #define DBL_TAP_ADDR    ((volatile uint32_t *)(HSRAM_ADDR + HSRAM_SIZE - 4))
 #endif
 // A board may define a DPL_TAP_ADDR_ALT, which will be set as well
-// Needed at the moment for Sparkfun SAMD51 Thing Plus
+// Needed at the moment for SparkFun SAMD51 Thing Plus
 #define DBL_TAP_MAGIC_LOADER 0xf01669ef
 #define DBL_TAP_MAGIC_RESET 0xf02669ef
 

--- a/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/board.json
+++ b/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/board.json
@@ -11,5 +11,5 @@
     "product": "Micromod STM32",
     "thumbnail": "",
     "url": "",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
+++ b/ports/stm32/boards/SPARKFUN_MICROMOD_STM32/mpconfigboard.h
@@ -1,4 +1,4 @@
-// The Sparkfun MicroMod spec uses a zero-based peripheral numbering scheme.
+// The SparkFun MicroMod spec uses a zero-based peripheral numbering scheme.
 // In cases where the 0th peripheral is the default, the "0" is omitted from
 // the name (e.g. "I2C" instead of "I2C0").
 //


### PR DESCRIPTION
### Summary

This is a follow up PR to 1e92bdd206f6f87ba65ea05c5b2623fca0b926cd correcting more of the instances where "Sparkfun" should be "SparkFun".

### Testing

Aesthetic change, did not test.
