### PR TITLE
py/emitnative: Let emitters know the compiled entity's name.

### DIFF
--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -164,12 +164,12 @@ void asm_arm_bx_reg(asm_arm_t *as, uint reg_src);
 // Holds a pointer to mp_fun_table
 #define REG_FUN_TABLE ASM_ARM_REG_FUN_TABLE
 
-#define ASM_T               asm_arm_t
-#define ASM_END_PASS        asm_arm_end_pass
-#define ASM_ENTRY           asm_arm_entry
-#define ASM_EXIT            asm_arm_exit
+#define ASM_T                           asm_arm_t
+#define ASM_END_PASS                    asm_arm_end_pass
+#define ASM_ENTRY(as, num_locals, name) asm_arm_entry((as), (num_locals))
+#define ASM_EXIT                        asm_arm_exit
 
-#define ASM_JUMP            asm_arm_b_label
+#define ASM_JUMP                        asm_arm_b_label
 #define ASM_JUMP_IF_REG_ZERO(as, reg, label, bool_test) \
     do { \
         asm_arm_cmp_reg_i8(as, reg, 0); \

--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -718,7 +718,7 @@ void asm_rv32_emit_optimised_xor(asm_rv32_t *state, mp_uint_t rd, mp_uint_t rs);
 void asm_rv32_emit_store_reg_reg_offset(asm_rv32_t *state, mp_uint_t source, mp_uint_t base, int32_t offset, mp_uint_t operation_size);
 
 #define ASM_T asm_rv32_t
-#define ASM_ENTRY(state, labels) asm_rv32_entry(state, labels)
+#define ASM_ENTRY(state, labels, name) asm_rv32_entry(state, labels)
 #define ASM_EXIT(state) asm_rv32_exit(state)
 #define ASM_END_PASS(state) asm_rv32_end_pass(state)
 

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -403,12 +403,12 @@ void asm_thumb_b_rel12(asm_thumb_t *as, int rel);
 
 #define REG_FUN_TABLE ASM_THUMB_REG_FUN_TABLE
 
-#define ASM_T               asm_thumb_t
-#define ASM_END_PASS        asm_thumb_end_pass
-#define ASM_ENTRY           asm_thumb_entry
-#define ASM_EXIT            asm_thumb_exit
+#define ASM_T                           asm_thumb_t
+#define ASM_END_PASS                    asm_thumb_end_pass
+#define ASM_ENTRY(as, num_locals, name) asm_thumb_entry((as), (num_locals))
+#define ASM_EXIT                        asm_thumb_exit
 
-#define ASM_JUMP            asm_thumb_b_label
+#define ASM_JUMP                        asm_thumb_b_label
 #define ASM_JUMP_IF_REG_ZERO(as, reg, label, bool_test) \
     do { \
         asm_thumb_cmp_rlo_i8(as, reg, 0); \

--- a/py/asmx64.h
+++ b/py/asmx64.h
@@ -154,12 +154,12 @@ void asm_x64_call_ind(asm_x64_t *as, size_t fun_id, int temp_r32);
 // Holds a pointer to mp_fun_table
 #define REG_FUN_TABLE ASM_X64_REG_FUN_TABLE
 
-#define ASM_T               asm_x64_t
-#define ASM_END_PASS        asm_x64_end_pass
-#define ASM_ENTRY           asm_x64_entry
-#define ASM_EXIT            asm_x64_exit
+#define ASM_T                           asm_x64_t
+#define ASM_END_PASS                    asm_x64_end_pass
+#define ASM_ENTRY(as, num_locals, name) asm_x64_entry((as), (num_locals))
+#define ASM_EXIT                        asm_x64_exit
 
-#define ASM_JUMP            asm_x64_jmp_label
+#define ASM_JUMP                        asm_x64_jmp_label
 #define ASM_JUMP_IF_REG_ZERO(as, reg, label, bool_test) \
     do { \
         if (bool_test) { \

--- a/py/asmx86.h
+++ b/py/asmx86.h
@@ -149,12 +149,12 @@ void asm_x86_call_ind(asm_x86_t *as, size_t fun_id, mp_uint_t n_args, int temp_r
 // Holds a pointer to mp_fun_table
 #define REG_FUN_TABLE ASM_X86_REG_FUN_TABLE
 
-#define ASM_T               asm_x86_t
-#define ASM_END_PASS        asm_x86_end_pass
-#define ASM_ENTRY           asm_x86_entry
-#define ASM_EXIT            asm_x86_exit
+#define ASM_T                           asm_x86_t
+#define ASM_END_PASS                    asm_x86_end_pass
+#define ASM_ENTRY(as, num_locals, name) asm_x86_entry((as), (num_locals))
+#define ASM_EXIT                        asm_x86_exit
 
-#define ASM_JUMP            asm_x86_jmp_label
+#define ASM_JUMP                        asm_x86_jmp_label
 #define ASM_JUMP_IF_REG_ZERO(as, reg, label, bool_test) \
     do { \
         if (bool_test) { \

--- a/py/asmxtensa.h
+++ b/py/asmxtensa.h
@@ -340,9 +340,9 @@ void asm_xtensa_l32r(asm_xtensa_t *as, mp_uint_t reg, mp_uint_t label);
 #define ASM_NUM_REGS_SAVED ASM_XTENSA_NUM_REGS_SAVED
 #define REG_FUN_TABLE ASM_XTENSA_REG_FUN_TABLE
 
-#define ASM_ENTRY(as, nlocal)   asm_xtensa_entry((as), (nlocal))
-#define ASM_EXIT(as)            asm_xtensa_exit((as))
-#define ASM_CALL_IND(as, idx)   asm_xtensa_call_ind((as), (idx))
+#define ASM_ENTRY(as, nlocal, name)   asm_xtensa_entry((as), (nlocal))
+#define ASM_EXIT(as)                  asm_xtensa_exit((as))
+#define ASM_CALL_IND(as, idx)         asm_xtensa_call_ind((as), (idx))
 
 #else
 // Configuration for windowed calls with window size 8
@@ -370,9 +370,9 @@ void asm_xtensa_l32r(asm_xtensa_t *as, mp_uint_t reg, mp_uint_t label);
 #define ASM_NUM_REGS_SAVED ASM_XTENSA_NUM_REGS_SAVED_WIN
 #define REG_FUN_TABLE ASM_XTENSA_REG_FUN_TABLE_WIN
 
-#define ASM_ENTRY(as, nlocal)   asm_xtensa_entry_win((as), (nlocal))
-#define ASM_EXIT(as)            asm_xtensa_exit_win((as))
-#define ASM_CALL_IND(as, idx)   asm_xtensa_call_ind_win((as), (idx))
+#define ASM_ENTRY(as, nlocal, name)   asm_xtensa_entry_win((as), (nlocal))
+#define ASM_EXIT(as)                  asm_xtensa_exit_win((as))
+#define ASM_CALL_IND(as, idx)         asm_xtensa_call_ind_win((as), (idx))
 
 #endif
 

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -108,8 +108,8 @@ static void asm_debug_end_pass(asm_debug_t *as) {
     (void)as;
 }
 
-static void asm_debug_entry(asm_debug_t *as, int num_locals) {
-    asm_debug_printf(as, "ENTRY(num_locals=%d)\n", num_locals);
+static void asm_debug_entry(asm_debug_t *as, int num_locals, char *name) {
+    asm_debug_printf(as, "ENTRY(%s, num_locals=%d)\n", name != NULL ? name : "?", num_locals);
 }
 
 static void asm_debug_exit(asm_debug_t *as) {
@@ -195,8 +195,8 @@ static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int r
 
 #define ASM_T               asm_debug_t
 #define ASM_END_PASS        asm_debug_end_pass
-#define ASM_ENTRY(as, num_locals) \
-    asm_debug_entry(as, num_locals)
+#define ASM_ENTRY(as, num_locals, name) \
+    asm_debug_entry(as, num_locals, name)
 #define ASM_EXIT(as) \
     asm_debug_exit(as)
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -426,6 +426,11 @@
 #define MICROPY_EMIT_INLINE_RV32 (0)
 #endif
 
+// Whether to enable the human-readable native instructions emitter
+#ifndef MICROPY_EMIT_NATIVE_DEBUG
+#define MICROPY_EMIT_NATIVE_DEBUG (0)
+#endif
+
 // Convenience definition for whether any native emitter is enabled
 #define MICROPY_EMIT_NATIVE (MICROPY_EMIT_X64 || MICROPY_EMIT_X86 || MICROPY_EMIT_THUMB || MICROPY_EMIT_ARM || MICROPY_EMIT_XTENSA || MICROPY_EMIT_XTENSAWIN || MICROPY_EMIT_RV32 || MICROPY_EMIT_NATIVE_DEBUG)
 


### PR DESCRIPTION
### Summary

This PR introduces an optional feature to provide to native emitters the fully qualified name of the entity they are compiling.

This is achieved by altering the generic ASM API to provide a third argument to the entry function, containing the name of the entity being compiled.  Currently only the debug emitter uses this feature, as it is not really useful for other emitters for the time being; in fact the macros in question just strip the name away.

As discussed in #17548, this brings more descriptive output to the debug emitter, in preparation for a new machine-readable JSON output emitter that would need to know the entity name being processed as well.

### Testing

Testing had to be performed manually, by checking the output of `mpy-cross -X emit=native -march=debug` for a variety of existing MicroPython test files containing all possible entities to be handled by the compiler framework along with their nested variants.  The usual battery of CI tests was also ran through Github to be sure nothing out of the ordinary would happen.

### Trade-offs and Alternatives

In theory there shouldn't be any changes in any other emitter that actually generates binary code, this code should only affect `mpy-cross`.