### PR TITLE
extmod/network_cyw43: Disconnect STA if making inactive.

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -143,6 +143,9 @@ static mp_obj_t network_cyw43_active(size_t n_args, const mp_obj_t *args) {
         return mp_obj_new_bool(if_active[self->itf]);
     } else {
         bool value = mp_obj_is_true(args[1]);
+        if (!value && self->itf == CYW43_ITF_STA) {
+            cyw43_wifi_leave(self->cyw, self->itf);
+        }
         cyw43_wifi_set_up(self->cyw, self->itf, value, get_country_code());
         if_active[self->itf] = value;
         return mp_const_none;


### PR DESCRIPTION
### Summary

esp32 port will disconnect if `active(0)` is called on a STA interface, but rp2 port stays associated without this change.

Noticed while running `multi_wlan` tests for #17272 with a `boot.py` file in place that associates to my local network, as this test currently calls `active(0)` during init to disable any previous activity.

*This work was funded through GitHub Sponsors.*

### Testing

* Re-ran `multi_wlan` tests on RPI_PICO_W and RPI_PICO2_W with this change and a `boot.py` that associates to my local network. These tests now pass. Didn't test cyw43 on other ports, but happy to test more if necessary.
* Did some manual testing to confirm that it's safe to call `cyw43_wifi_leave()` in corner cases (when interface inactive, already disconnected, mid-connection attempt, etc.) It does occasionally seem to report `join` state after being made inactive part-way through a connection attempt, which might indicate a driver race/bug(?) However it's generally consistent, and I think this change is still an improvement.

### Trade-offs and Alternatives

* Possibly this fix should be pushed down one layer into the CYW43 driver? Calling `cyw43_wifi_set_up(..., CYW43_ITF_STA, false, ...)` currently a no-op.
