### PR TITLE
tools/verifygitlog.py: Allow long co-author and sign-off names.

### DIFF
--- a/tools/verifygitlog.py
+++ b/tools/verifygitlog.py
@@ -105,8 +105,12 @@ def verify_message_body(raw_body, err):
 
     # Message body lines.
     for line in raw_body[2:]:
-        # Long lines with URLs are exempt from the line length rule.
-        if len(line) >= 76 and "://" not in line:
+        # Long lines with URLs or human names are exempt from the line length rule.
+        if len(line) >= 76 and not (
+            "://" in line
+            or line.startswith("Co-authored-by: ")
+            or line.startswith("Signed-off-by: ")
+        ):
             err.error("Message lines should be 75 or less characters: " + line)
 
     if not raw_body[-1].startswith("Signed-off-by: ") or "@" not in raw_body[-1]:


### PR DESCRIPTION
While rebasing https://github.com/micropython/micropython/pull/13390 I noticed that the commit messages were being rejected due to the author name on the required `Signed-off-by:` line being longer than the maximum line length. I don't think we should be enforcing a maximum length for human names.

This change disables the line length check for lines that start with `Co-authored-by: ` or `Signed-off-by: `.

I've opened a sibling PR on for updating micropython-lib as well: https://github.com/micropython/micropython-lib/pull/1007