### PR TITLE
rp2/rp2_flash: Add MICROPY_HW_FLASH_MAX_FREQ.

### DIFF
--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -49,6 +49,14 @@
 static_assert(MICROPY_HW_ROMFS_BYTES % 4096 == 0, "ROMFS size must be a multiple of 4K");
 static_assert(MICROPY_HW_FLASH_STORAGE_BYTES % 4096 == 0, "Flash storage size must be a multiple of 4K");
 
+#ifndef MICROPY_HW_FLASH_MAX_FREQ
+// Emulate Pico SDK's SYS_CLK_HZ / PICO_FLASH_SPI_CLKDIV behaviour by default
+// On RP2040 if PICO_USE_FASTEST_SUPPORTED_CLOCK is set then SYS_CLK_HZ can be
+// 200MHz, potentially putting timings derived from PICO_FLASH_SPI_CLKDIV
+// out of range.
+#define MICROPY_HW_FLASH_MAX_FREQ (SYS_CLK_HZ / PICO_FLASH_SPI_CLKDIV)
+#endif
+
 #ifndef MICROPY_HW_FLASH_STORAGE_BASE
 #define MICROPY_HW_FLASH_STORAGE_BASE (PICO_FLASH_SIZE_BYTES - MICROPY_HW_FLASH_STORAGE_BYTES)
 #endif
@@ -104,9 +112,8 @@ static bool use_multicore_lockout(void) {
 // and core1 locked out if relevant.
 static void __no_inline_not_in_flash_func(rp2_flash_set_timing_internal)(int clock_hz) {
 
-    // Use the minimum divisor assuming a 133MHz flash.
-    const int max_flash_freq = 133000000;
-    int divisor = (clock_hz + max_flash_freq - 1) / max_flash_freq;
+    // Use the minimum divisor based upon our target MICROPY_HW_FLASH_MAX_FREQ
+    int divisor = (clock_hz + MICROPY_HW_FLASH_MAX_FREQ - 1) / MICROPY_HW_FLASH_MAX_FREQ;
 
     #if PICO_RP2350
     // Make sure flash is deselected - QMI doesn't appear to have a busy flag(!)


### PR DESCRIPTION
### Summary

⚠️  This is a critical fix for a regression introduced in https://github.com/micropython/micropython/commit/91cff8e4f10ea665c5f3f4b16d62c98d6ca22037 which rendered some (at least XIAO RP2350) boards unbootable.

I've tested [v1.25.0 (2025-04-15) .uf2](https://micropython.org/resources/firmware/SEEED_XIAO_RP2350-20250415-v1.25.0.uf2) on a XIAO RP2350 and, indeed, it's doesn't boot.

Replaces: https://github.com/micropython/micropython/pull/17374

Breakage reported: https://github.com/micropython/micropython/issues/17375

Assuming a 133MHz capable flash caused rp2_flash_set_timing_internal to set out of range dividers for some boards (anything with value of 4 and flash that doesn't tolerate higher speeds.)

This affected the XIAO RP2350 board, making it non-bootable.

Since Pico SDK's PICO_FLASH_SPI_CLKDIV is entirely unreliable on a system with a variable system clock (users can change it at runtime) then use it only to work out a default MICROPY_HW_FLASH_MAX_FREQ.

This value can be overridden in board config.

Note that RP2350's default clock is 150MHz, RP2040's is 125MHz and it has been certified at 200MHz so it's quite possible that PICO_FLASH_SPI_CLKDIV is unreliable even at standard RP2 clocks.

(If flash timings are marginal then this can manifest as instability rather than outright failure.)

### Testing

I tested boards at 250MHz to make sure we hit the worst case.

| Board              | Result                |
|---------------|----------------|
| RPI_PICO2      | 883/884 pass  |
| RPI_PICO         | 903/904 pass  |
| RPI_PICO2_W | 891/892 pass  |
| RPI_PICO_W    | 872/871 pass   |
| SEED_XIAO_RP2350 | 883/884 pass |

Note the failing test was `ports/rp2/rp2_dma.py` which, entirely predictably, failed with some variation of:

```
test_printing (__main__.Test) ... ok
test_pack_unpack_ctrl (__main__.Test) ... ok
test_register_access (__main__.Test) ... ok
test_close (__main__.Test) ... ok
test_simple_memory_copy (__main__.Test) ... ok
test_time_taken_for_large_memory_copy (__main__.Test) ... FAIL
test_config_trigger (__main__.Test) ... ok
test_irq (__main__.Test) ...irq fired
 ok

======================================================================
FAIL: test_time_taken_for_large_memory_copy <class 'Test'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "unittest/__init__.py", line 399, in run_one
  File "<stdin>", line 114, in test_time_taken_for_large_memory_copy
  File "unittest/__init__.py", line 187, in assertIn
AssertionError: Expected 25 to be in range(30, 80)

----------------------------------------------------------------------
Ran 8 tests

FAILED (failures=1, errors=0)
```

(Because the chip was clocked too fast)

I'm pretty sure we can crank the Pico, Pico W, Pico 2 and Pico 2 W chips faster, based on nothing but the lack of any loud and consistent shouting about them not working. (Though there might be marginal cases.)

The test suite probably doesn't do much to exercise the flash, save for `ports/rp2/rp2_thread_reset_part1.py` and `ports/rp2/rp2_thread_reset_part2.py`...

---

@Lesords I don't have a XIAO RP2350. Can you confirm this change works for you?

Since you seemed to suggest that your flash chips work (reliably and repeatably?) at 60MHz, would you like me to include 

```c
#define MICROPY_HW_FLASH_MAX_FREQ               (60000000)
```

in `SEEED_XIAO_RP2350/mpconfigboard.h`?

Note: I should probably avail myself of some non-Pimoroni RP2 boards to test. This was an unintended consequence of this change, but we definitely could have caught it with more contentious testing and less tunnel vision.

### Trade-offs and Alternatives

We don't really have much wiggle room here. `PICO_FLASH_SPI_CLKDIV` can't be relied upon where the end-user has control of the system clock. We can, however, at least use it to derive a default maximum clock value for the flash. Therefore - by my estimation - it's not appropriate to simply revert the breaking change.