### PR TITLE
cpydiff: various improvements

### DIFF
--- a/tests/cpydiff/core_fstring_concat.py
+++ b/tests/cpydiff/core_fstring_concat.py
@@ -1,5 +1,5 @@
 """
-categories: Core
+categories: Core,f-strings
 description: f-strings don't support concatenation with adjacent literals if the adjacent literals contain braces
 cause: MicroPython is optimised for code space.
 workaround: Use the + operator between literal strings when they are not both f-strings

--- a/tests/cpydiff/core_fstring_parser.py
+++ b/tests/cpydiff/core_fstring_parser.py
@@ -1,5 +1,5 @@
 """
-categories: Core
+categories: Core,f-strings
 description: f-strings cannot support expressions that require parsing to resolve unbalanced nested braces and brackets
 cause: MicroPython is optimised for code space.
 workaround: Always use balanced braces and brackets in expressions inside f-strings

--- a/tests/cpydiff/core_fstring_repr.py
+++ b/tests/cpydiff/core_fstring_repr.py
@@ -1,5 +1,5 @@
 """
-categories: Core
+categories: Core,f-strings
 description: f-strings don't support !a conversions
 cause: MicropPython does not implement ascii()
 workaround: None

--- a/tests/cpydiff/syntax_arg_unpacking.py
+++ b/tests/cpydiff/syntax_arg_unpacking.py
@@ -1,5 +1,5 @@
 """
-categories: Syntax
+categories: Syntax,Unpacking
 description: Argument unpacking does not work if the argument being unpacked is the nth or greater argument where n is the number of bits in an MP_SMALL_INT.
 cause: The implementation uses an MP_SMALL_INT to flag args that need to be unpacked.
 workaround: Use fewer arguments.

--- a/tests/cpydiff/syntax_literal_underscore.py
+++ b/tests/cpydiff/syntax_literal_underscore.py
@@ -1,0 +1,19 @@
+"""
+categories: Syntax,Literals
+description: uPy accepts underscores in numeric literals where CPy doesn't
+cause: Different parser implementation
+
+Micropython's tokenizer ignores underscores in numeric literals, while CPython
+rejects multiple consecutive underscores and underscores after the last digit.
+
+workaround: Remove the underscores not accepted by CPython.
+"""
+
+try:
+    print(eval("1__1"))
+except SyntaxError:
+    print("Should not work")
+try:
+    print(eval("1_"))
+except SyntaxError:
+    print("Should not work")

--- a/tests/cpydiff/syntax_spaces.py
+++ b/tests/cpydiff/syntax_spaces.py
@@ -1,5 +1,5 @@
 """
-categories: Syntax,Spaces
+categories: Syntax,Literals
 description: uPy requires spaces between literal numbers and keywords or ".", CPy doesn't
 cause: Different parser implementation
 

--- a/tests/cpydiff/syntax_spaces.py
+++ b/tests/cpydiff/syntax_spaces.py
@@ -1,8 +1,15 @@
 """
 categories: Syntax,Spaces
 description: uPy requires spaces between literal numbers and keywords, CPy doesn't
-cause: Unknown
-workaround: Unknown
+cause: Different parser implementation
+
+Micropython's tokenizer treats a sequence like ``1and`` as a single token, while CPython treats it as two tokens.
+
+Since CPython 3.11, this syntax causes a ``SyntaxWarning`` for an "invalid literal".
+
+workaround: Add a space between the integer literal and the intended next token.
+
+This also fixes the ``SyntaxWarning`` in CPython.
 """
 
 try:

--- a/tests/cpydiff/syntax_spaces.py
+++ b/tests/cpydiff/syntax_spaces.py
@@ -1,11 +1,11 @@
 """
 categories: Syntax,Spaces
-description: uPy requires spaces between literal numbers and keywords, CPy doesn't
+description: uPy requires spaces between literal numbers and keywords or ".", CPy doesn't
 cause: Different parser implementation
 
 Micropython's tokenizer treats a sequence like ``1and`` as a single token, while CPython treats it as two tokens.
 
-Since CPython 3.11, this syntax causes a ``SyntaxWarning`` for an "invalid literal".
+Since CPython 3.11, when the literal number is followed by a token, this syntax causes a ``SyntaxWarning`` for an "invalid literal". When a literal number is followed by a "." denoting attribute access, CPython does not warn.
 
 workaround: Add a space between the integer literal and the intended next token.
 
@@ -22,5 +22,9 @@ except SyntaxError:
     print("Should have worked")
 try:
     print(eval("1if 1else 0"))
+except SyntaxError:
+    print("Should have worked")
+try:
+    print(eval("0x1.to_bytes(1)"))
 except SyntaxError:
     print("Should have worked")

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -219,6 +219,8 @@ def gen_rst(results):
     class_ = []
     for output in results:
         section = output.class_.split(",")
