### PR TITLE
shared/timeutils: Standardize supported date range on all platforms.

### DIFF
--- a/extmod/modtime.c
+++ b/extmod/modtime.c
@@ -58,7 +58,7 @@ static mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
         return mp_time_localtime_get();
     } else {
         // Convert given seconds to tuple.
-        mp_int_t seconds = mp_obj_get_int(args[0]);
+        mp_timestamp_t seconds = timeutils_obj_get_timestamp(args[0]);
         timeutils_struct_time_t tm;
         timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
         mp_obj_t tuple[8] = {
@@ -90,7 +90,7 @@ static mp_obj_t time_mktime(mp_obj_t tuple) {
         mp_raise_TypeError(MP_ERROR_TEXT("mktime needs a tuple of length 8 or 9"));
     }
 
-    return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),
+    return timeutils_obj_from_timestamp(timeutils_mktime(mp_obj_get_int(elem[0]),
         mp_obj_get_int(elem[1]), mp_obj_get_int(elem[2]), mp_obj_get_int(elem[3]),
         mp_obj_get_int(elem[4]), mp_obj_get_int(elem[5])));
 }

--- a/extmod/vfs_fat.c
+++ b/extmod/vfs_fat.c
@@ -326,7 +326,7 @@ static mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
     } else {
         mode |= MP_S_IFREG;
     }
