### PR TITLE
extmod/modframebuf: Add attributes for width, height, format and stride.

### DIFF
--- a/docs/library/framebuf.rst
+++ b/docs/library/framebuf.rst
@@ -120,6 +120,25 @@ Drawing text
     dimensions of 8x8 pixels and there is currently no way to change the font.
 
 
+Attributes
+----------
+
+.. attribute:: FrameBuffer.width
+
+    Gets the width of the FrameBuffer in pixels.
+
+.. attribute:: FrameBuffer.height
+
+    Gets the height of the FrameBuffer in pixels.
+
+.. attribute:: FrameBuffer.format
+
+    Gets the format of the FrameBuffer, which is one of the constants defined in this module.
+
+.. attribute:: FrameBuffer.stride
+
+    Gets the stride of the FrameBuffer in pixels (horizontal offset between lines).
+
 Other methods
 -------------
 

--- a/examples/natmod/framebuf/framebuf.c
+++ b/examples/natmod/framebuf/framebuf.c
@@ -14,6 +14,16 @@ void *memset(void *s, int c, size_t n) {
 
 mp_obj_full_type_t mp_type_framebuf;
 
+/**
+ * When building native modules tools/mpy_ld.py is used to preprocess the 
+ * source for things like QSTR registration. As this tool currently does
+ * not support #include statements we list QSTR_* from extmod/modframebuf.c
+ * here to ensure they're included in the build.
+ * MP_QSTR_width
+ * MP_QSTR_height
+ * MP_QSTR_format
+ * MP_QSTR_stride
+ */
 #include "extmod/modframebuf.c"
 
 mp_map_elem_t framebuf_locals_dict_table[12];
@@ -25,7 +35,8 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     mp_type_framebuf.base.type = (void*)&mp_type_type;
     mp_type_framebuf.name = MP_QSTR_FrameBuffer;
     MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, make_new, framebuf_make_new, 0);
-    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, buffer, framebuf_get_buffer, 1);
+    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, attr, framebuf_attr, 1);
+    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, buffer, framebuf_get_buffer, 2);
     framebuf_locals_dict_table[0] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_fill), MP_OBJ_FROM_PTR(&framebuf_fill_obj) };
     framebuf_locals_dict_table[1] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_fill_rect), MP_OBJ_FROM_PTR(&framebuf_fill_rect_obj) };
     framebuf_locals_dict_table[2] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_pixel), MP_OBJ_FROM_PTR(&framebuf_pixel_obj) };
@@ -38,7 +49,7 @@ mp_obj_t mpy_init(mp_obj_fun_bc_t *self, size_t n_args, size_t n_kw, mp_obj_t *a
     framebuf_locals_dict_table[9] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_blit), MP_OBJ_FROM_PTR(&framebuf_blit_obj) };
     framebuf_locals_dict_table[10] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_scroll), MP_OBJ_FROM_PTR(&framebuf_scroll_obj) };
     framebuf_locals_dict_table[11] = (mp_map_elem_t){ MP_OBJ_NEW_QSTR(MP_QSTR_text), MP_OBJ_FROM_PTR(&framebuf_text_obj) };
-    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, locals_dict, (void*)&framebuf_locals_dict, 2);
+    MP_OBJ_TYPE_SET_SLOT(&mp_type_framebuf, locals_dict, (void*)&framebuf_locals_dict, 3);
 
     mp_store_global(MP_QSTR_FrameBuffer, MP_OBJ_FROM_PTR(&mp_type_framebuf));
     mp_store_global(MP_QSTR_MVLSB, MP_OBJ_NEW_SMALL_INT(FRAMEBUF_MVLSB));

--- a/extmod/modframebuf.c
+++ b/extmod/modframebuf.c
@@ -347,6 +347,25 @@ static void framebuf_args(const mp_obj_t *args_in, mp_int_t *args_out, int n) {
     }
 }
 
