### PR TITLE
py/obj: Fix nan handling in REPR_C and REPR_D.

### DIFF
--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -266,6 +266,11 @@ typedef long mp_off_t;
 #endif
 #endif
 
+// VC++ 2017 fixes
+#if (_MSC_VER < 1920)
+#define MICROPY_PY_MATH_COPYSIGN_FIX_NAN (1)
+#endif
+
 // CL specific definitions
 
 #ifndef __cplusplus

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -161,6 +161,11 @@ MATH_FUN_2(atan2, atan2)
 MATH_FUN_1_TO_INT(ceil, ceil)
 // copysign(x, y)
 static mp_float_t MICROPY_FLOAT_C_FUN(copysign_func)(mp_float_t x, mp_float_t y) {
+    #if MICROPY_PY_MATH_COPYSIGN_FIX_NAN
+    if (isnan(y)) {
+        y = 0.0;
+    }
+    #endif
     return MICROPY_FLOAT_C_FUN(copysign)(x, y);
 }
 MATH_FUN_2(copysign, copysign_func)

--- a/py/obj.h
+++ b/py/obj.h
@@ -184,13 +184,15 @@ static inline bool mp_obj_is_small_int(mp_const_obj_t o) {
 #define MP_OBJ_NEW_SMALL_INT(small_int) ((mp_obj_t)((((mp_uint_t)(small_int)) << 1) | 1))
 
 #if MICROPY_PY_BUILTINS_FLOAT
-#define MP_OBJ_NEW_CONST_FLOAT(f) MP_ROM_PTR((mp_obj_t)((((((uint64_t)f) & ~3) | 2) + 0x80800000) & 0xffffffff))
+#include <math.h>
+// note: MP_OBJ_NEW_CONST_FLOAT should be a MP_ROM_PTR but that macro isn't available yet
+#define MP_OBJ_NEW_CONST_FLOAT(f) ((mp_obj_t)((((((uint64_t)f) & ~3) | 2) + 0x80800000) & 0xffffffff))
 #define mp_const_float_e  MP_OBJ_NEW_CONST_FLOAT(0x402df854)
 #define mp_const_float_pi MP_OBJ_NEW_CONST_FLOAT(0x40490fdb)
+#define mp_const_float_nan MP_OBJ_NEW_CONST_FLOAT(0x7fc00000)
 #if MICROPY_PY_MATH_CONSTANTS
 #define mp_const_float_tau MP_OBJ_NEW_CONST_FLOAT(0x40c90fdb)
 #define mp_const_float_inf MP_OBJ_NEW_CONST_FLOAT(0x7f800000)
-#define mp_const_float_nan MP_OBJ_NEW_CONST_FLOAT(0xffc00000)
 #endif
 
 static inline bool mp_obj_is_float(mp_const_obj_t o) {
@@ -207,6 +209,10 @@ static inline mp_float_t mp_obj_float_get(mp_const_obj_t o) {
     return num.f;
 }
 static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
+    if (isnan(f)) {
+        // prevent creation of bad nanboxed pointers via array.array or struct
+        return mp_const_float_nan;
+    }
     union {
         mp_float_t f;
         mp_uint_t u;
@@ -257,12 +263,13 @@ static inline bool mp_obj_is_immediate_obj(mp_const_obj_t o) {
 #error MICROPY_OBJ_REPR_D requires MICROPY_FLOAT_IMPL_DOUBLE
 #endif
 
+#include <math.h>
 #define mp_const_float_e {((mp_obj_t)((uint64_t)0x4005bf0a8b145769 + 0x8004000000000000))}
 #define mp_const_float_pi {((mp_obj_t)((uint64_t)0x400921fb54442d18 + 0x8004000000000000))}
+#define mp_const_float_nan {((mp_obj_t)((uint64_t)0x7ff8000000000000 + 0x8004000000000000))}
 #if MICROPY_PY_MATH_CONSTANTS
 #define mp_const_float_tau {((mp_obj_t)((uint64_t)0x401921fb54442d18 + 0x8004000000000000))}
 #define mp_const_float_inf {((mp_obj_t)((uint64_t)0x7ff0000000000000 + 0x8004000000000000))}
-#define mp_const_float_nan {((mp_obj_t)((uint64_t)0xfff8000000000000 + 0x8004000000000000))}
 #endif
 
 static inline bool mp_obj_is_float(mp_const_obj_t o) {
@@ -276,6 +283,13 @@ static inline mp_float_t mp_obj_float_get(mp_const_obj_t o) {
     return num.f;
 }
 static inline mp_obj_t mp_obj_new_float(mp_float_t f) {
+    if (isnan(f)) {
+        // prevent creation of bad nanboxed pointers via array.array or struct
+        struct {
+            uint64_t r;
+        } num = mp_const_float_nan;
+        return num.r;
+    }
     union {
         mp_float_t f;
         uint64_t r;

--- a/tests/float/float_array.py
+++ b/tests/float/float_array.py
@@ -19,4 +19,10 @@ def test(a):
 test(array("f"))
 test(array("d"))
 
-print("{:.4f}".format(array("f", bytes(array("I", [0x3DCCCCCC])))[0]))
+# hand-crafted floats, including non-standard nan
+for float_hex in (0x3DCCCCCC, 0x7F800024, 0x7FC00004):
+    f = array("f", bytes(array("I", [float_hex])))[0]
+    if type(f) is float:
+        print("{:.4e}".format(f))
+    else:
+        print(f)

--- a/tests/float/math_constants_extra.py
+++ b/tests/float/math_constants_extra.py
@@ -9,9 +9,12 @@ except (ImportError, AttributeError):
     raise SystemExit
 
 print(math.tau == 2.0 * math.pi)
+print(math.copysign(1.0, math.tau))
 
 print(math.inf == float("inf"))
 print(-math.inf == -float("inf"))
+print(math.copysign(1.0, math.inf))
 
 print(isnan(math.nan))
 print(isnan(-math.nan))
+print(math.copysign(1.0, math.nan))


### PR DESCRIPTION
### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

CPython `math.nan` is positive with regards to `math.copysign()`.
In MicroPython, this is only true with REPR_A and REPR_B.

In addition, REPR_C and REPR_D (nanbox) should only use the _true_ `nan` to prevent system crash in case of hand-crafted floats.

This problem has been discovered while working on a test code for https://github.com/micropython/micropython/pull/17444
Fixing the issue without changing the constant used for `math.nan` did break an existing `copysign` test case.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

A new test case has been added to specific test the behaviour of `math` constants with regard to `copysign`.
Test cases creating special nans that were improperly interpreted in REPR_C have also been added.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

Fixing `nan` signaling flag does not change code size.

The extra check in  `mp_obj_new_float` will increase code size, but 
1. `nanbox` platform is probably not very sensitive to larger code as it uses 64 bit objects. As the added code prevents a crash, it is probably worth the small size increase. 
2. The impact on REPR_C appears to be quite small (as tested on ARMv4), and is actually more than compensated by removing the unnecessary bit-clearing code in the opposite function (`mp_obj_float_get`). Indeed, leaving bit 1 provides a better estimation of the original float value than always biasing the result toward zero by clearing both low bits.
