### PR TITLE
extmod/asyncio/stream.py: Add ipv6 support to start_server().

### DIFF
--- a/extmod/asyncio/stream.py
+++ b/extmod/asyncio/stream.py
@@ -180,11 +180,11 @@ async def start_server(cb, host, port, backlog=5, ssl=None):
     import socket
 
     # Create and bind server socket.
-    host = socket.getaddrinfo(host, port)[0]  # TODO this is blocking!
-    s = socket.socket()
+    addr_info = socket.getaddrinfo(host, port)[0]  # TODO this is blocking!
+    s = socket.socket(addr_info[0])  # Use address family from getaddrinfo
     s.setblocking(False)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(host[-1])
+    s.bind(addr_info[-1])
     s.listen(backlog)
 
     # Create and return server object and task.


### PR DESCRIPTION
### Summary

I'm starting to use ipv6 more with micropython devices as their discoverability can actually be much better on a local network, without worrying about needing to manually configure (ipv4) ip addresses.

To that end, this PR adds support to start_server() to automatically use the parsed protocol, ie setting `socket.AF_INET` or `socket.AF_INET6` on the socket as parsed by `getaddrinfo()`

When adding unit tests for this change, I found the multi-test runner was missing support for ipv6 ip address detection, so that's been added as well (in a separate commit)

The ip address detection in multi-test runner has also been updated to use the newer / preferred `network.ipconfig("addr4")` style interface by default, falling back to ipconfig if needed.

### Testing

Unit tests are included which check ipv6 support in both `net_hosted` style test and `mult_net` tests. 

Without the change to `extmod/asyncio/stream.py` the tests fails with `OSError: 97`


### Trade-offs and Alternatives

