### PR TITLE
tests/extmod/vfs_rom.py: Clear sys.path before running test.

### DIFF
--- a/tests/extmod/vfs_rom.py
+++ b/tests/extmod/vfs_rom.py
@@ -394,6 +394,7 @@ class TestMounted(TestBase):
     def setUp(self):
         self.orig_sys_path = list(sys.path)
         self.orig_cwd = os.getcwd()
+        sys.path = []
         vfs.mount(vfs.VfsRom(self.romfs), "/test_rom")
 
     def tearDown(self):


### PR DESCRIPTION
### Summary

If `sys.path` is not cleared, and the target has certain files/directories (such as "test") in its filesystem, then these interfere with the unit tests.

### Testing

Tested on PYBD-SF2 which contained a directory called "test" in its current directory (and hence path).  The test fails without the fix in this PR.
