### PR TITLE
Optimise `machine.time_pulse_us` implementation for code size, and switch esp8266 port to use it

### DIFF
--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -31,19 +31,34 @@
 #if MICROPY_PY_MACHINE_PULSE
 
 MP_WEAK mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
+    mp_uint_t nchanges = 2;
     mp_uint_t start = mp_hal_ticks_us();
-    while (mp_hal_pin_read(pin) != pulse_level) {
-        if ((mp_uint_t)(mp_hal_ticks_us() - start) >= timeout_us) {
-            return (mp_uint_t)-2;
+    for (;;) {
+        // Sample ticks and pin as close together as possible, and always in the same
+        // order each time around the loop.  This gives the most accurate measurement.
+        mp_uint_t t = mp_hal_ticks_us();
+        int pin_value = mp_hal_pin_read(pin);
+
+        if (pin_value == pulse_level) {
+            // Pin is at desired value.  Flip desired value and see if we are done.
+            pulse_level = 1 - pulse_level;
+            if (--nchanges == 0) {
+                return t - start;
+            }
+            start = t;
+        } else {
+            // Pin hasn't changed yet, check for timeout.
+            mp_uint_t dt = t - start;
+            if (dt >= timeout_us) {
+                return -nchanges;
+            }
+
+            // Allow a port to perform background task processing if needed.
+            #ifdef MICROPY_PY_MACHINE_TIME_PULSE_US_HOOK
+            MICROPY_PY_MACHINE_TIME_PULSE_US_HOOK(dt);
+            #endif
         }
     }
-    start = mp_hal_ticks_us();
-    while (mp_hal_pin_read(pin) == pulse_level) {
-        if ((mp_uint_t)(mp_hal_ticks_us() - start) >= timeout_us) {
-            return (mp_uint_t)-1;
-        }
-    }
-    return mp_hal_ticks_us() - start;
 }
 
 static mp_obj_t machine_time_pulse_us_(size_t n_args, const mp_obj_t *args) {

--- a/extmod/machine_pulse.c
+++ b/extmod/machine_pulse.c
@@ -30,7 +30,7 @@
 
 #if MICROPY_PY_MACHINE_PULSE
 
-MP_WEAK mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
+mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
     mp_uint_t nchanges = 2;
     mp_uint_t start = mp_hal_ticks_us();
     for (;;) {

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -27,10 +27,19 @@
 #include "user_interface.h"
 #include "py/ringbuf.h"
 #include "shared/runtime/interrupt_char.h"
+#include "ets_alt_task.h"
 #include "xtirq.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION() esp_disable_irq()
 #define MICROPY_END_ATOMIC_SECTION(state) esp_enable_irq(state)
+
+// During machine.time_pulse_us, feed WDT every now and then.
+#define MICROPY_PY_MACHINE_TIME_PULSE_US_HOOK(dt) \
+    do { \
+        if ((dt & 0xffff) == 0xffff && !ets_loop_dont_feed_sw_wdt) { \
+            system_soft_wdt_feed(); \
+        } \
+    } while (0)
 
 void mp_sched_keyboard_interrupt(void);
 

--- a/ports/esp8266/modmachine.c
+++ b/ports/esp8266/modmachine.c
@@ -33,7 +33,6 @@
 #include "os_type.h"
 #include "osapi.h"
 #include "etshal.h"
-#include "ets_alt_task.h"
 #include "user_interface.h"
 
 // #define MACHINE_WAKE_IDLE (0x01)
@@ -327,32 +326,3 @@ MP_DEFINE_CONST_OBJ_TYPE(
     print, esp_timer_print,
     locals_dict, &esp_timer_locals_dict
     );
-
-// Custom version of this function that feeds system WDT if necessary
-mp_uint_t machine_time_pulse_us(mp_hal_pin_obj_t pin, int pulse_level, mp_uint_t timeout_us) {
-    int nchanges = 2;
-    uint32_t start = system_get_time(); // in microseconds
-    for (;;) {
-        uint32_t dt = system_get_time() - start;
-
-        // Check if pin changed to wanted value
-        if (mp_hal_pin_read(pin) == pulse_level) {
-            if (--nchanges == 0) {
-                return dt;
-            }
-            pulse_level = 1 - pulse_level;
-            start = system_get_time();
-            continue;
-        }
-
-        // Check for timeout
-        if (dt >= timeout_us) {
-            return (mp_uint_t)-nchanges;
-        }
-
-        // Only feed WDT every now and then, to make sure edge timing is accurate
-        if ((dt & 0xffff) == 0xffff && !ets_loop_dont_feed_sw_wdt) {
-            system_soft_wdt_feed();
-        }
-    }
-}


### PR DESCRIPTION
### Summary

The esp8266 has a custom implementation of `machine.time_pulse_us()`, which is needed so it can feed the WDT during long waits for a pin change.  It doesn't need to have a separate implementation, instead we can use the common one with an optional hook for a port to do work during the busy wait loops.

This PR:
1. Reworks the common implementation of `machine.time_pulse_us()` to be more like the esp8266 version.  That cuts down code size a little, and improves accuracy a little.
2. Switches esp8266 to use this common implementation.

Also, motivation comes from #16160: this PR should make that PR much simpler (and lower cost) to implement.

### Testing

Tested with a range of square waves from 125Hz to 4kHz on:
- PYBD_SF2: this has a very accurate measurement and accuracy is unchanged with this PR
- RPI_PICO2_W: same as PYBD_SF2, very accurate and unchanged with this PR
- ESP8266: for the frequencies it can handle (up to about 1kHz) this PR is slightly more accurate than before: for example a pulse that is 1000us long, it would measure between 998 and 1000us with an average of 999us.  Now it measures between 999us and 1001us with an average of 1000us.

Also tested the timeout argument, a value of 5000000 still takes 5s and doesn't lead to a WDT timeout on esp8266.

### Trade-offs and Alternatives

This is an optimisation.  There is no change in the API.  As tested above, the accuracy is at least the same if not better due to better sampling of ticks and pin at the same point in the code.