### PR TITLE
extmod/modlwip.c: Fix crash when calling recv on listening socket

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -825,6 +825,12 @@ static mp_uint_t lwip_tcp_receive(lwip_socket_obj_t *socket, byte *buf, mp_uint_
     // Check for any pending errors
     STREAM_ERROR_CHECK(socket);
 
+    if (socket->state == STATE_LISTENING) {
+        // original socket in listening state, not the accepted connection.
+        *_errno = MP_ENOTCONN;
+        return -1;
+    }
+
     if (socket->incoming.tcp.pbuf == NULL) {
 
         // Non-blocking socket or flag

--- a/tests/multi_net/tcp_accept_recv.py
+++ b/tests/multi_net/tcp_accept_recv.py
@@ -1,30 +1,73 @@
-# Test recv on socket that just accepted a connection
+# Test recv on listening socket after accept(), with various listen() arguments
 
 import socket
 
 PORT = 8000
 
+# Test cases for listen() function
+LISTEN_ARGS = [None, 0, 1, 2]  # None means no argument
+
 
 # Server
 def instance0():
     multitest.globals(IP=multitest.get_network_ip())
-    s = socket.socket()
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
-    s.listen(1)
     multitest.next()
-    s.accept()
-    try:
-        print("recv", s.recv(10))  # should raise Errno 107 ENOTCONN
-    except OSError as er:
-        print(er.errno in (107, 128))
-    s.close()
+
+    test_num = 0
+    for blocking_mode in [True, False]:
+        for listen_arg in LISTEN_ARGS:
+            test_num += 1
+            s = socket.socket()
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+
+            # Call listen with or without argument based on test case
+            if listen_arg is None:
+                print(f"Test case {test_num}/8: listen() blocking={blocking_mode}")
+                s.listen()
+            else:
+                print(f"Test case {test_num}/8: listen({listen_arg}) blocking={blocking_mode}")
+                s.listen(listen_arg)
+
+            # Signal client that server is ready
+            multitest.broadcast(f"server_ready_{test_num}")
+
+            # Wait for client connection
+            c, _ = s.accept()
+
+            # Set blocking mode after accept
+            s.setblocking(blocking_mode)
+
+            try:
+                print("recv", s.recv(10))  # should raise Errno 107 ENOTCONN
+            except OSError as er:
+                # Verify the error code is either 107 (ENOTCONN) or 128 (ENOTCONN on Windows)
+                print(er.errno in (107, 128))
+
+            # Cleanup
+            c.close()
+            s.close()
+
+            # Signal client we're done with this test case
+            multitest.broadcast(f"server_done_{test_num}")
 
 
 # Client
 def instance1():
     multitest.next()
-    s = socket.socket()
-    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
-    s.send(b"GET / HTTP/1.0\r\n\r\n")
-    s.close()
+
+    test_num = 0
+    for blocking_mode in [True, False]:
+        for _ in LISTEN_ARGS:
+            test_num += 1
+            # Wait for server to be ready
+            multitest.wait(f"server_ready_{test_num}")
+
+            # Connect to server
+            s = socket.socket()
+            s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+            s.send(b"GET / HTTP/1.0\r\n\r\n")
+            s.close()
+
+            # Wait for server to finish this test case
+            multitest.wait(f"server_done_{test_num}")


### PR DESCRIPTION
### Summary

Fix an issue where calling `recv()` on a listening socket after `accept()` would cause a hard fault crash on
MicroPython hardware. This happens when user code incorrectly tries to receive data on the listening socket
instead of the accepted connection.

With this fix, MicroPython now properly raises an `OSError` with `errno=107` (ENOTCONN) similar to CPython,
instead of crashing. This makes the behavior consistent with standard socket implementations and improves error
handling.

The bug is demonstrated by the following code pattern:
```python
import socket
s = socket.socket(socket.AF_INET)
s.bind(('0.0.0.0', 8882))
s.listen()
s.accept()   # connection not saved
s.recv(3)  # incorrectly calling recv on listening socket
```
Once data is sent to this socket from
```python
import socket
s = socket.socket(socket.AF_INET)
s.connect(('127.0.0.1', 8882))
s.send(b'abc')
```
The first device crashes with a hard fault.

Closes #16697 (the root cause of the `wrap_socket()` crash is calling recv on a listening socket.)

### Testing

Added a new test file tests/multi_net/tcp_accept_recv_listen.py that demonstrates the fix by intentionally
triggering the error condition and checking for the appropriate exception.

Testing was performed against a pyboard-d (WIFI):
``` bash
./run-multitests.py -i pyb:/dev/ttyACM0 -i cpython multi_net/tcp_accept_recv.py
```

The test confirms that a proper OSError is raised with the correct errno value (107/ENOTCONN) instead of
crashing.

---
While this bug was found / fixed manually the unit test and documentation was created with AI support from Claude Code.
