### PR TITLE
unix/modsocket: Accept a host+port array for socket.connect.

### DIFF
--- a/tests/ports/unix/modsocket_connect.py
+++ b/tests/ports/unix/modsocket_connect.py
@@ -1,0 +1,101 @@
+# Test socket.socket.connect() for both IPv4 and IPv6.
+
+try:
+    import socket
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+import os
+import unittest
+
+
+TEST_HOSTNAME = "example.com"
+TEST_PORT = 80
+
+
+class Test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # If the IPv6 address for example.com fails then skip AF_INET6 tests.
+        try:
+            entries = socket.getaddrinfo(TEST_HOSTNAME, TEST_PORT, socket.AF_INET6)
+            cls._has_ipv6 = len(entries) > 0
+        except:
+            cls._has_ipv6 = False
+
+        # The GitHub CI runner just doesn't work when it comes to IPv6.
+        if os.getenv("GITHUB_ACTIONS") == "true":
+            cls._has_ipv6 = False
+
+        # If the IPv4 address for example.com fails then skip AF_INET tests.
+        try:
+            entries = socket.getaddrinfo(TEST_HOSTNAME, TEST_PORT, socket.AF_INET)
+            cls._has_ipv4 = len(entries) > 0
+        except:
+            cls._has_ipv4 = False
+
+    def test_hostname_connect_ipv4(self):
+        if not self._has_ipv4:
+            self.skipTest(
+                "IPv4 connectivity may not be available or temporary name resolution failure detected"
+            )
+
+        s = socket.socket(socket.AF_INET)
+        try:
+            s.connect((TEST_HOSTNAME, TEST_PORT))
+            s.send(b"GET /\n\n")
+            data = s.recv(8)
+            self.assertTrue(len(data) > 0)
+        finally:
+            s.close()
+
+    def test_hostname_connect_ipv6(self):
+        if not self._has_ipv6:
+            self.skipTest(
+                "IPv6 connectivity may not be available or temporary name resolution failure detected"
+            )
+
+        s = socket.socket(socket.AF_INET6)
+        try:
+            s.connect((TEST_HOSTNAME, TEST_PORT))
+            s.send(b"GET /\n\n")
+            data = s.recv(8)
+            self.assertTrue(len(data) > 0)
+        finally:
+            s.close()
+
+    def test_sockaddr_connect_ipv4(self):
+        if not self._has_ipv4:
+            self.skipTest(
+                "IPv4 connectivity may not be available or temporary name resolution failure detected"
+            )
+
+        sockaddr = socket.getaddrinfo(TEST_HOSTNAME, TEST_PORT, socket.AF_INET)[0][-1]
+        s = socket.socket(socket.AF_INET)
+        try:
+            s.connect(sockaddr)
+            s.send(b"GET /\n\n")
+            data = s.recv(8)
+            self.assertTrue(len(data) > 0)
+        finally:
+            s.close()
+
+    def test_sockaddr_connect_ipv6(self):
+        if not self._has_ipv6:
+            self.skipTest(
+                "IPv6 connectivity may not be available or temporary name resolution failure detected"
+            )
+
+        sockaddr = socket.getaddrinfo(TEST_HOSTNAME, TEST_PORT, socket.AF_INET6)[0][-1]
+        s = socket.socket(socket.AF_INET6)
+        try:
+            s.connect(sockaddr)
+            s.send(b"GET /\n\n")
+            data = s.recv(8)
+            self.assertTrue(len(data) > 0)
+        finally:
+            s.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This PR lets `socket.connect` accept an array containing a hostname string and a port number as the address to connect to, if the socket family is either `AF_INET` or `AF_INET6`.  The existing behaviour of accepting a serialised sockaddr structure as the connection address is still present, maintaining compatibility with existing code.

This brings the behaviour of socket.connect almost in line with the other embedded ports' versions that use LWIP, and somewhat with CPython as well.  The differences are as follows:

* Addresses in numeric form are not supported: this is not supported in LWIP either but CPython can handle them
* Connection argument can be either a two-elements list or tuple: this matches LWIP's implementation, but CPython can only accept a tuple for `AF_INET`/`AF_INET6`
* A regular hostname can be passed as the address: this is not supported in LWIP (dotted quads only, see `netutils_parse_inet_addr` in `shared/netutils/netutils.c` as invoked by `extmod/modsocket.c`), but is supported in CPython.

Hostname resolution is performed internally via a call to `socket.getaddrinfo`, and in case of multiple compatible entries mapped to a single hostname the first one returned by `getaddrinfo(2)` will be used.

### Testing

This has been tested manually as such (numeric addresses are what www.google.com resolves to me from here):

```python
import socket

data = {
    socket.AF_INET: ["www.google.com", "64.233.184.99"],
    socket.AF_INET6: ["www.google.com", "2a00:1450:400c:c0b::69"],
}

for k, v in data.items():
    sf = (k,)
    for addr in v:
        s = socket.socket(*sf)
        s.connect((addr, 80))
        s.write("GET /\n\n")
        if len(s.recv(100)) != 100:
            raise Exception
        print(sf, addr, ": SUCCESS [STRING]")
        s.close()
        s = socket.socket(*sf)
        a = socket.getaddrinfo(addr, 80, k)[0][-1]
        s.connect(a)
        s.write("GET /\n\n")
        if len(s.recv(100)) != 100:
            raise Exception
        print(sf, addr, ": SUCCESS [SOCKADDR]")
        s.close()
```

with the output:

```
(2,) www.google.com : SUCCESS [STRING]
(2,) www.google.com : SUCCESS [SOCKADDR]
(2,) 64.233.184.99 : SUCCESS [STRING]
(2,) 64.233.184.99 : SUCCESS [SOCKADDR]
(10,) www.google.com : SUCCESS [STRING]
(10,) www.google.com : SUCCESS [SOCKADDR]
(10,) 2a00:1450:400c:c0b::69 : SUCCESS [STRING]
(10,) 2a00:1450:400c:c0b::69 : SUCCESS [SOCKADDR]
```

~~I see `extmod/ssl_basic.py` uses `test.example.com` for its tests - if a test file is required I may use that host myself as well.~~

Edit: a test file with ipv4/ipv6 connection tests using both host+port pair and a pre-resolved sockaddr buffer have been added.

### Trade-offs and Alternatives

There is a slight footprint increase for the Unix port but, considering the average computing power and storage facilities of the average environment the Unix port runs in, the quality of life improvements, and increased compatibility should be enough benefits to make these code changes useful.