### PR TITLE
tools/mpremote: Add automatic reconnection feature

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -54,6 +54,10 @@ If no command is specified, the default command is ``repl``. Additionally, if
 any command needs to access the device, and no earlier ``connect`` has been
 specified, then an implicit ``connect auto`` is added.
 
+By default, ``mpremote`` will automatically reconnect to the device if it
+disconnects. You can disable this behavior using the ``once`` command, the
+``MPREMOTE_RECONNECT`` environment variable, or the user config file.
+
 In order to get the device into a known state for any action command
 (except ``repl``), once connected ``mpremote`` will stop any running program
 and soft-reset the device before running the first command. You can control
@@ -67,6 +71,7 @@ The full list of supported commands are:
 - `connect <mpremote_command_connect>`
 - `disconnect <mpremote_command_disconnect>`
 - `resume <mpremote_command_resume>`
+- `once <mpremote_command_once>`
 - `soft_reset <mpremote_command_soft_reset>`
 - `repl <mpremote_command_repl>`
 - `eval <mpremote_command_eval>`
@@ -134,6 +139,20 @@ The full list of supported commands are:
 
   This disables :ref:`auto-soft-reset <mpremote_reset>`. This is useful if you
   want to run a subsequent command on a board without first soft-resetting it.
+
+.. _mpremote_command_once:
+
+- **once** -- disable automatic reconnection on disconnect:
+
+  .. code-block:: bash
+
+      $ mpremote once
+
+  This disables automatic reconnection, causing mpremote to exit when the
+  device disconnects. By default, mpremote will automatically reconnect to
+  the device if it disconnects. The ``once`` command is useful for scripts
+  that should exit on disconnect (e.g., in automated testing or CI/CD
+  environments).
 
 .. _mpremote_command_soft_reset:
 
@@ -469,6 +488,38 @@ Auto-soft-reset behaviour can be controlled by the ``resume`` command. This
 might be useful to use the ``eval`` command to inspect the state of of the
 device.  The ``soft-reset`` command can be used to perform an explicit soft
 reset in the middle of a sequence of commands.
+
+.. _mpremote_configuration:
+
+Configuration
+-------------
+
+``mpremote`` can be configured via environment variables and a user
+configuration file.
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+The following environment variables control default behavior:
+
+- ``MPREMOTE_RECONNECT``: Controls automatic reconnection on disconnect.
+  Set to ``0`` or ``false`` to disable (exit on disconnect).
+  Set to ``1``, ``true``, ``yes``, or ``on`` to enable (reconnect automatically).
+  The default is enabled. This setting takes precedence over the config file.
+
+User Configuration File
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The user configuration file (see :ref:`mpremote_shortcuts` for location details)
+can contain a ``reconnect`` variable to control the default reconnection behavior:
+
+.. code-block:: python3
+
+    # Disable auto-reconnect by default
+    reconnect = False
+
+Note that the ``MPREMOTE_RECONNECT`` environment variable takes precedence
+over the config file setting.
 
 .. _mpremote_shortcuts:
 

--- a/tools/mpremote/mpremote/console.py
+++ b/tools/mpremote/mpremote/console.py
@@ -96,8 +96,19 @@ class ConsoleWindows:
         return 1 if self.ctrl_c or msvcrt.kbhit() else 0
 
     def waitchar(self, pyb_serial):
-        while not (self.inWaiting() or pyb_serial.inWaiting()):
-            time.sleep(0.01)
+        import serial
+
+        while True:
+            try:
+                if self.inWaiting() or pyb_serial.inWaiting():
+                    break
+                time.sleep(0.01)
+            except serial.SerialException as e:
+                if "ClearCommError failed" in str(e):
+                    # Device disconnected on Windows
+                    raise serial.SerialException("Device disconnected")
+                else:
+                    raise
 
     def readchar(self):
         if self.ctrl_c:


### PR DESCRIPTION
### Summary
This PR adds automatic reconnection capability to mpremote and makes it the default behavior. When a MicroPython device disconnects, mpremote automatically reconnects to the same device, eliminating the need to manually restart the tool during development.

Reconnection is now enabled by default. Users can opt-out via:
- The `once` command for per-invocation control
- `MPREMOTE_RECONNECT` environment variable (supports 0/1/true/false/yes/no/on, case-insensitive)
- Config file setting (`reconnect = False` in `~/.config/mpremote/config.py`)
- Priority: `once` command > env var > config file > default (enabled)

Key features:
- Always reconnects to the exact same port that was previously connected when originally started in `connect auto` mode
- Always reconnects to the exact same device (on any port) when started in `connect id:abc123` mode
- Preserves resume state through reconnections
- Handles Windows COM port timing issues with retry logic

Usage:
```bash
# Reconnect is now the default
mpremote repl

# Disable reconnect for this invocation
mpremote once repl

# Disable via environment variable
MPREMOTE_RECONNECT=0 mpremote repl

# Disable via config file
echo "reconnect = False" >> ~/.config/mpremote/config.py
```

This builds on the existing disconnect handling improvements that were previously merged.

### Testing
Manual testing was performed on Linux with Pyboard D and Windows 11 with ESP32S2 devices. Tests used scripted USB power cycling (via uhubctl) to simulate disconnects and verify reconnection behavior. Testing covered default auto-reconnect, the `once` command opt-out, environment variable control (including priority override behavior where `once` takes precedence over `MPREMOTE_RECONNECT=1`), auto mode port-specific reconnection, ID mode device tracking across port changes, multiple device scenarios, resume state preservation, and environment variable parsing with various formats.

### Trade-offs and Alternatives
Making reconnect the default is a breaking change for scripts that expect mpremote to exit on disconnect. These scripts will need to use the `once` command or set `MPREMOTE_RECONNECT=0`. However, the new default is more intuitive for the primary use case (interactive development).

Design decisions:
- Default changed based on maintainer feedback
- Always reconnects to the exact same port (even in auto mode) rather than any available device, prioritizing safety in multi-device environments
- Added retry logic with delays specifically for Windows COM port timing issues
- Multiple opt-out mechanisms with clear priority order provide flexibility for different use cases
- `once` command takes highest priority as it's the most explicit user intention

The code size increase from the reconnect logic is justified by the significant improvement in developer workflow.