### PR TITLE
mpremote: Fix disconnect handling on Windows and Linux.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -620,7 +620,11 @@ def main():
         # If no commands were "actions" then implicitly finish with the REPL
         # using default args.
         if state.run_repl_on_completion():
-            do_repl(state, argparse_repl().parse_args([]))
+            disconnected = do_repl(state, argparse_repl().parse_args([]))
+
+            # Handle disconnection message
+            if disconnected:
+                print("\ndevice disconnected")
 
         return 0
     except CommandError as e:

--- a/tools/mpremote/mpremote/repl.py
+++ b/tools/mpremote/mpremote/repl.py
@@ -7,51 +7,53 @@ def do_repl_main_loop(
     state, console_in, console_out_write, *, escape_non_printable, code_to_inject, file_to_inject
 ):
     while True:
-        console_in.waitchar(state.transport.serial)
-        c = console_in.readchar()
-        if c:
-            if c in (b"\x1d", b"\x18"):  # ctrl-] or ctrl-x, quit
-                break
-            elif c == b"\x04":  # ctrl-D
-                # special handling needed for ctrl-D if filesystem is mounted
-                state.transport.write_ctrl_d(console_out_write)
-            elif c == b"\x0a" and code_to_inject is not None:  # ctrl-j, inject code
-                state.transport.serial.write(code_to_inject)
-            elif c == b"\x0b" and file_to_inject is not None:  # ctrl-k, inject script
-                console_out_write(bytes("Injecting %s\r\n" % file_to_inject, "utf8"))
-                state.transport.enter_raw_repl(soft_reset=False)
-                with open(file_to_inject, "rb") as f:
-                    pyfile = f.read()
-                try:
-                    state.transport.exec_raw_no_follow(pyfile)
-                except TransportError as er:
-                    console_out_write(b"Error:\r\n")
-                    console_out_write(er)
-                state.transport.exit_raw_repl()
-            else:
-                state.transport.serial.write(c)
-
         try:
-            n = state.transport.serial.inWaiting()
-        except OSError as er:
-            if er.args[0] == 5:  # IO error, device disappeared
-                print("device disconnected")
-                break
-
-        if n > 0:
-            dev_data_in = state.transport.serial.read(n)
-            if dev_data_in is not None:
-                if escape_non_printable:
-                    # Pass data through to the console, with escaping of non-printables.
-                    console_data_out = bytearray()
-                    for c in dev_data_in:
-                        if c in (8, 9, 10, 13, 27) or 32 <= c <= 126:
-                            console_data_out.append(c)
-                        else:
-                            console_data_out.extend(b"[%02x]" % c)
+            console_in.waitchar(state.transport.serial)
+            c = console_in.readchar()
+            if c:
+                if c in (b"\x1d", b"\x18"):  # ctrl-] or ctrl-x, quit
+                    break
+                elif c == b"\x04":  # ctrl-D
+                    # special handling needed for ctrl-D if filesystem is mounted
+                    state.transport.write_ctrl_d(console_out_write)
+                elif c == b"\x0a" and code_to_inject is not None:  # ctrl-j, inject code
+                    state.transport.serial.write(code_to_inject)
+                elif c == b"\x0b" and file_to_inject is not None:  # ctrl-k, inject script
+                    console_out_write(bytes("Injecting %s\r\n" % file_to_inject, "utf8"))
+                    state.transport.enter_raw_repl(soft_reset=False)
+                    with open(file_to_inject, "rb") as f:
+                        pyfile = f.read()
+                    try:
+                        state.transport.exec_raw_no_follow(pyfile)
+                    except TransportError as er:
+                        console_out_write(b"Error:\r\n")
+                        console_out_write(er)
+                    state.transport.exit_raw_repl()
                 else:
-                    console_data_out = dev_data_in
-                console_out_write(console_data_out)
+                    state.transport.serial.write(c)
+
+            n = state.transport.serial.inWaiting()
+            if n > 0:
+                dev_data_in = state.transport.serial.read(n)
+                if dev_data_in is not None:
+                    if escape_non_printable:
+                        # Pass data through to the console, with escaping of non-printables.
+                        console_data_out = bytearray()
+                        for c in dev_data_in:
+                            if c in (8, 9, 10, 13, 27) or 32 <= c <= 126:
+                                console_data_out.append(c)
+                            else:
+                                console_data_out.extend(b"[%02x]" % c)
+                    else:
+                        console_data_out = dev_data_in
+                    console_out_write(console_data_out)
+
+        except OSError as er:
+            if _is_disconnect_exception(er):
+                return True
+            else:
+                raise
+    return False
 
 
 def do_repl(state, args):
@@ -86,7 +88,7 @@ def do_repl(state, args):
             capture_file.flush()
 
     try:
