### PR TITLE
parsenum: Reduce code size.

### DIFF
--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -252,24 +252,18 @@ parse_start:
     const char *str_val_start = str;
 
     // determine what the string is
-    if (str + 2 < top && (str[0] | 0x20) == 'i') {
-        // string starts with 'i', should be 'inf' or 'infinity' (case insensitive)
-        if ((str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'f') {
-            // inf
-            str += 3;
-            dec_val = (mp_float_t)INFINITY;
-            if (str + 4 < top && (str[0] | 0x20) == 'i' && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'i' && (str[3] | 0x20) == 't' && (str[4] | 0x20) == 'y') {
-                // infinity
-                str += 5;
-            }
+    if (str + 2 < top && (str[0] | 0x20) == 'i' && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'f') {
+        // 'inf' or 'infinity' (case insensitive)
+        str += 3;
+        dec_val = (mp_float_t)INFINITY;
+        if (str + 4 < top && (str[0] | 0x20) == 'i' && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'i' && (str[3] | 0x20) == 't' && (str[4] | 0x20) == 'y') {
+            // infinity
+            str += 5;
         }
-    } else if (str + 2 < top && (str[0] | 0x20) == 'n') {
-        // string starts with 'n', should be 'nan' (case insensitive)
-        if ((str[1] | 0x20) == 'a' && (str[2] | 0x20) == 'n') {
-            // NaN
-            str += 3;
-            dec_val = MICROPY_FLOAT_C_FUN(nan)("");
-        }
+    } else if (str + 2 < top && (str[0] | 0x20) == 'n' && (str[1] | 0x20) == 'a' && (str[2] | 0x20) == 'n') {
+        // 'nan' (case insensitive)
+        str += 3;
+        dec_val = MICROPY_FLOAT_C_FUN(nan)("");
     } else {
         // string should be a decimal number
         parse_dec_in_t in = PARSE_DEC_IN_INTG;

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -252,9 +252,9 @@ parse_start:
     const char *str_val_start = str;
 
     // determine what the string is
-    if (str < top && (str[0] | 0x20) == 'i') {
+    if (str + 2 < top && (str[0] | 0x20) == 'i') {
         // string starts with 'i', should be 'inf' or 'infinity' (case insensitive)
-        if (str + 2 < top && (str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'f') {
+        if ((str[1] | 0x20) == 'n' && (str[2] | 0x20) == 'f') {
             // inf
             str += 3;
             dec_val = (mp_float_t)INFINITY;
@@ -263,9 +263,9 @@ parse_start:
                 str += 5;
             }
         }
-    } else if (str < top && (str[0] | 0x20) == 'n') {
+    } else if (str + 2 < top && (str[0] | 0x20) == 'n') {
         // string starts with 'n', should be 'nan' (case insensitive)
-        if (str + 2 < top && (str[1] | 0x20) == 'a' && (str[2] | 0x20) == 'n') {
+        if ((str[1] | 0x20) == 'a' && (str[2] | 0x20) == 'n') {
             // NaN
             str += 3;
             dec_val = MICROPY_FLOAT_C_FUN(nan)("");


### PR DESCRIPTION
### Summary

By avoiding two different checks of the string length, code size is reduced without changing behavior: Some invalid float/complex strings like "ix" will get handled just like "xx" in the main number literal parsing code instead.

The optimizer alone couldn't remove the reundant comparisons because it couldn't make a transformation that let an invalid string like "ix" pass into the generic number parsing code.

### Testing

Locally, I checked that the unix coverage tests still passed. I looked at the `size` of `parsenum.o` on the 64-bit coverage build as well as the `MICROBIT` board in the qemu port.