### PR TITLE
port/rp2/modmachine: Fix lightsleep watchdog interactions.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -36,8 +36,12 @@
 #include "clocks_extra.h"
 #include "hardware/pll.h"
 #include "hardware/structs/rosc.h"
+#if PICO_RP2040
+#include "hardware/structs/psm.h"
+#endif
 #include "hardware/structs/scb.h"
 #include "hardware/structs/syscfg.h"
+#include "hardware/structs/watchdog.h"
 #include "hardware/watchdog.h"
 #include "hardware/xosc.h"
 #include "pico/bootrom.h"
@@ -192,6 +196,8 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         clock_stop(clk_usb);
     }
 
+    bool watchdog_active = (watchdog_hw->ctrl & WATCHDOG_CTRL_ENABLE_BITS) != 0;
+
     clock_stop(clk_adc);
     #if PICO_RP2350
     clock_stop(clk_hstx);
@@ -218,6 +224,12 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     }
 
     // Disable ROSC.
+    #if PICO_RP2040
+    if (watchdog_active) {
+        // Configure Power-On State Machine to reset the ROSC on a watchdog timeout.
+        psm_hw->wdsel |= PSM_WDSEL_ROSC_BITS;
+    }
+    #endif
     rosc_hw->ctrl = ROSC_CTRL_ENABLE_VALUE_DISABLE << ROSC_CTRL_ENABLE_LSB;
 
     #if DEBUG_LIGHTSLEEP
@@ -243,7 +255,12 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
             #if PICO_RP2040
             clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_SYS_TIMER_BITS;
             #elif PICO_RP2350
-            clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
+            if (watchdog_active) {
+                // clk_sys watchdog and clk_ref ticks must be enabled for the watchdog counter to decrement on RP2350.
+                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS;
+            } else {
+                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
+            }
             #else
             #error Unknown processor
             #endif
@@ -299,6 +316,12 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     // Enable ROSC.
     rosc_hw->ctrl = ROSC_CTRL_ENABLE_VALUE_ENABLE << ROSC_CTRL_ENABLE_LSB;
+    #if PICO_RP2040
+    if (watchdog_active) {
+        // No longer need the Power-On State Machine to reset the ROSC on a watchdog timeout.
+        psm_hw->wdsel &= ~PSM_WDSEL_ROSC_BITS;
+    }
+    #endif
 
     // Bring back all clocks.
     runtime_init_clocks_optional_usb(disable_usb);


### PR DESCRIPTION
### Summary
_Second try at this change. I had trouble resolving a merge conflict in an earlier pull request and gave up._

Aside: I am a little hesitant to propose these changes. If the maintainers decide to reject this pull request I will understand.
Lightsleep on rp2 is gradually getting more complex and these changes would contribute to that complexity.

Fixes RP2040 issue #17228 and RP2350 issue #17229.

RP2040 issue is when watchdog timer expires while
lightsleep is running the RP2040 will lock up during power-on startup.
This occurs because the power-on state machine is configured to not re-initialize the ROSC and lightsleep stopped the ROSC.

RP2350 issue is the watchdog timer does not decrement while lightsleep is running.
Once lightsleep returns the timer will start decrementing again. This occurs because lightsleep clears the bit
CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS while sleeping.

### Testing
I ran the reproduction tests from the two issues.
I also ran tests/port/rp2/rp2_lightsleep.py.

### Trade-offs and Alternatives

General alternative. Document that lightsleep and watchdog don't play well together and leave the code as is.

Alternatives for RP2040 issue #17228:
- Raise issue for pico-sdk. Get them to change function _watchdog_enable() so the ROSC and XOSC do get reset on a watchdog timeout. The existing behavior in _watchdog_enable() has been there from day one. There might not be a good reason for it. Disadvantage: a possible long wait for a new pico-sdk release.
- Modify lightsleep to not stop the ROSC. I measure 4.96 milli-amps when lightsleep disables ROSC and 5.09 milli-amps when it does not. This is a small change.

Alternatives for the RP2350 issue #17229:
- I don't have any :-).

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

