### PR TITLE
tests: automatically skip tests that are too large for the target (not enough memory)

### DIFF
--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -1,3 +1,5 @@
+# Test sys.print_exception (MicroPython) / traceback.print_exception (CPython).
+
 try:
     import io
     import sys

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -269,22 +269,17 @@ def detect_test_platform(pyb, args):
     print()
 
 
-def prepare_script_for_target(args, *, script_filename=None, script_text=None, force_plain=False):
+def prepare_script_for_target(args, *, script_text=None, force_plain=False):
     if force_plain or (not args.via_mpy and args.emit == "bytecode"):
-        if script_filename is not None:
-            with open(script_filename, "rb") as f:
-                script_text = f.read()
+        # A plain test to run as-is, no processing needed.
+        pass
     elif args.via_mpy:
         tempname = tempfile.mktemp(dir="")
         mpy_filename = tempname + ".mpy"
 
-        if script_filename is None:
-            script_filename = tempname + ".py"
-            cleanup_script_filename = True
-            with open(script_filename, "wb") as f:
-                f.write(script_text)
-        else:
-            cleanup_script_filename = False
+        script_filename = tempname + ".py"
+        with open(script_filename, "wb") as f:
+            f.write(script_text)
 
         try:
             subprocess.check_output(
@@ -300,8 +295,7 @@ def prepare_script_for_target(args, *, script_filename=None, script_text=None, f
             script_text = b"__buf=" + bytes(repr(f.read()), "ascii") + b"\n"
 
         rm_f(mpy_filename)
-        if cleanup_script_filename:
-            rm_f(script_filename)
+        rm_f(script_filename)
 
         script_text += bytes(injected_import_hook_code, "ascii")
     else:


### PR DESCRIPTION
### Summary

Some tests are just too big for targets that don't have much heap memory.  Eg `tests/extmod/vfs_rom.py`.  Other tests are too large because the target doesn't have enough IRAM for native code, eg `tests/micropython/
viper_args.py`.

Previously, such tests were explicitly skipped on targets known to have little memory, eg esp8266.  But this doesn't scale to multiple targets, nor to more and more tests which are too large.

This PR addresses that by adding logic to the test runner so it can automatically skip tests when they don't fit in the target's memory.  It does this by prepending a `print('START TEST')` to every test, and if a `MemoryError` occurs before that line is printed then the test was too big.  This works for standard tests, tests that go via .mpy files, and tests that run in native emitter mode via .mpy files.

For tests that are too big, it prints `lrge  <test name>` on the output, and adds them to a separate list of skipped tests so they can be distinguished.  They are also written to the `_result.json` file in a separate entry.

### Testing

Tested on esp8266:
```
$ ./run-tests.py -t u0
platform=esp8266 arch=xtensa inlineasm=xtensa
pass  basics/0prelim.py 
pass  basics/andor.py 
...
pass  micropython/stack_use.py 
pass  micropython/viper_addr.py 
lrge  micropython/viper_args.py
lrge  micropython/viper_binop_arith.py
pass  micropython/viper_binop_arith_uint.py 
pass  micropython/viper_binop_bitwise_uint.py 
...
pass  misc/non_compliant_lexer.py 
pass  misc/print_exception.py 
skip  misc/rge_sm.py
skip  misc/sys_atexit.py
skip  misc/sys_exc_info.py
skip  misc/sys_settrace_features.py
skip  misc/sys_settrace_generator.py
skip  misc/sys_settrace_loop.py
785 tests performed (22822 individual testcases)
785 tests passed
115 tests skipped: binascii_crc32 builtin_compile <long line truncated>
3 tests skipped because they are too large: vfs_rom viper_args viper_binop_arith
```

Also ran `--via-mpy` tests on esp8266: it skipped the two tests `viper_args` and `viper_binop_arith` because they were too large but was able to run `vfs_rom` because that can fit when compiled as .mpy (although it still skipped due to the target not supporting `VfsRom` but at least it shows that the auto-skipping due to OOM is working well).

Also ran `--via-mpy --emit native` on esp8266: prior to this PR running that would have 343 tests fail, but now with this PR it's `348 tests skipped because they are too large` and `10 tests failed` which is a very big improvement.

Also ran tests on RPI_PICO2_W.  They run as usual and nothing is skipped.

### Trade-offs and Alternatives

- This makes each test slightly larger due to the added `print` statement.  As a consequence a test that may have fit previously might not fit now.  But such tests were already on the edge of having enough RAM to run anyway.
- Tests that rely on source-code line numbers in their output must start with a comment, so that the `print` can be inserted before the comment and not change the line numbering.
- It cannot detect tests that fail due to out-of-memory part way through.  Only those that fail upfront to even parse/compile (which accounts for the vast majority of tests anyway).
- Alternative would be to continue to manually maintain a list of the tests which are large, and detect the amount of heap memory on a target, and skip tests if the target is lower than a set threshold.  But this is time consuming and error prone.