### PR TITLE
tools/ci.sh: Enable a few more natmod tests on rv32imc and xtensa.

### DIFF
--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -32,6 +32,11 @@ SRC += $(addprefix $(realpath $(BTREE_DIR))/,\
 	mpool/mpool.c \
 	)
 
+ifeq ($(ARCH),xtensa)
+# Link with libm.a and libgcc.a from the toolchain
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk
 
 # btree needs gnu99 defined

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -10,4 +10,9 @@ SRC = deflate.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
+ifeq ($(ARCH),xtensa)
+# Link with libm.a and libgcc.a from the toolchain
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/framebuf/Makefile
+++ b/examples/natmod/framebuf/Makefile
@@ -10,4 +10,9 @@ SRC = framebuf.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
 ARCH = x64
 
+ifeq ($(ARCH),xtensa)
+# Link with libm.a and libgcc.a from the toolchain
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/random/Makefile
+++ b/examples/natmod/random/Makefile
@@ -10,4 +10,9 @@ SRC = random.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
+ifeq ($(ARCH),xtensa)
+# Link with libm.a and libgcc.a from the toolchain
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -524,22 +524,11 @@ function ci_native_mpy_modules_build {
     else
         arch=$1
     fi
-    for natmod in features1 features3 features4 heapq re
+    for natmod in deflate features1 features3 features4 framebuf heapq random re
     do
         make -C examples/natmod/$natmod clean
         make -C examples/natmod/$natmod ARCH=$arch
     done
-
-    # deflate, framebuf, and random currently cannot build on xtensa due to
-    # some symbols that have been removed from the compiler's runtime, in
-    # favour of being provided from ROM.
-    if [ $arch != "xtensa" ]; then
-        for natmod in deflate framebuf random
-        do
-            make -C examples/natmod/$natmod clean
-            make -C examples/natmod/$natmod ARCH=$arch
-        done
-    fi
 
     # features2 requires soft-float on armv7m, rv32imc, and xtensa.  On armv6m
     # the compiler generates absolute relocations in the object file
@@ -551,10 +540,8 @@ function ci_native_mpy_modules_build {
         make -C examples/natmod/features2 ARCH=$arch
     fi
 
-    # btree requires thread local storage support on rv32imc, whilst on xtensa
-    # it relies on symbols that are provided from ROM but not exposed to
-    # natmods at the moment.
-    if [ $arch != "rv32imc" ] && [ $arch != "xtensa" ]; then
+    # btree requires thread local storage support on rv32imc.
+    if [ $arch != "rv32imc" ]; then
         make -C examples/natmod/btree clean
         make -C examples/natmod/btree ARCH=$arch
     fi


### PR DESCRIPTION
### Summary

The `btree` natmod example can now build for rv32imc, and `random` can build for xtensa if it's linked with the standard C library.

### Testing

Tested by CI.