### PR TITLE
tools/mpremote: Add control for rts / dts running in linux.

### DIFF
--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -85,3 +85,15 @@ Examples:
     mpremote mip install aioble
     mpremote mip install github:org/repo@branch
     mpremote mip install gitlab:org/repo@branch
+
+Note for ESP-32 CAM with MB
+
+When using mpremote with the ESP-32 CAM attached to the ESP-32 CAM MB you might
+get into the situation that the communication is not working (i.e. you might
+get a timeout). To avoid this try using the following options:
+
+    mpremote connect --dtr 0 --rts 0 auto
+    mpremote connect --dtr 0 --rts 0 auto fs ls
+
+The commands may take some additional 1-2s to be executed in case the ESP32 is
+performing a hard reset.

--- a/tools/mpremote/README.md
+++ b/tools/mpremote/README.md
@@ -14,6 +14,9 @@ The full list of supported commands are:
     mpremote connect <device>         -- connect to given device
                                          device may be: list, auto, id:x, port:x
                                          or any valid device name/path
+                                         options:
+                                             --dtr [0|1|on|off]
+                                             --rts [0|1|on|off]
     mpremote disconnect               -- disconnect current device
     mpremote mount <local-dir>        -- mount local directory on device
     mpremote eval <string>            -- evaluate and print the string

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -19,6 +19,8 @@ class CommandError(Exception):
 
 def do_connect(state, args=None):
     dev = args.device[0] if args else "auto"
+    dtr = args.dtr[0] if args and args.dtr else None
+    rts = args.dtr[0] if args and args.rts else None
     do_disconnect(state)
 
     try:
@@ -42,7 +44,9 @@ def do_connect(state, args=None):
             for p in sorted(serial.tools.list_ports.comports()):
                 if p.vid is not None and p.pid is not None:
                     try:
-                        state.transport = SerialTransport(p.device, baudrate=115200)
+                        state.transport = SerialTransport(
+                            p.device, baudrate=115200, dtr=dtr, rts=rts
+                        )
                         return
                     except TransportError as er:
                         if not er.args[0].startswith("failed to access"):
@@ -54,14 +58,14 @@ def do_connect(state, args=None):
             dev = None
             for p in serial.tools.list_ports.comports():
                 if p.serial_number == serial_number:
-                    state.transport = SerialTransport(p.device, baudrate=115200)
+                    state.transport = SerialTransport(p.device, baudrate=115200, dtr=dtr, rts=rts)
                     return
             raise TransportError("no device with serial number {}".format(serial_number))
         else:
             # Connect to the given device.
             if dev.startswith("port:"):
                 dev = dev[len("port:") :]
-            state.transport = SerialTransport(dev, baudrate=115200)
+            state.transport = SerialTransport(dev, baudrate=115200, dtr=dtr, rts=rts)
             return
     except TransportError as er:
         msg = er.args[0]

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -101,6 +101,12 @@ def argparse_connect():
     cmd_parser.add_argument(
         "device", nargs=1, help="Either list, auto, id:x, port:x, or any valid device name/path"
     )
+    cmd_parser.add_argument(
+        "--dtr", nargs=1, choices=['0', '1', 'on', 'off'], help="force dtr state"
+    )
+    cmd_parser.add_argument(
+        "--rts", nargs=1, choices=['0', '1', 'on', 'off'], help="force rts state"
+    )
     return cmd_parser
 
 

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -136,7 +136,6 @@ class SerialTransport(Transport):
                 break
             elif self.serial.inWaiting() > 0:
                 new_data = self.serial.read(1)
-                # print ("newData=", new_data, file=sys.stderr)
                 if data_consumer:
                     data_consumer(new_data)
                     data = new_data
@@ -155,34 +154,36 @@ class SerialTransport(Transport):
         return data
 
     def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
-        self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
-        self.serial.flush()
         if self.dtr or self.rts:
-            print("wait for repl prompt...", file=sys.stderr)
-            data = self.read_until(1, b"\r\n>>> ", timeout_overall=min(timeout_overall, 2))
-
-            # print(data, file=sys.stderr)
-            if not data.endswith(b"\r\n>>> "):
-                # do it a second time in case some code is running after hard reset
-                print("not found, sent ctrl-c and wait again...", file=sys.stderr)
+            print("Special handling in DTR / RTS mode, might need to wait for controller to boot")
+            self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
+            time.sleep(0.1)
+            self.serial.flush()
+            self.serial.flushInput()
+            for cnt in range(timeout_overall):
+                if cnt > 0:
+                    print("not found, send ctrl-c again and wait again...")
                 self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
                 self.serial.flush()
-                data = self.read_until(1, b"\r\n>>> ", timeout_overall=min(timeout_overall, 2))
-                if not data.endswith(b"\r\n>>> "):
-                    print(data)
-                    raise TransportError("could not find repl mode")
-            print("###found", file=sys.stderr)
+                print("wait for REPL prompt...")
+                data = self.read_until(1, b"\r\n>>> ", timeout_overall=1)
+                if data.endswith(b"\r\n>>> "):
+                    print("REPL prompt found")
+                    break
+            else:
+                raise TransportError("could not find repl mode")
+        else:
+            self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
+            self.serial.flush()
         # flush input (without relying on serial.flushInput())
         n = self.serial.inWaiting()
         while n > 0:
             self.serial.read(n)
             n = self.serial.inWaiting()
-        print("###flush done, enter raw", file=sys.stderr)
+
         self.serial.write(b"\r\x01")  # ctrl-A: enter raw REPL
         self.serial.flush()
         if soft_reset and not self.dtr and not self.rts:
