### PR TITLE
Add compile-time checking of mp_printf format strings

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -171,6 +171,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - name: Install packages
+      run: source tools/ci.sh && ci_unix_float_setup
     - name: Build
       run: tools/ci.sh unix_float_build
     - name: Run main test suite

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -234,6 +234,24 @@ You can also specify which board to use:
 See `ports/stm32/boards <https://github.com/micropython/micropython/tree/master/ports/stm32/boards>`_
 for the available boards. e.g. "PYBV11" or "NUCLEO_WB55".
 
+Compile-time format string checking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When gcc is used to build MicroPython, a plugin can be used for compile-time
+checking of ``mp_printf`` format strings. The plugin is enabled by setting the
+Makefile variable ``MICROPY_USE_COMPILER_PLUGIN=gcc`` before including
+``py/mkrules.mk``.
+
+The plugin doesn't work:
+ * With non-gcc compilers (including clang, which is sometimes installed on
+   Macs with the name "gcc")
+ * On Windows systems, where the steps for building a plugin are more complicated
+ * With MicroPython builds that use cmake rather than traditional make.
+ * If the necessary files for plugin development are not installed. In Debian
+   bookworm, for instance, the files to build plugins for ``gcc`` are in
+   ``gcc-12-plugin-dev``, and the files to build plugins for
+   ``riscv64-unknown-elf-gcc`` are in ``gcc-12-plugin-dev-riscv64-linux-gnu``.
+
 Building the documentation
 --------------------------
 

--- a/extmod/machine_can.c
+++ b/extmod/machine_can.c
@@ -664,7 +664,7 @@ static void machine_can_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
             break;
     }
 
-    mp_printf(print, "CAN(%d, bitrate=%u, mode=CAN.%q, sjw=%u, tseg1=%u, tseg2=%u, f_clock=%u)",
+    mp_printf(print, "CAN(" INT_FMT ", bitrate=%u, mode=CAN.%q, sjw=%u, tseg1=%u, tseg2=%u, f_clock=%u)",
         self->can_idx + 1,
         actual_bitrate,
         mode,

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -147,7 +147,7 @@ CFLAGS += -fno-strict-aliasing
 CFLAGS += -I$(BOARD_DIR)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
 
-LDFLAGS += $(CFLAGS) -nostdlib
+LDFLAGS += $(filter-out -fplugin%, $(CFLAGS)) -nostdlib
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)
 LDFLAGS += -mthumb -mabi=aapcs $(addprefix -T,$(LD_FILES)) -L boards/
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -171,7 +171,7 @@ ifeq ($(LTO),1)
 CFLAGS += -flto=auto
 # LTO requires passing compiler flags to the linker as it will run the assembler.
 # To avoid risk of missing something relevant, pass all flags except for preprocessor args
-LDFLAGS += $(filter-out -I%,$(filter-out -D%,$(CFLAGS)))
+LDFLAGS += $(filter-out -fplugin%, $(filter-out -I%,$(filter-out -D%,$(CFLAGS))))
 
 $(BUILD)/stm32_it.o $(BUILD)/pendsv.o: CFLAGS += -fno-lto
 endif

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -647,10 +647,10 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "mp_obj_list_optional_arg same list? %d\n", MP_OBJ_TO_PTR(list) == as_ptr);
 
         as_ptr = mp_obj_list_optional_arg(mp_const_none, list_len);
-        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list len %d\n", as_ptr->len);
+        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list len " SIZE_FMT "\n", as_ptr->len);
 
         as_ptr = mp_obj_list_optional_arg(MP_OBJ_NULL, list_len);
-        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list from NULL len %d\n", as_ptr->len);
+        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list from NULL len " SIZE_FMT "\n", as_ptr->len);
     }
 
     // runtime utils