+        if len(section) < 2:
+            raise SystemExit("Each item must have at least 2 categories")
         for i in range(len(section)):
             section[i] = section[i].rstrip()
             if section[i] in CLASSMAP:

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -228,8 +228,8 @@ def gen_rst(results):
                     filename = section[i].replace(" ", "_").lower()
                     rst = open(os.path.join(DOCPATH, filename + ".rst"), "w")
                     rst.write(HEADER)
-                    rst.write(section[i] + "\n")
-                    rst.write(RSTCHARS[0] * len(section[i]))
+                    rst.write(section[0] + "\n")
+                    rst.write(RSTCHARS[0] * len(section[0]) + "\n\n")
                     rst.write(time.strftime("\nGenerated %a %d %b %Y %X UTC\n\n", time.gmtime()))
                     # If a file docs/differences/<filename>_preamble.txt exists
                     # then its output is inserted after the top-level heading,
@@ -247,7 +247,7 @@ def gen_rst(results):
         class_ = section
         rst.write(".. _cpydiff_%s:\n\n" % os.path.splitext(output.name)[0])
         rst.write(output.desc + "\n")
-        rst.write("~" * len(output.desc) + "\n\n")
+        rst.write(RSTCHARS[min(i + 1, len(RSTCHARS) - 1)] * len(output.desc) + "\n\n")
         if output.cause != "Unknown":
             rst.write("**Cause:** " + output.cause + "\n\n")
         if output.workaround != "Unknown":

--- a/tools/gen-cpydiff.py
+++ b/tools/gen-cpydiff.py
@@ -45,6 +45,12 @@ else:
     CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
     MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/build-standard/micropython")
 
+# Set PYTHONIOENCODING so that CPython will use utf-8 on systems which set another encoding in the locale
+os.environ["PYTHONIOENCODING"] = "utf-8"
+
+# Set PYTHONUNBUFFERED so that CPython will interleave stdout & stderr without buffering
+os.environ["PYTHONUNBUFFERED"] = "a non-empty string"
+
 TESTPATH = "../tests/cpydiff"
 DOCPATH = "../docs/genrst"
 SRCDIR = "../docs/differences"
@@ -111,7 +117,7 @@ def run_tests(tests):
     results = []
     for test in tests:
         test_fullpath = os.path.join(TESTPATH, test.name)
-        with open(test_fullpath, "rb") as f:
+        with open(test_fullpath, "r") as f:
             input_py = f.read()
 
         process = subprocess.Popen(
@@ -119,20 +125,22 @@ def run_tests(tests):
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
         )
-        output_cpy = [com.decode("utf8") for com in process.communicate(input_py)]
+        output_cpy = process.communicate(input_py)[0]
 
         process = subprocess.Popen(
             MICROPYTHON,
             shell=True,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
         )
-        output_upy = [com.decode("utf8") for com in process.communicate(input_py)]
+        output_upy = process.communicate(input_py)[0]
 
-        if output_cpy[0] == output_upy[0] and output_cpy[1] == output_upy[1]:
+        if output_cpy == output_upy:
             print("Error: Test has same output in CPython vs MicroPython: " + test_fullpath)
             same_results = True
         else:
@@ -246,9 +254,9 @@ def gen_rst(results):
             rst.write("**Workaround:** " + output.workaround + "\n\n")
 
         rst.write("Sample code::\n\n" + indent(output.code, TAB) + "\n")
-        output_cpy = indent("".join(output.output_cpy[0:2]), TAB).rstrip()
+        output_cpy = indent(output.output_cpy, TAB).rstrip()
         output_cpy = ("::\n\n" if output_cpy != "" else "") + output_cpy
-        output_upy = indent("".join(output.output_upy[0:2]), TAB).rstrip()
+        output_upy = indent(output.output_upy, TAB).rstrip()
         output_upy = ("::\n\n" if output_upy != "" else "") + output_upy
         table = gen_table([["CPy output:", output_cpy], ["uPy output:", output_upy]])
         rst.write(table)


### PR DESCRIPTION
### Summary

This makes multiple improvements to the cpydiff generated documentation, including adding information
about literals that parse differently, but also fixing a problem I noted with the headings.

I can split the changes out into multiple PRs if necessary; but I tried to make each commit self-contained.

### Testing

I built the docs locally and compared them to the existing docs. Besides the new documentation, this fixes the appearance of the headers in line and in the TOC.

Before:
![image](https://github.com/user-attachments/assets/56470c12-b233-41cb-b43f-221fb3cb9ff7)

After:
![image](https://github.com/user-attachments/assets/02b479f9-bc42-4f21-9998-a6d23f7097e5)

Closes: #17224