### PR TITLE
nrf/softdevice : Add function to set the BT address

### DIFF
--- a/ports/nrf/drivers/bluetooth/ble_drv.c
+++ b/ports/nrf/drivers/bluetooth/ble_drv.c
@@ -279,6 +279,26 @@ void ble_drv_address_get(ble_drv_addr_t * p_addr) {
     memcpy(p_addr->addr, local_ble_addr.addr, 6);
 }
 
+
+void ble_drv_address_set(ble_drv_addr_t * p_addr) {
+    SD_TEST_OR_ENABLE();
+
+    ble_gap_addr_t local_ble_addr;
+    local_ble_addr.addr_id_peer = 0x00;
+    local_ble_addr.addr_type = 0x00; // BLE_GAP_ADDR_TYPE_PUBLIC
+    memcpy(local_ble_addr.addr, p_addr->addr, 6);
+
+#if (BLUETOOTH_SD == 110)
+    uint32_t err_code = sd_ble_gap_address_set(&local_ble_addr);
+#else
+    uint32_t err_code = sd_ble_gap_addr_set(&local_ble_addr);
+#endif
+
+    if (err_code != 0) {
+        mp_raise_msg_varg(&mp_type_OSError, MP_ERROR_TEXT("Can't set the device address. status: 0x" HEX2_FMT), (uint16_t)err_code);
+    }
+}
+
 bool ble_drv_uuid_add_vs(uint8_t * p_uuid, uint8_t * idx) {
     SD_TEST_OR_ENABLE();
 

--- a/ports/nrf/drivers/bluetooth/ble_drv.h
+++ b/ports/nrf/drivers/bluetooth/ble_drv.h
@@ -80,6 +80,8 @@ uint8_t ble_drv_stack_enabled(void);
 
 void ble_drv_address_get(ble_drv_addr_t * p_addr);
 
+void ble_drv_address_set(ble_drv_addr_t * p_addr);
+
 bool ble_drv_uuid_add_vs(uint8_t * p_uuid, uint8_t * idx);
 
 bool ble_drv_service_add(ubluepy_service_obj_t * p_service_obj);

--- a/ports/nrf/modules/ble/modble.c
+++ b/ports/nrf/modules/ble/modble.c
@@ -81,10 +81,37 @@ mp_obj_t ble_obj_address(void) {
     return mac_str;
 }
 
+/// \method address_set()
+/// Set device address 
+mp_obj_t ble_obj_address_set(mp_obj_t ble_obj_address_set_obj) {
+
+    mp_buffer_info_t bufinfo;
+    mp_get_buffer_raise(ble_obj_address_set_obj, &bufinfo, MP_BUFFER_READ);
+
+    // Check if the buffer has at least 6 bytes
+    if (bufinfo.len != 6) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Not a valid MAC address"));
+        return mp_const_none;
+    }
+
+    ble_drv_addr_t new_ble_addr;
+
+    // Manually copy the bytes from the buffer to the addr field
+    for (int i = 0; i < 6; i++) {
+        new_ble_addr.addr[5-i] = ((uint8_t *)bufinfo.buf)[i];
+    }
+
+    ble_drv_address_set(&new_ble_addr);
+    
+    return mp_const_none;
+}
+
+
 static MP_DEFINE_CONST_FUN_OBJ_0(ble_obj_enable_obj, ble_obj_enable);
 static MP_DEFINE_CONST_FUN_OBJ_0(ble_obj_disable_obj, ble_obj_disable);
 static MP_DEFINE_CONST_FUN_OBJ_0(ble_obj_enabled_obj, ble_obj_enabled);
 static MP_DEFINE_CONST_FUN_OBJ_0(ble_obj_address_obj, ble_obj_address);
+static MP_DEFINE_CONST_FUN_OBJ_1(ble_obj_address_set_obj, ble_obj_address_set);
 
 static const mp_rom_map_elem_t ble_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ble) },
@@ -92,6 +119,7 @@ static const mp_rom_map_elem_t ble_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_disable),  MP_ROM_PTR(&ble_obj_disable_obj) },
     { MP_ROM_QSTR(MP_QSTR_enabled),  MP_ROM_PTR(&ble_obj_enabled_obj) },
     { MP_ROM_QSTR(MP_QSTR_address),  MP_ROM_PTR(&ble_obj_address_obj) },
+    { MP_ROM_QSTR(MP_QSTR_address_set),  MP_ROM_PTR(&ble_obj_address_set_obj) },
 };
 
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
On NRF port, this PR implements `sd_ble_gap_addr_set`  from the [Soft Device API](https://docs.nordicsemi.com/bundle/s140_v7.3.0_api/page/group_b_l_e_g_a_p_f_u_n_c_t_i_o_n_s.html#gaef69dc212534adf4b78d211edce2267b). You can customize the bluetooth mac address. 

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I have only tested it on a Xiao BLE board with SD v140. 
```
Connected to MicroPython at /dev/ttyACM0
Use Ctrl-] or Ctrl-x to exit this shell
MicroPython v1.26.0-preview.163.gdf80ad06c on 2025-06-01; XIAO nRF52840 Sense with NRF52840
Type "help()" for more information.
>>> a = bytearray([0xa1,0xba,0xc1,0xa4,0x3c,0x23])
>>> import ble
>>> ble.address()
'c8:e6:c1:a4:3c:f3'
>>> ble.address_set(a)
>>> ble.address()
'a1:ba:c1:a4:3c:23'
>>>
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

This is my first PR, and I am quite rusty with C. I am not sure if this is a clean binding, as I am not familiar with the MP_* objects and methods. Also, I have set the addr_type to `BLE_GAP_ADDR_TYPE_PUBLIC`.    

Maybe it is better to have only a ble.address() method with 2 signatures instead (0 argument = get, otherwise set) ? 