--- a/py/gccplugin.mk
+++ b/py/gccplugin.mk
@@ -1,0 +1,23 @@
+PLUGINDIR := $(shell $(CC) -print-file-name=plugin)/include
+ifeq ($(realpath $(PLUGINDIR)/gcc-plugin.h),)
+$(error plugin header $(PLUGINDIR)/gcc-plugin.h for $(CC) does not exist. Install the correct gcc-plugins package.)
+endif
+HOSTCXX ?= g++
+
+CHECKS_PLUGIN :=  $(BUILD)/micropython_checks.so
+CFLAGS += -fplugin=$(CHECKS_PLUGIN)
+
+.PHONY: plugin
+plugin: $(CHECKS_PLUGIN)
+
+$(CHECKS_PLUGIN): $(TOP)/tools/micropython_checks.cc | $(BUILD)/
+	$(ECHO) "PLUGIN $@"
+	$(Q)$(HOSTCXX)  -o $@ -shared $^ \
+		-std=gnu++11 -fPIC -Wall -O -fno-rtti \
+		-I$(PLUGINDIR)
+
+# All objects depend on the checks plugin
+$(OBJ): $(CHECKS_PLUGIN)
+
+# And so do these very special targets
+QSTR_GLOBAL_REQUIREMENTS += $(CHECKS_PLUGIN)

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -20,6 +20,10 @@ OBJ_EXTRA_ORDER_DEPS =
 # Generate header files.
 OBJ_EXTRA_ORDER_DEPS += $(HEADER_BUILD)/moduledefs.h $(HEADER_BUILD)/root_pointers.h
 
+ifeq ($(MICROPY_USE_COMPILER_PLUGIN),gcc)
+include $(TOP)/py/gccplugin.mk
+endif
+
 ifeq ($(MICROPY_ROM_TEXT_COMPRESSION),1)
 # If compression is enabled, trigger the build of compressed.data.h...
 OBJ_EXTRA_ORDER_DEPS += $(HEADER_BUILD)/compressed.data.h

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -29,6 +29,16 @@ function ci_gcc_riscv_setup {
     riscv64-unknown-elf-gcc --version
 }
 
