### PR TITLE
shared/tinyusb: Use device event hook to schedule USB task.

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -103,10 +103,6 @@ CFLAGS += -Wl,-T$(BUILD)/ensemble.ld \
           -Wl,--print-memory-usage \
           -Wl,--no-warn-rwx-segment
 
-ifeq ($(MCU_CORE),M55_HP)
-CFLAGS += -Wl,--wrap=dcd_event_handler
-endif
-
 ################################################################################
 # Source files and libraries
 

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -97,10 +97,6 @@ if(MICROPY_PY_TINYUSB)
     list(APPEND MICROPY_INC_TINYUSB
         ${MICROPY_DIR}/shared/tinyusb/
     )
-
-    list(APPEND MICROPY_LINK_TINYUSB
-        -Wl,--wrap=dcd_event_handler
-    )
 endif()
 
 list(APPEND MICROPY_SOURCE_PORT
@@ -259,10 +255,6 @@ target_compile_options(${MICROPY_TARGET} PUBLIC
     -Wno-clobbered
     -Wno-deprecated-declarations
     -Wno-missing-field-initializers
-)
-
-target_link_options(${MICROPY_TARGET} PUBLIC
-     ${MICROPY_LINK_TINYUSB}
 )
 
 # Additional include directories needed for private NimBLE headers.

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -268,7 +268,6 @@ SRC_C += $(addprefix lib/tinyusb/src/,\
 	portable/nordic/nrf5x/dcd_nrf5x.c \
 	)
 
-LDFLAGS += -Wl,--wrap=dcd_event_handler
 endif
 
 DRIVERS_SRC_C += $(addprefix modules/,\

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -129,14 +129,7 @@ CFLAGS_MCU_m4 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4 -mfpu=fpv4-s
 
 CFLAGS_MCU_m0 = $(CFLAGS_CORTEX_M) -fshort-enums -mtune=cortex-m0 -mcpu=cortex-m0 -mfloat-abi=soft
 
-# linker wrap does not work with lto on older gcc/binutils: https://sourceware.org/bugzilla/show_bug.cgi?id=24406
-GCC_VERSION = $(shell arm-none-eabi-gcc -dumpversion)
-GCC_MAJOR_VERS = $(word 1,$(subst ., ,$(GCC_VERSION)))
-ifeq ($(shell test $(GCC_MAJOR_VERS) -ge 10; echo $$?),0)
 LTO ?= 1
-else
-LTO ?= 0
-endif
 
 ifeq ($(LTO),1)
 CFLAGS += -flto

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -157,9 +157,6 @@ LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
 LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
 endif
 
-# Hook tinyusb USB interrupt if used to service usb task.
-LDFLAGS += --wrap=dcd_event_handler
-
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=armv7m
 

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -525,7 +525,6 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
 
 target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
-    -Wl,--wrap=dcd_event_handler
     -Wl,--wrap=runtime_init_clocks
 )
 

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -113,8 +113,6 @@ LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
 LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
 endif
 
-LDFLAGS += --wrap=dcd_event_handler
-
 MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH)
 
 SRC_C += \

--- a/shared/tinyusb/mp_usbd.c
+++ b/shared/tinyusb/mp_usbd.c
@@ -30,10 +30,6 @@
 
 #include "mp_usbd.h"
 
-#ifndef NO_QSTR
-#include "device/dcd.h"
-#endif
-
 #if !MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
 
 void mp_usbd_task(void) {
@@ -47,13 +43,8 @@ void mp_usbd_task_callback(mp_sched_node_t *node) {
 
 #endif // !MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
 
-extern void __real_dcd_event_handler(dcd_event_t const *event, bool in_isr);
-
-// If -Wl,--wrap=dcd_event_handler is passed to the linker, then this wrapper
-// will be called and allows MicroPython to schedule the TinyUSB task when
-// dcd_event_handler() is called from an ISR.
-TU_ATTR_FAST_FUNC void __wrap_dcd_event_handler(dcd_event_t const *event, bool in_isr) {
-    __real_dcd_event_handler(event, in_isr);
+// Schedule the TinyUSB task on demand, when there is a new USB device event
+TU_ATTR_FAST_FUNC void tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr) {
     mp_usbd_schedule_task();
     mp_hal_wake_main_task_from_isr();
 }


### PR DESCRIPTION
### Summary

Previously MicroPython ports would linker-wrap dcd_event_handler in order to schedule the USB task callback to run when needed.

TinyUSB 0.16 added proper support for an event hook to do the same thing without the hacky linker wrapping. (See https://github.com/hathach/tinyusb/pull/2303)

(The vendored TinyUSB is 0.17.0 since 09fa90e, the version in ESP-IDF is 0.18.0 for both ESP-IDF V5.2 and V5.4.1.)

As a bonus: 

* This resolves a possible reported issue with LTO+linker wrap on the nrf port (as there's no more linker wrapping).
* Can revert commit 62e0fa04 from #15158 for the same reason (no more linker wrap in the nrf port)

*This work was funded through GitHub Sponsors.*

### Testing

* Built `RPI_PICO` and `ESP32_GENERIC_S3` boards, interacted with the default REPL, and also ran the `usb/device/mouse` example on both boards.
