### PR TITLE
mpprint: Improve coverage and remove dead code

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -220,6 +220,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%X\n", 0x80000000); // should print unsigned
         mp_printf(&mp_plat_print, "abc\n%"); // string ends in middle of format specifier
         mp_printf(&mp_plat_print, "%%\n"); // literal % character
+        mp_printf(&mp_plat_print, ".%-3s.\n", "a"); // left adjust
     }
 
     // GC

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -413,8 +413,6 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 flags |= PF_FLAG_SHOW_SIGN;
             } else if (*fmt == ' ') {
                 flags |= PF_FLAG_SPACE_SIGN;
-            } else if (*fmt == '!') {
-                flags |= PF_FLAG_NO_TRAILZ;
             } else if (*fmt == '0') {
                 flags |= PF_FLAG_PAD_AFTER_SIGN;
                 fill = '0';

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -32,11 +32,11 @@
 #define PF_FLAG_SHOW_SIGN         (0x002)
 #define PF_FLAG_SPACE_SIGN        (0x004)
 #define PF_FLAG_NO_TRAILZ         (0x008)
-#define PF_FLAG_SHOW_PREFIX       (0x010)
-#define PF_FLAG_PAD_AFTER_SIGN    (0x020)
-#define PF_FLAG_CENTER_ADJUST     (0x040)
-#define PF_FLAG_ADD_PERCENT       (0x080)
-#define PF_FLAG_SHOW_OCTAL_LETTER (0x100)
+#define PF_FLAG_SHOW_PREFIX       (0x008)
+#define PF_FLAG_PAD_AFTER_SIGN    (0x010)
+#define PF_FLAG_CENTER_ADJUST     (0x020)
+#define PF_FLAG_ADD_PERCENT       (0x040)
+#define PF_FLAG_SHOW_OCTAL_LETTER (0x080)
 #define PF_FLAG_SEP_POS           (9) // must be above all the above PF_FLAGs
 
 #if MICROPY_PY_IO && MICROPY_PY_SYS_STDFILES

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -31,7 +31,6 @@
 #define PF_FLAG_LEFT_ADJUST       (0x001)
 #define PF_FLAG_SHOW_SIGN         (0x002)
 #define PF_FLAG_SPACE_SIGN        (0x004)
-#define PF_FLAG_NO_TRAILZ         (0x008)
 #define PF_FLAG_SHOW_PREFIX       (0x008)
 #define PF_FLAG_PAD_AFTER_SIGN    (0x010)
 #define PF_FLAG_CENTER_ADJUST     (0x020)

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -14,6 +14,7 @@ false true
 80000000
 abc
 %
+.a  .
 # GC
 0
 0


### PR DESCRIPTION
### Summary

I was looking at coverage misses in mpprint .c. This PR is the result of investigating some un-covered lines.

mpprint: Remove unused "PF_FLAG_NO_TRAILZ" flag and re-number the other flags.

Leave PF_FLAG_SEP_POS at 9 (the highest position that probably works with 16-bit integers like the pic16bit port)

coverage: Test left adjusted print.

### Testing

I ran the Unix coverage tests locally.

I looked at git history and found no indication that the NO_TRAILZ flag was ever implemented or that "%!" was used as an mp_printf format string in practice.