### PR TITLE
alif: Add support for machine_pin IRQ.

### DIFF
--- a/ports/alif/irq.h
+++ b/ports/alif/irq.h
@@ -48,6 +48,7 @@
 #define IRQ_PRI_USB             NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 7, 0)
 #define IRQ_PRI_HWSEM           NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 8, 0)
 #define IRQ_PRI_GPU             NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 10, 0)
+#define IRQ_PRI_GPIO            NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 50, 0)
 #define IRQ_PRI_RTC             NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 100, 0)
 #define IRQ_PRI_CYW43           NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 126, 0)
 #define IRQ_PRI_PENDSV          NVIC_EncodePriority(NVIC_PRIORITYGROUP_7, 127, 0)

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -55,6 +55,7 @@
 
 extern uint8_t __StackTop, __StackLimit;
 extern uint8_t __GcHeapStart, __GcHeapEnd;
+extern void machine_pin_irq_deinit(void);
 
 MP_NORETURN void panic(const char *msg) {
     mp_hal_stdout_tx_strn("\nFATAL ERROR:\n", 14);
@@ -164,6 +165,7 @@ int main(void) {
         mp_bluetooth_deinit();
         #endif
         soft_timer_deinit();
+        machine_pin_irq_deinit();
         gc_sweep_all();
         mp_deinit();
     }

--- a/ports/alif/mphalport.h
+++ b/ports/alif/mphalport.h
@@ -90,6 +90,9 @@ extern ringbuf_t stdin_ringbuf;
 #define MP_HAL_PIN_SPEED_LOW                    (0)
 #define MP_HAL_PIN_SPEED_HIGH                   (PADCTRL_SLEW_RATE_FAST)
 
+#define MP_HAL_PIN_TRIGGER_FALL                 (1)
+#define MP_HAL_PIN_TRIGGER_RISE                 (2)
+
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
 
 #define MP_HAL_PIN_ALT(function, unit)          (MP_HAL_PIN_ALT_MAKE((MP_HAL_PIN_ALT_##function), (unit)))


### PR DESCRIPTION
### Summary

Adds support for machine.Pin.IRQ().

### Testing

Rising/falling edge seems to work fine. Also made sure IRQs are disabled on soft-reset.

### Trade-offs and Alternatives

I think `mpirq.c` needs a finaliser, this way we won't need `machine_pin_irq_deinit();`: when the object is collected, it could just disable the IRQ by calling `trigger(0)`. Also, it would be nice if `mp_irq_obj_t` could just add the `flags` and `trigger` as they seem to be used by all ports, and all ports use this weird object to wrap `mp_irq_obj_t` to add the fields.

Finally, CYW43 should use the Python API to create a pin and register an IRQ, and set it to reserved. For now I just avoided redefining the IRQ handler so it builds.