### PR TITLE
cpydiff: Document complex() parsing difference.

### DIFF
--- a/tests/cpydiff/types_complex_parser.py
+++ b/tests/cpydiff/types_complex_parser.py
@@ -1,0 +1,14 @@
+"""
+categories: Types,complex
+description: MicroPython's complex() accepts certain incorrect values that CPython rejects
+cause: MicroPython is highly optimized for memory usage.
+workaround: Do not use non-standard complex literals as argument to complex()
+
+MicroPython's ``complex()`` function accepts literals that contain a space and
+no sign between the real and imaginary parts, and interprets it as a plus.
+"""
+
+try:
+    print(complex("1 1j"))
+except ValueError:
+    print("ValueError")


### PR DESCRIPTION
### Summary

In https://github.com/micropython/micropython/pull/17384 it was decided that fixing this difference was not worth the code size increase.

### Testing

Built & viewed the documentation locally
![image](https://github.com/user-attachments/assets/fe9be310-d043-4ed6-9dfe-4b6392d833c1)


