### PR TITLE
pyproject.toml: Enforce trailing newline on python files.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,8 @@ exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/micropython/heapalloc_fail_tstring.py",
   "tests/micropython/viper_args.py",
 ]
-extend-select = ["C9", "PLC"]
-extend-ignore = [
+extend-select = ["C9", "PLC", "W292"]
+ignore = [
   "E401",
   "E402",
   "E722",


### PR DESCRIPTION
### Summary

Update the ruff.lint config to enforce adding newline at the end of python files: https://docs.astral.sh/ruff/rules/missing-newline-at-end-of-file/

C files should already be covered by uncrustify:  https://github.com/micropython/micropython/blob/4dff9cbf1aa6681eea146cf8900d00cf2d93bb0f/tools/uncrustify.cfg#L1415

### Testing

I removed the end of file newline from an existing unit test, `git add` the file then tried to:
``` bash
anl@STEP:~/micropython$ git add tests/multi_net/udp_data_multi.py
anl@STEP:~/micropython$ git commit
MicroPython codeformat.py for changed C files............................Passed
ruff.....................................................................Passed
ruff-format..............................................................Failed
- hook id: ruff-format
- files were modified by this hook

1 file reformatted

Spellcheck for changed files (codespell).................................Passed
```

The newline was then added to the file automatically.
``` diff
diff --git a/tests/multi_net/udp_data_multi.py b/tests/multi_net/udp_data_multi.py
index 4edc0a52bb..630b28f7c7 100644
--- a/tests/multi_net/udp_data_multi.py
+++ b/tests/multi_net/udp_data_multi.py
@@ -66,4 +66,4 @@ def instance1():
             multitest.broadcast("data sent burst={}".format(burst))
             # Wait for the server to finish receiving.
             multitest.wait("data received burst={}".format(burst))
-        s.close()
\ No newline at end of file
+        s.close()
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

