### PR TITLE
tests/micropython: Add missing SystemExit after printing SKIP.

### DIFF
--- a/tests/micropython/meminfo.py
+++ b/tests/micropython/meminfo.py
@@ -5,8 +5,9 @@ import micropython
 # these functions are not always available
 if not hasattr(micropython, "mem_info"):
     print("SKIP")
-else:
-    micropython.mem_info()
-    micropython.mem_info(1)
-    micropython.qstr_info()
-    micropython.qstr_info(1)
+    raise SystemExit
+
+micropython.mem_info()
+micropython.mem_info(1)
+micropython.qstr_info()
+micropython.qstr_info(1)

--- a/tests/micropython/memstats.py
+++ b/tests/micropython/memstats.py
@@ -5,13 +5,14 @@ import micropython
 # these functions are not always available
 if not hasattr(micropython, "mem_total"):
     print("SKIP")
-else:
-    t = micropython.mem_total()
-    c = micropython.mem_current()
-    p = micropython.mem_peak()
+    raise SystemExit
 
-    l = list(range(10000))
+t = micropython.mem_total()
+c = micropython.mem_current()
+p = micropython.mem_peak()
 
-    print(micropython.mem_total() > t)
-    print(micropython.mem_current() > c)
-    print(micropython.mem_peak() > p)
+l = list(range(10000))
+
+print(micropython.mem_total() > t)
+print(micropython.mem_current() > c)
+print(micropython.mem_peak() > p)

--- a/tests/micropython/stack_use.py
+++ b/tests/micropython/stack_use.py
@@ -3,5 +3,6 @@ import micropython
 
 if not hasattr(micropython, "stack_use"):
     print("SKIP")
-else:
-    print(type(micropython.stack_use()))  # output varies
+    raise SystemExit
+
+print(type(micropython.stack_use()))  # output varies


### PR DESCRIPTION
### Summary

The test runner expects `print("SKIP")` to be followed by `raise SystemExit`.  Otherwise it waits for 10 seconds for the target to do a soft reset before timing out and continuing.

### Testing

Tested on PYBD_SF6.  Prior to this change it would wait 10 seconds after running `memstats.py`.  With this PR it no longer waits.