### PR TITLE
extmod/mbedtls: Implement DTLS HelloVerify, update test for MSG_PEEK

### DIFF
--- a/extmod/mbedtls/mbedtls_config_common.h
+++ b/extmod/mbedtls/mbedtls_config_common.h
@@ -123,4 +123,8 @@ void m_tracked_free(void *ptr);
 
 #endif
 
+// Workaround for a mimxrt platform driver header that defines ARRAY_SIZE,
+// which is also defined in some mbedtls source files.
+#undef ARRAY_SIZE
+
 #endif // MICROPY_INCLUDED_MBEDTLS_CONFIG_COMMON_H

--- a/extmod/mbedtls/mbedtls_config_common.h
+++ b/extmod/mbedtls/mbedtls_config_common.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_MBEDTLS_CONFIG_COMMON_H
 #define MICROPY_INCLUDED_MBEDTLS_CONFIG_COMMON_H
 
+#include "py/mpconfig.h"
+
 // If you want to debug MBEDTLS uncomment the following and
 // pass "3" to mbedtls_debug_set_threshold in socket_new.
 // #define MBEDTLS_DEBUG_C
@@ -89,11 +91,17 @@
 #define MBEDTLS_SHA384_C
 #define MBEDTLS_SHA512_C
 #define MBEDTLS_SSL_CLI_C
-#define MBEDTLS_SSL_PROTO_DTLS
 #define MBEDTLS_SSL_SRV_C
 #define MBEDTLS_SSL_TLS_C
 #define MBEDTLS_X509_CRT_PARSE_C
 #define MBEDTLS_X509_USE_C
+
+#if MICROPY_PY_SSL_DTLS
+#define MBEDTLS_SSL_PROTO_DTLS
+#define MBEDTLS_SSL_DTLS_ANTI_REPLAY
+#define MBEDTLS_SSL_DTLS_HELLO_VERIFY
+#define MBEDTLS_SSL_COOKIE_C
+#endif
 
 // A port may enable this option to select additional bare-metal configuration.
 #if MICROPY_MBEDTLS_CONFIG_BARE_METAL

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -62,6 +62,9 @@
 #include "mbedtls/ecdsa.h"
 #include "mbedtls/asn1.h"
 #endif
+#ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+#include "mbedtls/ssl_cookie.h"
+#endif
 
 #ifndef MICROPY_MBEDTLS_CONFIG_BARE_METAL
 #define MICROPY_MBEDTLS_CONFIG_BARE_METAL (0)
@@ -92,6 +95,9 @@ typedef struct _mp_obj_ssl_context_t {
     #if MICROPY_PY_SSL_ECDSA_SIGN_ALT
     mp_obj_t ecdsa_sign_callback;
     #endif
+    #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+    mbedtls_ssl_cookie_ctx cookie_ctx;
+    #endif
 } mp_obj_ssl_context_t;
 
 // This corresponds to an SSLSocket object.
@@ -117,7 +123,8 @@ static const mp_obj_type_t ssl_socket_type;
 static const MP_DEFINE_STR_OBJ(mbedtls_version_obj, MBEDTLS_VERSION_STRING_FULL);
 
 static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t sock,
-    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname);
+    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname,
+    mp_obj_t client_id);
 
 /******************************************************************************/
 // Helper functions.
@@ -320,6 +327,16 @@ static mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     mbedtls_ssl_conf_dbg(&self->conf, mbedtls_debug, NULL);
     #endif
 
+    #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+    mbedtls_ssl_cookie_init(&self->cookie_ctx);
+    ret = mbedtls_ssl_cookie_setup(&self->cookie_ctx, mbedtls_ctr_drbg_random, &self->ctr_drbg);
+    if (ret != 0) {
+        mbedtls_raise_error(ret);
+    }
+    mbedtls_ssl_conf_dtls_cookies(&self->conf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check,
+        &self->cookie_ctx);
+    #endif
+
     return MP_OBJ_FROM_PTR(self);
 }
 
