### PR TITLE
asmbase: Fix assertion error with viper code.

### DIFF
--- a/py/asmbase.c
+++ b/py/asmbase.c
@@ -53,7 +53,7 @@ void mp_asm_base_start_pass(mp_asm_base_t *as, int pass) {
     } else {
         // allocating executable RAM is platform specific
         MP_PLAT_ALLOC_EXEC(as->code_offset, (void **)&as->code_base, &as->code_size);
-        assert(as->code_base != NULL);
+        assert(as->code_size == 0 || as->code_base != NULL);
     }
     as->pass = pass;
     as->suppress = false;


### PR DESCRIPTION

### Summary

In the case of viper code it's possible to reach MP_ASM_PASS_EMIT with a code size of 0 bytes. Update the assertion accordingly.

After this change, `mpy-cross -march=debug' on the viper tests creates output that looks plausible to me, though I am not experienced in reading the output.


Closes: #17467


### Testing

I locally ran mpy-cross on some viper files.

### Trade-offs and Alternatives

As this just changes an assertion it's unlikely to affect real ports.

I briefly considered that the code size could also be forced non-zero but this would add code and doesn't appear to be necessary. Or, that the debug backend emitter could set its own length, but this does not seem to be necessary.