### PR TITLE
Wake on ext0 only if supported

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -33,6 +33,8 @@ Functions
     or a valid Pin object.  *level* should be ``esp32.WAKEUP_ALL_LOW`` or
     ``esp32.WAKEUP_ANY_HIGH``.
 
+    .. note:: This is only available for boards that have ext0 support
+
 .. function:: wake_on_ext1(pins, level)
 
     Configure how EXT1 wakes the device from sleep.  *pins* can be ``None``

--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -18,6 +18,8 @@ Functions
     Configure whether or not a touch will wake the device from sleep.
     *wake* should be a boolean value.
 
+    .. note:: This is only available for boards that have touch sensor support
+
 .. function:: wake_on_ulp(wake)
 
     Configure whether or not the Ultra-Low-Power co-processor can wake the

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -325,9 +325,11 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 mp_raise_ValueError(MP_ERROR_TEXT("bad wake value"));
             }
 
+            #if SOC_TOUCH_SENSOR_SUPPORTED
             if (machine_rtc_config.wake_on_touch) { // not compatible
                 mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
             }
+            #endif
 
             if (!RTC_IS_VALID_EXT_PIN(index)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for wake"));

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -335,6 +335,7 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid pin for wake"));
             }
 
+            #if SOC_PM_SUPPORT_EXT0_WAKEUP
             if (machine_rtc_config.ext0_pin == -1) {
                 machine_rtc_config.ext0_pin = index;
             } else if (machine_rtc_config.ext0_pin != index) {
@@ -343,10 +344,13 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
 
             machine_rtc_config.ext0_level = trigger == GPIO_INTR_LOW_LEVEL ? 0 : 1;
             machine_rtc_config.ext0_wake_types = wake;
+            #endif
         } else {
+            #if SOC_PM_SUPPORT_EXT0_WAKEUP
             if (machine_rtc_config.ext0_pin == index) {
                 machine_rtc_config.ext0_pin = -1;
             }
+            #endif
 
             if (handler == mp_const_none) {
                 handler = MP_OBJ_NULL;

--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -83,7 +83,9 @@ static const machine_rtc_obj_t machine_rtc_obj = {{&machine_rtc_type}};
 
 machine_rtc_config_t machine_rtc_config = {
     .ext1_pins = 0,
+    #if SOC_PM_SUPPORT_EXT0_WAKEUP
     .ext0_pin = -1
+    #endif
 };
 
 static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -33,7 +33,9 @@
 typedef struct {
     uint64_t ext1_pins; // set bit == pin#
     int8_t ext0_pin;   // just the pin#, -1 == None
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     bool wake_on_touch : 1;
+    #endif
     #if SOC_ULP_SUPPORTED
     bool wake_on_ulp : 1;
     #endif

--- a/ports/esp32/machine_rtc.h
+++ b/ports/esp32/machine_rtc.h
@@ -32,15 +32,19 @@
 
 typedef struct {
     uint64_t ext1_pins; // set bit == pin#
+    #if SOC_PM_SUPPORT_EXT0_WAKEUP
     int8_t ext0_pin;   // just the pin#, -1 == None
+    #endif
     #if SOC_TOUCH_SENSOR_SUPPORTED
     bool wake_on_touch : 1;
     #endif
     #if SOC_ULP_SUPPORTED
     bool wake_on_ulp : 1;
     #endif
+    #if SOC_PM_SUPPORT_EXT0_WAKEUP
     bool ext0_level : 1;
     wake_type_t ext0_wake_types;
+    #endif
     bool ext1_level : 1;
 } machine_rtc_config_t;
 

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -47,6 +47,7 @@
 #include "../multi_heap_platform.h"
 #include "../heap_private.h"
 
+#if SOC_TOUCH_SENSOR_SUPPORTED
 static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
 
     if (machine_rtc_config.ext0_pin != -1) {
@@ -57,12 +58,16 @@ static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(esp32_wake_on_touch_obj, esp32_wake_on_touch);
+#endif
 
 static mp_obj_t esp32_wake_on_ext0(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     if (machine_rtc_config.wake_on_touch) {
         mp_raise_ValueError(MP_ERROR_TEXT("no resources"));
     }
+    #endif
+
     enum {ARG_pin, ARG_level};
     const mp_arg_t allowed_args[] = {
         { MP_QSTR_pin,  MP_ARG_OBJ, {.u_obj = mp_obj_new_int(machine_rtc_config.ext0_pin)} },
@@ -259,7 +264,9 @@ static MP_DEFINE_CONST_FUN_OBJ_0(esp32_idf_task_info_obj, esp32_idf_task_info);
 static const mp_rom_map_elem_t esp32_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_esp32) },
 
+    #if SOC_TOUCH_SENSOR_SUPPORTED
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
     #if SOC_ULP_SUPPORTED

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -60,6 +60,7 @@ static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
 static MP_DEFINE_CONST_FUN_OBJ_1(esp32_wake_on_touch_obj, esp32_wake_on_touch);
 #endif
 
+#if SOC_PM_SUPPORT_EXT0_WAKEUP
 static mp_obj_t esp32_wake_on_ext0(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
 
     #if SOC_TOUCH_SENSOR_SUPPORTED
@@ -94,6 +95,7 @@ static mp_obj_t esp32_wake_on_ext0(size_t n_args, const mp_obj_t *pos_args, mp_m
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(esp32_wake_on_ext0_obj, 0, esp32_wake_on_ext0);
+#endif
 
 static mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {ARG_pins, ARG_level};
@@ -267,7 +269,9 @@ static const mp_rom_map_elem_t esp32_module_globals_table[] = {
     #if SOC_TOUCH_SENSOR_SUPPORTED
     { MP_ROM_QSTR(MP_QSTR_wake_on_touch), MP_ROM_PTR(&esp32_wake_on_touch_obj) },
     #endif
+    #if SOC_PM_SUPPORT_EXT0_WAKEUP
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext0), MP_ROM_PTR(&esp32_wake_on_ext0_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_wake_on_ext1), MP_ROM_PTR(&esp32_wake_on_ext1_obj) },
     #if SOC_ULP_SUPPORTED
     { MP_ROM_QSTR(MP_QSTR_wake_on_ulp), MP_ROM_PTR(&esp32_wake_on_ulp_obj) },


### PR DESCRIPTION
ports/esp32: esp32.wake_on_ext0 should only be available on boards
          that have SOC_PM_SUPPORT_EXT0_WAKEUP=y
docs/library/esp32.rst: update docs to reflect that wake_on_ext0
          is only available for boards that have support for ext0

### Summary

Having code wrapped by definitions of whether or not the capability is supported on the
board instead of what board it is, is better practice.
I introduced this so that when using the method wake_on_ext0 on boards that don't
support it, it will be clear that it is not supported, instead of silently failing.


### Testing

I tested this on the ESP32C3

Merge this after https://github.com/micropython/micropython/pull/17393
