### PR TITLE
rp2/machine_pin: Replace macros with Pico SDK functions.

### DIFF
--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -46,12 +46,6 @@
 
 #define GPIO_IRQ_ALL (0xf)
 
-// Macros to access the state of the hardware.
-#define GPIO_GET_FUNCSEL(id) ((iobank0_hw->io[(id)].ctrl & IO_BANK0_GPIO0_CTRL_FUNCSEL_BITS) >> IO_BANK0_GPIO0_CTRL_FUNCSEL_LSB)
-#define GPIO_IS_OUT(id) (sio_hw->gpio_oe & (1 << (id)))
-#define GPIO_IS_PULL_UP(id) (padsbank0_hw->io[(id)] & PADS_BANK0_GPIO0_PUE_BITS)
-#define GPIO_IS_PULL_DOWN(id) (padsbank0_hw->io[(id)] & PADS_BANK0_GPIO0_PDE_BITS)
-
 // Open drain behaviour is simulated.
 #define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (1 << (id)))
 
@@ -198,13 +192,13 @@ const machine_pin_obj_t *machine_pin_find(mp_obj_t pin) {
 
 static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pin_obj_t *self = self_in;
-    uint funcsel = GPIO_GET_FUNCSEL(self->id);
+    uint funcsel = gpio_get_function(self->id);
     qstr mode_qst;
     if (!is_ext_pin(self)) {
         if (funcsel == GPIO_FUNC_SIO) {
             if (GPIO_IS_OPEN_DRAIN(self->id)) {
                 mode_qst = MP_QSTR_OPEN_DRAIN;
-            } else if (GPIO_IS_OUT(self->id)) {
+            } else if (gpio_is_dir_out(self->id)) {
                 mode_qst = MP_QSTR_OUT;
             } else {
                 mode_qst = MP_QSTR_IN;
@@ -214,11 +208,11 @@ static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
         }
         mp_printf(print, "Pin(%q, mode=%q", self->name, mode_qst);
         bool pull_up = false;
-        if (GPIO_IS_PULL_UP(self->id)) {
+        if (gpio_is_pulled_up(self->id)) {
             mp_printf(print, ", pull=%q", MP_QSTR_PULL_UP);
             pull_up = true;
         }
-        if (GPIO_IS_PULL_DOWN(self->id)) {
+        if (gpio_is_pulled_down(self->id)) {
             if (pull_up) {
                 mp_printf(print, "|%q", MP_QSTR_PULL_DOWN);
             } else {
@@ -411,7 +405,7 @@ static mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
         machine_pin_ext_set(self, self->last_output_value ^ 1);
         #endif
     } else if (GPIO_IS_OPEN_DRAIN(self->id)) {
-        if (GPIO_IS_OUT(self->id)) {
+        if (gpio_is_dir_out(self->id)) {
             gpio_set_dir(self->id, GPIO_IN);
         } else {
             gpio_set_dir(self->id, GPIO_OUT);

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -46,9 +46,6 @@
 
 #define GPIO_IRQ_ALL (0xf)
 
-// Open drain behaviour is simulated.
-#define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (MACHINE_PIN_OD_BIT << (id)))
-
 #ifndef MICROPY_HW_PIN_RESERVED
 #define MICROPY_HW_PIN_RESERVED(i) (0)
 #endif
@@ -296,7 +293,7 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
                 mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid pin af: %d"), af);
             }
             gpio_set_function(self->id, af);
-            machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << self->id);
+            GPIO_DISABLE_OPEN_DRAIN(self->id);
         }
     }
 

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -47,7 +47,7 @@
 #define GPIO_IRQ_ALL (0xf)
 
 // Open drain behaviour is simulated.
-#define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (1 << (id)))
+#define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (1ULL << (id)))
 
 #ifndef MICROPY_HW_PIN_RESERVED
 #define MICROPY_HW_PIN_RESERVED(i) (0)

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -47,7 +47,7 @@
 #define GPIO_IRQ_ALL (0xf)
 
 // Open drain behaviour is simulated.
-#define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (1ULL << (id)))
+#define GPIO_IS_OPEN_DRAIN(id) (machine_pin_open_drain_mask & (MACHINE_PIN_OD_BIT << (id)))
 
 #ifndef MICROPY_HW_PIN_RESERVED
 #define MICROPY_HW_PIN_RESERVED(i) (0)
@@ -83,7 +83,11 @@ static const mp_irq_methods_t machine_pin_irq_methods;
 static const int num_intr_regs = sizeof(iobank0_hw->intr) / sizeof(iobank0_hw->intr[0]);
 
 // Mask with "1" indicating that the corresponding pin is in simulated open-drain mode.
+#if NUM_BANK0_GPIOS > 32
 uint64_t machine_pin_open_drain_mask;
+#else
+uint32_t machine_pin_open_drain_mask;
+#endif
 
 #if MICROPY_HW_PIN_EXT_COUNT
 static inline bool is_ext_pin(__unused const machine_pin_obj_t *self) {
@@ -292,7 +296,7 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
                 mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("invalid pin af: %d"), af);
             }
             gpio_set_function(self->id, af);
-            machine_pin_open_drain_mask &= ~(1ULL << self->id);
+            machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << self->id);
         }
     }
 

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -133,13 +133,13 @@ static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
 
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_IN);
-    machine_pin_open_drain_mask &= ~(1 << pin);
+    machine_pin_open_drain_mask &= ~(1ULL << pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_output(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_OUT);
-    machine_pin_open_drain_mask &= ~(1 << pin);
+    machine_pin_open_drain_mask &= ~(1ULL << pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
@@ -151,7 +151,7 @@ static inline void mp_hal_pin_open_drain_with_value(mp_hal_pin_obj_t pin, int v)
         gpio_put(pin, 0);
         gpio_set_dir(pin, GPIO_OUT);
     }
-    machine_pin_open_drain_mask |= 1 << pin;
+    machine_pin_open_drain_mask |= 1ULL << pin;
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -123,7 +123,13 @@ static inline mp_uint_t mp_hal_get_cpu_freq(void) {
 #define MP_HAL_PIN_PULL_UP              (1)
 #define MP_HAL_PIN_PULL_DOWN            (2)
 
+#if NUM_BANK0_GPIOS > 32
 extern uint64_t machine_pin_open_drain_mask;
+#define MACHINE_PIN_OD_BIT 1ULL
+#else
+extern uint32_t machine_pin_open_drain_mask;
+#define MACHINE_PIN_OD_BIT 1U
+#endif
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
 
@@ -133,13 +139,13 @@ static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
 
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_IN);
-    machine_pin_open_drain_mask &= ~(1ULL << pin);
+    machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_output(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_OUT);
-    machine_pin_open_drain_mask &= ~(1ULL << pin);
+    machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
@@ -151,7 +157,7 @@ static inline void mp_hal_pin_open_drain_with_value(mp_hal_pin_obj_t pin, int v)
         gpio_put(pin, 0);
         gpio_set_dir(pin, GPIO_OUT);
     }
