### PR TITLE
extmod/vfs_lfsx: Fix errno value raised from chdir.

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -300,7 +300,7 @@ static mp_obj_t MP_VFS_LFSx(chdir)(mp_obj_t self_in, mp_obj_t path_in) {
         struct LFSx_API (info) info;
         int ret = LFSx_API(stat)(&self->lfs, path, &info);
         if (ret < 0 || info.type != LFSx_MACRO(_TYPE_DIR)) {
-            mp_raise_OSError(-MP_ENOENT);
+            mp_raise_OSError(MP_ENOENT);
         }
     }
 

--- a/tests/extmod/vfs_lfs_error.py
+++ b/tests/extmod/vfs_lfs_error.py
@@ -1,7 +1,7 @@
 # Test for VfsLittle using a RAM device, testing error handling
 
 try:
-    import vfs
+    import errno, vfs
 
     vfs.VfsLfs1
     vfs.VfsLfs2
@@ -41,14 +41,14 @@ def test(bdev, vfs_class):
     # mkfs with too-small block device
     try:
         vfs_class.mkfs(RAMBlockDevice(1))
-    except OSError:
-        print("mkfs OSError")
+    except OSError as er:
+        print("mkfs OSError", er.errno > 0)
 
     # mount with invalid filesystem
     try:
         vfs_class(bdev)
-    except OSError:
-        print("mount OSError")
+    except OSError as er:
+        print("mount OSError", er.errno > 0)
 
     # set up for following tests
     vfs_class.mkfs(bdev)
@@ -60,60 +60,60 @@ def test(bdev, vfs_class):
     # ilistdir
     try:
         fs.ilistdir("noexist")
-    except OSError:
-        print("ilistdir OSError")
+    except OSError as er:
+        print("ilistdir OSError", er)
 
     # remove
     try:
         fs.remove("noexist")
-    except OSError:
-        print("remove OSError")
+    except OSError as er:
+        print("remove OSError", er)
 
     # rmdir
     try:
         fs.rmdir("noexist")
-    except OSError:
-        print("rmdir OSError")
+    except OSError as er:
+        print("rmdir OSError", er)
 
     # rename
     try:
         fs.rename("noexist", "somethingelse")
-    except OSError:
-        print("rename OSError")
+    except OSError as er:
+        print("rename OSError", er)
 
     # mkdir
     try:
         fs.mkdir("testdir")
-    except OSError:
-        print("mkdir OSError")
+    except OSError as er:
+        print("mkdir OSError", er)
 
     # chdir to nonexistent
     try:
         fs.chdir("noexist")
-    except OSError:
-        print("chdir OSError")
+    except OSError as er:
+        print("chdir OSError", er)
     print(fs.getcwd())  # check still at root
 
     # chdir to file
     try:
         fs.chdir("testfile")
-    except OSError:
-        print("chdir OSError")
+    except OSError as er:
+        print("chdir OSError", er)
     print(fs.getcwd())  # check still at root
 
     # stat
     try:
         fs.stat("noexist")
-    except OSError:
-        print("stat OSError")
+    except OSError as er:
+        print("stat OSError", er)
 
     # error during seek
     with fs.open("testfile", "r") as f:
         f.seek(1 << 30)  # SEEK_SET
         try:
             f.seek(1 << 30, 1)  # SEEK_CUR
-        except OSError:
-            print("seek OSError")
+        except OSError as er:
+            print("seek OSError", er)
 
 
 bdev = RAMBlockDevice(30)

--- a/tests/extmod/vfs_lfs_error.py.exp
+++ b/tests/extmod/vfs_lfs_error.py.exp
@@ -1,28 +1,28 @@
 test <class 'VfsLfs1'>
-mkfs OSError
-mount OSError
-ilistdir OSError
-remove OSError
-rmdir OSError
-rename OSError
-mkdir OSError
-chdir OSError
+mkfs OSError True
+mount OSError True
+ilistdir OSError [Errno 2] ENOENT
+remove OSError [Errno 2] ENOENT
+rmdir OSError [Errno 2] ENOENT
+rename OSError [Errno 2] ENOENT
+mkdir OSError [Errno 17] EEXIST
+chdir OSError [Errno 2] ENOENT
 /
-chdir OSError
+chdir OSError [Errno 2] ENOENT
 /
-stat OSError
-seek OSError
+stat OSError [Errno 2] ENOENT
+seek OSError [Errno 22] EINVAL
 test <class 'VfsLfs2'>
-mkfs OSError
-mount OSError
-ilistdir OSError
-remove OSError
-rmdir OSError
-rename OSError
-mkdir OSError
-chdir OSError
+mkfs OSError True
+mount OSError True
+ilistdir OSError [Errno 2] ENOENT
+remove OSError [Errno 2] ENOENT
+rmdir OSError [Errno 2] ENOENT
+rename OSError [Errno 2] ENOENT
+mkdir OSError [Errno 17] EEXIST
+chdir OSError [Errno 2] ENOENT
 /
-chdir OSError
+chdir OSError [Errno 2] ENOENT
 /
-stat OSError
-seek OSError
+stat OSError [Errno 2] ENOENT
+seek OSError [Errno 22] EINVAL


### PR DESCRIPTION
### Summary

Littlefs was raising a negative errno if chdir failed, when it should be a positive errno.

### Testing

Tests have been updated to cover this case (and other cases which were already correct).
