### PR TITLE
ports/rp2/boards/SPARKFUN_XRP_CONTROLLER_BETA: Fix default I2C.

### DIFF
--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER_BETA/mpconfigboard.h
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER_BETA/mpconfigboard.h
@@ -24,5 +24,9 @@
 int mp_hal_is_pin_reserved(int n);
 #define MICROPY_HW_PIN_RESERVED(i) mp_hal_is_pin_reserved(i)
 
+// Set the default I2C to I2C1 on pins 18 and 19 which route to the qwiic connector
+#undef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C (1)
+
 #define MICROPY_HW_I2C1_SDA (18)
 #define MICROPY_HW_I2C1_SCL (19)


### PR DESCRIPTION
### Summary

Our XRP Controller Beta board incorporates a Raspberry Pi Pico W, so in its mpconfigboard.cmake file we simply incorporate `set(PICO_BOARD "pico_w")`. We want all of the same defines as the Pico W besides `PICO_DEFAULT_I2C` which we would like to set to 1 such that we use I2C1 with SDA=18 and SCL=19 by default. 

### Testing

Tested with an XRP Controller Beta Board to make sure default I2C creation now uses I2C1 with scl=19 and sda=18:
```
>>> import machine
>>> machine.I2C()
I2C(1, freq=399361, scl=19, sda=18, timeout=50000)
```

### Trade-offs and Alternatives
Alternative ways to do this:
1) We could instead do this in the mpconfigboard.cmake with `add_compile_definitions(PICO_DEFAULT_I2C=1)` or similar.
2) We could submit a PR to pico-sdk to add this as its own board (similar to [the pico_w.h definition](https://github.com/raspberrypi/pico-sdk/blob/master/src/boards/include/boards/pico_w.h)) and then update our mpconfigboard.cmake with `set(PICO_BOARD "sparkfun_xrp_controller_beta")`. This seemed like a little bit of overkill since the only thing we want to change is `PICO_DEFAULT_I2C` so our first go was to try to set this directly in micropython instead. 

