### PR TITLE
ports/esp32: esp32.wake_on_ulp should only be available on boards

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -23,6 +23,8 @@ Functions
     Configure whether or not the Ultra-Low-Power co-processor can wake the
     device from sleep. *wake* should be a boolean value.
 
+    .. note:: This is only available for boards that have ULP coprocessor support.
+
 .. function:: wake_on_ext0(pin, level)
 
     Configure how EXT0 wakes the device from sleep.  *pin* can be ``None``

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -34,7 +34,9 @@ typedef struct {
     uint64_t ext1_pins; // set bit == pin#
     int8_t ext0_pin;   // just the pin#, -1 == None
     bool wake_on_touch : 1;
+    #if SOC_ULP_SUPPORTED
     bool wake_on_ulp : 1;
+    #endif
     bool ext0_level : 1;
     wake_type_t ext0_wake_types;
     bool ext1_level : 1;

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -126,6 +126,7 @@ static mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(esp32_wake_on_ext1_obj, 0, esp32_wake_on_ext1);
 
+#if SOC_ULP_SUPPORTED
 static mp_obj_t esp32_wake_on_ulp(const mp_obj_t wake) {
     if (machine_rtc_config.ext0_pin != -1) {
         mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
@@ -134,6 +135,7 @@ static mp_obj_t esp32_wake_on_ulp(const mp_obj_t wake) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(esp32_wake_on_ulp_obj, esp32_wake_on_ulp);
+#endif
 
 #if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
 static mp_obj_t esp32_gpio_deep_sleep_hold(const mp_obj_t enable) {
@@ -260,7 +262,9 @@ static const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
+    #if SOC_ULP_SUPPORTED
     { MP_ROM_QSTR(MP_QSTR_wake_on_ulp), MP_ROM_PTR(&esp32_wake_on_ulp_obj) },
+    #endif
     #if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
     { MP_ROM_QSTR(MP_QSTR_gpio_deep_sleep_hold), MP_ROM_PTR(&esp32_gpio_deep_sleep_hold_obj) },
     #endif


### PR DESCRIPTION
ports/esp32: esp32.wake_on_ulp should only be available on boards
          that have SOC_ULP_SUPPORTED=y
docs/library/esp32.rst: update docs to reflect that wake_on_ulp
          is only available for boards that support ulp coprocessor

### Summary

Having code wrapped by definitions of whether or not the capability is supported on the
board instead of what board it is, is better practice.
I introduced this so that when using the method wake_on_ulp on boards that don't
support it, it will be clear that it is not supported, instead of silently failing.

### Testing

I tested this on the ESP32C3


