### PR TITLE
stm32: Change SPI IRQ priority.

### DIFF
--- a/ports/stm32/irq.h
+++ b/ports/stm32/irq.h
@@ -155,6 +155,9 @@ static inline void restore_irq_pri(uint32_t state) {
 // SDIO must be higher priority than DMA for SDIO DMA transfers to work.
 #define IRQ_PRI_SDIO            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 4, 0)
 
+// SPI must be higher priority than DMA for SPI DMA transfers to work.
+#define IRQ_PRI_SPI             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 4, 0)
+
 // DMA should be higher priority than USB, since USB Mass Storage calls
 // into the sdcard driver which waits for the DMA to complete.
 #define IRQ_PRI_DMA             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 5, 0)
@@ -171,8 +174,6 @@ static inline void restore_irq_pri(uint32_t state) {
 #define IRQ_PRI_CAN             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 7, 0)
 
 #define IRQ_PRI_SUBGHZ_RADIO    NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 8, 0)
-
-#define IRQ_PRI_SPI             NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 8, 0)
 
 #define IRQ_PRI_HSEM            NVIC_EncodePriority(NVIC_PRIORITYGROUP_4, 10, 0)
 


### PR DESCRIPTION
### Summary

On STM32H5/H7, SPI flash cannot use as storage device with DMA.
SPI interruption may not be genearated even if DMA transfer has been done.
This is due to lower priority of SPI interruption than DMA.

This PR changes SPI interrupt priority more higher than DMA's priority.

### Testing

Tested:
* NUCLEO-H563ZI with W25Q32BVSSIG
* Custom STM32H723VG board with W25Q64JVSIQ

### Trade-offs and Alternatives

There is no negative impact because only STM32H5/H7 HAL requires SPI IRQs to be enabled and handled.