### PR TITLE
samd/boards: Change the SparkFun vendor name to SparkFun.

### DIFF
--- a/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/board.json
+++ b/ports/samd/boards/SPARKFUN_REDBOARD_TURBO/board.json
@@ -17,5 +17,5 @@
     "product": "SparkFun RedBoard Turbo",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/14812",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }

--- a/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/board.json
+++ b/ports/samd/boards/SPARKFUN_SAMD21_DEV_BREAKOUT/board.json
@@ -15,5 +15,5 @@
     "product": "SparkFun SAMD21 Dev Breakout",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/13672",
-    "vendor": "Sparkfun"
+    "vendor": "SparkFun"
 }


### PR DESCRIPTION
### Summary

In the board.json files the vendor name was mis-spelled as "Sparkfun", causing two vendors showing up at the download pages. This PR changes the vendor name to "SparkFun". Only the board.json files are affected. No other file uses the style "Sparkfun". The documentation files use "SparkFun"..

### Testing

No testing is required or possible. The result should show up in the next days at the download site.

### Trade-offs and Alternatives

None