@@ -366,6 +383,11 @@ static mp_obj_t ssl_context___del__(mp_obj_t self_in) {
     mbedtls_ctr_drbg_free(&self->ctr_drbg);
     mbedtls_entropy_free(&self->entropy);
     mbedtls_ssl_config_free(&self->conf);
+    #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+    if (self->is_dtls_server) {
+        mbedtls_ssl_cookie_free(&self->cookie_ctx);
+    }
+    #endif
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(ssl_context___del___obj, ssl_context___del__);
@@ -468,11 +490,14 @@ static mp_obj_t ssl_context_load_verify_locations(mp_obj_t self_in, mp_obj_t cad
 static MP_DEFINE_CONST_FUN_OBJ_2(ssl_context_load_verify_locations_obj, ssl_context_load_verify_locations);
 
 static mp_obj_t ssl_context_wrap_socket(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_server_side, ARG_do_handshake_on_connect, ARG_server_hostname };
+    enum { ARG_server_side, ARG_do_handshake_on_connect, ARG_server_hostname, ARG_client_id };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_server_side, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
         { MP_QSTR_do_handshake_on_connect, MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = true} },
         { MP_QSTR_server_hostname, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+        { MP_QSTR_client_id, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        #endif
     };
 
     // Parse arguments.
@@ -481,9 +506,14 @@ static mp_obj_t ssl_context_wrap_socket(size_t n_args, const mp_obj_t *pos_args,
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args - 2, pos_args + 2, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
+    mp_obj_t client_id = mp_const_none;
+    #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+    client_id = args[ARG_client_id].u_obj;
+    #endif
+
     // Create and return the new SSLSocket object.
     return ssl_socket_make_new(self, sock, args[ARG_server_side].u_bool,
-        args[ARG_do_handshake_on_connect].u_bool, args[ARG_server_hostname].u_obj);
+        args[ARG_do_handshake_on_connect].u_bool, args[ARG_server_hostname].u_obj, client_id);
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(ssl_context_wrap_socket_obj, 2, ssl_context_wrap_socket);
 
@@ -580,7 +610,7 @@ static int _mbedtls_timing_get_delay(void *ctx) {
 #endif
 
 static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t sock,
-    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname) {
+    bool server_side, bool do_handshake_on_connect, mp_obj_t server_hostname, mp_obj_t client_id) {
 
     // Store the current SSL context.
     store_active_context(ssl_context);
@@ -633,6 +663,21 @@ static mp_obj_t ssl_socket_make_new(mp_obj_ssl_context_t *ssl_context, mp_obj_t 
 
     #ifdef MBEDTLS_SSL_PROTO_DTLS
     mbedtls_ssl_set_timer_cb(&o->ssl, o, _mbedtls_timing_set_delay, _mbedtls_timing_get_delay);
+    #endif
+    #ifdef MBEDTLS_SSL_DTLS_HELLO_VERIFY
+    if (client_id != mp_const_none) {
+        mp_buffer_info_t buf;
+        if (mp_get_buffer(client_id, &buf, MP_BUFFER_READ)) {
+            ret = mbedtls_ssl_set_client_transport_id(&o->ssl, buf.buf, buf.len);
+        } else {
+            ret = MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
+        }
+        if (ret != 0) {
+            goto cleanup;
+        }
+    } else {
+        // TODO: should it be an error not to provide this argument for DTLS server?
+    }
     #endif
 
     mbedtls_ssl_set_bio(&o->ssl, &o->sock, _mbedtls_ssl_send, _mbedtls_ssl_recv, NULL);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1941,6 +1941,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_SSL_MBEDTLS_NEED_ACTIVE_CONTEXT (MICROPY_PY_SSL_ECDSA_SIGN_ALT)
 #endif
 
+// Whether to support DTLS protocol (non-CPython feature)
+#ifndef MICROPY_PY_SSL_DTLS
+#define MICROPY_PY_SSL_DTLS (MICROPY_SSL_MBEDTLS && MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
 // Whether to provide the "vfs" module
 #ifndef MICROPY_PY_VFS
 #define MICROPY_PY_VFS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES && MICROPY_VFS)

--- a/tests/extmod/tls_dtls.py
+++ b/tests/extmod/tls_dtls.py
@@ -34,8 +34,18 @@ client_socket = DummySocket()
 # Wrap the DTLS Server
 dtls_server_ctx = SSLContext(PROTOCOL_DTLS_SERVER)
 dtls_server_ctx.verify_mode = CERT_NONE
-dtls_server = dtls_server_ctx.wrap_socket(server_socket, do_handshake_on_connect=False)
+dtls_server = dtls_server_ctx.wrap_socket(
+    server_socket, do_handshake_on_connect=False, client_id=b'dummy_client_id'
+)
 print("Wrapped DTLS Server")
+
+# wrap DTLS server with invalid client_id
+try:
+    dtls_server = dtls_server_ctx.wrap_socket(
+        server_socket, do_handshake_on_connect=False, client_id=4
+    )
+except OSError:
+    print("Failed to wrap DTLS Server with invalid client_id")
 
 # Wrap the DTLS Client
 dtls_client_ctx = SSLContext(PROTOCOL_DTLS_CLIENT)

--- a/tests/extmod/tls_dtls.py.exp
+++ b/tests/extmod/tls_dtls.py.exp
@@ -1,3 +1,4 @@
 Wrapped DTLS Server
+Failed to wrap DTLS Server with invalid client_id
 Wrapped DTLS Client
 OK

--- a/tests/multi_net/tls_dtls_server_client.py
+++ b/tests/multi_net/tls_dtls_server_client.py
@@ -34,28 +34,36 @@ def instance0():
 
     multitest.next()
 
-    # Wait for the client to connect.
-    data, client_addr = s.recvfrom(1)
-    print("incoming connection", data)
-
-    # Connect back to the client, so the UDP socket can be used like a stream.
-    s.connect(client_addr)
-
-    # Create the DTLS context and load the certificate.
     ctx = tls.SSLContext(tls.PROTOCOL_DTLS_SERVER)
     ctx.load_cert_chain(cert, key)
 
-    # Wrap the UDP socket in server mode.
-    print("wrap socket")
-    s = ctx.wrap_socket(s, server_side=1)
+    # Because of "hello verify required", we expect the peer
+    # to connect twice: once to set the cookie, then second time
+    # successfully.
+    #
+    # As this isn't a real server, we hard-code two connection attempts
+    for _ in range(2):
+        print("waiting")
+        # Wait for the client to connect so we know their address
+        _, client_addr = s.recvfrom(1, socket.MSG_PEEK)
+        print("incoming connection")
+        s.connect(client_addr)  # Connect back to the client
 
-    # Transfer some data.
-    for _ in range(4):
-        print(s.recv(16))
-        s.send(b"server to client")
+        # Wrap the UDP socket in server mode.
+        try:
+            s = ctx.wrap_socket(s, server_side=1, client_id=repr(client_addr).encode())
+        except OSError as e:
+            print(e)
+            continue  # wait for second connection
 
-    # Close the DTLS and UDP connection.
-    s.close()
+        # Transfer some data.
+        for i in range(4):
+            print(s.recv(32))
+            s.send(b"server to client " + str(i).encode())
+
+        # Close the DTLS and UDP connection.
+        s.close()
+        break
 
 
 # DTLS client.
@@ -68,9 +76,6 @@ def instance1():
     print("connect")
     s.connect(addr)
 
-    # Send one byte to indicate a connection, and so the server can obtain our address.
-    s.write("X")
-
     # Create a DTLS context and load the certificate.
     ctx = tls.SSLContext(tls.PROTOCOL_DTLS_CLIENT)
     ctx.verify_mode = tls.CERT_REQUIRED
@@ -81,9 +86,9 @@ def instance1():
     s = ctx.wrap_socket(s, server_hostname="micropython.local")
 
     # Transfer some data.
-    for _ in range(4):
-        s.send(b"client to server")
-        print(s.recv(16))
+    for i in range(4):
+        s.send(b"client to server " + str(i).encode())
+        print(s.recv(32))
 
     # Close the DTLS and UDP connection.
     s.close()

--- a/tests/multi_net/tls_dtls_server_client.py.exp
+++ b/tests/multi_net/tls_dtls_server_client.py.exp
@@ -1,14 +1,17 @@
 --- instance0 ---
-incoming connection b'X'
-wrap socket
-b'client to server'
-b'client to server'
-b'client to server'
-b'client to server'
+waiting
+incoming connection
+(-27264, 'MBEDTLS_ERR_SSL_HELLO_VERIFY_REQUIRED')
+waiting
+incoming connection
+b'client to server 0'
+b'client to server 1'
+b'client to server 2'
+b'client to server 3'
 --- instance1 ---
 connect
 wrap socket
-b'server to client'
-b'server to client'
-b'server to client'
-b'server to client'
+b'server to client 0'
+b'server to client 1'
+b'server to client 2'
+b'server to client 3'


### PR DESCRIPTION
### Summary

* Updates the DTLS support initially added in #15764.
* DTLS 1.2 requires the HelloVerify protocol. This was already enabled on esp32 port (part of ESP-IDF config), and this PR enables it on bare metal ports as well as anti-replay attack protection.
* HelloVerify requires a cookie store to be implemented in the server application that calls mbedTLS. We're using the cookie implementation from mbedTLS (implemented in C), the only Python-facing addition is a new `client_id` argument for `wrap_socket()`. MicroPython DTLS server code has to pass a transport-specific client identifier (as bytes) here, in order for HelloVerify to work correctly. The same SSLContext should be reused for all incoming connections.
* Add a config flag to disable DTLS on bare metal ports that don't need it. Enabled on "Extra" and above by default, so I think all ports with mbedTLS will get DTLS by default.
* Updated the multi_net test to work with HelloVerify and the new `MSG_PEEK` receive flag added in #17312. No longer needs an additional byte to be sent at the start of each connection.

### Testing

* Ran multi_net tests, including updated dtls test, on rp2, stm32 (PYBD_SF2) and esp32 ports. I'm still having (seemingly unrelated) issues with high outgoing UDP packet loss on rp2, but stm32 and esp32 ports passed the test in both directions.
* Manually tested the mbedTLS in-tree `dtls_server` and `dtls_client` programs against a MicroPython client and server (adapted from the multi_net test, with the mbedTLS test certificates swapped in). Tests worked, suggesting MicroPython should now work with any DTLS 1.2 peer.

### Trade-offs and Alternatives

* It's not clear how high the risk of MicroPython DTLS servers amplifying a DDoS attack is, so perhaps the HelloVerify support is not needed on the server side. However, connecting to a (compliant) DTLS 1.2 server requires the DTLS client to implement HelloVerify, and mbedTLS (reasonably) treats HelloVerify as enabled for both server and client concurrently so we need to implement something on the server side or remove DTLS server support (see below for some discussion of this). The "best case" code size impact of only supporting DTLS client is still about half of what's added by this PR.

*This work was funded through GitHub sponsors.*