### PR TITLE
all/mpbthciport.c: Don't restart BLE polling if already running.

### DIFF
--- a/ports/mimxrt/mpbthciport.c
+++ b/ports/mimxrt/mpbthciport.c
@@ -49,6 +49,8 @@ uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
 static mp_sched_node_t mp_bluetooth_hci_sched_node;
 static soft_timer_entry_t mp_bluetooth_hci_soft_timer;
 
+static bool mp_bluetooth_hci_poll_active = false;
+
 static void mp_bluetooth_hci_soft_timer_callback(soft_timer_entry_t *self) {
     mp_bluetooth_hci_poll_now();
 }
@@ -63,7 +65,10 @@ void mp_bluetooth_hci_init(void) {
 }
 
 static void mp_bluetooth_hci_start_polling(void) {
-    mp_bluetooth_hci_poll_now();
+    // Poll now unless it's already running
+    if (!mp_bluetooth_hci_poll_active) {
+        mp_bluetooth_hci_poll_now();
+    }
 }
 
 void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
@@ -73,7 +78,9 @@ void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
 // For synchronous mode, we run all BLE stack code inside a scheduled task.
 static void run_events_scheduled_task(mp_sched_node_t *node) {
     // This will process all buffered HCI UART data, and run any callouts or events.
+    mp_bluetooth_hci_poll_active = true;
     mp_bluetooth_hci_poll();
+    mp_bluetooth_hci_poll_active = false;
 }
 
 // Called periodically (systick) or directly (e.g. UART RX IRQ) in order to

--- a/ports/renesas-ra/mpbthciport.c
+++ b/ports/renesas-ra/mpbthciport.c
@@ -45,6 +45,8 @@ uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
 static mp_sched_node_t mp_bluetooth_hci_sched_node;
 static soft_timer_entry_t mp_bluetooth_hci_soft_timer;
 
+static bool mp_bluetooth_hci_poll_active = false;
+
 static void mp_bluetooth_hci_soft_timer_callback(soft_timer_entry_t *self) {
     mp_bluetooth_hci_poll_now();
 }
@@ -59,7 +61,10 @@ void mp_bluetooth_hci_init(void) {
 }
 
 static void mp_bluetooth_hci_start_polling(void) {
-    mp_bluetooth_hci_poll_now();
+    // Poll now unless it's already running
+    if (!mp_bluetooth_hci_poll_active) {
+        mp_bluetooth_hci_poll_now();
+    }
 }
 
 void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
@@ -69,7 +74,9 @@ void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
 // For synchronous mode, we run all BLE stack code inside a scheduled task.
 static void run_events_scheduled_task(mp_sched_node_t *node) {
     // This will process all buffered HCI UART data, and run any callouts or events.
+    mp_bluetooth_hci_poll_active = true;
     mp_bluetooth_hci_poll();
+    mp_bluetooth_hci_poll_active = false;
 }
 
 // Called periodically (systick) or directly (e.g. UART RX IRQ) in order to

--- a/ports/rp2/mpbthciport.c
+++ b/ports/rp2/mpbthciport.c
@@ -45,6 +45,8 @@ uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
 static soft_timer_entry_t mp_bluetooth_hci_soft_timer;
 static mp_sched_node_t mp_bluetooth_hci_sched_node;
 
+static bool mp_bluetooth_hci_poll_active = false;
+
 // This is called by soft_timer and executes at PendSV level.
 static void mp_bluetooth_hci_soft_timer_callback(soft_timer_entry_t *self) {
     mp_bluetooth_hci_poll_now();
@@ -68,7 +70,9 @@ void mp_bluetooth_hci_poll_in_ms(uint32_t ms) {
 static void run_events_scheduled_task(mp_sched_node_t *node) {
     (void)node;
     // This will process all buffered HCI UART data, and run any callouts or events.
+    mp_bluetooth_hci_poll_active = true;
     mp_bluetooth_hci_poll();
+    mp_bluetooth_hci_poll_active = false;
 }
 
 // Called periodically (systick) or directly (e.g. UART RX IRQ) in order to
@@ -82,7 +86,10 @@ void mp_bluetooth_hci_poll_now(void) {
 mp_obj_t mp_bthci_uart;
 
 static void mp_bluetooth_hci_start_polling(void) {
-    mp_bluetooth_hci_poll_now();
+    // Poll now unless it's already running
+    if (!mp_bluetooth_hci_poll_active) {
+        mp_bluetooth_hci_poll_now();
+    }
 }
 
 int mp_bluetooth_hci_uart_init(uint32_t port, uint32_t baudrate) {

--- a/ports/stm32/mpbthciport.c
+++ b/ports/stm32/mpbthciport.c
@@ -43,6 +43,8 @@ uint8_t mp_bluetooth_hci_cmd_buf[4 + 256];
 // Soft timer for scheduling a HCI poll.
 static soft_timer_entry_t mp_bluetooth_hci_soft_timer;
 
+static bool mp_bluetooth_hci_poll_active = false;
+
 // This is called by soft_timer and executes at IRQ_PRI_PENDSV.
 static void mp_bluetooth_hci_soft_timer_callback(soft_timer_entry_t *self) {
     mp_bluetooth_hci_poll_now();
@@ -58,7 +60,10 @@ void mp_bluetooth_hci_init(void) {
 }
 
 static void mp_bluetooth_hci_start_polling(void) {
-    mp_bluetooth_hci_poll_now();
+    // Poll now unless it's already running
+    if (!mp_bluetooth_hci_poll_active) {
+        mp_bluetooth_hci_poll_now();
+    }
 }
 
 void mp_bluetooth_hci_poll_in_ms_default(uint32_t ms) {
@@ -75,7 +80,9 @@ static mp_sched_node_t mp_bluetooth_hci_sched_node;
 static void run_events_scheduled_task(mp_sched_node_t *node) {
     // This will process all buffered HCI UART data, and run any callouts or events.
     (void)node;
+    mp_bluetooth_hci_poll_active = true;
     mp_bluetooth_hci_poll();
+    mp_bluetooth_hci_poll_active = false;
 }
 
 // Called periodically (systick) or directly (e.g. UART RX IRQ) in order to


### PR DESCRIPTION
### Summary

When nimble stack  schedules a reset (ble_hs_reset) it's handled in `mp_bluetooth_nimble_os_eventq_run_all()` which itself is run in `mp_bluetooth_hci_poll()`.

The stack reset process starts with running `mp_bluetooth_hci_uart_deinit` then `mp_bluetooth_hci_uart_init`. The init function ends with `mp_bluetooth_hci_start_polling();` which brings us to this PR, a C scheduled hci poll can result in a re-schedule of itself in the event of a stack reset (failure / non-resonse detected from radio).

This was first discovered in https://github.com/micropython/micropython/issues/17246


### Testing

This has been tested on a stm32wb55 with the radio firware wiped so the nimble stack continually attempts to re-init the hci connection.

### Trade-offs and Alternatives

This issue can also be avoided with the C scheduler loop break first proposed in https://github.com/micropython/micropython/pull/17248/commits/af4a8e9cfc6df2467bb492d4794e377a8d80cb37
