### PR TITLE
py/emitndebug: Indicate signedness for setcc opcodes.

### DIFF
--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -2634,7 +2634,7 @@ static void emit_native_binary_op(emit_t *emit, mp_binary_op_t op) {
                     break;
             }
             #elif N_DEBUG
-            asm_debug_setcc_reg_reg_reg(emit->as, op_idx, REG_RET, REG_ARG_2, reg_rhs);
+            asm_debug_setcc_reg_reg_reg(emit->as, op_idx, REG_RET, REG_ARG_2, reg_rhs, vtype_lhs == VTYPE_UINT);
             #else
             #error not implemented
             #endif

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -166,8 +166,8 @@ static void asm_debug_reg_reg_label(asm_debug_t *as, const char *op, int reg1, i
     asm_debug_printf(as, "%s(%s, %s, label_%u)\n", op, reg_name_table[reg1], reg_name_table[reg2], label);
 }
 
-static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int reg2, int reg3) {
-    asm_debug_printf(as, "setcc(%d, %s, %s, %s)\n", op, reg_name_table[reg1], reg_name_table[reg2], reg_name_table[reg3]);
+static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int reg2, int reg3, bool unsigned_comparison) {
+    asm_debug_printf(as, "setcc(%d, %s, %s, %s, %s)\n", op, reg_name_table[reg1], reg_name_table[reg2], reg_name_table[reg3], unsigned_comparison ? "true" : "false");
 }
 
 // The following macros provide a (mostly) arch-independent API to


### PR DESCRIPTION
### Summary

This commit changes the output of the `setcc` opcode in the debug emitter, in order to know whether a comparison operates on signed or unsigned values.

With this change the `setcc` opcode turns from being described as `setcc(<cc>, <dest>, <lhs>, <rhs>)` into `setcc(<cc>, <dest>, <lhs>, <rhs>, <unsigned>)`.  As integer variables in Python are signed by default, the flag is made to be `true` for unsigned comparisons, as they are the special case.

I'm working on a tool that generates retargettable binary code from the output of the debug emitter, and not knowing whether a `setcc` operation is supposed to work on signed or unsigned variables is sort of a problem.

Given that this seems to be the only piece missing for third parties to consume the debug emitter's output, it'd be a shame for that opcode to block that.

### Testing

Testing was performed by printing the output of `mpy-cross -X emit=native -march=debug test.py`, with `test.py` being as such:

```py
@micropython.viper
def signed(c: int, n: int):
    print(c == n)

@micropython.viper
def unsigned(c: uint, n: uint):
    print(c == n)
```

and checking that the first function would contain a `setcc` opcode with `false` as its last argument, and the second function would contain a `setcc` opcode with `true` as its last argument.

### Trade-offs and Alternatives

The (limited) size increase is limited to `mpy-cross`, and thus is not really impacting any existing port.  There's no other way to access the pre-emitted opcodes list, short of adding a new emitter that outputs that list in a structured data format like JSON or XML. 