### PR TITLE
rp2: Add temporary workaround for GCC 15.1 build failure.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -84,6 +84,9 @@ endif()
 list(APPEND GIT_SUBMODULES lib/mbedtls)
 list(APPEND GIT_SUBMODULES lib/tinyusb)
 
+# Workaround for pico-sdk host toolchain issue, see directory for details
+list(APPEND CMAKE_MODULE_PATH "${MICROPY_PORT_DIR}/tools_patch")
+
 # Include component cmake fragments
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)

--- a/ports/rp2/tools_patch/Findpioasm.cmake
+++ b/ports/rp2/tools_patch/Findpioasm.cmake
@@ -1,0 +1,58 @@
+# Finds (or builds) the pioasm executable
+#
+# This will define the following imported targets
+#
+#     pioasm
+#
+
+# This is a temporary patched copy of pico-sdk file Findpioasm.cmake to work around
+# a host toolchain issue with GCC 15.1:
+# https://github.com/raspberrypi/pico-sdk/issues/2448
+
+if (NOT TARGET pioasm)
+    # todo we would like to use pckgconfig to look for it first
+    # see https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
+
+    include(ExternalProject)
+
+    set(PIOASM_SOURCE_DIR ${PICO_SDK_PATH}/tools/pioasm)
+    set(PIOASM_BINARY_DIR ${CMAKE_BINARY_DIR}/pioasm)
+    set(PIOASM_INSTALL_DIR ${CMAKE_BINARY_DIR}/pioasm-install CACHE PATH "Directory where pioasm has been installed" FORCE)
+
+    set(pioasmBuild_TARGET pioasmBuild)
+    set(pioasm_TARGET pioasm)
+
+    if (NOT TARGET ${pioasmBuild_TARGET})
+        pico_message_debug("PIOASM will need to be built")
+#        message("Adding external project ${pioasmBuild_Target} in ${CMAKE_CURRENT_LIST_DIR}}")
+        ExternalProject_Add(${pioasmBuild_TARGET}
+                PREFIX pioasm
+                SOURCE_DIR ${PIOASM_SOURCE_DIR}
+                BINARY_DIR ${PIOASM_BINARY_DIR}
+                INSTALL_DIR ${PIOASM_INSTALL_DIR}
+                CMAKE_ARGS
+                    "--no-warn-unused-cli"
+                    "-DCMAKE_MAKE_PROGRAM:FILEPATH=${CMAKE_MAKE_PROGRAM}"
+                    "-DPIOASM_FLAT_INSTALL=1"
+                    "-DCMAKE_INSTALL_PREFIX=${PIOASM_INSTALL_DIR}"
+                    "-DCMAKE_RULE_MESSAGES=OFF" # quieten the build
+                    "-DCMAKE_INSTALL_MESSAGE=NEVER" # quieten the install
+                    # Toolchain workaround follows
+                    "-DCMAKE_CXX_FLAGS=-include cstdint"
+                CMAKE_CACHE_ARGS "-DPIOASM_EXTRA_SOURCE_FILES:STRING=${PIOASM_EXTRA_SOURCE_FILES}"
+                BUILD_ALWAYS 1 # force dependency checking
+                EXCLUDE_FROM_ALL TRUE
+                )
+    endif()
+
+    if (CMAKE_HOST_WIN32)
+        set(pioasm_EXECUTABLE ${PIOASM_INSTALL_DIR}/pioasm/pioasm.exe)
+    else()
+        set(pioasm_EXECUTABLE ${PIOASM_INSTALL_DIR}/pioasm/pioasm)
+    endif()
+    add_executable(${pioasm_TARGET} IMPORTED GLOBAL)
+    set_property(TARGET ${pioasm_TARGET} PROPERTY IMPORTED_LOCATION
+            ${pioasm_EXECUTABLE})
+
+    add_dependencies(${pioasm_TARGET} ${pioasmBuild_TARGET})
+endif()


### PR DESCRIPTION
### Summary

This is a workaround for building `pioasm` for the host on the RP2 port when the compiler is GCC 15.1. This happens transparently during the MicroPython build for boards with CYW43 wireless chip.

The root cause is tracked in https://github.com/raspberrypi/pico-sdk/issues/2448 but patching the tool provides a stop-gap until a new pico-sdk release is available.

*This work was funded through GitHub Sponsors.*

### Testing

* Verified `RPI_PICO2_W` build succeeds again with this change and GCC 15.1

### Trade-offs and Alternatives

* Could wait for pico-sdk to apply a fix and update, however would either need to update to a pre-release SDK or wait a fairly long time. This workaround can be removed when we next update pico-sdk.