### PR TITLE
unix/mpthreadport: Fix type / comparison of PTHREAD_STACK_MIN.

### DIFF
--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -250,8 +250,8 @@ mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size
     }
 
     // minimum stack size is set by pthreads
-    if (*stack_size < PTHREAD_STACK_MIN) {
-        *stack_size = PTHREAD_STACK_MIN;
+    if (*stack_size < (size_t)PTHREAD_STACK_MIN) {
+        *stack_size = (size_t)PTHREAD_STACK_MIN;
     }
 
     // ensure there is enough stack to include a stack-overflow margin


### PR DESCRIPTION
### Summary

When compiling the unix port on my recently updated ubuntu machine I ran into this error:
``` make
mpthreadport.c: In function ‘mp_thread_create’:
mpthreadport.c:253:21: error: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
  253 |     if (*stack_size < PTHREAD_STACK_MIN) {
      |                     ^
cc1: all warnings being treated as errors
See https://github.com/micropython/micropython/wiki/Build-Troubleshooting
make: *** [../../py/mkrules.mk:101: build-standard/mpthreadport.o] Error 1
make: *** Waiting for unfinished jobs....
make: Leaving directory '/home/corona/micropython/ports/unix'
```
It looks like my gcc was updated:
``` bash
[corona@Telie micropython]$ gcc --version
gcc (GCC) 14.2.1 20250207
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

The variable `PTHREAD_STACK_MIN` is defined by the pthread libraries:
``` bash
/usr/include/bits/pthread_stack_min.h
1:/* Definition of PTHREAD_STACK_MIN.  Linux version.
20:#define PTHREAD_STACK_MIN    16384
```

It seems GCC 14 got stricter with warn/errs like `-Wsign-compare` and types a "bare number" as a `long int` that can't be compared to a (unsigned) `size_t ` ?

### Testing

With this change the unix port compiled again. The thread unit tests pass:
``` bash
[corona@Telie tests]$ ./run-tests.py ./thread/thread*.py
platform=linux arch=x64
pass  ./thread/thread_heap_lock.py
pass  ./thread/thread_ident1.py
pass  ./thread/thread_lock1.py
pass  ./thread/thread_exc2.py
pass  ./thread/thread_exit2.py
pass  ./thread/thread_lock2.py
pass  ./thread/thread_gc1.py
pass  ./thread/thread_lock5.py
pass  ./thread/thread_qstr1.py
pass  ./thread/thread_shared1.py
pass  ./thread/thread_shared2.py
pass  ./thread/thread_sleep1.py
pass  ./thread/thread_lock3.py
pass  ./thread/thread_lock4.py
pass  ./thread/thread_stacksize1.py
pass  ./thread/thread_exit1.py
pass  ./thread/thread_coop.py
pass  ./thread/thread_exc1.py
pass  ./thread/thread_sleep2.py
pass  ./thread/thread_start1.py
pass  ./thread/thread_start2.py
pass  ./thread/thread_stdin.py
22 tests performed (127 individual testcases)
22 tests passed
```

### Trade-offs and Alternatives

The function could accept a ssize_t instead but that's arguably a broader change.   
Perhaps there's a compiler flag to work around this default signing of integers a different way?