### PR TITLE
tools/pyboard.py: Port recent patchs from mpremote serial transport, to add timeouts for non-responsive serial ports

### DIFF
--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -267,7 +267,14 @@ class ProcessPtyToTerminal:
 
 class Pyboard:
     def __init__(
-        self, device, baudrate=115200, user="micro", password="python", wait=0, exclusive=True
+        self,
+        device,
+        baudrate=115200,
+        user="micro",
+        password="python",
+        wait=0,
+        exclusive=True,
+        timeout=None,
     ):
         self.in_raw_repl = False
         self.use_raw_paste = True
@@ -283,7 +290,11 @@ class Pyboard:
             import serial.tools.list_ports
 
             # Set options, and exclusive if pyserial supports it
-            serial_kwargs = {"baudrate": baudrate, "interCharTimeout": 1}
+            serial_kwargs = {
+                "baudrate": baudrate,
+                "timeout": timeout,
+                "interCharTimeout": 1,
+            }
             if serial.__version__ >= "3.3":
                 serial_kwargs["exclusive"] = exclusive
 
@@ -324,13 +335,20 @@ class Pyboard:
         self.serial.close()
 
     def read_until(self, min_num_bytes, ending, timeout=10, data_consumer=None):
-        # if data_consumer is used then data is not accumulated and the ending must be 1 byte long
-        assert data_consumer is None or len(ending) == 1
+        """
+        min_num_bytes: Obsolete.
+        ending: Return if 'ending' matches.
+        timeout [s]: Return if timeout between characters. None: Infinite timeout.
+        data_consumer: Use callback for incoming characters.
+            If data_consumer is used then data is not accumulated and the ending must be 1 byte long
 
-        data = self.serial.read(min_num_bytes)
-        if data_consumer:
-            data_consumer(data)
-        timeout_count = 0
+        It is not visible to the caller why the function returned. It could be ending or timeout.
+        """
+        assert data_consumer is None or len(ending) == 1
+        assert isinstance(timeout, (type(None), int, float))
+
+        data = b""
+        begin_char_s = time.monotonic()
         while True:
             if data.endswith(ending):
                 break
@@ -341,10 +359,9 @@ class Pyboard:
                     data = new_data
                 else:
                     data = data + new_data
-                timeout_count = 0
+                begin_char_s = time.monotonic()
             else:
-                timeout_count += 1
-                if timeout is not None and timeout_count >= 100 * timeout:
+                if timeout is not None and time.monotonic() >= begin_char_s + timeout:
                     break
                 time.sleep(0.01)
         return data

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -275,6 +275,7 @@ class Pyboard:
         wait=0,
         exclusive=True,
         timeout=None,
+        write_timeout=5,
     ):
         self.in_raw_repl = False
         self.use_raw_paste = True
@@ -293,6 +294,7 @@ class Pyboard:
             serial_kwargs = {
                 "baudrate": baudrate,
                 "timeout": timeout,
+                "write_timeout": write_timeout,
                 "interCharTimeout": 1,
             }
             if serial.__version__ >= "3.3":
@@ -376,6 +378,12 @@ class Pyboard:
         return data
 
     def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
+        try:
+            self._enter_raw_repl_unprotected(soft_reset, timeout_overall)
+        except OSError as er:
+            raise PyboardError("could not enter raw repl: {}".format(er))
+
+    def _enter_raw_repl_unprotected(self, soft_reset, timeout_overall):
         self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
 
         # flush input (without relying on serial.flushInput())

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -334,11 +334,14 @@ class Pyboard:
     def close(self):
         self.serial.close()
 
-    def read_until(self, min_num_bytes, ending, timeout=10, data_consumer=None):
+    def read_until(
+        self, min_num_bytes, ending, timeout=10, data_consumer=None, timeout_overall=None
+    ):
         """
         min_num_bytes: Obsolete.
         ending: Return if 'ending' matches.
         timeout [s]: Return if timeout between characters. None: Infinite timeout.
+        timeout_overall [s]: Return not later than timeout_overall. None: Infinite timeout.
         data_consumer: Use callback for incoming characters.
             If data_consumer is used then data is not accumulated and the ending must be 1 byte long
 
@@ -346,9 +349,10 @@ class Pyboard:
         """
         assert data_consumer is None or len(ending) == 1
         assert isinstance(timeout, (type(None), int, float))
+        assert isinstance(timeout_overall, (type(None), int, float))
 
         data = b""
-        begin_char_s = time.monotonic()
+        begin_overall_s = begin_char_s = time.monotonic()
         while True:
             if data.endswith(ending):
                 break
@@ -363,10 +367,15 @@ class Pyboard:
             else:
                 if timeout is not None and time.monotonic() >= begin_char_s + timeout:
                     break
+                if (
+                    timeout_overall is not None
+                    and time.monotonic() >= begin_overall_s + timeout_overall
+                ):
+                    break
                 time.sleep(0.01)
         return data
 
-    def enter_raw_repl(self, soft_reset=True):
+    def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
         self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
 
         # flush input (without relying on serial.flushInput())
@@ -378,7 +387,9 @@ class Pyboard:
         self.serial.write(b"\r\x01")  # ctrl-A: enter raw REPL
 
         if soft_reset:
-            data = self.read_until(1, b"raw REPL; CTRL-B to exit\r\n>")
+            data = self.read_until(
+                1, b"raw REPL; CTRL-B to exit\r\n>", timeout_overall=timeout_overall
+            )
             if not data.endswith(b"raw REPL; CTRL-B to exit\r\n>"):
                 print(data)
                 raise PyboardError("could not enter raw repl")
@@ -388,12 +399,12 @@ class Pyboard:
             # Waiting for "soft reboot" independently to "raw REPL" (done below)
             # allows boot.py to print, which will show up after "soft reboot"
             # and before "raw REPL".
-            data = self.read_until(1, b"soft reboot\r\n")
+            data = self.read_until(1, b"soft reboot\r\n", timeout_overall=timeout_overall)
             if not data.endswith(b"soft reboot\r\n"):
                 print(data)
                 raise PyboardError("could not enter raw repl")
 
-        data = self.read_until(1, b"raw REPL; CTRL-B to exit\r\n")
+        data = self.read_until(1, b"raw REPL; CTRL-B to exit\r\n", timeout_overall=timeout_overall)
         if not data.endswith(b"raw REPL; CTRL-B to exit\r\n"):
             print(data)
             raise PyboardError("could not enter raw repl")


### PR DESCRIPTION
### Summary

This applies #16513 and #16616 (made for mpremote) to `tools/pyboard.py`.  They add timeouts to the initial connection phase to a target board, to help with non-responsive serial ports.  Without these patches `pyboard.py` can hang indefinitely waiting for a board to respond.

### Testing

To be tested by @hmaerki on Octoprobe.

### Trade-offs and Alternatives

The test runners still use `pyboard.py`.  Eventually it would be good to change them to use `mpremote` as the backend, but that's a lot more effort.
