### PR TITLE
modmachine: Add `machine.wake_pins`.

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -163,6 +163,13 @@ Power related functions
 
    Availability: ESP32, WiPy.
 
+.. function:: wake_pins()
+
+   Returns the GPIO pin numbers of those pins which caused wakeup from deep sleep as a
+   tuple of integers.
+
+   Availability: ESP32.
+
 Miscellaneous functions
 -----------------------
 

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -36,6 +36,7 @@
 #include "esp_sleep.h"
 #include "esp_pm.h"
 
+#include "py/objtuple.h"
 #include "modmachine.h"
 #include "machine_rtc.h"
 
@@ -73,6 +74,7 @@
     \
     /* Wake reasons */ \
     { MP_ROM_QSTR(MP_QSTR_wake_reason), MP_ROM_PTR(&machine_wake_reason_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_wake_pins), MP_ROM_PTR(&machine_wake_pins_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_PIN_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_EXT0) }, \
     { MP_ROM_QSTR(MP_QSTR_EXT0_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_EXT0) }, \
     { MP_ROM_QSTR(MP_QSTR_EXT1_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_EXT1) }, \
@@ -309,6 +311,39 @@ static mp_obj_t machine_wake_reason(size_t n_args, const mp_obj_t *pos_args, mp_
     return MP_OBJ_NEW_SMALL_INT(esp_sleep_get_wakeup_cause());
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_wake_reason_obj, 0,  machine_wake_reason);
+
+static mp_obj_t machine_wake_pins(void) {
+    uint64_t status = 0;
+    int len, index;
+
+    // There will be only one wake-up source, so it is OK to logically OR all the
+    // wake-up source statuses.
+    #if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP && SOC_DEEP_SLEEP_SUPPORTED
+    status |= esp_sleep_get_gpio_wakeup_status();
+    #endif
+
+    #if SOC_PM_SUPPORT_EXT1_WAKEUP && SOC_RTCIO_PIN_COUNT > 0
+    status |= esp_sleep_get_ext1_wakeup_status();
+    #endif
+
+    // Only a few (~8) pins might cause wakeup.
+    // Therefore, we calculate the required space in a first pass.
+    for (index = 0, len = 0; index < 64; index++) {
+        len += (status & (1ULL << index)) ? 1 : 0;
+    }
+    if (len) {
+        mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
+
+        for (index = 0, len = 0; index < 64; index++) {
+            if (status & (1ULL << index)) {
+                tuple->items[len++] = MP_OBJ_NEW_SMALL_INT(index);
+            }
+        }
+        return MP_OBJ_FROM_PTR(tuple);
+    }
+    return mp_obj_new_tuple(0, NULL);
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(machine_wake_pins_obj, machine_wake_pins);
 
 MP_NORETURN static void mp_machine_reset(void) {
     esp_restart();


### PR DESCRIPTION
### Summary

When waking from deep sleep, it could be helpful to know what pins triggered the wake up since the wake pins could be configured to multiple pins.

Based on work that @m-cas did in this PR - https://github.com/micropython/micropython/pull/15498.

### Testing

Tested ESP32_GENERIC_C3 with:

```
import machine
import esp32
esp32.wake_on_gpio((machine.Pin(5),machine.Pin(2)), esp32.WAKEUP_ANY_HIGH)
machine.deepsleep()
```

After wakeup checked that `machine.wake_pins()` returned the correct pin that trigerred the wake.

### Trade-offs and Alternatives

I decided to place the method in `machine` together with `wake_reason`, since it is feasible that other ports
will want the exact same interface.
