### PR TITLE
ports/alif/boards/ALIF_ENSEMBLE: Add deploy instructions.

### DIFF
--- a/ports/alif/Makefile
+++ b/ports/alif/Makefile
@@ -21,6 +21,7 @@ Reset\n\
 Exit
 
 ALIF_TOC_CONFIG = alif_cfg.json
+ALIF_TOC_BIN = $(BUILD)/firmware.toc.bin
 ALIF_TOC_APPS = $(BUILD)/$(ALIF_TOC_CONFIG)
 ALIF_TOC_CFLAGS += -DTOC_CFG_FILE=$(ALIF_TOOLKIT_CFG_FILE)
 
@@ -69,7 +70,7 @@ include $(TOP)/extmod/extmod.mk
 # Main targets
 
 .PHONY: all
-all: $(BUILD)/firmware.toc.bin
+all: $(BUILD)/firmware.zip
 
 # Force make commands to run the targets every time
 # regardless of whether firmware.toc.bin already exists
@@ -90,15 +91,19 @@ $(BUILD)/$(ALIF_TOC_CONFIG): mcu/$(ALIF_TOC_CONFIG).in | $(BUILD)
 	$(ECHO) "Preprocess toc config $@"
 	$(Q)$(CPP) -P -E $(ALIF_TOC_CFLAGS) - < mcu/$(ALIF_TOC_CONFIG).in > $@
 
-$(BUILD)/firmware.toc.bin: $(ALIF_TOC_APPS)
+$(ALIF_TOC_BIN): $(ALIF_TOC_APPS)
 	$(Q)python $(ALIF_TOOLS)/app-gen-toc.py \
 		--filename $(abspath $(BUILD)/$(ALIF_TOC_CONFIG)) \
 		--output-dir $(BUILD) \
 		--firmware-dir $(BUILD) \
 		--output $@
 
+$(BUILD)/firmware.zip: $(ALIF_TOC_BIN) $(ALIF_TOC_APPS)
+	$(ECHO) "Create $@"
+	$(Q)$(ZIP) -q - $(BUILD)/application_package.ds $^ > $@
+
 .PHONY: deploy
-deploy: $(BUILD)/firmware.toc.bin
+deploy: $(ALIF_TOC_BIN)
 	$(ECHO) "Writing $< to the board"
 	$(Q)python $(ALIF_TOOLS)/app-write-mram.py \
 		--cfg-part $(ALIF_TOOLKIT_CFG_PART) \

--- a/ports/alif/README.md
+++ b/ports/alif/README.md
@@ -19,3 +19,61 @@ The following more advanced features will follow later:
 - Ethernet support.
 - SDRAM support.
 - Other machine modules.
+
+Build instructions
+------------------
+
+Before building the firmware for a given board the MicroPython cross-compiler
+must be built; it will be used to pre-compile some of the built-in scripts to
+bytecode.  The cross-compiler is built and run on the host machine, using:
+```bash
+$ make -C mpy-cross
+```
+
+This command should be executed from the root directory of this repository.
+All other commands below should be executed from the ports/alif/ directory.
+
+An ARM compiler is required for the build, along with the associated binary
+utilities.  The recommended toolchain version to use with this port is
+Arm GNU toolchain version 13.3.Rel1. The compiler can be changed using the
+`CROSS_COMPILE` variable when invoking `make`.
+
+Next, the board to build must be selected. The default board is `ALIF_ENSEMBLE`
+but any of the names of the subdirectories in the `boards/` directory is valid.
+The board name must be passed as the argument to `BOARD=` when invoking `make`.
+
+All boards require certain submodules to be obtained before they can be built.
+The correct set of submodules can be initialised using (with `ALIF_ENSEMBLE`
+as an example of the selected board):
+```bash
+make BOARD=ALIF_ENSEMBLE submodules
+```
+
+Then to build the board's firmware run:
+```bash
+make BOARD=ALIF_ENSEMBLE
+```
+
+The above command should produce binary images in the `build-ALIF_ENSEMBLE/`
+subdirectory (or the equivalent directory for the board specified).
+
+### Update the SE Firmware
+
+The SE firmware must be updated **before** flashing the main firmware to match
+the version used by MicroPython. This step only needs to be performed once.
+Connect the board to your PC via the **SE UART USB** port (on the Ensemble kit,
+this is labeled **PRG USB**), then run:
+
+```bash
+make update-system-package
+```
+
+**Note:** The board must be power-cycled after this step.
+
+### Deploy MicroPython
+
+To flash the firmware, run:
+
+```bash
+make BOARD=ALIF_ENSEMBLE deploy
+```

