### PR TITLE
stm32/boards/ARDUINO_PORTENTA_H7: Free reserved timer.

### DIFF
--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -30,7 +30,6 @@ typedef unsigned int mp_uint_t;     // must be pointer size
 #define MICROPY_HW_ENABLE_SDCARD    (1)
 #define MICROPY_HW_ENABLE_MMCARD    (0)
 #define MICROPY_HW_ENTER_BOOTLOADER_VIA_RESET   (0)
-#define MICROPY_HW_TIM_IS_RESERVED(id) (id == 1)
 
 // ROMFS config
 #define MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI       (1)


### PR DESCRIPTION
### Summary

This patch frees the timer pin used for the camera clock on Portenta carrier, and vision shield, allowing users to use it with `tim`. The pin doesn't strictly need to be reserved, as the timer module only deinitializes timers that were used. See https://github.com/micropython/micropython/commit/b6649b922e0ff7fa263b05d560f4c11a3910d1d9#commitcomment-160466116

### Testing

Tested Portenta firmware still works.