### PR TITLE
py/scheduler: Allow C scheduler callbacks to re-queue themselves.

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -184,6 +184,18 @@ static void pairheap_test(size_t nops, int *ops) {
     mp_printf(&mp_plat_print, "\n");
 }
 
+static mp_sched_node_t mp_coverage_sched_node;
+static bool coverage_sched_function_continue;
+
+static void coverage_sched_function(mp_sched_node_t *node) {
+    (void)node;
+    mp_printf(&mp_plat_print, "scheduled function\n");
+    if (coverage_sched_function_continue) {
+        // Re-scheduling node will cause it to run again next time scheduled functions are run
+        mp_sched_schedule_node(&mp_coverage_sched_node, coverage_sched_function);
+    }
+}
+
 // function to run extra tests for things that can't be checked by scripts
 static mp_obj_t extra_coverage(void) {
     // mp_printf (used by ports that don't have a native printf)
@@ -621,6 +633,19 @@ static mp_obj_t extra_coverage(void) {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
         }
         mp_handle_pending(true);
+
+        coverage_sched_function_continue = true;
+        mp_sched_schedule_node(&mp_coverage_sched_node, coverage_sched_function);
+        for (int i = 0; i < 3; ++i) {
+            mp_printf(&mp_plat_print, "loop\n");
+            mp_handle_pending(true);
+        }
+        // Clear this flag to prevent the function scheduling itself again
+        coverage_sched_function_continue = false;
+        // Will only run the first time through this loop, then not scheduled again
+        for (int i = 0; i < 3; ++i) {
+            mp_handle_pending(true);
+        }
     }
 
     // ringbuf

--- a/ports/unix/variants/coverage/mpconfigvariant.h
+++ b/ports/unix/variants/coverage/mpconfigvariant.h
@@ -44,6 +44,7 @@
 #undef MICROPY_VFS_ROM_IOCTL
 #define MICROPY_VFS_ROM_IOCTL          (1)
 #define MICROPY_PY_CRYPTOLIB_CTR       (1)
+#define MICROPY_SCHEDULER_STATIC_NODES (1)
 
 // Enable os.uname for attrtuple coverage test
 #define MICROPY_PY_OS_UNAME            (1)

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -122,6 +122,13 @@ unlocked
 KeyboardInterrupt: 
 KeyboardInterrupt: 
 10
+loop
+scheduled function
+loop
+scheduled function
+loop
+scheduled function
+scheduled function
 # ringbuf
 99 0
 98 1


### PR DESCRIPTION
### Summary

Currently if a scheduler callbacks queues a new C scheduled callback, that callback will run in the same schedule pass. This means if a scheduler callback re-queues itself, it can "infinite loop" inside the scheduler.

This change means that any call to `mp_handle_pending()` will only process the callbacks which were queued when `mp_handle_pending()` started running. Therefore any callback which re-queues itself should have that callback handled the next time `mp_handle_pending()` is called.

This is an alternative to #17248 and should remove the need for #17264. Fixes #17246.

This does create potential for some additional callback latency (i.e. if an interrupt fires while a different scheduler callback is running, the interrupt callback is now deferred until the next scheduler run). However the worst-case scheduler latency remains similar (interrupt fires at end of one scheduler pass, has to wait until the next one). I think most MicroPython systems only sparsely call C scheduler callbacks, so this shouldn't be noticeable in most cases.

There is also potential for a misbehaving callback that re-schedules itself continuously to degrade performance of MicroPython (as the callback runs continuously with some allowance for Python code to run), whereas before it would have locked up MicroPython entirely which is more obviously broken.

*This work was funded through GitHub Sponsors.*

### Testing

* I adapted the test case @andrewleech added in #17248 for the new behaviour and resubmitted here, so coverage test now includes C scheduler callbacks (testing the new logic).
* Manually ran the rp2 unit tests on RP2_PICO board. As this is a tickless port I felt it had the most potential for an interrupt timing bug to surface due to this change. All passed.

### Trade-offs and Alternatives

* Possible to manually add anti-recursion checks in callbacks, i.e. approach in #17264, but it can get fiddly quickly.