-            print("###is soft reset", file=sys.stderr)
-
             data = self.read_until(
                 1, b"raw REPL; CTRL-B to exit\r\n>", timeout_overall=timeout_overall
             )

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -44,7 +44,9 @@ from .transport import TransportError, TransportExecError, Transport
 class SerialTransport(Transport):
     fs_hook_mount = "/remote"  # MUST match the mount point in fs_hook_code
 
-    def __init__(self, device, baudrate=115200, wait=0, exclusive=True, timeout=None):
+    def __init__(
+        self, device, baudrate=115200, wait=0, exclusive=True, timeout=None, dtr=None, rts=None
+    ):
         self.in_raw_repl = False
         self.use_raw_paste = True
         self.device_name = device
@@ -80,6 +82,14 @@ class SerialTransport(Transport):
                     self.serial.open()
                 else:
                     self.serial = serial.Serial(device, **serial_kwargs)
+                    if dtr:
+                        self.serial.dtr = (
+                            dtr == "1" or dtr == "on"
+                        )  # DTR False = gpio0 High = Normal boot
+                    if rts:
+                        self.serial.rts = (
+                            rts == "1" or rts == "on"
+                        )  # RTS False = EN High = MCU enabled
                 break
             except OSError:
                 if wait == 0:

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -155,20 +155,15 @@ class SerialTransport(Transport):
 
     def enter_raw_repl(self, soft_reset=True, timeout_overall=10):
         if self.dtr or self.rts:
-            print("Special handling in DTR / RTS mode, might need to wait for controller to boot")
             self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
             time.sleep(0.1)
             self.serial.flush()
             self.serial.flushInput()
             for cnt in range(timeout_overall):
-                if cnt > 0:
-                    print("not found, send ctrl-c again and wait again...")
                 self.serial.write(b"\r\x03")  # ctrl-C: interrupt any running program
                 self.serial.flush()
-                print("wait for REPL prompt...")
                 data = self.read_until(1, b"\r\n>>> ", timeout_overall=1)
                 if data.endswith(b"\r\n>>> "):
-                    print("REPL prompt found")
                     break
             else:
                 raise TransportError("could not find repl mode")
@@ -188,7 +183,6 @@ class SerialTransport(Transport):
                 1, b"raw REPL; CTRL-B to exit\r\n>", timeout_overall=timeout_overall
             )
             if not data.endswith(b"raw REPL; CTRL-B to exit\r\n>"):
-                print(data)
                 raise TransportError("could not enter raw repl")
 
             self.serial.write(b"\x04")  # ctrl-D: soft reset
@@ -198,12 +192,10 @@ class SerialTransport(Transport):
             # and before "raw REPL".
             data = self.read_until(1, b"soft reboot\r\n", timeout_overall=timeout_overall)
             if not data.endswith(b"soft reboot\r\n"):
-                print(data)
                 raise TransportError("could not enter raw repl")
 
         data = self.read_until(1, b"raw REPL; CTRL-B to exit\r\n", timeout_overall=timeout_overall)
         if not data.endswith(b"raw REPL; CTRL-B to exit\r\n"):
-            print(data)
             raise TransportError("could not enter raw repl")
 
         self.in_raw_repl = True
@@ -288,7 +280,6 @@ class SerialTransport(Transport):
                 # Device doesn't support raw-paste, fall back to normal raw REPL.
                 data = self.read_until(1, b"w REPL; CTRL-B to exit\r\n>")
                 if not data.endswith(b"w REPL; CTRL-B to exit\r\n>"):
-                    print(data)
                     raise TransportError("could not enter raw repl")
             # Don't try to use raw-paste mode again for this connection.
             self.use_raw_paste = False

--- a/tools/mpremote/tests/run-mpremote-tests.sh
+++ b/tools/mpremote/tests/run-mpremote-tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 TEST_DIR=$(dirname $0)
-MPREMOTE=${TEST_DIR}/../mpremote.py
+MPREMOTE=${MPREMOTE:-${TEST_DIR}/../mpremote.py}
 
 if [ -z "$1" ]; then
     # Find tests matching test_*.sh


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

`mpremote` is not working on my laptop running Ubuntu 24.04.2 LTS when trying to connect to an `ESP32-CAM` with the `CAM-MB`. This board has DTR connected to RST and requires DTR to be LOW for the ESP to be running. By adding the new options `--dtr [0|1|off|on]` and `--rts [0|1|off|on]` you can steer the logical level of the two lines.

In addition, many drivers seem to pull the signals up either when the device is closed or opened. This causes the ESP32 to perform a hard reset, which can take more than 1s. A special loop has been added if entering raw REPL mode is required.

The PR also solves #11451.


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
For the test I'm using the modified code since some weeks with an ESP32-CAM and MB, ESP32 NodeMCU Dev Kit C V2 and ESP8266 NodeMCU with ESP-12F module. I used it to copy files, install modules and with the REPL, or cause.

In addition, some of the tests in `tools/mpremote/tests` can be run as well, but not all. As the ESP will perform are hard reset in my case, the tests using the `resume` command will not work. To run the other tests, you need to provide the environment variable MPREMOTE to point to the mpremote.py while adding the required options:
```bash
cd .../tools/mpremote/tests
export MPREMOTE="$(pwd)/../mpremote.py connect --dtr 0 --rts 0 auto"
./run-mpremote-tests.sh ./test_eval_exec_run.sh
./test_eval_exec_run.sh: OK
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

When running without providing one of the new options, the code runs as before.