-        do_repl_main_loop(
+        return do_repl_main_loop(
             state,
             console,
             console_out_write,
@@ -98,3 +100,22 @@ def do_repl(state, args):
         console.exit()
         if capture_file is not None:
             capture_file.close()
+
+
+def _is_disconnect_exception(exception):
+    """
+    Check if an exception indicates device disconnect.
+
+    Returns True if the exception indicates the device has disconnected,
+    False otherwise.
+    """
+    if isinstance(exception, OSError):
+        if hasattr(exception, 'args') and len(exception.args) > 0:
+            # IO error, device disappeared
+            if exception.args[0] == 5:
+                return True
+        # Check for common disconnect messages in the exception string
+        exception_str = str(exception)
+        disconnect_indicators = ["Write timeout", "Device disconnected", "ClearCommError failed"]
+        return any(indicator in exception_str for indicator in disconnect_indicators)
+    return False


### PR DESCRIPTION
### Summary
Improves device disconnection handling in mpremote to show a clean "device disconnected" message instead of stack traces on Windows and fixes terminal formatting issues on Linux.

#### Problem

  When a device disconnects during an mpremote session:
  - Windows: Shows a full stack trace with ClearCommError failed or similar errors
  - Linux: 'device disconnected' with unclear terminal formatting, causing indentation issues

####   Solution

  This PR fixes disconnect handling to:
  1. Catch serial disconnection exceptions in both console.py and repl.py
  2. Properly exit terminal raw mode before showing the message
  3. Display a clean "device disconnected" message after terminal cleanup
  4. Ensure consistent behavior across Windows and Linux platforms

####   File Changes

`tools/mpremote/mpremote/console.py`:
  - Windows: Modified waitchar() to catch SerialException and re-raise with cleaner message
  - Added proper exception handling for ClearCommError failed cases

`tools/mpremote/mpremote/repl.py`:
  - Modified do_repl_main_loop() to catch serial exceptions and return disconnect state
  - Added checks for both Windows and Linux disconnect error patterns

`tools/mpremote/mpremote/main.py`:
  - Modified main loop to handle disconnect state after console cleanup
  - Added newline and message printing after terminal mode is restored

### Testing

  Before/After Examples - I connected to ESP32S2 (usb serial) and once confirmed the repl is working, physically unplug the devices.

  Windows (Before)
```
PS C:\Users\anl> mpremote
Connected to MicroPython at COM7
Use Ctrl-] or Ctrl-x to exit this shell
MicroPython v1.25.0-1.ge7b0fe4775.dirty on 2025-05-09; Generic ESP32S2 module with ESP32S2
Type "help()" for more information.
>>>
>>> Traceback (most recent call last):
  File "C:\Users\anl\AppData\Roaming\uv\python\cpython-3.10.11-windows-x86_64-none\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\anl\AppData\Roaming\uv\python\cpython-3.10.11-windows-x86_64-none\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "c:\users\anl\.local\bin\mpremote.exe\__main__.py", line 8, in <module>
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\mpremote\main.py", line 584, in main
    disconnected = do_repl(state, argparse_repl().parse_args([]))
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\mpremote\repl.py", line 102, in do_repl
    disconnected = do_repl_main_loop(
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\mpremote\repl.py", line 11, in do_repl_main_loop
    console_in.waitchar(state.transport.serial)
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\mpremote\console.py", line 99, in waitchar
    while not (self.inWaiting() or pyb_serial.inWaiting()):
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\serial\serialutil.py", line 594, in inWaiting
    return self.in_waiting
  File "C:\Users\anl\AppData\Roaming\uv\tools\mpremote\lib\site-packages\serial\serialwin32.py", line 259, in in_waiting
    raise SerialException("ClearCommError failed ({!r})".format(ctypes.WinError()))
serial.serialutil.SerialException: ClearCommError failed (PermissionError(13, 'The device does not recognize the command.', None, 22))
PS C:\Users\anl>
```
  Windows (After)
```
PS C:\Users\anl> mpremote
Connected to MicroPython at COM7
Use Ctrl-] or Ctrl-x to exit this shell
MicroPython v1.25.0-1.ge7b0fe4775.dirty on 2025-05-09; Generic ESP32S2 module with ESP32S2
Type "help()" for more information.
>>>
>>>
>>>
device disconnected
PS C:\Users\anl>
```
  Linux (Before)
```
anl@ANL2-LAP:~/micropython/tools/mpremote$ mpremote
Connected to MicroPython at /dev/ttyACM0
Use Ctrl-] or Ctrl-x to exit this shell
MicroPython v1.25.0-1.ge7b0fe4775.dirty on 2025-05-09; Generic ESP32S2 module with ESP32S2
Type "help()" for more information.
>>>
>>> device disconnected
                       anl@ANL2-LAP:~/micropython/tools/mpremote$
```
  Linux (After)
```
anl@ANL2-LAP:~/micropython/tools/mpremote$ mpremote
Connected to MicroPython at /dev/ttyACM0
Use Ctrl-] or Ctrl-x to exit this shell
MicroPython v1.25.0-1.ge7b0fe4775.dirty on 2025-05-09; Generic ESP32S2 module with ESP32S2
Type "help()" for more information.
>>>
>>>
device disconnected
anl@ANL2-LAP:~/micropython/tools/mpremote$ 
```

  - Tested on Windows 11 with ESP32S2 USB serial
  - Tested on Linux (Ubuntu WSL) with ESP32S2 USB serial
  - Verified terminal formatting is restored properly
  - Confirmed clean exit without stack traces
