### PR TITLE
ports/rps: Make FLASH LENGTH match PICO_FLASH_SIZE_BYTES in .ld files.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -525,6 +525,7 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
 
 target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
+    -Wl,--defsym=__micropy_flash_size__=${PICO_FLASH_SIZE_BYTES}
     -Wl,--wrap=dcd_event_handler
     -Wl,--wrap=runtime_init_clocks
 )

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -525,10 +525,23 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
 
 target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
-    -Wl,--defsym=__micropy_flash_size__=${PICO_FLASH_SIZE_BYTES}
     -Wl,--wrap=dcd_event_handler
     -Wl,--wrap=runtime_init_clocks
 )
+
+if(PICO_FLASH_SIZE_BYTES GREATER 0)
+    target_link_options(${MICROPY_TARGET} PRIVATE
+        -Wl,--defsym=__micropy_flash_size__=${PICO_FLASH_SIZE_BYTES}
+    )
+elseif(PICO_RP2040)
+    target_link_options(${MICROPY_TARGET} PRIVATE
+        -Wl,--defsym=__micropy_flash_size__=2048k # Default to 2MB
+    )
+elseif(PICO_RP2350)
+    target_link_options(${MICROPY_TARGET} PRIVATE
+        -Wl,--defsym=__micropy_flash_size__=4096k # Default to 4MB
+    )
+endif()
 
 if(PICO_RP2350)
     target_link_options(${MICROPY_TARGET} PRIVATE

--- a/ports/rp2/memmap_mp_rp2040.ld
+++ b/ports/rp2/memmap_mp_rp2040.ld
@@ -23,7 +23,7 @@
 
 MEMORY
 {
-    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 2048k
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = __micropy_flash_size__
     RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 256k
     SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k

--- a/ports/rp2/memmap_mp_rp2350.ld
+++ b/ports/rp2/memmap_mp_rp2350.ld
@@ -23,7 +23,7 @@
 
 MEMORY
 {
-    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 4096k
+    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = __micropy_flash_size__
     RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 512k
     SCRATCH_X(rwx) : ORIGIN = 0x20080000, LENGTH = 4k
     SCRATCH_Y(rwx) : ORIGIN = 0x20081000, LENGTH = 4k


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
Resolves #17343

This dynamically sets the `FLASH` `LENGTH` value in the `.ld` files to match `PICO_FLASH_SIZE_BYTES`, meaning it should match the size of the actual flash chip on whatever board is being built.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
I have a project that requires over 4MB of flash for the firmware. I'm building the project for a board that has a 16MB flash chip, which is set by `PICO_FLASH_SIZE_BYTES`. Without these changes, I get the following error from the linker:

```
firmware.elf section `.text' will not fit in region `FLASH'`
region `FLASH' overflowed by xxxx bytes
```

After these changes, it works fine.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->
I do not believe this has any tradeoffs.

However, a possible alternative is to make the `FLASH` `LENGTH` truly configurable instead of dynamically set to match the board's flash size. I don't know whether that would actually be useful for anything though, so IMO best to keep it simple.
