### PR TITLE
github/workflows: Stop using windows-2019 runner for Windows CI.

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -28,13 +28,10 @@ jobs:
         visualstudio: ['2017', '2019', '2022']
         include:
         - visualstudio: '2017'
-          runner: windows-latest
           vs_version: '[15, 16)'
         - visualstudio: '2019'
-          runner: windows-2019
           vs_version: '[16, 17)'
         - visualstudio: '2022'
-          runner: windows-2022
           vs_version: '[17, 18)'
         # trim down the number of jobs in the matrix
         exclude:
@@ -42,9 +39,9 @@ jobs:
           configuration: Debug
         - visualstudio: '2019'
           configuration: Debug
+    runs-on: windows-latest
     env:
       CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
-    runs-on: ${{ matrix.runner }}
     steps:
     - name: Install Visual Studio 2017
       if: matrix.visualstudio == '2017'
@@ -52,13 +49,15 @@ jobs:
         choco install visualstudio2017buildtools
         choco install visualstudio2017-workload-vctools
         choco install windows-sdk-8.1
+    - name: Install Visual Studio 2019
+      if: matrix.visualstudio == '2019'
+      run: |
+        choco install visualstudio2019buildtools
+        choco install visualstudio2019-workload-vctools
+        choco install windows-sdk-8.1
     - uses: microsoft/setup-msbuild@v2
       with:
         vs-version: ${{ matrix.vs_version }}
-    - uses: actions/setup-python@v5
-      if: matrix.runner == 'windows-2019'
-      with:
-        python-version: '3.9'
     - uses: actions/checkout@v4
     - name: Build mpy-cross.exe
       run: msbuild mpy-cross\mpy-cross.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }}
@@ -103,7 +102,7 @@ jobs:
             env: i686
           - sys: mingw64
             env: x86_64
-    runs-on: windows-2022
+    runs-on: windows-latest
     env:
       CHERE_INVOKING: enabled_from_arguments
     defaults:

--- a/py/objfloat.c
+++ b/py/objfloat.c
@@ -34,6 +34,11 @@
 
 #if MICROPY_PY_BUILTINS_FLOAT
 
+// Workaround a bug in Windows SDK version 10.0.26100.0, where NAN is no longer constant.
+#if defined(_MSC_VER) && !defined(_UCRT_NOISY_NAN)
+#define _UCRT_NOISY_NAN
+#endif
+
 #include <math.h>
 #include "py/formatfloat.h"
 
@@ -45,13 +50,6 @@
 #endif
 #ifndef M_PI
 #define M_PI (3.14159265358979323846)
-#endif
-
-// Workaround a bug in recent MSVC where NAN is no longer constant.
-// (By redefining back to the previous MSVC definition of NAN)
-#if defined(_MSC_VER) && _MSC_VER >= 1942
-#undef NAN
-#define NAN (-(float)(((float)(1e+300 * 1e+300)) * 0.0F))
 #endif
 
 typedef struct _mp_obj_float_t {


### PR DESCRIPTION
### Summary

This runner has been deprecated by GitHub.

### Testing

CI should test this.