### PR TITLE
mpy-cross: exit with error if arch not given when needed, and add `emit=host` option to help

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -130,7 +130,7 @@ static int usage(char **argv) {
         "Target specific options:\n"
         "-msmall-int-bits=number : set the maximum bits used to encode a small-int\n"
         "-march=<arch> : set architecture for native emitter;\n"
-        "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp, armv7emdp, xtensa, xtensawin, rv32imc, debug\n"
+        "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp, armv7emdp, xtensa, xtensawin, rv32imc, host, debug\n"
         "\n"
         "Implementation specific options:\n", argv[0]
         );

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -350,6 +350,15 @@ MP_NOINLINE int main_(int argc, char **argv) {
         }
     }
 
+    #if MICROPY_EMIT_NATIVE
+    if ((MP_STATE_VM(default_emit_opt) == MP_EMIT_OPT_NATIVE_PYTHON
+         || MP_STATE_VM(default_emit_opt) == MP_EMIT_OPT_VIPER)
+        && mp_dynamic_compiler.native_arch == MP_NATIVE_ARCH_NONE) {
+        mp_printf(&mp_stderr_print, "arch not specified\n");
+        exit(1);
+    }
+    #endif
+
     if (input_file == NULL) {
         mp_printf(&mp_stderr_print, "no input file\n");
         exit(1);


### PR DESCRIPTION
### Summary

This PR addresses two minor issues with `mpy-cross`:
1. `mpy-cross` will crash if called as `mpy-cross -X emit=native foo.py`, because it tries to use the native emitter with no target architecture set; fixed by checking that an architecture is set when `-X emit=native` or `X emit=viper` is used
2. document the availability of the `-X emit=host` option in the help

### Testing

Tested by running `mpy-cross -X emit=native`, it now raises an exception.

Also ran `mpy-cross -h` to see the modified help message.