### PR TITLE
Create board folder for pybstick26-esp32c3 board.

### DIFF
--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/board.json
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/board.json
@@ -1,0 +1,23 @@
+{
+    "deploy": [
+        "../deploy_nativeusb.md"
+    ],
+    "deploy_options": {
+        "flash_offset": "0"
+    },
+    "docs": "",
+    "features": [
+        "BLE",
+        "External Flash",
+	"RGB LED",
+        "WiFi"
+    ],
+    "images": [
+        "https://github.com/mchobby/pyboard-driver/blob/master/PYBStick-ESP32-C3/docs/_static/GAR-PYBSTICK26-C3-mUSB-00.JPG"
+    ],
+    "mcu": "esp32c3",
+    "product": "PYBSTICK26_ESP32C3",
+    "thumbnail": "",
+    "url": "https://shop.mchobby.be/fr/pybstick/2505-pybstick26-esp32-c3-micropython-et-arduino-3232100025059.html",
+    "vendor": "Garatronic"
+}

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/manifest.py
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/manifest.py
@@ -1,0 +1,2 @@
+include("$(PORT_DIR)/boards/manifest.py")
+freeze("./modules")

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/modules/pybstick26_esp32c3.py
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/modules/pybstick26_esp32c3.py
@@ -1,0 +1,29 @@
+# PYBSTICK26-ESP32C3 MicroPython Helper Library
+# V1.0 by fpie for GARATRONIC (2025)
+#
+
+from micropython import const
+from machine import Pin
+
+# Pin Assignments
+
+# SPI
+SPI_MOSI = const(7)
+SPI_MISO = const(2)
+SPI_CLK = const(6)
+
+# I2C
+I2C_SDA = const(0)
+I2C_SCL = const(1)
+
+# LED
+LED = const(8)
+
+# BUTTONS
+BUTTON_A = const(9)
+BUTTON_B = const(5)
+
+# Built-in peripherals
+
+led = Pin(LED, Pin.OUT, value=0)
+button = Pin(BUTTON_B, Pin.IN, Pin.PULL_UP)

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.cmake
@@ -1,0 +1,9 @@
+set(IDF_TARGET esp32c3)
+
+set(SDKCONFIG_DEFAULTS
+    boards/sdkconfig.base
+    boards/sdkconfig.ble
+    boards/GARATRONIC_PYBSTICK26_ESP32C3/sdkconfig.board
+)
+
+set(MICROPY_FROZEN_MANIFEST ${MICROPY_BOARD_DIR}/manifest.py)

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.h
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.h
@@ -1,0 +1,10 @@
+#define MICROPY_HW_BOARD_NAME               "PYBSTICK26_ESP32C3"
+#define MICROPY_HW_MCU_NAME                 "ESP32C3"
+#define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "pybstick26_esp32c3"
+
+#define MICROPY_HW_I2C0_SCL                 (1)
+#define MICROPY_HW_I2C0_SDA                 (0)
+
+#define MICROPY_HW_SPI1_MOSI                (7)
+#define MICROPY_HW_SPI1_MISO                (2)
+#define MICROPY_HW_SPI1_SCK                 (6)

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/sdkconfig.board
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/sdkconfig.board
@@ -1,0 +1,4 @@
+CONFIG_ESP32C3_REV_MIN_3=y
+
+# Workaround for https://github.com/espressif/esp-idf/issues/14456
+CONFIG_ESP_SYSTEM_HW_STACK_GUARD=n


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
esp32c3 based board at pybstick26 form factor from Garatronic.
based on lolin c3 board, with extra feature : rgb leds, two dual role buttons.


### Testing

Test, compilated with esp-idf 4.5.1

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

