### PR TITLE
unix/modsocket: Add "sendall" method to socket class.

### DIFF
--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -333,6 +333,12 @@ static mp_obj_t socket_send(size_t n_args, const mp_obj_t *args) {
     mp_obj_socket_t *self = MP_OBJ_TO_PTR(args[0]);
     int flags = 0;
 
+    bool is_sendall = false;
+    if (n_args < 2) {
+        is_sendall = true;
+        n_args += 2;
+    }
+
     if (n_args > 2) {
         flags = mp_obj_get_int(args[2]);
     }
@@ -342,9 +348,18 @@ static mp_obj_t socket_send(size_t n_args, const mp_obj_t *args) {
     ssize_t out_sz;
     MP_HAL_RETRY_SYSCALL(out_sz, send(self->fd, bufinfo.buf, bufinfo.len, flags),
         mp_raise_OSError(err));
+    if (is_sendall && ((size_t)out_sz != bufinfo.len)) {
+        mp_raise_OSError(MP_EINTR);
+    }
     return MP_OBJ_NEW_SMALL_INT(out_sz);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_send_obj, 2, 3, socket_send);
+
+static mp_obj_t socket_sendall(size_t n_args, const mp_obj_t *args) {
+    socket_send(n_args - 2, args);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(socket_sendall_obj, 2, 3, socket_sendall);
 
 static mp_obj_t socket_sendto(size_t n_args, const mp_obj_t *args) {
     mp_obj_socket_t *self = MP_OBJ_TO_PTR(args[0]);
@@ -511,6 +526,7 @@ static const mp_rom_map_elem_t socket_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_recv), MP_ROM_PTR(&socket_recv_obj) },
     { MP_ROM_QSTR(MP_QSTR_recvfrom), MP_ROM_PTR(&socket_recvfrom_obj) },
     { MP_ROM_QSTR(MP_QSTR_send), MP_ROM_PTR(&socket_send_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sendall), MP_ROM_PTR(&socket_sendall_obj) },
     { MP_ROM_QSTR(MP_QSTR_sendto), MP_ROM_PTR(&socket_sendto_obj) },
     { MP_ROM_QSTR(MP_QSTR_setsockopt), MP_ROM_PTR(&socket_setsockopt_obj) },
     { MP_ROM_QSTR(MP_QSTR_setblocking), MP_ROM_PTR(&socket_setblocking_obj) },

--- a/tests/multi_net/tcp_sendall.py
+++ b/tests/multi_net/tcp_sendall.py
@@ -1,0 +1,71 @@
+# Simple test of a TCP server and client transferring data using sendall.
+
+import socket
+
+if not hasattr(socket.socket, "sendall"):
+    print("SKIP")
+    raise SystemExit
+
+PORT = 8000
+
+# This is the smallest send buffer size supported by Linux, see socket(7).
+SEND_SIZE = 1024
+BUFFERS = 8
+
+
+# G. D. Nguyen, "Fast CRCs", vol. 18, no. 10, pp. 1321-1331, Oct. 2009
+# https://dl.acm.org/doi/abs/10.1109/TC.2009.83
+def calculate_checksum(buffer):
+    checksum = 0
+    for byte in buffer:
+        checksum = (checksum ^ byte) & 0xFFFF
+        for step in range(16):
+            if (checksum & 0x8000) != 0:
+                checksum = ((checksum << 1) ^ 0x8005) & 0xFFFF
+            else:
+                checksum = (checksum << 1) & 0xFFFF
+    return checksum
+
+
+# Server
+def instance0():
+    multitest.globals(IP=multitest.get_network_ip())
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
+    s.listen()
+    multitest.next()
+    s2, _ = s.accept()
+    buffer = b""
+    while len(buffer) < SEND_SIZE * BUFFERS:
+        buffer += s2.recv(SEND_SIZE * BUFFERS)
+    s2.send(b"%08x" % len(buffer))
+    s2.send(b"%04x" % calculate_checksum(buffer))
+    s2.close()
+    s.close()
+    print("received {} bytes".format(len(buffer)))
+
+
+# Client
+def instance1():
+    multitest.next()
+    s = socket.socket()
+    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+    # Try our best to trigger a partial send in socket.sendall
+    if hasattr(socket, "SO_SNDBUF"):
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, SEND_SIZE)
+    buffer = bytearray(SEND_SIZE * BUFFERS)
+    for index in range(len(buffer)):
+        buffer[index] = index & 0xFF
+    expected_checksum = calculate_checksum(buffer)
+    s.sendall(buffer)
+    print("sent {} bytes".format(len(buffer)))
+    length = int(s.recv(8), 16)
+    if length != len(buffer):
+        raise Exception("sendall len fail (expected %d, got %d)" % (len(buffer), length))
+    checksum = int(s.recv(4), 16)
+    if checksum != expected_checksum:
+        raise Exception(
+            "sendall checksum fail (expected %04x, got %04x)" % (expected_checksum, checksum)
+        )
+    s.close()


### PR DESCRIPTION
### Summary

This PR adds an implementation for "socket.sendall" to the Unix port.

Right now the implementation is a wrapper over a single "socket.send" call, since it wasn't possible to let "socket.send" perform a partial transfer.  With no partial transfers it is not possible to have a testable implementation following the expected behaviour, so a single send operation is done and OSErr(EINTR) is raised if a partial transfer occurs.

The discussion for the issue linked to this PR contains more information about the efforts made to let partial transfers happen.

This fixes #16803.

### Testing

A new test is introduced to exercise `socket.sendall`, called `tests/multi_net/tcp_sendall.py`.  This could have been folded into `tests/multi_net/tcp_data.py`, but the Zephyr port doesn't have a `socket.sendall` implementation.

### Trade-offs and Alternatives

There's a modest size increase.  The footprint increase could have been smaller if `socket.sendall` was aliased to `socket.send` like the CC3200 port does, but then the behaviour would be slightly incompatible with CPython (`socket.sendall` is supposed to return `None`, not the sent bytes count).