### PR TITLE
tests/extmod/random_extra_float.py: Skip when funcs not available.

### DIFF
--- a/tests/extmod/random_extra_float.py
+++ b/tests/extmod/random_extra_float.py
@@ -1,12 +1,8 @@
 try:
     import random
-except ImportError:
-    print("SKIP")
-    raise SystemExit
 
-try:
-    random.randint
-except AttributeError:
+    random.random
+except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
 


### PR DESCRIPTION
### Summary

This test was factored out from `random_extra.py` back in commit 6572029dc0665e58c2ea7355c9e541bdf83105a4, and the skip logic copied from that file.  But the skip logic needs to test that the `random` and `uniform` functions exist, not `randint`.

This commit fixes that skip logic.

### Testing

Tested on RPI_PICO2_W in RISCV mode, the test now correctly skips.