### PR TITLE
mpprint: Add %R (print object) & %K (print exception).

### DIFF
--- a/py/modthread.c
+++ b/py/modthread.c
@@ -189,10 +189,8 @@ static void *thread_entry(void *args_in) {
             // swallow exception silently
         } else {
             // print exception out
-            mp_printf(MICROPY_ERROR_PRINTER, "Unhandled exception in thread started by ");
-            mp_obj_print_helper(MICROPY_ERROR_PRINTER, args->fun, PRINT_REPR);
-            mp_printf(MICROPY_ERROR_PRINTER, "\n");
-            mp_obj_print_exception(MICROPY_ERROR_PRINTER, MP_OBJ_FROM_PTR(exc));
+            mp_printf(MICROPY_ERROR_PRINTER, "Unhandled exception in thread started by %R\n%K",
+                PRINT_REPR, args->fun, MP_OBJ_FROM_PTR(exc));
         }
     }
 

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -475,6 +475,17 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 chrs += mp_print_strn(print, &str, 1, flags, fill, width);
                 break;
             }
+            case 'K': {
+                mp_obj_t obj = va_arg(args, mp_obj_t);
+                mp_obj_print_exception(print, obj);
+                break;
+            }
+            case 'R': {
+                mp_print_kind_t kind = va_arg(args, int);
+                mp_obj_t obj = va_arg(args, mp_obj_t);
+                mp_obj_print_helper(print, obj, kind);
+                break;
+            }
             case 'q': {
                 qstr qst = va_arg(args, qstr);
                 size_t len;

--- a/py/objattrtuple.c
+++ b/py/objattrtuple.c
@@ -38,8 +38,7 @@ void mp_obj_attrtuple_print_helper(const mp_print_t *print, const qstr *fields, 
         if (i > 0) {
             mp_print_str(print, ", ");
         }
-        mp_printf(print, "%q=", fields[i]);
-        mp_obj_print_helper(print, o->items[i], PRINT_REPR);
+        mp_printf(print, "%q=%R", fields[i], PRINT_REPR, o->items[i]);
     }
     mp_print_str(print, ")");
 }

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -39,11 +39,7 @@ typedef struct _mp_obj_bound_meth_t {
 static void bound_meth_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_bound_meth_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_printf(print, "<bound_method %p ", o);
-    mp_obj_print_helper(print, o->self, PRINT_REPR);
-    mp_print_str(print, ".");
-    mp_obj_print_helper(print, o->meth, PRINT_REPR);
-    mp_print_str(print, ">");
+    mp_printf(print, "<bound_method %p %R.%R>", o, PRINT_REPR, o->self, PRINT_REPR, o->meth);
 }
 #endif
 

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -30,13 +30,7 @@
 static void cell_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_cell_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_printf(print, "<cell %p ", o->obj);
-    if (o->obj == MP_OBJ_NULL) {
-        mp_print_str(print, "(nil)");
-    } else {
-        mp_obj_print_helper(print, o->obj, PRINT_REPR);
-    }
-    mp_print_str(print, ">");
+    mp_printf(print, "<cell %p %R>", o->obj, PRINT_REPR, o->obj);
 }
 #endif
 

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -63,16 +63,10 @@ static mp_obj_t closure_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const
 static void closure_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_closure_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_print_str(print, "<closure ");
-    mp_obj_print_helper(print, o->fun, PRINT_REPR);
-    mp_printf(print, " at %p, n_closed=%u ", o, (int)o->n_closed);
+    mp_printf(print, "<closure %R at %p, n_closed=%u", PRINT_REPR, o->fun, o, (int)o->n_closed);
     for (size_t i = 0; i < o->n_closed; i++) {
-        if (o->closed[i] == MP_OBJ_NULL) {
-            mp_print_str(print, "(nil)");
-        } else {
-            mp_obj_print_helper(print, o->closed[i], PRINT_REPR);
-        }
         mp_print_str(print, " ");
+        mp_obj_print_helper(print, o->closed[i], PRINT_REPR);
     }
     mp_print_str(print, ">");
 }


### PR DESCRIPTION
As well as adding some use sites to get an idea of whether this is saving code size.

This also makes that `mp_obj_print_helper` print `MP_OBJ_NULL` objects as `(nil)` (regardless of NDEBUG), which is otherwise written at several use sites.

With just a few sites modified to use %R & %K, it already saved around 28 bytes on MPS2_AN385 according to a quick local test.

### Summary

I noticed that often there is an alternation between calling `mp_printf` & `mp_print_obj_helper`. I hypothesized that overall code size might be reduced by adding a %-format for whole objects to mp_printf.

### Testing

I locally ran the unix coverage suite & built a qemu build for size comparison.

### Trade-offs and Alternatives

* Somewhat arbitrarily I chose `%R` for objects and `%K` for exceptions. I initially decided to pass in the print kind for `%R` but this may be unneeded as in the sites I converted so far, the print type is statically known to be `PRINT_REPR`.
 * Printing some deeply nested objects will terminate sooner when it goes through a path that uses `%R`, as now `mp_printf` will be on the stack too.
 * This would require updates to the printf format string checker in #17556, which I will do if this PR is accepted and that PR is deemed desirable.
 * There are probably more sites amenable to conversion. I only converted enough sites to show that there was a size savings to be had.