-    machine_pin_open_drain_mask |= 1ULL << pin;
+    machine_pin_open_drain_mask |= MACHINE_PIN_OD_BIT << pin;
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -123,12 +123,17 @@ static inline mp_uint_t mp_hal_get_cpu_freq(void) {
 #define MP_HAL_PIN_PULL_UP              (1)
 #define MP_HAL_PIN_PULL_DOWN            (2)
 
+// Open drain behaviour is simulated.
 #if NUM_BANK0_GPIOS > 32
 extern uint64_t machine_pin_open_drain_mask;
-#define MACHINE_PIN_OD_BIT 1ULL
+#define GPIO_IS_OPEN_DRAIN(id)          (machine_pin_open_drain_mask & (1ULL << id))
+#define GPIO_ENABLE_OPEN_DRAIN(id)      (machine_pin_open_drain_mask |= (1ULL << id))
+#define GPIO_DISABLE_OPEN_DRAIN(id)     (machine_pin_open_drain_mask &= ~(1ULL << id))
 #else
 extern uint32_t machine_pin_open_drain_mask;
-#define MACHINE_PIN_OD_BIT 1U
+#define GPIO_IS_OPEN_DRAIN(id)          (machine_pin_open_drain_mask & (1U << id))
+#define GPIO_ENABLE_OPEN_DRAIN(id)      (machine_pin_open_drain_mask |= (1U << id))
+#define GPIO_DISABLE_OPEN_DRAIN(id)     (machine_pin_open_drain_mask &= ~(1U << id))
 #endif
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
@@ -139,13 +144,13 @@ static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
 
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_IN);
-    machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << pin);
+    GPIO_DISABLE_OPEN_DRAIN(pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
 static inline void mp_hal_pin_output(mp_hal_pin_obj_t pin) {
     gpio_set_dir(pin, GPIO_OUT);
-    machine_pin_open_drain_mask &= ~(MACHINE_PIN_OD_BIT << pin);
+    GPIO_DISABLE_OPEN_DRAIN(pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 
@@ -157,7 +162,7 @@ static inline void mp_hal_pin_open_drain_with_value(mp_hal_pin_obj_t pin, int v)
         gpio_put(pin, 0);
         gpio_set_dir(pin, GPIO_OUT);
     }
-    machine_pin_open_drain_mask |= MACHINE_PIN_OD_BIT << pin;
+    GPIO_ENABLE_OPEN_DRAIN(pin);
     gpio_set_function(pin, GPIO_FUNC_SIO);
 }
 


### PR DESCRIPTION
Replace custom macros with Pico SDK functions, enabling support for RP2350B variant chips with > 32 GPIOs.

I had missed this when porting to RP2350/RP2350B, since it only affects the string representation of a pin and has no functional implications (at least where users aren't inspecting that text to detect pin state).

### Summary

Fixes an issue raised in  #17241 where `machine_pin_print` was not reporting the correct pin direction for GPIOs >= 32, since the output states are stored in `gpio_oe_hi`

### Testing

A basic test on an RP2350B board (Pimoroni Pico Plus 2) to make sure `machine_pin_print` produces the correct string:

```python
>>> machine.Pin(31, machine.Pin.OUT)
Pin(GPIO31, mode=OUT)
>>> machine.Pin(33, machine.Pin.OUT)
Pin(GPIO33, mode=OUT)
>>> machine.Pin(33, machine.Pin.OUT, machine.Pin.PULL_UP)
Pin(GPIO33, mode=OUT, pull=PULL_UP)
>>> machine.Pin(33, machine.Pin.OUT, machine.Pin.PULL_DOWN)
Pin(GPIO33, mode=OUT, pull=PULL_DOWN)
```

And for funcsel:

```python
>>> a = machine.Pin(0)
>>> b = machine.Pin(1)
>>> i2c = machine.I2C(0, sda=a, scl=b)
>>> print(a)
Pin(GPIO0, mode=ALT, pull=PULL_UP, alt=I2C)
>>> print(b)
Pin(GPIO1, mode=ALT, pull=PULL_UP, alt=I2C)
```

And for open-drain `machine_pin_toggle`, observe the output enable bit being toggled:

```python
>>> od = machine.Pin(3, machine.Pin.OPEN_DRAIN)
>>> print(od)
Pin(GPIO3, mode=OPEN_DRAIN)
>>> od.toggle()
>>> f"{machine.mem32[0xd0000030] & 0xffffffff:32b}"
'10000000000000000000000000000000'
>>> od.toggle()
>>> f"{machine.mem32[0xd0000030] & 0xffffffff:32b}"
'10000000000000000000000000001000'
```

### Trade-offs and Alternatives

This is a low-impact change affecting (fixing) only the output of `machine_pin_print`. It might actually result in a small size increase (🤞) but is a better choice than trying to reimplement SDK functions and dealing with future repercussions.

Edit: I lied. This affects `machine_pin_toggle` too!