+function ci_gcc_plugin_setup {
+    if [ $# -eq 0 ]; then
+        GCC_VER=$(echo __GNUC__ | gcc -P -E -)
+        sudo apt-get install gcc-${GCC_VER}-plugin-dev
+    else
+        GCC_VER=$(echo __GNUC__ | ${1}-gcc -P -E -)
+        sudo apt-get install gcc-${GCC_VER}-plugin-dev-${1}
+    fi
+}
+
 function ci_picotool_setup {
     # Manually installing picotool ensures we use a release version, and speeds up the build.
     git clone https://github.com/raspberrypi/pico-sdk.git
@@ -153,6 +163,7 @@ function ci_code_size_report {
 function ci_mpy_format_setup {
     sudo apt-get update
     sudo pip3 install pyelftools
+    ci_gcc_plugin_setup
     python3 --version
 }
 
@@ -322,11 +333,11 @@ function ci_mimxrt_setup {
 function ci_mimxrt_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1020_EVK submodules
-    make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1020_EVK
+    make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1020_EVK MICROPY_USE_COMPILER_PLUGIN=gcc
     make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40 submodules
-    make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40 USER_C_MODULES=../../examples/usercmodule
+    make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40 USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1060_EVK submodules
-    make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1060_EVK CFLAGS_EXTRA=-DMICROPY_HW_USB_MSC=1
+    make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1060_EVK CFLAGS_EXTRA=-DMICROPY_HW_USB_MSC=1 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -340,10 +351,10 @@ function ci_nrf_build {
     ports/nrf/drivers/bluetooth/download_ble_stack.sh s140_nrf52_6_1_1
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/nrf submodules
-    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10040
-    make ${MAKEOPTS} -C ports/nrf BOARD=MICROBIT USER_C_MODULES=../../examples/usercmodule
-    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10056 SD=s140
-    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10090
+    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10040 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/nrf BOARD=MICROBIT USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10056 SD=s140 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/nrf BOARD=PCA10090 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -352,11 +363,12 @@ function ci_nrf_build {
 function ci_powerpc_setup {
     sudo apt-get update
     sudo apt-get install gcc-powerpc64le-linux-gnu libc6-dev-ppc64el-cross
+    ci_gcc_plugin_setup powerpc64le-linux-gnu
 }
 
 function ci_powerpc_build {
-    make ${MAKEOPTS} -C ports/powerpc UART=potato
-    make ${MAKEOPTS} -C ports/powerpc UART=lpc_serial
+    make ${MAKEOPTS} -C ports/powerpc UART=potato MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/powerpc UART=lpc_serial MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -396,17 +408,17 @@ function ci_qemu_build_arm_prepare {
 
 function ci_qemu_build_arm_bigendian {
     ci_qemu_build_arm_prepare
-    make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
+    make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 function ci_qemu_build_arm_sabrelite {
     ci_qemu_build_arm_prepare
-    make ${MAKEOPTS} -C ports/qemu BOARD=SABRELITE test_full
+    make ${MAKEOPTS} -C ports/qemu BOARD=SABRELITE test_full MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 function ci_qemu_build_arm_thumb_softfp {
     ci_qemu_build_arm_prepare
-    make BOARD=MPS2_AN385 ${MAKEOPTS} -C ports/qemu USER_C_MODULES=../../examples/usercmodule test_full
+    make BOARD=MPS2_AN385 ${MAKEOPTS} -C ports/qemu USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc test_full
 
     # Test building native .mpy with ARM-M softfp architectures.
     ci_native_mpy_modules_build armv6m
@@ -433,7 +445,7 @@ function ci_qemu_build_arm_thumb_hardfp {
 function ci_qemu_build_rv32 {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 submodules
-    make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test_full
+    make ${MAKEOPTS} -C ports/qemu BOARD=VIRT_RV32 test_full MICROPY_USE_COMPILER_PLUGIN=gcc
 
     # Test building and running native .mpy with rv32imc architecture.
     ci_native_mpy_modules_build rv32imc
@@ -461,13 +473,13 @@ function ci_renesas_ra_setup {
 function ci_renesas_ra_board_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/renesas-ra submodules
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=RA4M1_CLICKER
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M2 USER_C_MODULES=../../examples/usercmodule
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M1
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4M1
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4W1
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=RA4M1_CLICKER MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M2 USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M1 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4M1 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4W1 MICROPY_USE_COMPILER_PLUGIN=gcc
     make ${MAKEOPTS} -C ports/renesas-ra BOARD=ARDUINO_PORTENTA_C33 submodules
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=ARDUINO_PORTENTA_C33
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=ARDUINO_PORTENTA_C33 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -505,8 +517,8 @@ function ci_samd_setup {
 function ci_samd_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/samd submodules
-    make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M0_EXPRESS
-    make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M4_EXPRESS
+    make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M0_EXPRESS MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M4_EXPRESS MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -534,12 +546,12 @@ function ci_stm32_pyb_build {
     make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF2 submodules
     git submodule update --init lib/btstack
     git submodule update --init lib/mynewt-nimble
-    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBV11 MICROPY_PY_NETWORK_WIZNET5K=5200 USER_C_MODULES=../../examples/usercmodule
-    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF2
-    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF6 COPT=-O2 NANBOX=1 MICROPY_BLUETOOTH_NIMBLE=0 MICROPY_BLUETOOTH_BTSTACK=1
-    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBV10 CFLAGS_EXTRA='-DMBOOT_FSLOAD=1 -DMBOOT_VFS_LFS2=1'
-    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBD_SF6
-    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=STM32F769DISC CFLAGS_EXTRA='-DMBOOT_ADDRESS_SPACE_64BIT=1 -DMBOOT_SDCARD_ADDR=0x100000000ULL -DMBOOT_SDCARD_BYTE_SIZE=0x400000000ULL -DMBOOT_FSLOAD=1 -DMBOOT_VFS_FAT=1'
+    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBV11 MICROPY_PY_NETWORK_WIZNET5K=5200 USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF2 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF6 COPT=-O2 NANBOX=1 MICROPY_BLUETOOTH_NIMBLE=0 MICROPY_BLUETOOTH_BTSTACK=1 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBV10 CFLAGS_EXTRA='-DMBOOT_FSLOAD=1 -DMBOOT_VFS_LFS2=1' MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBD_SF6 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=STM32F769DISC CFLAGS_EXTRA='-DMBOOT_ADDRESS_SPACE_64BIT=1 -DMBOOT_SDCARD_ADDR=0x100000000ULL -DMBOOT_SDCARD_BYTE_SIZE=0x400000000ULL -DMBOOT_FSLOAD=1 -DMBOOT_VFS_FAT=1' MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 function ci_stm32_nucleo_build {
@@ -550,15 +562,15 @@ function ci_stm32_nucleo_build {
     git submodule update --init lib/mynewt-nimble
 
     # Test building various MCU families, some with additional options.
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC
-    make ${MAKEOPTS} -C ports/stm32 BOARD=STM32H573I_DK CFLAGS_EXTRA='-DMICROPY_HW_TINYUSB_STACK=1'
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI COPT=-O2 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1'
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG DEBUG=1
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_F091RC MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=STM32H573I_DK CFLAGS_EXTRA='-DMICROPY_HW_TINYUSB_STACK=1' MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI COPT=-O2 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1' MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L073RZ MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L476RG DEBUG=1 MICROPY_USE_COMPILER_PLUGIN=gcc
 
     # Test building a board with mboot packing enabled (encryption, signing, compression).
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1
-    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32/mboot BOARD=NUCLEO_WB55 USE_MBOOT=1 MBOOT_ENABLE_PACKING=1 MICROPY_USE_COMPILER_PLUGIN=gcc
     # Test mboot_pack_dfu.py created a valid file, and that its unpack-dfu command works.
     BOARD_WB55=ports/stm32/boards/NUCLEO_WB55
     BUILD_WB55=ports/stm32/build-NUCLEO_WB55
@@ -575,13 +587,13 @@ function ci_stm32_misc_build {
 
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/stm32 BOARD=ARDUINO_GIGA submodules
-    make ${MAKEOPTS} -C ports/stm32 BOARD=ARDUINO_GIGA
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G0B1RE
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G474RE
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L152RE
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_N657X0
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_U5A5ZJ_Q
-    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WL55
+    make ${MAKEOPTS} -C ports/stm32 BOARD=ARDUINO_GIGA MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G0B1RE MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G474RE MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L152RE MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_N657X0 MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_U5A5ZJ_Q MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WL55 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################
@@ -724,13 +736,16 @@ function ci_unix_coverage_setup {
     pip3 install setuptools
     pip3 install pyelftools
     pip3 install ar
+    ci_gcc_plugin_setup
     gcc --version
     python3 --version
 }
 
 function ci_unix_coverage_build {
+    # (Ensure mpy-cross is built with the plugin too)
+    make ${MAKEOPTS} -C mpy-cross MICROPY_USE_COMPILER_PLUGIN=gcc
     # note: the coverage variant incorporates ../../examples/usercmodule, set in mpconfigvariant.mk
-    ci_unix_build_helper VARIANT=coverage
+    ci_unix_build_helper VARIANT=coverage MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper gcc
 }
 
@@ -771,6 +786,7 @@ function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
+    ci_gcc_plugin_setup
     python -m pip install pyelftools
     python -m pip install ar
     gcc --version
@@ -778,7 +794,7 @@ function ci_unix_32bit_setup {
 }
 
 function ci_unix_coverage_32bit_build {
-    ci_unix_build_helper VARIANT=coverage MICROPY_FORCE_32BIT=1
+    ci_unix_build_helper VARIANT=coverage MICROPY_FORCE_32BIT=1 MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper gcc -m32
 }
 
@@ -791,7 +807,7 @@ function ci_unix_coverage_32bit_run_native_mpy_tests {
 }
 
 function ci_unix_nanbox_build {
-    ci_unix_build_helper VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1"
+    ci_unix_build_helper VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1" MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper gcc -m32
 }
 
@@ -800,15 +816,19 @@ function ci_unix_nanbox_run_tests {
 }
 
 function ci_unix_longlong_build {
-    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}" MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 function ci_unix_longlong_run_tests {
     ci_unix_run_tests_full_helper longlong
 }
 
+function ci_unix_float_setup {
+    ci_gcc_plugin_setup
+}
+
 function ci_unix_float_build {
-    ci_unix_build_helper VARIANT=standard CFLAGS_EXTRA="-DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT"
+    ci_unix_build_helper VARIANT=standard CFLAGS_EXTRA="-DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT" MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper gcc
 }
 
@@ -906,13 +926,14 @@ function ci_unix_qemu_mips_setup {
     sudo apt-get update
     sudo apt-get install gcc-mips-linux-gnu g++-mips-linux-gnu libc6-mips-cross libltdl-dev
     sudo apt-get install qemu-user-static
+    ci_gcc_plugin_setup mips-linux-gnu
     qemu-mips-static --version
     sudo mkdir -p /usr/gnemul
     sudo ln -s /usr/mips-linux-gnu /usr/gnemul/qemu-mips
 }
 
 function ci_unix_qemu_mips_build {
-    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_MIPS[@]}"
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_MIPS[@]}" MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper mips-linux-gnu-gcc
 }
 
@@ -927,13 +948,14 @@ function ci_unix_qemu_arm_setup {
     sudo apt-get update
     sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libltdl-dev
     sudo apt-get install qemu-user-static
+    ci_gcc_plugin_setup arm-linux-gnueabi
     qemu-arm-static --version
     sudo mkdir -p /usr/gnemul
     sudo ln -s /usr/arm-linux-gnueabi /usr/gnemul/qemu-arm
 }
 
 function ci_unix_qemu_arm_build {
-    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_ARM[@]}"
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_ARM[@]}" MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper arm-linux-gnueabi-gcc
 }
 
@@ -951,13 +973,14 @@ function ci_unix_qemu_riscv64_setup {
     python3 -m pip install pyelftools
     python3 -m pip install ar
     sudo apt-get install qemu-user-static
+    ci_gcc_plugin_setup riscv64-linux-gnu
     qemu-riscv64-static --version
     sudo mkdir -p /usr/gnemul
     sudo ln -s /usr/riscv64-linux-gnu /usr/gnemul/qemu-riscv64
 }
 
 function ci_unix_qemu_riscv64_build {
-    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_RISCV64[@]}"
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_RISCV64[@]}" MICROPY_USE_COMPILER_PLUGIN=gcc
     ci_unix_build_ffi_lib_helper riscv64-linux-gnu-gcc
     ci_native_mpy_modules_build rv64imc
 }
@@ -994,8 +1017,8 @@ function ci_windows_setup {
 function ci_windows_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/windows submodules
-    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32- USER_C_MODULES=../../examples/usercmodule
-    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=x86_64-w64-mingw32- BUILD=build-standard-w64
+    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32- USER_C_MODULES=../../examples/usercmodule MICROPY_USE_COMPILER_PLUGIN=gcc
+    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=x86_64-w64-mingw32- BUILD=build-standard-w64 MICROPY_USE_COMPILER_PLUGIN=gcc
 }
 
 ########################################################################################

--- a/tools/micropython_checks.cc
+++ b/tools/micropython_checks.cc
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: 2014 Roger Ferrer Ibanez
+// SPDX-FileCopyrightText: 2020 Eddy S
+// SPDX-FileCopyrightText: 2025 Jeff Epler
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <iostream>
+#include <cassert>
+#include <set>
+#include <utility>
+#include <algorithm>
+
+// This is the first gcc header to be included
+#include "gcc-plugin.h"
+#include "plugin-version.h"
+
+// gcc headers have order, don't blindly re-order
+#include "cp/cp-tree.h"
+#include "context.h"
+#include "function.h"
+#include "internal-fn.h"
+#include "is-a.h"
+#include "predict.h"
+#include "basic-block.h"
+#include "tree.h"
+#include "tree-ssa-alias.h"
+#include "gimple-expr.h"
+#include "gimple.h"
+#include "gimple-ssa.h"
+#include "tree-pretty-print.h"
+#include "tree-pass.h"
+#include "tree-ssa-operands.h"
+#include "tree-phinodes.h"
+#include "print-tree.h"
+#include "stringpool.h"
+#include "attribs.h"
+#include "gimple-pretty-print.h"
+#include "gimple-iterator.h"
+#include "gimple-walk.h"
+#include "diagnostic.h"
+#include "stringpool.h"
+
+#include "ssa-iterators.h"
+
+// We must assert that this plugin is GPL compatible
+int plugin_is_GPL_compatible;
+
+static struct plugin_info my_gcc_plugin_info = {
+    "1.0",
+    "Validate MicroPython mp_printf argument types against format string"};
+
+namespace {
+const pass_data micropython_checks_data = {
+    GIMPLE_PASS,
+    "micropython_checks", /* name */
+    OPTGROUP_NONE,        /* optinfo_flags */
+    TV_NONE,              /* tv_id */
+    PROP_gimple_any,      /* properties_required */
+    0,                    /* properties_provided */
+    0,                    /* properties_destroyed */
+    0,                    /* todo_flags_start */
+    0                     /* todo_flags_finish */
+};
+
+struct micropython_checks : gimple_opt_pass {
+    micropython_checks(gcc::context *ctx)
+        : gimple_opt_pass(micropython_checks_data, ctx) {}
+
+    virtual unsigned int execute(function *fun) override {
+        // This phase has two steps, first we remove redundant LHS from
+        // GIMPLE_CALLs
+        walk(fun);
+
+        return 0;
+    }
+
+    virtual micropython_checks *clone() override {
+        // We do not clone ourselves
+        return this;
+    }
+
+    static bool is_mpprint_call(const tree fn) {
+        if (!fn)
+            return false;
+        if (fn->base.code != ADDR_EXPR)
+            return false;
+        if (!fn->base.constant_flag)
+            return false;
+        const tree op = fn->exp.operands[0];
+        if (op->base.code != FUNCTION_DECL)
+            return false;
+        const tree name = op->decl_minimal.name;
+        if (name->base.code != IDENTIFIER_NODE)
+            return false;
+        return strcmp((const char *)name->identifier.id.str, "mp_printf") == 0;
+    }
+
+    static const char *mpprint_format_arg(gimple *stmt) {
+        tree fn = gimple_call_fn(stmt);
+        if (!is_mpprint_call(fn))
+            return NULL;
+        unsigned nargs = gimple_call_num_args(stmt);
+        if (nargs < 2)
+            return NULL;
+        tree arg = gimple_call_arg(stmt, 1);
+        if (!arg->base.constant_flag)
+            return NULL;
+        if (arg->base.code != ADDR_EXPR)
+            return NULL;
+        tree op = arg->exp.operands[0];
+        if (op->base.code != STRING_CST)
+            return NULL;
+        return op->string.str;
+    }
+
+    void walk(function *fun) {
+        basic_block bb;
+        FOR_ALL_BB_FN(bb, fun) {
+            gimple_stmt_iterator gsi;
+            for (gsi = gsi_start_bb(bb); !gsi_end_p(gsi); gsi_next(&gsi)) {
+                gimple *stmt = gsi_stmt(gsi);
+
+                // location_t loc = gimple_location (stmt);
+                switch (gimple_code(stmt)) {
+                case GIMPLE_CALL: {
+                    const char *fmt = mpprint_format_arg(stmt),
+                               *fmt_start = nullptr;
+
+                    if (!fmt) {
+                        break;
+                    }
+
+                    unsigned nargs = gimple_call_num_args(stmt);
+                    unsigned argno = 2;
+
+                    auto require_double = [&](int argno) {
+                        auto arg = gimple_call_arg(stmt, argno);
+                        location_t loc = gimple_location(stmt);
+
+                        auto tp = arg ? arg->exp.typed.type : 0;
+                        if (tp)
+                            tp = TYPE_CANONICAL(tp);
+                        if (!tp 
+                                || tp->base.code != REAL_TYPE
+                                || tp->type_common.precision != double_type_node->type_common.precision) {
+                            warning_at(loc, OPT_Wformat_,
+                                       "argument %d: Format %q.*s requires a "
+                                       "%<double%> argument, not %qE",
+                                       argno + 1, (int)(fmt - fmt_start + 1),
+                                       fmt_start, arg);
+                        }
+                    };
+
+                    auto require_ptr = [&](int argno) {
+                        auto arg = gimple_call_arg(stmt, argno);
+                        if (!arg ||
+                            arg->exp.typed.type->base.code != POINTER_TYPE) {
+                            volatile location_t loc = gimple_location(stmt);
+                            warning_at(
+                                loc, OPT_Wformat_,
+                                "argument %d: Format %q.*s requires a pointer "
+                                "argument, not %qE",
+                                argno + 1, (int)(fmt - fmt_start + 1),
+                                fmt_start, arg);
+                        }
+                    };
+
+                    auto require_sized_int = [&](int argno, tree type1,
+                                                 tree type2) {
+                        auto arg = gimple_call_arg(stmt, argno);
+                        location_t loc = gimple_location(stmt);
+
+                        auto tp = arg ? arg->exp.typed.type : 0;
+                        if (tp && (tp->base.code != INTEGER_TYPE ||
+                                   tp->type_common.precision !=
+                                       type1->type_common.precision)) {
+                            warning_at(
+                                loc, OPT_Wformat_,
+                                "argument %d: Format %q.*s requires a %qT or "
+                                "%qT (%d bits), not %qT [size %d]",
+                                argno + 1, (int)(fmt - fmt_start + 1),
+                                fmt_start, type1, type2,
+                                type2->type_common.precision, tp,
+                                tp->type_common.precision);
+                        }
+                    };
+
+                    auto require_int = [&require_sized_int](int argno) {
+                        require_sized_int(argno, integer_type_node,
+                                          unsigned_type_node);
+                    };
+                    auto require_long = [&require_sized_int](int argno) {
+                        require_sized_int(argno, long_integer_type_node,
+                                          long_unsigned_type_node);
+                    };
+                    auto require_long_long = [&require_sized_int](int argno) {
+                        require_sized_int(argno, long_long_integer_type_node,
+                                          long_long_unsigned_type_node);
+                    };
+                    auto require_qstr = [&require_sized_int](int argno) {
+                        require_sized_int(argno, size_type_node,
+                                          signed_size_type_node);
+                    };
+
+                    for (;;) {
+                        while (*fmt != '\0' && *fmt != '%') {
+                            ++fmt;
+                        }
+
+                        if (*fmt == '\0') {
+                            break;
+                        }
+
+                        fmt_start = fmt;
+
+                        // move past % character
+                        ++fmt;
+
+                        if (*fmt == '%') {
+                            ++fmt;
+                            continue;
+                        }
+
+                        // parse flags, if they exist
+                        while (*fmt != '\0') {
+                            if (*fmt == '-') {
+                            } else if (*fmt == '+') {
+                            } else if (*fmt == ' ') {
+                            } else if (*fmt == '0') {
+                            } else {
+                                break;
+                            }
+                            ++fmt;
+                        }
+
+                        // parse width, if it exists
+                        int width = 0;
+                        for (; '0' <= *fmt && *fmt <= '9'; ++fmt) {
+                            width = width * 10 + *fmt - '0';
+                        }
+
+                        // parse precision, if it exists
+                        int prec = -1;
+                        if (*fmt == '.') {
+                            ++fmt;
+                            if (*fmt == '*') {
+                                ++fmt;
+                                require_int(argno++);
+                            } else {
+                                prec = 0;
+                                for (; '0' <= *fmt && *fmt <= '9'; ++fmt) {
+                                    prec = prec * 10 + *fmt - '0';
+                                }
+                            }
+                            if (prec < 0) {
+                                prec = 0;
+                            }
+                        }
+
+                        // parse long specifiers
+
+                        bool long_arg = false;
+                        if (*fmt == 'l') {
+                            ++fmt;
+                            long_arg = true;
+                        }
+                        switch (*fmt) {
+                        case 'b':
+                        case 'B':
+                        case 'i':
+                        case 'u':
+                        case 'd':
+                        case 'x':
+                        case 'X':
+                        case 'o':
+                        case 'O':
+                            if (long_arg)
+                                require_long(argno++);
+                            else
+                                require_int(argno++);
+                            break;
+
+                        case 'c':
+                            require_int(argno++);
+                            break;
+
+                        case 'q':
+                            require_qstr(argno++);
+                            break;
+
+                        case 's':
+                        case 'p':
+                        case 'P':
+                            require_ptr(argno++);
+                            break;
+
+                        case 'e':
+                        case 'E':
+                        case 'f':
+                        case 'F':
+                        case 'g':
+                        case 'G':
+                            require_double(argno++);
+                            break;
+
+                        case 'l':
+                            ++fmt;
+                            if (*fmt != 'u' && *fmt != 'd' && *fmt != 'x' && *fmt != 'X') {
+                                location_t loc = gimple_location(stmt);
+                                warning_at(loc, OPT_Wformat_,
+                                           "Bad format specification with ll%c",
+                                           *fmt);
+                            }
+                            require_long_long(argno++);
+                            break;
+                        default: {
+                            location_t loc = gimple_location(stmt);
+                            warning_at(loc, OPT_Wformat_,
+                                       "Bad format specification with %c",
+                                       *fmt);
+                        } break;
+                        }
+                    }
+                    if (argno != nargs) {
+                        location_t loc = gimple_location(stmt);
+                        warning_at(loc, OPT_Wformat_,
+                                   "Wrong # arguments. Supplied %d, used %d",
+                                   nargs, argno);
+                    }
+                } break;
+                case GIMPLE_ASSIGN:
+                case GIMPLE_ASM:
+                case GIMPLE_COND:
+                case GIMPLE_GOTO:
+                case GIMPLE_LABEL:
+                case GIMPLE_NOP:
+                case GIMPLE_OMP_ATOMIC_LOAD:
+                case GIMPLE_OMP_ATOMIC_STORE:
+                case GIMPLE_OMP_CONTINUE:
+                case GIMPLE_OMP_CRITICAL:
+                case GIMPLE_OMP_FOR:
+                case GIMPLE_OMP_MASTER:
+                case GIMPLE_OMP_ORDERED:
+                case GIMPLE_OMP_PARALLEL:
+                case GIMPLE_OMP_RETURN:
+                case GIMPLE_OMP_SECTION:
+                case GIMPLE_OMP_SECTIONS:
+                case GIMPLE_OMP_SECTIONS_SWITCH:
+                case GIMPLE_OMP_SINGLE:
+                case GIMPLE_PHI:
+                case GIMPLE_RESX:
+                case GIMPLE_RETURN:
+                case GIMPLE_SWITCH:
+                    // TODO: complete the remaining trees
+                    break;
+                default:
+                    // TODO: even more trees in newer gcc versions
+                    break;
+                    gcc_unreachable();
+                }
+            }
+        }
+    }
+
+    void micropython_checks_lhs(const std::set<tree> &unused_lhs,
+                                function *fun) {
+        basic_block bb;
+        FOR_ALL_BB_FN(bb, fun) {
+            gimple_stmt_iterator gsi;
+            for (gsi = gsi_start_bb(bb); !gsi_end_p(gsi); gsi_next(&gsi)) {
+                gimple *stmt = gsi_stmt(gsi);
+
+                switch (gimple_code(stmt)) {
+                case GIMPLE_CALL: {
+                    tree lhs = gimple_call_lhs(stmt);
+                    if (unused_lhs.find(lhs) != unused_lhs.end()) {
+                        // Deliberately similar to the code in tree-cfg.c
+                        tree fdecl = gimple_call_fndecl(stmt);
+                        tree ftype = gimple_call_fntype(stmt);
+
+                        if (lookup_attribute("micropython_checks",
+                                             TYPE_ATTRIBUTES(ftype))) {
+                            location_t loc = gimple_location(stmt);
+
+                            if (fdecl)
+                                warning_at(loc, OPT_Wunused_result,
+                                           "ignoring return value of %qD, "
+                                           "declared with attribute warn "
+                                           "unused result",
+                                           fdecl);
+                            else
+                                warning_at(loc, OPT_Wunused_result,
+                                           "ignoring return value of function "
+                                           "declared with attribute warn "
+                                           "unused result");
+                        }
+                    }
+                    break;
+                }
+                default:
+                    // Do nothing
+                    break;
+                }
+            }
+        }
+    }
+};
+} // namespace
+
+int plugin_init(struct plugin_name_args *plugin_info,
+                struct plugin_gcc_version *version) {
+    // We check the current gcc loading this plugin against the gcc we used to
+    // created this plugin
+    if (!plugin_default_version_check(version, &gcc_version)) {
+        std::cerr << "This GCC plugin is for version "
+                  << GCCPLUGIN_VERSION_MAJOR << "." << GCCPLUGIN_VERSION_MINOR
+                  << "\n";
+        return 1;
+    }
+
+    register_callback(plugin_info->base_name,
+                      /* event */ PLUGIN_INFO,
+                      /* callback */ NULL, /* user_data */ &my_gcc_plugin_info);
+
+    // Register the phase right after cfg
+    struct register_pass_info pass_info;
+
+    pass_info.pass = new micropython_checks(g);
+    pass_info.reference_pass_name = "cfg";
+    pass_info.ref_pass_instance_number = 1;
+    pass_info.pos_op = PASS_POS_INSERT_AFTER;
+
+    register_callback(plugin_info->base_name, PLUGIN_PASS_MANAGER_SETUP, NULL,
+                      &pass_info);
+
+    return 0;
+}


### PR DESCRIPTION
### Summary

It's always nice when errors can be detected at compile time. In traditional C programs, gcc can check that the printf argument types match the printf format string. This has not been possible up to now with mp_printf, because it has both extensions to standard printf (e.g., the `%q` format type) and is missing things in standard printf (e.g., `%zd` is not supported).

To that end, I have developed a GCC plugin that does this checking at compile time, and enabled it during the ci build process where possible.

### Testing

I built the unix port coverage variant & ran the tests locally. The plugin itself should cause no code changes, and the code size check (which does NOT turn on the plugin) reports no size change.

A total of 45 sites in ci.sh use the new plugin.

### Trade-offs and Alternatives

As a gcc plugin this can only support gcc-based toolchains. clang and proprietary compilers cannot use the plugin. This does not seem important, as this feature only produces diagnostics.

The plugin is GPL licensed. I started with a GPL-licensed plugin template, and plugins need to be GPL-or-compatible in license in order to be loaded in gcc anyway. The plugin code IMO does not affect the license situation of the output object code, as you'd get the exact same code with or without the plugin.

Missing support for:
 * Knowing whether `%ll` is runtime-supported
 * handling enum argmuents properly (just one enum was %d printed across all checked builds and I added a cast instead of fixing the checker)
 * non-gnumake based builds
 * mingw-based builds on windows (mingw-based cross builds are checked though)
 * mac-based builds

I never specifically measured the build-time impact of enabling the plugin.