### PR TITLE
Wake on touch only if supported

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -18,6 +18,8 @@ Functions
     Configure whether or not a touch will wake the device from sleep.
     *wake* should be a boolean value.
 
+    .. note:: This is only available for boards that have touch sensor support
+
 .. function:: wake_on_ulp(wake)
 
     Configure whether or not the Ultra-Low-Power co-processor can wake the

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -325,9 +325,11 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 mp_raise_ValueError(MP_ERROR_TEXT("bad wake value"));
             }
 
+            #if SOC_TOUCH_SENSOR_SUPPORTED
             if (machine_rtc_config.wake_on_touch) { // not compatible
                 mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
             }
+            #endif
 
             if (!RTC_IS_VALID_EXT_PIN(index)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for wake"));

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -33,7 +33,9 @@
 typedef struct {
     uint64_t ext1_pins; // set bit == pin#
     int8_t ext0_pin;   // just the pin#, -1 == None
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     bool wake_on_touch : 1;
+    #endif
     #if SOC_ULP_SUPPORTED
     bool wake_on_ulp : 1;
     #endif

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -47,6 +47,7 @@
 #include "../multi_heap_platform.h"
 #include "../heap_private.h"
 
+#if SOC_TOUCH_SENSOR_SUPPORTED
 static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
 
     if (machine_rtc_config.ext0_pin != -1) {
@@ -57,12 +58,16 @@ static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(esp32_wake_on_touch_obj, esp32_wake_on_touch);
+#endif
 
 static mp_obj_t esp32_wake_on_ext0(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     if (machine_rtc_config.wake_on_touch) {
         mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
     }
+    #endif
+
     enum {ARG_pin, ARG_level};
     const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin,  MP_ARG_OBJ, {.u_obj = mp_obj_new_int(machine_rtc_config.ext0_pin)} },
@@ -259,7 +264,9 @@ static MP_DEFINE_CONST_FUN_OBJ_0(esp32_idf_task_info_obj, esp32_idf_task_info);
 static const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_esp32) },
 
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
     #if SOC_ULP_SUPPORTED


### PR DESCRIPTION
esp32: esp32.wake_on_touch should only be available on boards
that have SOC_TOUCH_SENSOR_SUPPORTED =y
docs/library/esp32.rst: update docs to reflect that wake_on_touch
is only available for boards that have touch sensor support

### Summary

Having code wrapped by definitions of whether or not the capability is supported on the
board instead of what board it is, is better practice.
I introduced this so that when using the method wake_on_touch on boards that don't
support it, it will be clear that it is not supported, instead of silently failing.

### Testing

I tested this on the ESP32C3