### PR TITLE
tools/mpremote: Make resume the default behaviour

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -54,11 +54,12 @@ If no command is specified, the default command is ``repl``. Additionally, if
 any command needs to access the device, and no earlier ``connect`` has been
 specified, then an implicit ``connect auto`` is added.
 
-In order to get the device into a known state for any action command
-(except ``repl``), once connected ``mpremote`` will stop any running program
-and soft-reset the device before running the first command. You can control
-this behavior using the ``resume`` and ``soft-reset`` commands.
-See :ref:`auto-connection and auto-soft-reset <mpremote_reset>` for more details.
+Once connected, ``mpremote`` will stop any running program before running an
+action command, but it will not clear the interpreter state.  Variables and
+imports therefore persist from one command to the next, and from one invocation
+of ``mpremote`` to the next.  Use the ``soft-reset`` command where a clean state
+is required.  See :ref:`auto-connection and soft-reset <mpremote_reset>` for
+more details.
 
 Multiple commands can be specified and they will be run sequentially.
 
@@ -66,7 +67,6 @@ The full list of supported commands are:
 
 - `connect <mpremote_command_connect>`
 - `disconnect <mpremote_command_disconnect>`
-- `resume <mpremote_command_resume>`
 - `soft_reset <mpremote_command_soft_reset>`
 - `repl <mpremote_command_repl>`
 - `eval <mpremote_command_eval>`
@@ -122,18 +122,8 @@ The full list of supported commands are:
 
       $ mpremote disconnect
 
-  After a disconnect, :ref:`auto-soft-reset <mpremote_reset>` is enabled.
-
-.. _mpremote_command_resume:
-
-- **resume** -- maintain existing interpreter state for subsequent commands:
-
-  .. code-block:: bash
-
-      $ mpremote resume
-
-  This disables :ref:`auto-soft-reset <mpremote_reset>`. This is useful if you
-  want to run a subsequent command on a board without first soft-resetting it.
+  A subsequent command will reconnect, keeping the interpreter state that was
+  on the device.
 
 .. _mpremote_command_soft_reset:
 
@@ -143,8 +133,7 @@ The full list of supported commands are:
 
       $ mpremote soft-reset
 
-  This will clear out the Python heap and restart the interpreter.  It also
-  prevents the subsequent command from triggering :ref:`auto-soft-reset <mpremote_reset>`.
+  This will clear out the Python heap and restart the interpreter.
 
 .. _mpremote_command_repl:
 
@@ -172,7 +161,7 @@ The full list of supported commands are:
   to access the Read Eval Print Loop that is running on the MicroPython
   device. Strictly, the ``repl`` command is just functioning as a terminal
   (or "serial monitor") to access the device. Because this command does not
-  trigger the :ref:`auto-reset behavior <mpremote_reset>`, this means that if
+  stop a running program, this means that if
   a program is currently running, you will first need to interrupt it with
   ``Ctrl-C`` to get to the REPL, which will then allow you to access program
   state. You can also use ``mpremote soft-reset repl`` to get a "clean" REPL
@@ -549,18 +538,30 @@ Connection and disconnection will be done automatically at the start and end of
 the execution of the tool, if such commands are not explicitly given.  Automatic
 connection will search for the first available USB serial device.
 
-Once connected to a device, ``mpremote`` will automatically soft-reset the
-device if needed.  This clears the Python heap and restarts the interpreter,
-making sure that subsequent Python code executes in a fresh environment.  Auto
-soft-reset is performed the first time one of the following commands are
-executed: ``mount``, ``eval``, ``exec``, ``run``, ``fs``.  After doing a
-soft-reset for the first time, it will not be done again automatically, until a
-``disconnect`` command is issued.
+``mpremote`` does not soft-reset the device on its own.  An action command such
+as ``mount``, ``eval``, ``exec``, ``run`` or ``fs`` will interrupt a running
+program, but the Python heap is left alone, so variables and imported modules
+set up by an earlier command are still there.  This also holds across a
+``disconnect``, and across separate invocations of ``mpremote``.
 
-Auto-soft-reset behaviour can be controlled by the ``resume`` command. This
-might be useful to use the ``eval`` command to inspect the state of of the
-device.  The ``soft-reset`` command can be used to perform an explicit soft
-reset in the middle of a sequence of commands.
+Use the ``soft-reset`` command to clear the Python heap and restart the
+interpreter, either at the start of a sequence of commands or partway through
+it.  Note that a soft-reset drops the connection on some devices, such as those
+using a dynamic ``USBDevice`` or WebREPL, which is why it is left to the user to
+ask for.
+
+The old behaviour of soft-resetting on connection can be turned back on by
+setting ``auto_soft_reset`` in the :ref:`user configuration file
+<mpremote_shortcuts>`:
+
+.. code-block:: python3
+
+    auto_soft_reset = True
+
+With that set, ``mpremote`` soft-resets the device the first time a command
+needs the device, and again after each ``disconnect``.  The ``resume`` command
+skips that soft-reset for a single invocation, and is otherwise accepted but
+does nothing.
 
 .. _mpremote_shortcuts:
 
