### PR TITLE
Allow array.extend to take iterables

### DIFF
--- a/tests/basics/array_add.py
+++ b/tests/basics/array_add.py
@@ -14,3 +14,9 @@ print(a1)
 
 a1.extend(array.array('I', [5]))
 print(a1)
+
+a1.extend([6, 7])
+print(a1)
+
+a1.extend(i for i in (8, 9))
+print(a1)


### PR DESCRIPTION
### Summary

As outlined in #7408, CPython can extend an array with an iterable, while micropython doesn't. Fix this, and test it.

### Testing

I added tests for the refactored code, and ran the tests locally.

### Trade-offs and Alternatives

Extending an array with a list (or other known length sequence) could do better, by resizing the array once first.