### PR TITLE
tests/float/math_constants.py: Test actual e and pi constant values.

### DIFF
--- a/tests/float/math_constants.py
+++ b/tests/float/math_constants.py
@@ -1,11 +1,30 @@
 # Tests various constants of the math module.
+
+import sys
+
 try:
-    import math
-    from math import exp, cos
+    from array import array
+    from math import e, pi
 except ImportError:
     print("SKIP")
     raise SystemExit
 
-print(math.e == exp(1.0))
+# Hexadecimal representations of e and pi constants.
+e_truth_single = 0x402DF854
+pi_truth_single = 0x40490FDB
+e_truth_double = 0x4005BF0A8B145769
+pi_truth_double = 0x400921FB54442D18
 
-print(cos(math.pi))
+# Detect the floating-point precision of the system, to determine the exact values of
+# the constants (parsing the float from a decimal string can lead to inaccuracies).
+if float("1e300") == float("inf"):
+    # Single precision floats.
+    e_truth = array("f", e_truth_single.to_bytes(4, sys.byteorder))[0]
+    pi_truth = array("f", pi_truth_single.to_bytes(4, sys.byteorder))[0]
+else:
+    # Double precision floats.
+    e_truth = array("d", e_truth_double.to_bytes(8, sys.byteorder))[0]
+    pi_truth = array("d", pi_truth_double.to_bytes(8, sys.byteorder))[0]
+
+print("e:", e == e_truth or (e, e_truth, e - e_truth))
+print("pi:", pi == pi_truth or (pi, pi_truth, pi - pi_truth))


### PR DESCRIPTION
### Summary

The existing test for `math.e` and `math.pi` constants can fail on certain targets if the functions `math.exp()` and/or `math.cos()` are not accurate enough (eg out by an LSB of float precision).  Eg it currently fails on PYBD_SF6 which uses double precision floats.

This PR changes the test for these constants so that it tests the actual constant value, not the evaluation of `exp()` and `cos()` functions.

### Testing

New test ran successfully on the following targets:
- ESP8266 (30-bit precision with object representation C)
- ESP32, RP_PICO, PYBD_SF2 (32-bit precision)
- CPython, unix, PYBD_SF6 (64-bit precision)

EDIT: updated test to work on both little and big endian targets.  CI tests big endian on qemu-mips.
 
### Trade-offs and Alternatives

The target now requires `array.array` to run the test, but this is enabled at the same level as the `math` module so should always be available when testing these constants.

I did try improving our implementation of double-precision `exp()` so that `exp(1) == e` but that turned out to be very difficult (unsurprisingly).  There is a newer version of musl's math functions, and they do have an improved `exp()` function, but it costs 2k code size just to upgrade that function, and 10k to upgrade the entire double-precision library.  So I ruled out this option.