### PR TITLE
tests/extmod/asyncio_iterator_event.py: Use format instead of f-string.

### DIFF
--- a/tests/extmod/asyncio_iterator_event.py
+++ b/tests/extmod/asyncio_iterator_event.py
@@ -50,7 +50,7 @@ def schedule_watchdog(end_ticks):
 async def test(ai):
     for x in range(3):
         await asyncio.sleep(0.1)
-        ai.fetch_data(f"bar {x}")
+        ai.fetch_data("bar {}".format(x))
 
 
 class AsyncIterable:


### PR DESCRIPTION
### Summary

Some targets don't have f-strings enabled, so try not to use them in tests.  Rather use `str.format` which is more portable.

### Testing

Tested on SEEED_XIAO_SAMD21.  Before this change the test would fail with `SyntaxError`.  Now it skips.

