### PR TITLE
modio.BufferedWriter: Fix the case where write() fails.

### DIFF
--- a/py/modio.c
+++ b/py/modio.c
@@ -169,12 +169,13 @@ static mp_obj_t bufwriter_flush(mp_obj_t self_in) {
         int err;
         mp_uint_t out_sz = mp_stream_write_exactly(self->stream, self->buf, self->len, &err);
         (void)out_sz;
-        // TODO: try to recover from a case of non-blocking stream, e.g. move
-        // remaining chunk to the beginning of buffer.
-        assert(out_sz == self->len);
-        self->len = 0;
         if (err != 0) {
             mp_raise_OSError(err);
+        } else {
+            // TODO: try to recover from a case of non-blocking stream, e.g. move
+            // remaining chunk to the beginning of buffer.
+            assert(out_sz == self->len);
+            self->len = 0;
         }
     }
 

--- a/tests/basics/io_buffered_writer.py
+++ b/tests/basics/io_buffered_writer.py
@@ -31,13 +31,24 @@ print(type(hash(buf)))
 
 # Test failing flush()
 class MyIO(io.IOBase):
+    def __init__(self):
+        self.count = 0
+
     def write(self, buf):
-        return None
+        self.count += 1
+        if self.count < 3:
+            return None
+        print("writing", buf)
+        return len(buf)
+
 
 buf = io.BufferedWriter(MyIO(), 8)
+
 buf.write(b"foobar")
-try:
-    buf.flush()
-    print("flushed")
-except OSError:
-    print("OSError")
+
+for _ in range(4):
+    try:
+        buf.flush()
+        print("flushed")
+    except OSError:
+        print("OSError")

--- a/tests/basics/io_buffered_writer.py
+++ b/tests/basics/io_buffered_writer.py
@@ -28,3 +28,16 @@ print(bts.getvalue())
 
 # hashing a BufferedWriter
 print(type(hash(buf)))
+
+# Test failing flush()
+class MyIO(io.IOBase):
+    def write(self, buf):
+        return None
+
+buf = io.BufferedWriter(MyIO(), 8)
+buf.write(b"foobar")
+try:
+    buf.flush()
+    print("flushed")
+except OSError:
+    print("OSError")

--- a/tests/basics/io_buffered_writer.py.exp
+++ b/tests/basics/io_buffered_writer.py.exp
@@ -4,3 +4,4 @@ b'foobarfoobar'
 b'foobarfoobar'
 b'foo'
 <class 'int'>
+OSError

--- a/tests/basics/io_buffered_writer.py.exp
+++ b/tests/basics/io_buffered_writer.py.exp
@@ -5,3 +5,7 @@ b'foobarfoobar'
 b'foo'
 <class 'int'>
 OSError
+OSError
+writing bytearray(b'foobar')
+flushed
+flushed


### PR DESCRIPTION

### Summary

Previously, there was no test coverage of the "write failed" path. In fact, the assertion would fire instead of gracefully raising a Python exception.

Slightly re-organize the code to place the assertion later. Add a test case, and update the expected output.

### Testing

I ran the unix coverage tests locally.

### Trade-offs and Alternatives

I considered writing `assert(err || (out_sz == self->len));` but thought this was preferable.