### PR TITLE
py/misc: Fix fallback implementation of mp_popcount.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -390,7 +390,7 @@ static inline uint32_t mp_popcount(uint32_t x) {
     x = x - ((x >> 1) & 0x55555555);
     x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
     x = (x + (x >> 4)) & 0x0F0F0F0F;
-    return x * 0x01010101;
+    return (x * 0x01010101) >> 24;
 }
 #endif
 #endif


### PR DESCRIPTION
### Summary

The fallback `mp_popcount()` was broken, missing a shift.

### Testing

Tested using gcc 7.3.1 which does not have the popcount built-in and uses this fallback version.  Without the fix, `mpy-cross -march=rv32imc -X emit=native` produces mpy files with corrupt RISC-V machine code.  With the fix, `mpy-cross` output is correct.

Note: gcc 7.3.1 can be tested using docker image `larsks/esp-open-sdk`.

This bug was found as part of Octoprobe integration: https://github.com/octoprobe/testbed_micropython/issues/27