### PR TITLE
extmod/modlwip,esp32,unix: Add support for socket recv flags argument

### DIFF
--- a/docs/library/socket.rst
+++ b/docs/library/socket.rst
@@ -227,21 +227,27 @@ Methods
    has the same "no short writes" policy for blocking sockets, and will return
    number of bytes sent on non-blocking sockets.
 
-.. method:: socket.recv(bufsize)
+.. method:: socket.recv(bufsize, [flags])
 
    Receive data from the socket. The return value is a bytes object representing the data
    received. The maximum amount of data to be received at once is specified by bufsize.
+
+   Most ports support the optional *flags* argument. Available *flags* are defined as constants
+   in the socket module and have the same meaning as in CPython. ``MSG_PEEK`` and ``MSG_DONTWAIT``
+   are supported on all ports which accept the *flags* argument.
 
 .. method:: socket.sendto(bytes, address)
 
    Send data to the socket. The socket should not be connected to a remote socket, since the
    destination socket is specified by *address*.
 
-.. method:: socket.recvfrom(bufsize)
+.. method:: socket.recvfrom(bufsize, [flags])
 
   Receive data from the socket. The return value is a pair *(bytes, address)* where *bytes* is a
   bytes object representing the data received and *address* is the address of the socket sending
   the data.
+
+  See the `recv` function for an explanation of the optional *flags* argument.
 
 .. method:: socket.setsockopt(level, optname, value)
 

