### PR TITLE
tools/verifygitlog.py: Disallow a leading slash in commit subject line.

### DIFF
--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -116,8 +116,8 @@ def verify_message_body(raw_body, err):
 def verify_subject_line_prefix(prefix, err):
     ext = (".c", ".h", ".cpp", ".js", ".rst", ".md")
 
-    if prefix.startswith("."):
-        err.error('Subject prefix cannot begin with ".".')
+    if prefix.startswith((".", "/")):
+        err.error('Subject prefix cannot begin with "." or "/".')
 
     if prefix.endswith("/"):
         err.error('Subject prefix cannot end with "/".')


### PR DESCRIPTION
### Summary

Disallow a leading slash in commit subject line.

Prompted by #17290.

Follow up to #15823.

### Testing

Tested by making a commit with a leading slash, it gives an error as expected.

