### PR TITLE
extmod/vfs_lfsx: Allow overriding the LFS2 on-disk version format.

### DIFF
--- a/extmod/vfs_lfsx.c
+++ b/extmod/vfs_lfsx.c
@@ -104,6 +104,12 @@ static void MP_VFS_LFSx(init_config)(MP_OBJ_VFS_LFSx * self, mp_obj_t bdev, size
     config->read_buffer = m_new(uint8_t, config->cache_size);
     config->prog_buffer = m_new(uint8_t, config->cache_size);
     config->lookahead_buffer = m_new(uint8_t, config->lookahead_size);
+    #ifdef LFS2_MULTIVERSION
+    // This can be set to override the on-disk lfs version.
+    // eg. for compat with lfs2 < v2.6 add the following to make:
+    // CFLAGS += '-DLFS2_MULTIVERSION=0x00020000'
+    config->disk_version = LFS2_MULTIVERSION;
+    #endif
     #endif
 }
 


### PR DESCRIPTION
### Summary

Back in LFS2 version 2.6 they updated the on-disk version from 2.0 to 2.1 which broke back compatibility (aka older versions could no long read new version disk format) https://github.com/littlefs-project/littlefs/releases/tag/v2.6.0

Then in LFS2 v2.7 an optional `config->disk_version` was added to force the library to use an older disk format instead: https://github.com/littlefs-project/littlefs/releases/tag/v2.7.0

I've got an stm32wb55 application where I'm using current micropython, however units are already in the field with a mboot bootloader from an older version with v2.5 LFS2, so can only read the older disk format when using fsload.

This PR simply exposes `config->disk_version` as a compile time option if `LFS2_MULTIVERSION` is set, otherwise there is no change in behavior. 

Note: LFS2_MULTIVERSION needs to be defined at the `make` / `CFLAGS` level, setting it in `mpconfigboard.h` doesn't work as it's not included in the lfs2.c file in any way.


### Testing

This has been tested with and stm32wb55 build using mboot from a much older version. The on-disk format change can be seen by changing the `LFS2_MULTIVERSION` setting, once it's set to `0x00020000` any existing partitions cannot be mounted and need to be reformatted. 

After it was reformatted and a dfu file was copied on, I was able to use mboot fsload again to flash it.