@@ -587,6 +588,14 @@ This is typically:
 - ``$XDG_CONFIG_HOME/mpremote/config.py``
 - ``$HOME/.config/mpremote/config.py``
 - ``$env:LOCALAPPDATA/mpremote/config.py``
+
+The ``config.py`` file may set ``auto_soft_reset`` to control whether
+``mpremote`` soft-resets the device on connection, see
+:ref:`auto connection and soft-reset <mpremote_reset>`:
+
+.. code-block:: python3
+
+  auto_soft_reset = True
 
 The ``config.py``` file should define a dictionary named ``commands``. The keys of this dictionary are the shortcuts
 and the values are either a string or a list-of-strings:
@@ -696,11 +705,11 @@ device at ``/dev/ttyACM1``, printing each result.
 
 .. code-block:: bash
 
-  mpremote resume exec "print_state_info()" soft-reset
+  mpremote exec "print_state_info()" soft-reset
 
-Connect to the device without triggering a :ref:`soft reset <soft_reset>` and
-execute the ``print_state_info()`` function (e.g. to find out information about
-the current program state), then trigger a soft reset.
+Execute the ``print_state_info()`` function against the state already on the
+device (e.g. to find out information about the current program state), then
+trigger a :ref:`soft reset <soft_reset>`.
 
 .. code-block:: bash
 

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -88,7 +88,6 @@ def do_disconnect(state, _args=None):
         pass
     state.transport.close()
     state.transport = None
-    state._auto_soft_reset = True
 
 
 def show_progress_bar(size, total_size, op="copying"):
@@ -525,10 +524,6 @@ def do_mount(state, args):
 def do_umount(state, path):
     state.ensure_raw_repl()
     state.transport.umount_local()
-
-
-def do_resume(state, _args=None):
-    state._auto_soft_reset = False
 
 
 def do_soft_reset(state, _args=None):

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -88,7 +88,7 @@ def do_disconnect(state, _args=None):
         pass
     state.transport.close()
     state.transport = None
-    state._auto_soft_reset = True
+    state._auto_soft_reset = state._auto_soft_reset_default
 
 
 def show_progress_bar(size, total_size, op="copying"):
@@ -528,6 +528,8 @@ def do_umount(state, path):
 
 
 def do_resume(state, _args=None):
+    # Only has an effect when the auto_soft_reset config option is turned on,
+    # in which case this skips the soft-reset for the current connection.
     state._auto_soft_reset = False
 
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -35,7 +35,6 @@ from .commands import (
     do_exec,
     do_eval,
     do_run,
-    do_resume,
     do_rtc,
     do_soft_reset,
     do_romfs,
@@ -299,10 +298,6 @@ _COMMANDS = {
         do_edit,
         argparse_edit,
     ),
-    "resume": (
-        do_resume,
-        argparse_none("resume a previous mpremote session (will not auto soft-reset)"),
-    ),
     "soft-reset": (
         do_soft_reset,
         argparse_none("perform a soft-reset of the device"),
@@ -532,7 +527,7 @@ class State:
     def __init__(self):
         self.transport = None
         self._did_action = False
-        self._auto_soft_reset = True
+        self._auto_soft_reset = False
 
     def did_action(self):
         self._did_action = True

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -299,10 +299,6 @@ _COMMANDS = {
         do_edit,
         argparse_edit,
     ),
-    "resume": (
-        do_resume,
-        argparse_none("resume a previous mpremote session (will not auto soft-reset)"),
-    ),
     "soft-reset": (
         do_soft_reset,
         argparse_none("perform a soft-reset of the device"),
@@ -354,6 +350,16 @@ _COMMANDS = {
     "romfs": (
         do_romfs,
         argparse_romfs,
+    ),
+}
+
+# Commands that are still accepted on the command line but deliberately left out
+# of the help output, so existing scripts keep working without the command being
+# advertised for new use.
+_DEPRECATED_COMMANDS = {
+    "resume": (
+        do_resume,
+        argparse_none("no-op, retained for backwards compatibility"),
     ),
 }
 
@@ -530,10 +536,14 @@ def do_command_expansion(args):
 
 
 class State:
-    def __init__(self):
+    def __init__(self, auto_soft_reset=False):
         self.transport = None
         self._did_action = False
-        self._auto_soft_reset = True
+        # Whether to soft-reset the device the first time a command needs the
+        # raw REPL.  Off unless turned on by the auto_soft_reset config option,
+        # and re-armed on disconnect so the next connection starts fresh again.
+        self._auto_soft_reset_default = auto_soft_reset
+        self._auto_soft_reset = auto_soft_reset
 
     def did_action(self):
         self._did_action = True
@@ -570,7 +580,7 @@ def main():
     prepare_command_expansions(config)
 
     remaining_args = sys.argv[1:]
-    state = State()
+    state = State(auto_soft_reset=getattr(config, "auto_soft_reset", False))
 
     try:
         while remaining_args:
@@ -584,10 +594,10 @@ def main():
 
             # The (potentially rewritten) command must now be a base command.
             cmd = remaining_args.pop(0)
-            try:
-                handler_func, parser_func = _COMMANDS[cmd]
-            except KeyError:
+            command_entry = _COMMANDS.get(cmd) or _DEPRECATED_COMMANDS.get(cmd)
+            if command_entry is None:
                 raise CommandError(f"'{cmd}' is not a command")
+            handler_func, parser_func = command_entry
 
             # If this command (or any down the chain) has a terminator, then
             # limit the arguments passed for this command. They will be added

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -51,6 +51,20 @@ fi
 
 The `MPREMOTE_DEVICE` environment variable contains the device path passed via `-t`.
 
+## Device State
+
+`mpremote` carries interpreter state from one command to the next, so a test that
+needs a known starting point must ask for one with an explicit `soft-reset`:
+
+```bash
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+```
+
+Without it a test can pass on state left behind by an earlier test or an earlier
+run, which is not the same as passing. Mounting a RAM disk over one that is
+already mounted fails with `EPERM`, so any section that sets one up needs the
+reset, not just the first one in the file.
+
 ## Using the RAM Disk
 
 Tests that need a writable filesystem can use `ramdisk.py` to create a temporary

--- a/tools/mpremote/tests/test_errno.sh
+++ b/tools/mpremote/tests/test_errno.sh
@@ -20,19 +20,19 @@ vfs.mount(fs, '/fs')
 os.chdir('/fs')
 EOF
 
-$MPREMOTE run "${TMP}/fs.py"
+$MPREMOTE soft-reset run "${TMP}/fs.py"
 
 echo -----
-$MPREMOTE resume exec "fs.error = Exception()"
+$MPREMOTE exec "fs.error = Exception()"
 (
-  $MPREMOTE resume cat :Exception.py || echo "expect error"
+  $MPREMOTE cat :Exception.py || echo "expect error"
 ) 2> >(head -n1 >&2) # discard traceback specifics but keep main error message
 
 for errno in ENOENT EISDIR EEXIST ENODEV EINVAL EPERM EOPNOTSUPP ; do
 echo -----
-$MPREMOTE resume exec "fs.error = OSError(errno.$errno, '')"
-$MPREMOTE resume cat :$errno.py || echo "expect error"
+$MPREMOTE exec "fs.error = OSError(errno.$errno, '')"
+$MPREMOTE cat :$errno.py || echo "expect error"
 done
 
 echo -----
-$MPREMOTE resume exec "vfs.umount('/fs')"
+$MPREMOTE exec "vfs.umount('/fs')"

--- a/tools/mpremote/tests/test_eval_exec_run.sh
+++ b/tools/mpremote/tests/test_eval_exec_run.sh
@@ -5,7 +5,7 @@ set -e
 rm -f /tmp/run.py
 trap 'rm -f /tmp/run.py' EXIT
 
-$MPREMOTE exec "print('mpremote')"
+$MPREMOTE soft-reset exec "print('mpremote')"
 
 $MPREMOTE exec "print('before sleep'); import time; time.sleep(0.1); print('after sleep')"
 $MPREMOTE exec --no-follow "print('before sleep'); import time; time.sleep(0.1); print('after sleep')"

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -7,16 +7,16 @@ TEST_DIR=$(dirname $0)
 $MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
 
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume ls
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE ls
 
 echo -----
-$MPREMOTE resume touch a.py
-$MPREMOTE resume touch :b.py
-$MPREMOTE resume ls :
-$MPREMOTE resume cat a.py
-$MPREMOTE resume cat :b.py
-$MPREMOTE resume sha256sum a.py
+$MPREMOTE touch a.py
+$MPREMOTE touch :b.py
+$MPREMOTE ls :
+$MPREMOTE cat a.py
+$MPREMOTE cat :b.py
+$MPREMOTE sha256sum a.py
 echo -n "" | sha256sum
 
 echo -----
@@ -24,43 +24,43 @@ cat << EOF > "${TMP}/a.py"
 print("Hello")
 print("World")
 EOF
-$MPREMOTE resume cp "${TMP}/a.py" :
-$MPREMOTE resume cp "${TMP}/a.py" :b.py
-$MPREMOTE resume cp "${TMP}/a.py" :c.py
-$MPREMOTE resume cp :a.py :d.py
-$MPREMOTE resume ls
-$MPREMOTE resume exec "import a; import b; import c"
-$MPREMOTE resume sha256sum a.py
+$MPREMOTE cp "${TMP}/a.py" :
+$MPREMOTE cp "${TMP}/a.py" :b.py
+$MPREMOTE cp "${TMP}/a.py" :c.py
+$MPREMOTE cp :a.py :d.py
+$MPREMOTE ls
+$MPREMOTE exec "import a; import b; import c"
+$MPREMOTE sha256sum a.py
 cat "${TMP}/a.py" | sha256sum
 
 echo -----
-$MPREMOTE resume mkdir aaa
-$MPREMOTE resume mkdir :bbb
-$MPREMOTE resume cp "${TMP}/a.py" :aaa
-$MPREMOTE resume cp "${TMP}/a.py" :bbb/b.py
-$MPREMOTE resume cat :aaa/a.py bbb/b.py
+$MPREMOTE mkdir aaa
+$MPREMOTE mkdir :bbb
+$MPREMOTE cp "${TMP}/a.py" :aaa
+$MPREMOTE cp "${TMP}/a.py" :bbb/b.py
+$MPREMOTE cat :aaa/a.py bbb/b.py
 
 # Test cp -f (force copy).
 echo -----
-$MPREMOTE resume cp -f "${TMP}/a.py" :aaa
-$MPREMOTE resume cat :aaa/a.py
+$MPREMOTE cp -f "${TMP}/a.py" :aaa
+$MPREMOTE cat :aaa/a.py
 
 # Test cp where the destination has a trailing /.
 echo -----
-$MPREMOTE resume cp "${TMP}/a.py" :aaa/
-$MPREMOTE resume cp "${TMP}/a.py" :aaa/a.py/ || echo "expect error"
+$MPREMOTE cp "${TMP}/a.py" :aaa/
+$MPREMOTE cp "${TMP}/a.py" :aaa/a.py/ || echo "expect error"
 
 echo -----
-$MPREMOTE resume rm :b.py c.py
-$MPREMOTE resume ls
-$MPREMOTE resume rm :aaa/a.py bbb/b.py
-$MPREMOTE resume rmdir aaa :bbb
-$MPREMOTE resume ls
+$MPREMOTE rm :b.py c.py
+$MPREMOTE ls
+$MPREMOTE rm :aaa/a.py bbb/b.py
+$MPREMOTE rmdir aaa :bbb
+$MPREMOTE ls
 
 echo -----
-env EDITOR="sed -i s/Hello/Goodbye/" $MPREMOTE resume edit d.py
-$MPREMOTE resume sha256sum :d.py
-$MPREMOTE resume exec "import d"
+env EDITOR="sed -i s/Hello/Goodbye/" $MPREMOTE edit d.py
+$MPREMOTE sha256sum :d.py
+$MPREMOTE exec "import d"
 
 
 # Create a local directory structure and copy it to `:` on the device.
@@ -82,58 +82,58 @@ cat << EOF > "${TMP}/package/subpackage/y.py"
 def y():
   print("y")
 EOF
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume ls : :package :package/subpackage
-$MPREMOTE resume exec "import package; package.x(); package.y()"
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE ls : :package :package/subpackage
+$MPREMOTE exec "import package; package.x(); package.y()"
 
 
 # Same thing except with a destination directory name.
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume cp -r "${TMP}/package" :package2
-$MPREMOTE resume ls : :package2 :package2/subpackage
-$MPREMOTE resume exec "import package2; package2.x(); package2.y()"
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE cp -r "${TMP}/package" :package2
+$MPREMOTE ls : :package2 :package2/subpackage
+$MPREMOTE exec "import package2; package2.x(); package2.y()"
 
 
 # Copy to an existing directory, it will be copied inside.
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume mkdir :test
-$MPREMOTE resume cp -r "${TMP}/package" :test
-$MPREMOTE resume ls :test :test/package :test/package/subpackage
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE mkdir :test
+$MPREMOTE cp -r "${TMP}/package" :test
+$MPREMOTE ls :test :test/package :test/package/subpackage
 
 # Copy to non-existing sub-directory.
 echo -----
-$MPREMOTE resume cp -r "${TMP}/package" :test/package2
-$MPREMOTE resume ls :test :test/package2 :test/package2/subpackage
+$MPREMOTE cp -r "${TMP}/package" :test/package2
+$MPREMOTE ls :test :test/package2 :test/package2/subpackage
 
 # Copy from the device back to local.
 echo -----
 mkdir "${TMP}/copy"
-$MPREMOTE resume cp -r :test/package "${TMP}/copy"
+$MPREMOTE cp -r :test/package "${TMP}/copy"
 ls "${TMP}/copy" "${TMP}/copy/package" "${TMP}/copy/package/subpackage"
 
 # Copy from the device back to local with destination directory name.
 echo -----
-$MPREMOTE resume cp -r :test/package "${TMP}/copy/package2"
+$MPREMOTE cp -r :test/package "${TMP}/copy/package2"
 ls "${TMP}/copy" "${TMP}/copy/package2" "${TMP}/copy/package2/subpackage"
 
 
 # Copy from device to another location on the device with destination directory name.
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume cp -r :package :package3
-$MPREMOTE resume ls : :package3 :package3/subpackage
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE cp -r :package :package3
+$MPREMOTE ls : :package3 :package3/subpackage
 
 # Copy from device to another location on the device into an existing directory.
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume mkdir :package4
-$MPREMOTE resume cp -r :package :package4
-$MPREMOTE resume ls : :package4 :package4/package :package4/package/subpackage
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE mkdir :package4
+$MPREMOTE cp -r :package :package4
+$MPREMOTE ls : :package4 :package4/package :package4/package/subpackage
 
 # Repeat an existing copy with one file modified.
 echo -----
@@ -141,71 +141,71 @@ cat << EOF > "${TMP}/package/subpackage/y.py"
 def y():
   print("y2")
 EOF
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume ls : :package :package/subpackage
-$MPREMOTE resume exec "import package; package.x(); package.y()"
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE ls : :package :package/subpackage
+$MPREMOTE exec "import package; package.x(); package.y()"
 
 echo -----
 # Test rm -r functionality
 # start with a fresh ramdisk before each test
 # rm -r MCU current working directory
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume touch :a.py
-$MPREMOTE resume touch :b.py
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume rm -r -v :
-$MPREMOTE resume ls :
-$MPREMOTE resume ls :/ramdisk
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE touch :a.py
+$MPREMOTE touch :b.py
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE rm -r -v :
+$MPREMOTE ls :
+$MPREMOTE ls :/ramdisk
 
 echo -----
 # rm -r relative subfolder
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume touch :a.py
-$MPREMOTE resume mkdir :testdir
-$MPREMOTE resume cp -r "${TMP}/package" :testdir/package
-$MPREMOTE resume ls :testdir
-$MPREMOTE resume ls :testdir/package
-$MPREMOTE resume rm -r :testdir/package
-$MPREMOTE resume ls :/ramdisk
-$MPREMOTE resume ls :testdir
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE touch :a.py
+$MPREMOTE mkdir :testdir
+$MPREMOTE cp -r "${TMP}/package" :testdir/package
+$MPREMOTE ls :testdir
+$MPREMOTE ls :testdir/package
+$MPREMOTE rm -r :testdir/package
+$MPREMOTE ls :/ramdisk
+$MPREMOTE ls :testdir
 
 echo -----
 # rm -r non-existent path
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume ls :
-$MPREMOTE resume rm -r :nonexistent || echo "expect error"
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE ls :
+$MPREMOTE rm -r :nonexistent || echo "expect error"
 
 echo -----
 # rm -r absolute root
 # no -v to generate same output on stm32 and other ports
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume touch :a.py
-$MPREMOTE resume touch :b.py
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume cp -r "${TMP}/package" :package2
-$MPREMOTE resume rm -r :/ || echo "expect error"
-$MPREMOTE resume ls :
-$MPREMOTE resume ls :/ramdisk
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE touch :a.py
+$MPREMOTE touch :b.py
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE cp -r "${TMP}/package" :package2
+$MPREMOTE rm -r :/ || echo "expect error"
+$MPREMOTE ls :
+$MPREMOTE ls :/ramdisk
 
 echo -----
 # rm -r relative mountpoint
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume touch :a.py
-$MPREMOTE resume touch :b.py
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume exec "import os;os.chdir('/')"
-$MPREMOTE resume rm -r -v :ramdisk
-$MPREMOTE resume ls :/ramdisk
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE touch :a.py
+$MPREMOTE touch :b.py
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE exec "import os;os.chdir('/')"
+$MPREMOTE rm -r -v :ramdisk
+$MPREMOTE ls :/ramdisk
 
 echo -----
 # rm -r absolute mountpoint
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume touch :a.py
-$MPREMOTE resume touch :b.py
-$MPREMOTE resume cp -r "${TMP}/package" :
-$MPREMOTE resume exec "import os;os.chdir('/')"
-$MPREMOTE resume rm -r -v :/ramdisk
-$MPREMOTE resume ls :/ramdisk
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE touch :a.py
+$MPREMOTE touch :b.py
+$MPREMOTE cp -r "${TMP}/package" :
+$MPREMOTE exec "import os;os.chdir('/')"
+$MPREMOTE rm -r -v :/ramdisk
+$MPREMOTE ls :/ramdisk
 
 echo -----
 # try to delete existing folder in mounted filesystem

--- a/tools/mpremote/tests/test_fs_tree.sh
+++ b/tools/mpremote/tests/test_fs_tree.sh
@@ -8,65 +8,65 @@ $MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; 
 
 # setup 
 echo -----
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume ls
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE ls
 
 echo -----
 echo "empty tree"
-$MPREMOTE resume tree :
+$MPREMOTE tree :
 
 echo -----
-$MPREMOTE resume touch :a.py + touch :b.py  
-$MPREMOTE resume mkdir :foo + touch :foo/aa.py + touch :foo/ba.py
+$MPREMOTE touch :a.py + touch :b.py  
+$MPREMOTE mkdir :foo + touch :foo/aa.py + touch :foo/ba.py
 
 echo "small tree - :" 
-$MPREMOTE resume tree :
+$MPREMOTE tree :
 
 echo -----
 echo "no path" 
-$MPREMOTE resume tree 
+$MPREMOTE tree 
 
 echo -----
 echo "path = '.'" 
-$MPREMOTE resume tree .
+$MPREMOTE tree .
 
 echo -----
 echo "path = ':.'" 
-$MPREMOTE resume tree :.
+$MPREMOTE tree :.
 
 
 echo -----
 echo "multiple trees" 
-$MPREMOTE resume mkdir :bar + touch :bar/aaa.py + touch :bar/bbbb.py
-$MPREMOTE resume mkdir :bar/baz + touch :bar/baz/aaa.py + touch :bar/baz/bbbb.py
-$MPREMOTE resume mkdir :bar/baz/quux + touch :bar/baz/quux/aaa.py + touch :bar/baz/quux/bbbb.py
-$MPREMOTE resume mkdir :bar/baz/quux/xen + touch :bar/baz/quux/xen/aaa.py
+$MPREMOTE mkdir :bar + touch :bar/aaa.py + touch :bar/bbbb.py
+$MPREMOTE mkdir :bar/baz + touch :bar/baz/aaa.py + touch :bar/baz/bbbb.py
+$MPREMOTE mkdir :bar/baz/quux + touch :bar/baz/quux/aaa.py + touch :bar/baz/quux/bbbb.py
+$MPREMOTE mkdir :bar/baz/quux/xen + touch :bar/baz/quux/xen/aaa.py
 
-$MPREMOTE resume tree
+$MPREMOTE tree
 
 echo -----
 echo single path
-$MPREMOTE resume tree :foo
+$MPREMOTE tree :foo
 
 echo -----
 echo "multiple paths" 
-$MPREMOTE resume tree :foo :bar
+$MPREMOTE tree :foo :bar
 
 echo -----
 echo "subtree" 
-$MPREMOTE resume tree bar/baz
+$MPREMOTE tree bar/baz
 
 echo -----
 echo mountpoint
-$MPREMOTE resume tree :/ramdisk
+$MPREMOTE tree :/ramdisk
 
 echo -----
 echo non-existent folder : error
-$MPREMOTE resume tree :not_there || echo "expect error: $?"
+$MPREMOTE tree :not_there || echo "expect error: $?"
 
 echo -----
 echo file : error 
-$MPREMOTE resume tree :a.py || echo "expect error: $?"
+$MPREMOTE tree :a.py || echo "expect error: $?"
 
 echo -----
 echo "tree -s :"
@@ -76,14 +76,14 @@ dd if=/dev/zero of="${TMP}/data/file2.txt" bs=1 count=204 > /dev/null 2>&1
 dd if=/dev/zero of="${TMP}/data/file3.txt" bs=1 count=1096 > /dev/null 2>&1
 dd if=/dev/zero of="${TMP}/data/file4.txt" bs=1 count=2192 > /dev/null 2>&1
 
-$MPREMOTE resume cp -r "${TMP}/data" :
-$MPREMOTE resume tree -s :
+$MPREMOTE cp -r "${TMP}/data" :
+$MPREMOTE tree -s :
 echo -----
 echo "tree -s"
-$MPREMOTE resume tree -s
+$MPREMOTE tree -s
 echo -----
-$MPREMOTE resume tree --human :
+$MPREMOTE tree --human :
 echo -----
-$MPREMOTE resume tree -s --human : || echo "expect error: $?"
+$MPREMOTE tree -s --human : || echo "expect error: $?"
 echo -----
 

--- a/tools/mpremote/tests/test_mip_local_install.sh
+++ b/tools/mpremote/tests/test_mip_local_install.sh
@@ -31,12 +31,12 @@ cat > ${PACKAGE_DIR}/package.json <<EOF
 }
 EOF
 
-$MPREMOTE exec "mount_path='${target}'; do_chdir=False" run "${TEST_DIR}/ramdisk.py"
-$MPREMOTE resume mkdir ${target}/lib
+$MPREMOTE soft-reset exec "mount_path='${target}'; do_chdir=False" run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE mkdir ${target}/lib
 echo
 echo ---- Install package
-$MPREMOTE resume mip install --target=${target}/lib ${PACKAGE_DIR}/package.json
+$MPREMOTE mip install --target=${target}/lib ${PACKAGE_DIR}/package.json
 echo
 echo ---- Test package
-$MPREMOTE resume exec "import sys; sys.path.append(\"${target}/lib\")"
-$MPREMOTE resume exec "import ${PACKAGE}; ${PACKAGE}.hello()"
+$MPREMOTE exec "import sys; sys.path.append(\"${target}/lib\")"
+$MPREMOTE exec "import ${PACKAGE}; ${PACKAGE}.hello()"

--- a/tools/mpremote/tests/test_mount.sh
+++ b/tools/mpremote/tests/test_mount.sh
@@ -23,13 +23,13 @@ def y():
   print("y")
 EOF
 
-output=$($MPREMOTE mount ${TMP} eval "'mounted successfully'" 2>&1) || true
+output=$($MPREMOTE soft-reset mount ${TMP} eval "'mounted successfully'" 2>&1) || true
 if [[ "$output" == *"MemoryError"* ]]; then
     echo "SKIP ('MemoryError' insufficient memory)"
     exit 0
 fi
 
-$MPREMOTE mount ${TMP} exec "import mount_package; mount_package.x(); mount_package.y()"
+$MPREMOTE soft-reset mount ${TMP} exec "import mount_package; mount_package.x(); mount_package.y()"
 
 # Write to a file on the device and see that it's written locally.
 echo -----

--- a/tools/mpremote/tests/test_resume.sh
+++ b/tools/mpremote/tests/test_resume.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 set -e
 
-# The eval command will continue the state of the exec.
+# The eval command will continue the state of the exec (default resume behavior).
 echo -----
 $MPREMOTE exec "a = 'hello'" eval "a"
 
-# Automatic soft reset. `a` will trigger NameError.
+# With new default behavior, `a` will persist across sessions.
 echo -----
-$MPREMOTE eval "a" || true
+$MPREMOTE eval "a"
 
-# Resume will skip soft reset.
+# Variables persist by default (no resume command needed).
 echo -----
-$MPREMOTE exec "a = 'resume'"
-$MPREMOTE resume eval "a"
+$MPREMOTE exec "a = 'persists'"
+$MPREMOTE eval "a"
 
-# The eval command will continue the state of the exec.
+# Explicit soft-reset clears variables.
 echo -----
 $MPREMOTE exec "a = 'soft-reset'" eval "a" soft-reset eval "1+1" eval "a" || true
 
-# A disconnect will trigger auto-reconnect.
+# A disconnect will no longer reset state.
 echo -----
 $MPREMOTE eval "1+2" disconnect eval "2+3"

--- a/tools/mpremote/tests/test_resume.sh
+++ b/tools/mpremote/tests/test_resume.sh
@@ -1,23 +1,26 @@
 #!/bin/bash
 set -e
 
-# The eval command will continue the state of the exec.
+# Interpreter state is carried from one command to the next.
 echo -----
-$MPREMOTE exec "a = 'hello'" eval "a"
+$MPREMOTE soft-reset exec "a = 'hello'" eval "a"
 
-# Automatic soft reset. `a` will trigger NameError.
+# It is also carried between separate invocations of mpremote.
 echo -----
-$MPREMOTE eval "'a' in globals()" || true
+$MPREMOTE eval "a"
 
-# Resume will skip soft reset.
 echo -----
-$MPREMOTE exec "a = 'resume'"
+$MPREMOTE exec "a = 'persists'"
+$MPREMOTE eval "a"
+
+# The "resume" command is accepted for backwards compatibility and does nothing.
+echo -----
 $MPREMOTE resume eval "a"
 
-# The eval command will continue the state of the exec.
+# An explicit soft-reset clears the interpreter state.
 echo -----
 $MPREMOTE exec "a = 'soft-reset'" eval "a" soft-reset eval "1+1" eval "'a' in globals()" || true
 
-# A disconnect will trigger auto-reconnect.
+# A disconnect does not clear the interpreter state.
 echo -----
 $MPREMOTE eval "1+2" disconnect eval "2+3"

--- a/tools/mpremote/tests/test_resume.sh.exp
+++ b/tools/mpremote/tests/test_resume.sh.exp
@@ -1,11 +1,9 @@
 -----
 hello
 -----
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'a' isn't defined
+hello
 -----
-resume
+persists
 -----
 soft-reset
 2

--- a/tools/mpremote/tests/test_resume.sh.exp
+++ b/tools/mpremote/tests/test_resume.sh.exp
@@ -1,9 +1,11 @@
 -----
 hello
 -----
-False
+hello
 -----
-resume
+persists
+-----
+persists
 -----
 soft-reset
 2

--- a/tools/mpremote/tests/test_unicode.sh
+++ b/tools/mpremote/tests/test_unicode.sh
@@ -15,20 +15,20 @@ TEST_DIR=$(dirname $0)
 $MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
 
 # Initialize ramdisk for file tests
-$MPREMOTE run "${TEST_DIR}/ramdisk.py"
+$MPREMOTE soft-reset run "${TEST_DIR}/ramdisk.py"
 
 echo -----
 # Test UTF-8 output via exec (tests stdout_write_bytes UTF-8 handling)
-$MPREMOTE resume exec "print('Hello 世界')"
-$MPREMOTE resume exec "print('Emoji: 🎉🐍')"
-$MPREMOTE resume exec "print('Accents: café, naïve, résumé')"
+$MPREMOTE exec "print('Hello 世界')"
+$MPREMOTE exec "print('Emoji: 🎉🐍')"
+$MPREMOTE exec "print('Accents: café, naïve, résumé')"
 
 echo -----
 # Test Files with single quotes in names (tests _quote_path in transport.py)
-$MPREMOTE resume touch ":quote'test.txt"
-$MPREMOTE resume ls :
-$MPREMOTE resume rm ":quote'test.txt"
-$MPREMOTE resume ls :
+$MPREMOTE touch ":quote'test.txt"
+$MPREMOTE ls :
+$MPREMOTE rm ":quote'test.txt"
+$MPREMOTE ls :
 
 echo -----
 # Test Writing and reading UTF-8 content (tests transport and wr_bytes)
@@ -37,9 +37,9 @@ Hello 世界
 Emoji: 🎉🐍
 Café résumé naïve
 EOF
-$MPREMOTE resume cp "${TMP}/unicode_content.txt" :
-$MPREMOTE resume cat :unicode_content.txt
-$MPREMOTE resume sha256sum :unicode_content.txt
+$MPREMOTE cp "${TMP}/unicode_content.txt" :
+$MPREMOTE cat :unicode_content.txt
+$MPREMOTE sha256sum :unicode_content.txt
 cat "${TMP}/unicode_content.txt" | sha256sum
 
 echo -----
@@ -60,17 +60,17 @@ $MPREMOTE mount ${TMP} run "${TMP}/write_utf_to_mounted.py"
 echo -----
 # Test Command expansion with `=` sign (tests main.py fix)
 # The `=` in arguments should not cause errors
-$MPREMOTE resume exec "x = 'a=b'; print(x)"
+$MPREMOTE exec "x = 'a=b'; print(x)"
 
 echo -----
 # Test eval with Unicode strings
-$MPREMOTE resume eval "'Hello 世界'"
-$MPREMOTE resume eval "repr('日本語')"
+$MPREMOTE eval "'Hello 世界'"
+$MPREMOTE eval "repr('日本語')"
 
 echo -----
 # Test UTF-8 display on Windows
 # Testing mpremote on windows with bash is not straightforward,
 # but we can at least run the command that was problematic.
-$MPREMOTE resume exec "print('Hello World'); print('你好'); print('=' * 20)"
+$MPREMOTE exec "print('Hello World'); print('你好'); print('=' * 20)"
 
 echo -----


### PR DESCRIPTION
## Summary

Changes Python session state preservation to be the default behavior in mpremote. Previously, mpremote performed automatic soft-reset between command sessions, clearing variables and imports. Users had to explicitly use the `resume` command to preserve state.

This change makes the "resume" behavior the default and removes the `resume` command entirely. Users wanting the old auto soft-reset behavior can now explicitly add `soft-reset` to their command sequences.

**Example behavior change:**
```bash
# Before (auto soft-reset default):
mpremote exec "a = 1" eval "a"  # Would fail with NameError
mpremote resume exec "a = 1" eval "a"  # Would work

# After (resume default):
mpremote exec "a = 1" eval "a"  # Now works by default
mpremote soft-reset exec "a = 1" eval "a"  # Explicit soft-reset for old behavior
```

## Testing

- Updated existing `test_resume.sh` test to reflect new behavior
- All pre-commit hooks pass (ruff, codespell, codeformat.py)
- Tested that explicit `soft-reset` commands replicate the old default behavior

## Trade-offs and Alternatives

**Benefits:**
- More intuitive behavior - variables persist as users expect
- Reduces need for explicit `resume` commands in workflows
- Simplifies automation scripts that work with persistent state

**Breaking change considerations:**
- Existing scripts expecting auto soft-reset will see different behavior
- Some users may have automation that depends on clean state per command
- Migration path: add explicit `soft-reset` where clean state is required

**Implementation details:**
- Changed `State.__init__()` to set `_auto_soft_reset = False` by default
- Removed `do_resume()` function and command registration
- Removed auto-reset on disconnect to maintain consistency
- Explicit `soft-reset` command continues to work as before

This provides the same functionality as before but with inverted defaults, making the more commonly desired behavior (state persistence) the default while still allowing users to get clean state when needed.