+static void framebuf_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    mp_obj_framebuf_t *self = MP_OBJ_TO_PTR(self_in);
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute
+        if (attr == MP_QSTR_width) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->width);
+        } else if (attr == MP_QSTR_height) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->height);
+        } else if (attr == MP_QSTR_format) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->format);
+        } else if (attr == MP_QSTR_stride) {
+            dest[0] = MP_OBJ_NEW_SMALL_INT(self->stride);
+        } else {
+            // Continue lookup in locals_dict.
+            dest[1] = MP_OBJ_SENTINEL;
+        }
+    }
+}
+
 static mp_int_t framebuf_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
     mp_obj_framebuf_t *self = MP_OBJ_TO_PTR(self_in);
     return mp_get_buffer(self->buf_obj, bufinfo, flags) ? 0 : 1;
@@ -889,6 +908,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     MP_TYPE_FLAG_NONE,
     make_new, framebuf_make_new,
     buffer, framebuf_get_buffer,
+    attr, framebuf_attr,
     locals_dict, &framebuf_locals_dict
     );
 #endif

--- a/tests/extmod/framebuf_attr.py
+++ b/tests/extmod/framebuf_attr.py
@@ -1,0 +1,56 @@
+try:
+    import framebuf
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Test different formats
+formats = [
+    (framebuf.MONO_VLSB, "MONO_VLSB"),
+    (framebuf.MONO_HLSB, "MONO_HLSB"),
+    (framebuf.MONO_HMSB, "MONO_HMSB"),
+    (framebuf.RGB565, "RGB565"),
+    (framebuf.GS2_HMSB, "GS2_HMSB"),
+    (framebuf.GS4_HMSB, "GS4_HMSB"),
+    (framebuf.GS8, "GS8"),
+]
+
+# Test with different dimensions
+dimensions = [(8, 4), (16, 8), (128, 64)]
+
+for width, height in dimensions:
+    for fmt, name in formats:
+        # Create appropriate buffer size based on format
+        if fmt == framebuf.MONO_VLSB:
+            size = ((height + 7) // 8) * width
+        elif fmt == framebuf.MONO_HLSB or fmt == framebuf.MONO_HMSB:
+            size = ((width + 7) // 8) * height
+        elif fmt == framebuf.RGB565:
+            size = width * height * 2
+        elif fmt == framebuf.GS2_HMSB:
+            size = ((width + 3) // 4) * height
+        elif fmt == framebuf.GS4_HMSB:
+            size = ((width + 1) // 2) * height
+        elif fmt == framebuf.GS8:
+            size = width * height
+        else:
+            continue
+
+        buf = bytearray(size)
+        fb = framebuf.FrameBuffer(buf, width, height, fmt)
+
+        print(name, "{}x{}:".format(width, height))
+        print("width:", fb.width)
+        print("height:", fb.height)
+        print("format:", fb.format)
+        print("stride:", fb.stride)
+        print("format == {}: {}".format(name, fb.format == fmt))
+
+        # Try accessing a non-existent attribute (should fail)
+        try:
+            print(fb.non_existent)
+            print("ERROR: should have raised AttributeError")
+        except AttributeError:
+            print("Raised AttributeError correctly")
+
+        print()

--- a/tests/extmod/framebuf_attr.py.exp
+++ b/tests/extmod/framebuf_attr.py.exp
@@ -1,0 +1,168 @@
+MONO_VLSB 8x4:
+width: 8
+height: 4
+format: 0
+stride: 8
+format == MONO_VLSB: True
+Raised AttributeError correctly
+
+MONO_HLSB 8x4:
+width: 8
+height: 4
+format: 3
+stride: 8
+format == MONO_HLSB: True
+Raised AttributeError correctly
+
+MONO_HMSB 8x4:
+width: 8
+height: 4
+format: 4
+stride: 8
+format == MONO_HMSB: True
+Raised AttributeError correctly
+
+RGB565 8x4:
+width: 8
+height: 4
+format: 1
+stride: 8
+format == RGB565: True
+Raised AttributeError correctly
+
+GS2_HMSB 8x4:
+width: 8
+height: 4
+format: 5
+stride: 8
+format == GS2_HMSB: True
+Raised AttributeError correctly
+
+GS4_HMSB 8x4:
+width: 8
+height: 4
+format: 2
+stride: 8
+format == GS4_HMSB: True
+Raised AttributeError correctly
+
+GS8 8x4:
+width: 8
+height: 4
+format: 6
+stride: 8
+format == GS8: True
+Raised AttributeError correctly
+
+MONO_VLSB 16x8:
+width: 16
+height: 8
+format: 0
+stride: 16
+format == MONO_VLSB: True
+Raised AttributeError correctly
+
+MONO_HLSB 16x8:
+width: 16
+height: 8
+format: 3
+stride: 16
+format == MONO_HLSB: True
+Raised AttributeError correctly
+
+MONO_HMSB 16x8:
+width: 16
+height: 8
+format: 4
+stride: 16
+format == MONO_HMSB: True
+Raised AttributeError correctly
+
+RGB565 16x8:
+width: 16
+height: 8
+format: 1
+stride: 16
+format == RGB565: True
+Raised AttributeError correctly
+
+GS2_HMSB 16x8:
+width: 16
+height: 8
+format: 5
+stride: 16
+format == GS2_HMSB: True
+Raised AttributeError correctly
+
+GS4_HMSB 16x8:
+width: 16
+height: 8
+format: 2
+stride: 16
+format == GS4_HMSB: True
+Raised AttributeError correctly
+
+GS8 16x8:
+width: 16
+height: 8
+format: 6
+stride: 16
+format == GS8: True
+Raised AttributeError correctly
+
+MONO_VLSB 128x64:
+width: 128
+height: 64
+format: 0
+stride: 128
+format == MONO_VLSB: True
+Raised AttributeError correctly
+
+MONO_HLSB 128x64:
+width: 128
+height: 64
+format: 3
+stride: 128
+format == MONO_HLSB: True
+Raised AttributeError correctly
+
+MONO_HMSB 128x64:
+width: 128
+height: 64
+format: 4
+stride: 128
+format == MONO_HMSB: True
+Raised AttributeError correctly
+
+RGB565 128x64:
+width: 128
+height: 64
+format: 1
+stride: 128
+format == RGB565: True
+Raised AttributeError correctly
+
+GS2_HMSB 128x64:
+width: 128
+height: 64
+format: 5
+stride: 128
+format == GS2_HMSB: True
+Raised AttributeError correctly
+
+GS4_HMSB 128x64:
+width: 128
+height: 64
+format: 2
+stride: 128
+format == GS4_HMSB: True
+Raised AttributeError correctly
+
+GS8 128x64:
+width: 128
+height: 64
+format: 6
+stride: 128
+format == GS8: True
+Raised AttributeError correctly
+


### PR DESCRIPTION
### Summary

  This PR adds direct attribute access to the FrameBuffer class by implementing an attribute handler in the C code. Users can now access the width, height, format, and stride properties directly from
  framebuffer objects using standard attribute syntax (e.g., fb.width, fb.height, etc.).

  This makes it easier to work with framebuffers in applications where these properties need to be accessed frequently, eliminating the need to store and track these values separately. It's particularly
  useful when passing framebuffers between different functions or modules.

Prompted by https://github.com/orgs/micropython/discussions/17266

###  Testing

  I've added a comprehensive test suite in tests/extmod/framebuf_attr.py that validates all the framebuffer attributes with all supported formats:
  - MONO_VLSB, MONO_HLSB, MONO_HMSB
  - RGB565
  - GS2_HMSB, GS4_HMSB, GS8

  The test also checks various dimensions (8x4, 16x8, 128x64) and verifies that attempting to access non-existent attributes raises an AttributeError as expected.

  The implementation was tested on the Unix port, and since this change is contained within the framebuf module and doesn't interact with hardware-specific features, it should work consistently across all
   ports that support the framebuf module.

---

🤖 Generated with [Claude Code](https://claude.ai/code)
