### PR TITLE
github/workflows: Split QEMU/Arm builds into separate entries.

### DIFF
--- a/.github/workflows/ports_qemu.yml
+++ b/.github/workflows/ports_qemu.yml
@@ -20,13 +20,20 @@ concurrency:
 
 jobs:
   build_and_test_arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_func:  # names are functions in ci.sh
+          - bigendian
+          - sabrelite
+          - thumb
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install packages
       run: source tools/ci.sh && ci_qemu_setup_arm
-    - name: Build and run test suite
-      run: source tools/ci.sh && ci_qemu_build_arm
+    - name: Build and run test suite ci_qemu_build_arm_${{ matrix.ci_func }}
+      run: source tools/ci.sh && ci_qemu_build_arm_${{ matrix.ci_func }}
     - name: Print failures
       if: failure()
       run: tests/run-tests.py --print-failures

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -324,13 +324,24 @@ function ci_qemu_setup_rv32 {
     qemu-system-riscv32 --version
 }
 
-function ci_qemu_build_arm {
+function ci_qemu_build_arm_prepare {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/qemu submodules
+}
+
+function ci_qemu_build_arm_bigendian {
+    ci_qemu_build_arm_prepare
     make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
-    make ${MAKEOPTS} -C ports/qemu clean
-    make ${MAKEOPTS} -C ports/qemu test_full
+}
+
+function ci_qemu_build_arm_sabrelite {
+    ci_qemu_build_arm_prepare
     make ${MAKEOPTS} -C ports/qemu BOARD=SABRELITE test_full
+}
+
+function ci_qemu_build_arm_thumb {
+    ci_qemu_build_arm_prepare
+    make ${MAKEOPTS} -C ports/qemu test_full
 
     # Test building and running native .mpy with armv7m architecture.
     ci_native_mpy_modules_build armv7m


### PR DESCRIPTION
### Summary

This PR takes the QEMU/Arm CI build and test step and splits it into three separate steps (bigendian, sabrelite, thumb), to allow them to run in parallel.

Currently the QEMU/Arm CI build step would take up to 16 minutes, often being the last step blocking a full test run.  With this commit, when the steps run in parallel the time it takes to complete the QEMU/Arm build and test procedure is cut in half - taking between 8 to 9 minutes depending on the CI runner load.

### Testing

The various build types have been run locally in a CI-like environment, and the GitHub workflow was run successfully on my local branch.

### Trade-offs and Alternatives

QEMU/Arm runs are usually scheduled together to run in the same batch, saving up to 8 minutes on each full CI run.  However, in the worst case when the three build steps are run sequentially the overall time it takes to run the whole QEMU/Arm tests might be a couple dozen seconds longer than having a single monolithic step; this is due to `mpy-cross` being built three times and submodules being fetched three times as well.

This also increases the number of CI jobs by two entries - no idea if there's a hard cap on that.