--- a/ports/alif/boards/ALIF_ENSEMBLE/board.json
+++ b/ports/alif/boards/ALIF_ENSEMBLE/board.json
@@ -1,0 +1,17 @@
+{
+    "deploy": [
+        "./deploy.md"
+    ],
+    "docs": "",
+    "features": [
+        "Ethernet"
+    ],
+    "images": [
+        "ensemble-devkit-gen-2.jpg"
+    ],
+    "mcu": "AE722F80F55D5XX",
+    "product": "Ensemble E7 DevKit",
+    "thumbnail": "",
+    "url": "https://alifsemi.com/support/kits/ensemble-devkit/",
+    "vendor": "Alif Semiconductor"
+}

--- a/ports/alif/boards/ALIF_ENSEMBLE/deploy.md
+++ b/ports/alif/boards/ALIF_ENSEMBLE/deploy.md
@@ -1,0 +1,37 @@
+### Alif Security Toolkit
+
+This board can be programmed via the SE UART interface using the Alif Security
+Toolkit. MicroPython uses a custom version of the toolkit, which can be downloaded
+from [here](https://github.com/micropython/alif-security-toolkit/) or cloned:
+
+```bash
+git clone https://github.com/micropython/alif-security-toolkit/
+```
+
+---
+
+### Update the SE Firmware (Optional)
+
+If needed, update the SE firmware to match the version used by MicroPython. Ensure
+you have the correct port, part number, and chip revision.
+
+```bash
+python alif-security-toolkit/toolkit/updateSystemPackage.py --port /dev/ttyACM0 --cfg-part AE722F80F55D5LS --cfg-rev B4
+```
+
+**Note:** The board must be power-cycled after this step.
+
+---
+
+### Deploy MicroPython
+
+Download (or build) the firmware package, unzip it, then deploy it:
+
+```bash
+
+python alif-security-toolkit/toolkit/app-write-mram.py --port /dev/ttyACM0 --cfg-part AE722F80F55D5LS --cfg-rev B4 --pad --images file:build-ALIF_ENSEMBLE/application_package.ds
+```
+
+The MicroPython REPL is available on the second USB serial port, eg `/dev/ttyACM1`.
+
+---

--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -69,7 +69,9 @@ fi
 FW_TAG="-$FW_DATE-$FW_SEMVER"
 
 # build new firmware
-cd ports/cc3200
+cd ports/alif
+build_alif_boards ${FW_TAG} ${LOCAL_FIRMWARE}
+cd ../cc3200
 build_cc3200_boards ${FW_TAG} ${LOCAL_FIRMWARE}
 cd ../esp8266
 build_esp8266_boards ${FW_TAG} ${LOCAL_FIRMWARE}

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -86,6 +86,10 @@ function build_boards {
     done
 }
 
+function build_alif_boards {
+    build_boards modalif.c $1 $2 zip
+}
+
 function build_cc3200_boards {
     build_boards hal/cc3200_hal.c $1 $2 zip
 }


### PR DESCRIPTION
### Summary

Add deploy/build instructions for Ensemble E7 DevKit.

- [ ] Board images: https://github.com/micropython/micropython-media/pull/95

### Testing

I've tested these instructions, with another board, and they work fine. Testing with the devkit itself would be helpful.