-    mp_int_t seconds = timeutils_seconds_since_epoch(
+    mp_timestamp_t seconds = timeutils_seconds_since_epoch(
         1980 + ((fno.fdate >> 9) & 0x7f),
         (fno.fdate >> 5) & 0x0f,
         fno.fdate & 0x1f,
@@ -341,9 +341,9 @@ static mp_obj_t fat_vfs_stat(mp_obj_t vfs_in, mp_obj_t path_in) {
     t->items[4] = MP_OBJ_NEW_SMALL_INT(0); // st_uid
     t->items[5] = MP_OBJ_NEW_SMALL_INT(0); // st_gid
     t->items[6] = mp_obj_new_int_from_uint(fno.fsize); // st_size
-    t->items[7] = mp_obj_new_int_from_uint(seconds); // st_atime
-    t->items[8] = mp_obj_new_int_from_uint(seconds); // st_mtime
-    t->items[9] = mp_obj_new_int_from_uint(seconds); // st_ctime
+    t->items[7] = timeutils_obj_from_timestamp(seconds); // st_atime
+    t->items[8] = timeutils_obj_from_timestamp(seconds); // st_mtime
+    t->items[9] = timeutils_obj_from_timestamp(seconds); // st_ctime
 
     return MP_OBJ_FROM_PTR(t);
 }

--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -378,7 +378,7 @@ static mp_obj_t MP_VFS_LFSx(stat)(mp_obj_t self_in, mp_obj_t path_in) {
         mp_raise_OSError(-ret);
     }
 
-    mp_uint_t mtime = 0;
+    mp_timestamp_t mtime = 0;
     #if LFS_BUILD_VERSION == 2
     uint8_t mtime_buf[8];
     lfs2_ssize_t sz = lfs2_getattr(&self->lfs, path, LFS_ATTR_MTIME, &mtime_buf, sizeof(mtime_buf));
@@ -400,9 +400,9 @@ static mp_obj_t MP_VFS_LFSx(stat)(mp_obj_t self_in, mp_obj_t path_in) {
     t->items[4] = MP_OBJ_NEW_SMALL_INT(0); // st_uid
     t->items[5] = MP_OBJ_NEW_SMALL_INT(0); // st_gid
     t->items[6] = mp_obj_new_int_from_uint(info.size); // st_size
-    t->items[7] = mp_obj_new_int_from_uint(mtime); // st_atime
-    t->items[8] = mp_obj_new_int_from_uint(mtime); // st_mtime
-    t->items[9] = mp_obj_new_int_from_uint(mtime); // st_ctime
+    t->items[7] = timeutils_obj_from_timestamp(mtime); // st_atime
+    t->items[8] = timeutils_obj_from_timestamp(mtime); // st_mtime
+    t->items[9] = timeutils_obj_from_timestamp(mtime); // st_ctime
 
     return MP_OBJ_FROM_PTR(t);
 }

--- a/ports/cc3200/mods/modtime.c
+++ b/ports/cc3200/mods/modtime.c
@@ -50,5 +50,5 @@ static mp_obj_t mp_time_localtime_get(void) {
 
 // Returns the number of seconds, as an integer, since the Epoch.
 static mp_obj_t mp_time_time_get(void) {
-    return mp_obj_new_int(pyb_rtc_get_seconds());
+    return timeutils_obj_from_timestamp(pyb_rtc_get_seconds());
 }

--- a/ports/esp32/modtime.c
+++ b/ports/esp32/modtime.c
@@ -54,5 +54,5 @@ static mp_obj_t mp_time_localtime_get(void) {
 static mp_obj_t mp_time_time_get(void) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    return mp_obj_new_int(tv.tv_sec);
+    return timeutils_obj_from_timestamp(tv.tv_sec);
 }

--- a/ports/esp8266/modtime.c
+++ b/ports/esp8266/modtime.c
@@ -31,7 +31,7 @@
 
 // Return the localtime as an 8-tuple.
 static mp_obj_t mp_time_localtime_get(void) {
-    mp_int_t seconds = pyb_rtc_get_us_since_epoch() / 1000 / 1000;
+    mp_uint_t seconds = pyb_rtc_get_us_since_epoch() / 1000u / 1000u;
     timeutils_struct_time_t tm;
     timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
     mp_obj_t tuple[8] = {
@@ -50,5 +50,5 @@ static mp_obj_t mp_time_localtime_get(void) {
 // Returns the number of seconds, as an integer, since the Epoch.
 static mp_obj_t mp_time_time_get(void) {
     // get date and time
-    return mp_obj_new_int(pyb_rtc_get_us_since_epoch() / 1000 / 1000);
+    return timeutils_obj_from_timestamp(pyb_rtc_get_us_since_epoch() / 1000 / 1000);
 }

--- a/ports/mimxrt/modtime.c
+++ b/ports/mimxrt/modtime.c
@@ -51,14 +51,7 @@ static mp_obj_t mp_time_localtime_get(void) {
 static mp_obj_t mp_time_time_get(void) {
     snvs_lp_srtc_datetime_t t;
     SNVS_LP_SRTC_GetDatetime(SNVS, &t);
-    // EPOCH is 1970 for this port, which leads to the following trouble:
-    // timeutils_seconds_since_epoch() calls timeutils_seconds_since_2000(), and
-    // timeutils_seconds_since_2000() subtracts 2000 from year, but uses
-    // an unsigned number for seconds, That causes an underrun, which is not
-    // fixed by adding the TIMEUTILS_SECONDS_1970_TO_2000.
-    // Masking it to 32 bit for year < 2000 fixes it.
-    return mp_obj_new_int_from_ull(
+    return timeutils_obj_from_timestamp(
         timeutils_seconds_since_epoch(t.year, t.month, t.day, t.hour, t.minute, t.second)
-        & (t.year < 2000 ? 0xffffffff : 0xffffffffffff)
         );
 }

--- a/ports/renesas-ra/modtime.c
+++ b/ports/renesas-ra/modtime.c
@@ -53,5 +53,5 @@ static mp_obj_t mp_time_time_get(void) {
     rtc_init_finalise();
     ra_rtc_t time;
     ra_rtc_get_time(&time);
-    return mp_obj_new_int(timeutils_seconds_since_epoch(time.year, time.month, time.date, time.hour, time.minute, time.second));
+    return timeutils_obj_from_timestamp(timeutils_seconds_since_epoch(time.year, time.month, time.date, time.hour, time.minute, time.second));
 }

--- a/ports/stm32/modtime.c
+++ b/ports/stm32/modtime.c
@@ -59,5 +59,5 @@ static mp_obj_t mp_time_time_get(void) {
     RTC_TimeTypeDef time;
     HAL_RTC_GetTime(&RTCHandle, &time, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&RTCHandle, &date, RTC_FORMAT_BIN);
-    return mp_obj_new_int(timeutils_seconds_since_epoch(2000 + date.Year, date.Month, date.Date, time.Hours, time.Minutes, time.Seconds));
+    return timeutils_obj_from_timestamp(timeutils_seconds_since_epoch(2000 + date.Year, date.Month, date.Date, time.Hours, time.Minutes, time.Seconds));
 }

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -76,6 +76,7 @@
 #ifndef MICROPY_FLOAT_IMPL // can be configured by each board via mpconfigboard.mk
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #endif
+#define MICROPY_TIME_SUPPORT_Y1969_AND_BEFORE (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_SCHEDULER_STATIC_NODES (1)
 #define MICROPY_SCHEDULER_DEPTH     (8)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -52,6 +52,10 @@ CFLAGS += $(INC) $(CWARN) -std=gnu99 -DUNIX $(COPT) -I$(VARIANT_DIR) $(CFLAGS_EX
 # This option has no effect on 64-bit builds.
 CFLAGS += -D_FILE_OFFSET_BITS=64
 
+# Force the use of 64-bits for time_t in C library functions on 32-bit platforms.
+# This option has no effect on 64-bit builds.
+CFLAGS += -D_TIME_BITS=64
+
 # Debugging/Optimization
 ifdef DEBUG
 COPT ?= -Og

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -488,6 +488,26 @@ static mp_obj_t extra_coverage(void) {
         // mpz_set_from_float with 0 as argument
         mpz_set_from_float(&mpz, 0);
         mp_printf(&mp_plat_print, "%f\n", mpz_as_float(&mpz));
+
+        // convert a large integer value (stored in a mpz) to mp_uint_t and to ll;
+        mp_obj_t obj_bigint = mp_obj_new_int_from_uint((mp_uint_t)0xdeadbeef);
+        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        obj_bigint = mp_obj_new_int_from_ll(0xc0ffee777c0ffeell);
+        long long value_ll = mp_obj_get_ll(obj_bigint);
+        mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
+
+        // convert a large integer value (stored via a struct object) to uint and to ll
+        // `deadbeef` global is an uctypes.struct defined by extra_coverage.py
+        obj_bigint = mp_load_global(MP_QSTR_deadbeef);
+        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        value_ll = mp_obj_get_ll(obj_bigint);
+        mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
+
+        // convert a smaller integer value to mp_uint_t and to ll
+        obj_bigint = mp_obj_new_int_from_uint(0xc0ffee);
+        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        value_ll = mp_obj_get_ll(obj_bigint);
+        mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
     }
 
     // runtime utils
@@ -525,6 +545,22 @@ static mp_obj_t extra_coverage(void) {
         // mp_obj_int_get_uint_checked with negative big-int (should raise exception)
         if (nlr_push(&nlr) == 0) {
             mp_obj_int_get_uint_checked(mp_obj_new_int_from_ll(-2));
+            nlr_pop();
+        } else {
+            mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
+        }
+
+        // mp_obj_get_uint from a non-int object (should raise exception)
+        if (nlr_push(&nlr) == 0) {
+            mp_obj_get_uint(mp_const_none);
+            nlr_pop();
+        } else {
+            mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
+        }
+
+        // mp_obj_int_get_ll from a non-int object (should raise exception)
+        if (nlr_push(&nlr) == 0) {
+            mp_obj_get_ll(mp_const_none);
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -34,6 +34,7 @@
 
 #include "py/mphal.h"
 #include "py/runtime.h"
+#include "shared/timeutils/timeutils.h"
 
 #ifdef _WIN32
 static inline int msec_sleep_tv(struct timeval *tv) {
@@ -130,12 +131,7 @@ static mp_obj_t mod_time_gm_local_time(size_t n_args, const mp_obj_t *args, stru
     if (n_args == 0) {
         t = time(NULL);
     } else {
-        #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
-        mp_float_t val = mp_obj_get_float(args[0]);
-        t = (time_t)MICROPY_FLOAT_C_FUN(trunc)(val);
-        #else
-        t = mp_obj_get_int(args[0]);
-        #endif
+        t = (time_t)timeutils_obj_get_timestamp(args[0]);
     }
     struct tm *tm = time_func(&t);
 
@@ -196,7 +192,7 @@ static mp_obj_t mod_time_mktime(mp_obj_t tuple) {
     if (ret == -1) {
         mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("invalid mktime usage"));
     }
-    return mp_obj_new_int(ret);
+    return timeutils_obj_from_timestamp(ret);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_time_mktime_obj, mod_time_mktime);
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -124,6 +124,9 @@ typedef long mp_off_t;
 // VFS stat functions should return time values relative to 1970/1/1
 #define MICROPY_EPOCH_IS_1970       (1)
 
+// port modtime functions use time_t
+#define MICROPY_TIMESTAMP_IMPL      (MICROPY_TIMESTAMP_IMPL_TIME_T)
+
 // Assume that select() call, interrupted with a signal, and erroring
 // with EINTR, updates remaining timeout value.
 #define MICROPY_SELECT_REMAINING_TIME (1)

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -46,6 +46,10 @@ LDFLAGS += -lm -lbcrypt $(LDFLAGS_EXTRA)
 # This option has no effect on 64-bit builds.
 CFLAGS += -D_FILE_OFFSET_BITS=64
 
+# Force the use of 64-bits for time_t in C library functions on 32-bit platforms.
+# This option has no effect on 64-bit builds.
+CFLAGS += -D_TIME_BITS=64
+
 # Debugging/Optimization
 ifdef DEBUG
 CFLAGS += -g

--- a/py/obj.c
+++ b/py/obj.c
@@ -314,6 +314,36 @@ mp_int_t mp_obj_get_int(mp_const_obj_t arg) {
     return val;
 }
 
+#if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
+mp_uint_t mp_obj_get_uint(mp_const_obj_t arg) {
+    if (!mp_obj_is_exact_type(arg, &mp_type_int)) {
+        mp_obj_t as_int = mp_unary_op(MP_UNARY_OP_INT_MAYBE, (mp_obj_t)arg);
+        if (as_int == MP_OBJ_NULL) {
+            mp_raise_TypeError_int_conversion(arg);
+        }
+        arg = as_int;
+    }
+    return mp_obj_int_get_uint_checked(arg);
+}
+
+long long mp_obj_get_ll(mp_const_obj_t arg) {
+    if (!mp_obj_is_exact_type(arg, &mp_type_int)) {
+        mp_obj_t as_int = mp_unary_op(MP_UNARY_OP_INT_MAYBE, (mp_obj_t)arg);
+        if (as_int == MP_OBJ_NULL) {
+            mp_raise_TypeError_int_conversion(arg);
+        }
+        arg = as_int;
+    }
+    if (mp_obj_is_small_int(arg)) {
+        return MP_OBJ_SMALL_INT_VALUE(arg);
+    } else {
+        long long res;
+        mp_obj_int_to_bytes_impl((mp_obj_t)arg, MP_ENDIANNESS_BIG, sizeof(res), (byte *)&res);
+        return res;
+    }
+}
+#endif
+
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg) {
     if (mp_obj_is_int(arg)) {
         return mp_obj_int_get_truncated(arg);

--- a/py/obj.h
+++ b/py/obj.h
@@ -1051,6 +1051,8 @@ static inline bool mp_obj_is_integer(mp_const_obj_t o) {
 }
 
 mp_int_t mp_obj_get_int(mp_const_obj_t arg);
+mp_uint_t mp_obj_get_uint(mp_const_obj_t arg);
+long long mp_obj_get_ll(mp_const_obj_t arg);
 mp_int_t mp_obj_get_int_truncated(mp_const_obj_t arg);
 bool mp_obj_get_int_maybe(mp_const_obj_t arg, mp_int_t *value);
 #if MICROPY_PY_BUILTINS_FLOAT

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -295,6 +295,22 @@ mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
     return mp_obj_int_get_truncated(self_in);
 }
 
+mp_uint_t mp_obj_int_get_uint_checked(mp_const_obj_t self_in) {
+    if (mp_obj_is_small_int(self_in)) {
+        if (MP_OBJ_SMALL_INT_VALUE(self_in) >= 0) {
+            return MP_OBJ_SMALL_INT_VALUE(self_in);
+        }
+    } else {
+        const mp_obj_int_t *self = self_in;
+        long long value = self->val;
+        mp_uint_t truncated = (mp_uint_t)value;
+        if (value >= 0 && (long long)truncated == value) {
+            return truncated;
+        }
+    }
+    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("overflow converting long int to machine word"));
+}
+
 #if MICROPY_PY_BUILTINS_FLOAT
 mp_float_t mp_obj_int_as_float_impl(mp_obj_t self_in) {
     assert(mp_obj_is_exact_type(self_in, &mp_type_int));

--- a/shared/timeutils/timeutils.h
+++ b/shared/timeutils/timeutils.h
@@ -27,9 +27,23 @@
 #ifndef MICROPY_INCLUDED_LIB_TIMEUTILS_TIMEUTILS_H
 #define MICROPY_INCLUDED_LIB_TIMEUTILS_TIMEUTILS_H
 
+#include "py/obj.h"
+#if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+#include <math.h> // required for trunc()
+#endif
+
+// `timeutils_timestamp_t` is the type used internally by timeutils to
+// represent timestamps, and is always referenced to 1970.
+// It may not match the platform-specific `mp_timestamp_t`.
+#if MICROPY_TIME_SUPPORT_Y2100_AND_BEYOND || MICROPY_TIME_SUPPORT_Y1969_AND_BEFORE
+typedef long long timeutils_timestamp_t;
+#else
+typedef mp_uint_t timeutils_timestamp_t;
+#endif
+
 // The number of seconds between 1970/1/1 and 2000/1/1 is calculated using:
 // time.mktime((2000,1,1,0,0,0,0,0,0)) - time.mktime((1970,1,1,0,0,0,0,0,0))
-#define TIMEUTILS_SECONDS_1970_TO_2000 (946684800ULL)
+#define TIMEUTILS_SECONDS_1970_TO_2000 (946684800LL)
 
 typedef struct _timeutils_struct_time_t {
     uint16_t tm_year;       // i.e. 2014
@@ -45,66 +59,116 @@ typedef struct _timeutils_struct_time_t {
 bool timeutils_is_leap_year(mp_uint_t year);
 mp_uint_t timeutils_days_in_month(mp_uint_t year, mp_uint_t month);
 mp_uint_t timeutils_year_day(mp_uint_t year, mp_uint_t month, mp_uint_t date);
+int timeutils_calc_weekday(int y, int m, int d);
 
-void timeutils_seconds_since_2000_to_struct_time(mp_uint_t t,
+void timeutils_seconds_since_1970_to_struct_time(timeutils_timestamp_t t,
     timeutils_struct_time_t *tm);
 
 // Year is absolute, month/date are 1-based, hour/minute/second are 0-based.
-mp_uint_t timeutils_seconds_since_2000(mp_uint_t year, mp_uint_t month,
+timeutils_timestamp_t timeutils_seconds_since_1970(mp_uint_t year, mp_uint_t month,
     mp_uint_t date, mp_uint_t hour, mp_uint_t minute, mp_uint_t second);
 
 // Year is absolute, month/mday are 1-based, hours/minutes/seconds are 0-based.
-mp_uint_t timeutils_mktime_2000(mp_uint_t year, mp_int_t month, mp_int_t mday,
+timeutils_timestamp_t timeutils_mktime_1970(mp_uint_t year, mp_int_t month, mp_int_t mday,
     mp_int_t hours, mp_int_t minutes, mp_int_t seconds);
+
+static inline mp_timestamp_t timeutils_obj_get_timestamp(mp_obj_t o_in) {
+    #if MICROPY_PY_BUILTINS_FLOAT && MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE
+    mp_float_t val = mp_obj_get_float(o_in);
+    return (mp_timestamp_t)MICROPY_FLOAT_C_FUN(trunc)(val);
+    #elif MICROPY_TIMESTAMP_IMPL == MICROPY_TIMESTAMP_IMPL_UINT
+    return mp_obj_get_uint(o_in);
+    #else
+    return mp_obj_get_ll(o_in);
+    #endif
+}
+
+static inline mp_obj_t timeutils_obj_from_timestamp(mp_timestamp_t t) {
+    #if MICROPY_TIMESTAMP_IMPL == MICROPY_TIMESTAMP_IMPL_UINT
+    return mp_obj_new_int_from_uint(t);
+    #else
+    return mp_obj_new_int_from_ll(t);
+    #endif
+}
+
+static inline void timeutils_seconds_since_2000_to_struct_time(mp_timestamp_t t, timeutils_struct_time_t *tm) {
+    timeutils_seconds_since_1970_to_struct_time((timeutils_timestamp_t)(t + TIMEUTILS_SECONDS_1970_TO_2000), tm);
+}
+
+// Year is absolute, month/date are 1-based, hour/minute/second are 0-based.
+static inline mp_timestamp_t timeutils_seconds_since_2000(mp_uint_t year, mp_uint_t month, mp_uint_t date,
+    mp_uint_t hour, mp_uint_t minute, mp_uint_t second) {
+    return (mp_timestamp_t)timeutils_seconds_since_1970(year, month, date, hour, minute, second) - TIMEUTILS_SECONDS_1970_TO_2000;
+}
+
+// Year is absolute, month/mday are 1-based, hours/minutes/seconds are 0-based.
+static inline mp_timestamp_t timeutils_mktime_2000(mp_uint_t year, mp_int_t month, mp_int_t mday,
+    mp_int_t hours, mp_int_t minutes, mp_int_t seconds) {
+    return (mp_timestamp_t)timeutils_mktime_1970(year, month, mday, hours, minutes, seconds) - TIMEUTILS_SECONDS_1970_TO_2000;
+}
+
 
 // Select the Epoch used by the port.
 #if MICROPY_EPOCH_IS_1970
 
-static inline void timeutils_seconds_since_epoch_to_struct_time(uint64_t t, timeutils_struct_time_t *tm) {
-    // TODO this will give incorrect results for dates before 2000/1/1
-    timeutils_seconds_since_2000_to_struct_time((mp_uint_t)(t - TIMEUTILS_SECONDS_1970_TO_2000), tm);
-}
-
-// Year is absolute, month/mday are 1-based, hours/minutes/seconds are 0-based.
-static inline uint64_t timeutils_mktime(mp_uint_t year, mp_int_t month, mp_int_t mday, mp_int_t hours, mp_int_t minutes, mp_int_t seconds) {
-    return timeutils_mktime_2000(year, month, mday, hours, minutes, seconds) + TIMEUTILS_SECONDS_1970_TO_2000;
+static inline void timeutils_seconds_since_epoch_to_struct_time(mp_timestamp_t t, timeutils_struct_time_t *tm) {
+    timeutils_seconds_since_1970_to_struct_time(t, tm);
 }
 
 // Year is absolute, month/date are 1-based, hour/minute/second are 0-based.
-static inline uint64_t timeutils_seconds_since_epoch(mp_uint_t year, mp_uint_t month,
-    mp_uint_t date, mp_uint_t hour, mp_uint_t minute, mp_uint_t second) {
-    // TODO this will give incorrect results for dates before 2000/1/1
-    return timeutils_seconds_since_2000(year, month, date, hour, minute, second) + TIMEUTILS_SECONDS_1970_TO_2000;
+static inline mp_timestamp_t timeutils_seconds_since_epoch(mp_uint_t year, mp_uint_t month, mp_uint_t date,
+    mp_uint_t hour, mp_uint_t minute, mp_uint_t second) {
+    return timeutils_seconds_since_1970(year, month, date, hour, minute, second);
 }
 
-static inline mp_uint_t timeutils_seconds_since_epoch_from_nanoseconds_since_1970(uint64_t ns) {
-    return (mp_uint_t)(ns / 1000000000ULL);
+// Year is absolute, month/mday are 1-based, hours/minutes/seconds are 0-based.
+static inline mp_timestamp_t timeutils_mktime(mp_uint_t year, mp_int_t month, mp_int_t mday,
+    mp_int_t hours, mp_int_t minutes, mp_int_t seconds) {
+    return timeutils_mktime_1970(year, month, mday, hours, minutes, seconds);
 }
 
-static inline uint64_t timeutils_nanoseconds_since_epoch_to_nanoseconds_since_1970(uint64_t ns) {
+static inline mp_timestamp_t timeutils_seconds_since_epoch_from_nanoseconds_since_1970(int64_t ns) {
+    return (mp_timestamp_t)(ns / 1000000000LL);
+}
+
+static inline int64_t timeutils_seconds_since_epoch_to_nanoseconds_since_1970(mp_timestamp_t s) {
+    return (int64_t)s * 1000000000LL;
+}
+
+static inline int64_t timeutils_nanoseconds_since_epoch_to_nanoseconds_since_1970(int64_t ns) {
     return ns;
 }
 
 #else // Epoch is 2000
 
-#define timeutils_seconds_since_epoch_to_struct_time timeutils_seconds_since_2000_to_struct_time
-#define timeutils_seconds_since_epoch timeutils_seconds_since_2000
-#define timeutils_mktime timeutils_mktime_2000
-
-static inline uint64_t timeutils_seconds_since_epoch_to_nanoseconds_since_1970(mp_uint_t s) {
-    return ((uint64_t)s + TIMEUTILS_SECONDS_1970_TO_2000) * 1000000000ULL;
+static inline void timeutils_seconds_since_epoch_to_struct_time(mp_timestamp_t t, timeutils_struct_time_t *tm) {
+    timeutils_seconds_since_2000_to_struct_time(t, tm);
 }
 
-static inline mp_uint_t timeutils_seconds_since_epoch_from_nanoseconds_since_1970(uint64_t ns) {
-    return ns / 1000000000ULL - TIMEUTILS_SECONDS_1970_TO_2000;
+// Year is absolute, month/date are 1-based, hour/minute/second are 0-based.
+static inline mp_timestamp_t timeutils_seconds_since_epoch(mp_uint_t year, mp_uint_t month, mp_uint_t date,
+    mp_uint_t hour, mp_uint_t minute, mp_uint_t second) {
+    return timeutils_seconds_since_2000(year, month, date, hour, minute, second);
+}
+
+// Year is absolute, month/mday are 1-based, hours/minutes/seconds are 0-based.
+static inline mp_timestamp_t timeutils_mktime(mp_uint_t year, mp_int_t month, mp_int_t mday,
+    mp_int_t hours, mp_int_t minutes, mp_int_t seconds) {
+    return timeutils_mktime_2000(year, month, mday, hours, minutes, seconds);
+}
+
+static inline mp_timestamp_t timeutils_seconds_since_epoch_from_nanoseconds_since_1970(int64_t ns) {
+    return (mp_timestamp_t)(ns / 1000000000LL - TIMEUTILS_SECONDS_1970_TO_2000);
+}
+
+static inline int64_t timeutils_seconds_since_epoch_to_nanoseconds_since_1970(mp_timestamp_t s) {
+    return ((int64_t)s + TIMEUTILS_SECONDS_1970_TO_2000) * 1000000000LL;
 }
 
 static inline int64_t timeutils_nanoseconds_since_epoch_to_nanoseconds_since_1970(int64_t ns) {
-    return ns + TIMEUTILS_SECONDS_1970_TO_2000 * 1000000000ULL;
+    return ns + TIMEUTILS_SECONDS_1970_TO_2000 * 1000000000LL;
 }
 
 #endif
-
-int timeutils_calc_weekday(int y, int m, int d);
 
 #endif // MICROPY_INCLUDED_LIB_TIMEUTILS_TIMEUTILS_H

--- a/tests/extmod/time_mktime.py
+++ b/tests/extmod/time_mktime.py
@@ -1,0 +1,120 @@
+# test conversion from date tuple to timestamp and back
+
+try:
+    import time
+
+    time.localtime
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# Range of date expected to work on all MicroPython platforms
+MIN_YEAR = 1970
+MAX_YEAR = 2099
+# CPython properly supported date range:
+# - on Windows: year 1970 to 3000+
+# - on Unix:    year 1583 to 3000+
+
+# Start test from Jan 1, 2001 13:00 (Feb 2000 might already be broken)
+SAFE_DATE = (2001, 1, 1, 13, 0, 0, 0, 0, -1)
+
+
+# mktime function that checks that the result is reversible
+def safe_mktime(date_tuple):
+    try:
+        res = time.mktime(date_tuple)
+        chk = time.localtime(res)
+    except OverflowError:
+        print("safe_mktime:", date_tuple, "overflow error")
+        return None
+    if chk[0:5] != date_tuple[0:5]:
+        print("safe_mktime:", date_tuple[0:5], " -> ", res, " -> ", chk[0:5])
+        return None
+    return res
+
+
+# localtime function that checks that the result is reversible
+def safe_localtime(timestamp):
+    try:
+        res = time.localtime(timestamp)
+        chk = time.mktime(res)
+    except OverflowError:
+        print("safe_localtime:", timestamp, "overflow error")
+        return None
+    if chk != timestamp:
+        print("safe_localtime:", timestamp, " -> ", res, " -> ", chk)
+        return None
+    return res
+
+
+# look for smallest valid timestamps by iterating backwards on tuple
+def test_bwd(date_tuple):
+    curr_stamp = safe_mktime(date_tuple)
+    year = date_tuple[0]
+    month = date_tuple[1] - 1
+    if month < 1:
+        year -= 1
+        month = 12
+    while year >= MIN_YEAR:
+        while month >= 1:
+            next_tuple = (year, month) + date_tuple[2:]
+            next_stamp = safe_mktime(next_tuple)
+            # at this stage, only test consistency and monotonicity
+            if next_stamp is None or next_stamp >= curr_stamp:
+                return date_tuple
+            date_tuple = next_tuple
+            curr_stamp = next_stamp
+            month -= 1
+        year -= 1
+        month = 12
+    return date_tuple
+
+
+# test day-by-day to ensure that every date is properly converted
+def test_fwd(start_date):
+    DAYS_PER_MONTH = (0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+    curr_stamp = safe_mktime(start_date)
+    curr_date = safe_localtime(curr_stamp)
+    while curr_date[0] <= MAX_YEAR:
+        if curr_date[2] < 15:
+            skip_days = 13
+        else:
+            skip_days = 1
+        next_stamp = curr_stamp + skip_days * 86400
+        next_date = safe_localtime(next_stamp)
+        if next_date is None:
+            return curr_date
+        if next_date[2] != curr_date[2] + skip_days:
+            # next month
+            if next_date[2] != 1:
+                print("wrong day of month:", next_date)
+                return curr_date
+            # check the number of days in previous month
+            month_days = DAYS_PER_MONTH[curr_date[1]]
+            if month_days == 28 and curr_date[0] % 4 == 0:
+                if curr_date[0] % 100 != 0 or curr_date[0] % 400 == 0:
+                    month_days += 1
+            if curr_date[2] != month_days:
+                print("wrong day count in prev month:", curr_date[2], "vs", month_days)
+                return curr_date
+            if next_date[1] != curr_date[1] + 1:
+                # next year
+                if curr_date[1] != 12:
+                    print("wrong month count in prev year:", curr_date[1])
+                    return curr_date
+                if next_date[1] != 1:
+                    print("wrong month:", next_date)
+                    return curr_date
+                if next_date[0] != curr_date[0] + 1:
+                    print("wrong year:", next_date)
+                    return curr_date
+        curr_stamp = next_stamp
+        curr_date = next_date
+    return curr_date
+
+
+small_date = test_bwd(SAFE_DATE)
+large_date = test_fwd(small_date)
+print("tested from", small_date[0:3], "to", large_date[0:3])
+print(small_date[0:3], "wday is", small_date[6])
+print(large_date[0:3], "wday is", large_date[6])

--- a/tests/ports/unix/extra_coverage.py
+++ b/tests/ports/unix/extra_coverage.py
@@ -6,6 +6,16 @@ except NameError:
 
 import errno
 import io
+import uctypes
+
+# create an int-like variable used for coverage of `mp_obj_get_ll`
+buf = bytearray(b"\xde\xad\xbe\xef")
+struct = uctypes.struct(
+    uctypes.addressof(buf),
+    {"f32": uctypes.UINT32 | 0},
+    uctypes.BIG_ENDIAN,
+)
+deadbeef = struct.f32
 
 data = extra_coverage()
 

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -94,6 +94,12 @@ data
 1
 0
 0.000000
+deadbeef
+c0ffee777c0ffee
+deadbeef
+0deadbeef
+c0ffee
+000c0ffee
 # runtime utils
 TypeError: unsupported type for __abs__: 'str'
 TypeError: unsupported types for __divmod__: 'str', 'str'
@@ -102,6 +108,8 @@ TypeError: unsupported types for __divmod__: 'str', 'str'
 2
 OverflowError: overflow converting long int to machine word
 OverflowError: overflow converting long int to machine word
+TypeError: can't convert NoneType to int
+TypeError: can't convert NoneType to int
 ValueError: 
 Warning: test
 # format float


### PR DESCRIPTION
This is pull request is to ensure that time functions (`mktime`, `localtime` and `gmtime`) work properly on a reasonable date range, on all platforms, regardless of the epoch. 

It does fix issue #17340

### Summary

The most important point is to have a test case that checks conversion from timestamp to tuple and back for every day in the _supported time range_. This was currently missing. The new test code starts from 2001, first iterates *backward* on tuple to find the earliest supported date and then goes *forward* by adding 86400 to the timestamp, to verify that the date computations are correct, including leap years, and do not raise an overflow.

The second part of the pull request is to ensure that this test does actually pass on all platforms. 

The most severely affected platforms were 32 bit platforms using a 1970 epoch, as

1. there was an assumption that timestamps can be stored in a `mp_int_t`
2. conversion from the 1970 epoch to the 2000 epoch used internally by timeutils breaks computations for dates before 2000

On some of these platforms, the resulting supported date range was only 2001 to 2037. As 2038 is now only 13 years away, this clearly has to be fixed quickly.

Small code footprint beeing a key value for MicroPython, the suggested minimal _supported time range_ for all platforms is 1970 to 2099. This range can be covered using 32 bit timestamps on ressource-limited platforms, fixes the 1970 epoch problems and requires less code for handling of leap years.

Support for years 2100 and beyond is only enabled for platforms using 64 bit pointers, which are typically less ressource-constrained.


### Testing

The PR includes new test cases that verify the supported time range using architecture-independent Python code.


### Trade-offs and Alternatives

The new `timeutils` code has a smaller footprint than the original for 32 bit machines, as it does not have to handle signed inputs and does not have to handle century-based leap years. 

We could have opted to use signed timestamps centered on 2000, as was probably the original intent of the timeutils code. We felt however that it was more useful to fully support the 21st century rather going supporting dates back to 1940's but breaking in 2068. Handling timestamps as unsigned also simplifies the code by removing some checks for negative values.

We could have opted to upgrade all platforms to use 64-bit signed integers for time functions, which would have offered the broadest possible range for abstract date operations, spanning from the year 1600 to the year 3000 and beyond. However, this would have had a code size impact on 32-bit platforms, with little added value. We guessed that, if a specific application on a 32-bit platform required handling _exotic_ dates, a Python-based implementation would remain a good option.