### PR TITLE
tests: create a helper function to generate a test report and use it in all test runners

### DIFF
--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -166,7 +166,8 @@ def run_tests(target_truth, target, args, resolved_arch):
             with open(NATMOD_EXAMPLE_DIR + test_mpy, "rb") as f:
                 test_script += b"__buf=" + bytes(repr(f.read()), "ascii") + b"\n"
         except OSError:
-            print("----  {} - mpy file not compiled".format(test_file))
+            test_results.append((test_file, "skip", "mpy file not compiled"))
+            print("skip  {} - mpy file not compiled".format(test_file))
             continue
         test_script += bytes(injected_import_hook_code.format(test_module), "ascii")
         test_script += test_file_data


### PR DESCRIPTION
### Summary

This PR factors existing code in `run-tests.py` into a new helper function `create_test_report()`.  That function prints out a summary of the test run (eg number of tests passed, number failed, number skipped) and creates the `_results.json` file.

Then that function is reused by the three other test runners: `run-multitests.py`, `run-natmodtests.py` and `run-perfbench.py`.  So those tests runners now also generate a `_results.json` file with exactly the same format as `run-tests.py`.

This is useful, eg, for Octoprobe, which aims to print a concise summary of all tests runs that were performed.  It's very useful in that case that the test summary is in a computer-readable file and follows the same format.

For consistency this PR makes a minor change to the printed output of `run-tests.py`: instead of printing a shorthand name for tests that failed/skipped, it now prints the full name.  Eg what was previously printed as `attrtuple2` is now printed as `basics/attrtuple2.py`.  This makes the output a little longer (when there are failed/skipped tests) but helps to disambiguate the test name, eg which directory it's in.

### Testing

Ran the four test runners on the unix port and observed the output, and inspected the `_results.json` file.

CI will also test this change.

### Trade-offs and Alternatives

I tried to reuse code as much as possible, so there's less code duplication and the output format is consistent across the runners.  This had some minor trade-offs:
1. as mentioned above, `run-tests.py` now prints the full filename of failed/skipped tests
2. `run-multitests.py` when run with multiple permutations only saves the last run as `_results.json`; this isn't an issue for Octoprobe which only runs this with a single permutation
3. the three tests runners that now save a `_results.json` file will use the same output directory `tests/results/` by default, and hence overwrite any existing file (eg from `run-tests.py`); a user can always provide a different result directory to overcome this