--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -701,6 +701,7 @@ static const mp_rom_map_elem_t mp_module_socket_globals_table[] = {
 
     C(MSG_DONTROUTE),
     C(MSG_DONTWAIT),
+    C(MSG_PEEK),
 
     C(SOL_SOCKET),
     C(SO_BROADCAST),

--- a/tests/multi_net/tcp_recv_peek.py
+++ b/tests/multi_net/tcp_recv_peek.py
@@ -1,0 +1,46 @@
+# Test TCP recv with MSG_PEEK
+#
+# Note that bare metal LWIP only returns at most one packet's worth of TCP data
+# in any recv() call - including when peeking - so can't be too clever with
+# different recv() combinations
+import socket
+import random
+
+
+# Server
+def instance0():
+    PORT = random.randrange(10000, 50000)
+    multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+    s.listen()
+    multitest.next()
+    s2, _ = s.accept()
+    print(s2.recv(8, socket.MSG_PEEK))
+    print(s2.recv(8))
+    s2.send(b"1234567890")
+    multitest.broadcast("0-sent")
+    multitest.wait("1-sent")
+    print(s2.recv(5, socket.MSG_PEEK))
+    print(s2.recv(5, socket.MSG_PEEK))
+    multitest.broadcast("0-recved")
+    multitest.wait("1-recved")  # sync here necessary as MP sends RST if closing TCP early
+    s2.close()
+    s.close()
+
+
+# Client
+def instance1():
+    multitest.next()
+    s = socket.socket()
+    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+    s.send(b"abcdefgh")
+    multitest.broadcast("1-sent")
+    multitest.wait("0-sent")
+    s.send(b"klmnopqr")
+    print(s.recv(5, socket.MSG_PEEK))
+    print(s.recv(10))
+    multitest.broadcast("1-recved")
+    multitest.wait("0-recved")
+    s.close()

--- a/tests/multi_net/udp_recv_dontwait.py
+++ b/tests/multi_net/udp_recv_dontwait.py
@@ -1,0 +1,59 @@
+# Test UDP recv and recvfrom with MSG_DONTWAIT
+import random
+import socket
+
+try:
+    import errno, time
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+# Server
+def instance0():
+    PORT = random.randrange(10000, 50000)
+    multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+    multitest.next()
+    begin = time.ticks_ms()
+
+    # do some recvs before instance1 starts, when we know no packet is waiting
+    try:
+        print(s.recvfrom(8, socket.MSG_DONTWAIT))
+    except OSError as e:
+        print(e.errno == errno.EAGAIN)
+    try:
+        print(s.recv(8, socket.MSG_DONTWAIT))
+    except OSError as e:
+        print(e.errno == errno.EAGAIN)
+
+    # the above steps should not have taken any substantial time
+    elapsed = time.ticks_diff(time.ticks_ms(), begin)
+    print(True if elapsed < 50 else elapsed)
+
+    # Now instance1 will send us a UDP packet
+    multitest.broadcast("0-ready")
+    multitest.wait("1-sent")
+
+    for _ in range(10):  # retry if necessary, to allow for network delay
+        time.sleep_ms(100)
+        try:
+            print(s.recv(8, socket.MSG_DONTWAIT))
+            break
+        except OSError as er:
+            if er.errno != errno.EAGAIN:
+                raise er
+    s.close()
+
+
+# Client
+def instance1():
+    multitest.next()
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+    multitest.wait("0-ready")
+    print(s.send(b"abcdefgh"))
+    multitest.broadcast("1-sent")
+    s.close()

--- a/tests/multi_net/udp_recv_dontwait.py.exp
+++ b/tests/multi_net/udp_recv_dontwait.py.exp
@@ -1,0 +1,7 @@
+--- instance0 ---
+True
+True
+True
+b'abcdefgh'
+--- instance1 ---
+8

--- a/tests/multi_net/udp_recv_peek.py
+++ b/tests/multi_net/udp_recv_peek.py
@@ -1,0 +1,36 @@
+# Test UDP recv and recvfrom with MSG_PEEK
+import random
+import socket
+import time
+
+
+# Server
+def instance0():
+    PORT = random.randrange(10000, 50000)
+    multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+    multitest.next()
+    peek_bytes, peek_addr = s.recvfrom(8, socket.MSG_PEEK)
+    print(peek_bytes)
+    real_bytes, real_addr = s.recvfrom(8)
+    print(real_bytes)
+    print(peek_addr == real_addr)  # source addr should be the same for each
+    res = s.sendto(b"1234567890", peek_addr)
+    print(res)
+    print(s.recv(5, socket.MSG_PEEK))
+    print(s.recv(5, socket.MSG_PEEK))
+    s.close()
+
+
+# Client
+def instance1():
+    multitest.next()
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+    s.send(b"abcdefgh")
+    s.send(b"klmnopqr")
+    print(s.recv(5, socket.MSG_PEEK))
+    print(s.recv(10))
+    s.close()


### PR DESCRIPTION
### Summary

Goal of this PR is to have support for the `MSG_DONTWAIT` and `MSG_PEEK` flags for socket `recv` & `recvfrom` on unix, esp32, and all "bare metal" LWIP ports.

* Bare metal LWIP adds support for these flags in modlwip.c, with some refactoring to try and reduce the code size impact.
* esp32 port now passes these flags through to the LWIP BSD socket layer, which already supports them.
* unix port already had support for flags argument. `MSG_PEEK` constant is now exposed to Python code.
* Adds multi_net tests for the new flags.
* Adds docs for the `flags` argument.

Note: Zephyr & CC3200 ports have their own `socket` module implementations, support not added to these yet. Zephyr looks like it would be trivially easy, CC3200 I didn't look into.

### Testing

* Ran new and existing multi_net tests on ESP32_GENERIC_S3, RPI_PICO2_W, RPI_PICO_W and PYBD_SF2 boards. One outstanding issue that seems lower level than these changes, see [comment](https://github.com/micropython/micropython/pull/17312#issuecomment-2921051299).

### Trade-offs and Alternatives

* Support for `MSG_PEEK` is motivated by wanting to improve the DTLS support. Adding `MSG_DONTWAIT` as well was relatively easy, and both of these flags are potentially useful for socket programming on MicroPython. However I guess the obvious alternative is not to add them, or to implement them via a Python wrapper in the Python socket module (which would be hacky but possible).