### PR TITLE
esp32/main: Fix mp_deinit order.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -187,6 +187,10 @@ soft_reset_exit:
     mp_usbd_deinit();
     #endif
 
+    #ifdef MICROPY_PORT_DEINIT_FUNC
+    mp_deinit();
+    #endif
+
     gc_sweep_all();
 
     // Free any native code pointers that point to iRAM.
@@ -203,7 +207,10 @@ soft_reset_exit:
     socket_events_deinit();
     #endif
 
+    #ifndef MICROPY_PORT_DEINIT_FUNC
     mp_deinit();
+    #endif
+
     fflush(stdout);
     goto soft_reset;
 }


### PR DESCRIPTION
Move `mp_deinit` to be called before `gc_sweep_all` to prevent `mp_deinit` from double freeing memory if `MICROPY_PORT_DEINIT_FUNC` is defined and the function tries to free memory already freed by `gc_sweep_all`

### Summary

Prevent a core panic on soft-reset caused by "double freeing" memory.

### Testing

Tested with esp32 and https://github.com/lvgl/lv_binding_micropython/pull/383

### Trade-offs and Alternatives

Probably this PR https://github.com/micropython/micropython/pull/16063#

