### PR TITLE
tools/mpy_ld.py: support absolute relocations in text section on Thumb targets

### DIFF
--- a/examples/natmod/random/Makefile
+++ b/examples/natmod/random/Makefile
@@ -14,4 +14,9 @@ ifeq ($(ARCH),xtensa)
 MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
 endif
 
+ifeq ($(ARCH),$(filter $(ARCH),armv6m armv7m))
+# Link with libm.a for soft-float helper functions
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -63,14 +63,14 @@ else ifeq ($(ARCH),armv6m)
 # thumb
 CROSS = arm-none-eabi-
 CFLAGS_ARCH += -mthumb -mcpu=cortex-m0
-MICROPY_FLOAT_IMPL ?= none
+MICROPY_FLOAT_IMPL ?= float
 
 else ifeq ($(ARCH),armv7m)
 
 # thumb
 CROSS = arm-none-eabi-
 CFLAGS_ARCH += -mthumb -mcpu=cortex-m3
-MICROPY_FLOAT_IMPL ?= none
+MICROPY_FLOAT_IMPL ?= float
 
 else ifeq ($(ARCH),armv7emsp)
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -561,13 +561,11 @@ function ci_native_mpy_modules_build {
         make -C examples/natmod/$natmod ARCH=$arch
     done
 
-    # features2 requires soft-float on armv7m, rv32imc, and xtensa.  On armv6m
-    # the compiler generates absolute relocations in the object file
-    # referencing soft-float functions, which is not supported at the moment.
+    # features2 requires soft-float on rv32imc and xtensa.
     make -C examples/natmod/features2 ARCH=$arch clean
-    if [ $arch = "rv32imc" ] || [ $arch = "armv7m" ] || [ $arch = "xtensa" ]; then
+    if [ $arch = "rv32imc" ] || [ $arch = "xtensa" ]; then
         make -C examples/natmod/features2 ARCH=$arch MICROPY_FLOAT_IMPL=float
-    elif [ $arch != "armv6m" ]; then
+    else
         make -C examples/natmod/features2 ARCH=$arch
     fi
 

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -711,8 +711,9 @@ def do_relocation_text(env, text_addr, r):
         (addr, value) = process_riscv32_relocation(env, text_addr, r)
 
     elif env.arch.name == "EM_ARM" and r_info_type == R_ARM_ABS32:
-        # happens for soft-float on armv6m
-        raise ValueError("Absolute relocations not supported on ARM")
+        # Absolute relocation, handled as a data relocation.
+        do_relocation_data(env, text_addr, r)
+        return
 
     else:
         # Unknown/unsupported relocation
@@ -781,9 +782,9 @@ def do_relocation_data(env, text_addr, r):
     ):
         # Relocation in data.rel.ro to internal/external symbol
         if env.arch.word_size == 4:
-            struct_type = "<I"
+            struct_type = "<i"
         elif env.arch.word_size == 8:
-            struct_type = "<Q"
+            struct_type = "<q"
         if hasattr(s, "resolved"):
             s = s.resolved
         sec = s.section


### PR DESCRIPTION
### Summary

Add support for `R_ARM_ABS32` relocations in native .mpy files.

Also, enable float by default on `armv6m` and `armv7m` native mpy targets, since soft-float now works correctly.

Should fix issue #14430.

### Testing

Tested with `ARCH=armv6m` on RPI_PICO_W, and `ARCH=armv7emdp` on PYBD_SF6.  The update `features2` -- calling `sin()` and `cos()` -- works on both these targets.

### Trade-offs and Alternatives

This is a relatively minimal change, but nonetheless `tools/mpy_ld.py` is getting quite unwieldy now and pretty hard to follow what relocations are/aren't allowed.  Maybe in the future it can be cleaned up, but we'd need more tests before doing that to ensure something doesn't break.
