### PR TITLE
lwip: Support `family` specification in getaddrinfo.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1802,10 +1802,11 @@ static mp_obj_t lwip_getaddrinfo(size_t n_args, const mp_obj_t *args) {
     mp_obj_t host_in = args[0], port_in = args[1];
     const char *host = mp_obj_str_get_str(host_in);
     mp_int_t port = mp_obj_get_int(port_in);
+    mp_int_t family = 0;
 
     // If constraints were passed then check they are compatible with the supported params
     if (n_args > 2) {
-        mp_int_t family = mp_obj_get_int(args[2]);
+        family = mp_obj_get_int(args[2]);
         mp_int_t type = 0;
         mp_int_t proto = 0;
         mp_int_t flags = 0;
@@ -1818,7 +1819,7 @@ static mp_obj_t lwip_getaddrinfo(size_t n_args, const mp_obj_t *args) {
                 }
             }
         }
-        if (!((family == 0 || family == MOD_NETWORK_AF_INET)
+        if (!((family == 0 || family == MOD_NETWORK_AF_INET || family == MOD_NETWORK_AF_INET6)
               && (type == 0 || type == MOD_NETWORK_SOCK_STREAM)
               && proto == 0
               && flags == 0)) {
@@ -1829,11 +1830,23 @@ static mp_obj_t lwip_getaddrinfo(size_t n_args, const mp_obj_t *args) {
     getaddrinfo_state_t state;
     state.status = 0;
 
+    #if LWIP_VERSION_MAJOR >= 2
+    // If family was specified, then try and resolve the address type as
+    // requested. Otherwise, use the default from network configuration.
+    if (family == MOD_NETWORK_AF_INET) {
+        family = LWIP_DNS_ADDRTYPE_IPV4;
+    } else if (family == MOD_NETWORK_AF_INET6) {
+        family = LWIP_DNS_ADDRTYPE_IPV6;
+    } else {
+        family = mp_mod_network_prefer_dns_use_ip_version == 4 ? LWIP_DNS_ADDRTYPE_IPV4_IPV6 : LWIP_DNS_ADDRTYPE_IPV6_IPV4;
+    }
+    #endif
+
     MICROPY_PY_LWIP_ENTER
     #if LWIP_VERSION_MAJOR < 2
     err_t ret = dns_gethostbyname(host, (ip_addr_t *)&state.ipaddr, lwip_getaddrinfo_cb, &state);
     #else
-    err_t ret = dns_gethostbyname_addrtype(host, (ip_addr_t *)&state.ipaddr, lwip_getaddrinfo_cb, &state, mp_mod_network_prefer_dns_use_ip_version == 4 ? LWIP_DNS_ADDRTYPE_IPV4_IPV6 : LWIP_DNS_ADDRTYPE_IPV6_IPV4);
+    err_t ret = dns_gethostbyname_addrtype(host, (ip_addr_t *)&state.ipaddr, lwip_getaddrinfo_cb, &state, family);
     #endif
     MICROPY_PY_LWIP_EXIT
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

socket.getaddrinfo() supports the specification of an address family; however, the LwIP implementation does not use it. This change allows the application to specify the address family request in DNS resolution. If no family is specified, it falls back to the default preference configured with network.ipconfig().

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I've done some minimal testing on this using an RP2040 and a Wiznet W5100S. It works as expected and returns the address of the family requested. For example:
```
>>> import socket
>>> socket.getaddrinfo('www.google.com', 80)
[(2, 1, 0, '', ('216.239.38.120', 80))]
>>> socket.getaddrinfo('www.google.com', 80, socket.AF_INET6)
[(2, 1, 0, '', ('2001:4860:4802:32::78', 80))]
>>> socket.getaddrinfo('www.google.com', 80, socket.AF_INET)
[(2, 1, 0, '', ('216.239.38.120', 80))]
```


