### PR TITLE
tools/boardgen: Ensure locals_dict is generated with consistent order.

### DIFF
--- a/tools/boardgen.py
+++ b/tools/boardgen.py
@@ -108,6 +108,10 @@ class Pin:
             )
         )
 
+    # Iterate over board pin names in consistent sorted order.
+    def board_pin_names(self):
+        return sorted(self._board_pin_names, key=lambda x: x[0])
+
     # Override this to handle an af specified in af.csv.
     def add_af(self, af_idx, af_name, af):
         raise NotImplementedError
@@ -295,7 +299,7 @@ class PinGenerator:
             file=out_source,
         )
         for pin in self.available_pins():
-            for board_pin_name, board_hidden in pin._board_pin_names:
+            for board_pin_name, board_hidden in pin.board_pin_names():
                 if board_hidden:
                     # Don't include hidden pins in Pins.board.
                     continue
@@ -389,7 +393,7 @@ class PinGenerator:
 
             # #define pin_BOARDNAME (pin_CPUNAME)
             if board:
-                for board_pin_name, _board_hidden in pin._board_pin_names:
+                for board_pin_name, _board_hidden in pin.board_pin_names():
                     # Note: Hidden board pins are still available to C via the macro.
                     # Note: The RHS isn't wrapped in (), which is necessary to make the
                     # STATIC_AF_ macro work on STM32.


### PR DESCRIPTION
### Summary

`tools/boardgen.py` is used by the `make-pins.py` scripts in many ports to generate the pin definitions for the machine module.

In https://github.com/micropython/micropython/pull/17391#discussion_r2127729964 I found that this is currently generating the C structs for pin definitions with inconsistent ordering which makes it sometimes impossible to get a consistent built binary file even for no change in source files.

### Testing

Reviewed the generated files from running to see the content is the same as previously, however now with different / repeatable order.
``` bash
cd ports/stm32; 
python boards/make-pins.py --board-csv boards/PYBD_SF6/pins.csv --af-csv boards/stm32f767_af.csv --prefix boards/stm32f4xx_prefix.c          │
│   --output-source build-PYBD_SF6/pins_PYBD_SF6.c --output-header build-PYBD_SF6/genhdr/pins.h --output-af-const build-PYBD_SF6/genhdr/pins_af_const.h --output-af-defs build-PYBD_SF6/genhdr/pins_af_defs.h
```
