### PR TITLE
esp32/panichandler: Support building against IDFv5.4.2.

### DIFF
--- a/ports/esp32/panichandler.c
+++ b/ports/esp32/panichandler.c
@@ -42,11 +42,20 @@
 #endif
 
 void __real_esp_panic_handler(void *);
-void esp_panic_handler_reconfigure_wdts(uint32_t timeout_ms);
 void panic_print_str(const char *str);
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 2)
+void esp_panic_handler_reconfigure_wdts(uint32_t timeout_ms);
+#else
+void esp_panic_handler_feed_wdts(void);
+#endif
+
 void MICROPY_WRAP_PANICHANDLER_FUN(__wrap_esp_panic_handler)(void *info) {
+    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 2)
     esp_panic_handler_reconfigure_wdts(1000);
+    #else
+    esp_panic_handler_feed_wdts();
+    #endif
 
     const static char *msg = MICROPY_WRAP_PANICHANDLER_STR(
         "\r\n"


### PR DESCRIPTION
### Summary

A small follow-up to #14086, which implemented a wrapper around the built-in IDF panic handler to print additional MicroPython-specific information.

The IDF panic handler resets the watchdog timeout to prevent the printing of the error message from being cut off by a WDT reset. We use the exact same function call in our wrapper function for the same purpose.

In IDFv5.4.2 the function used for this was changed (from `esp_panic_handler_reconfigure_wdts`, see [here](https://github.com/espressif/esp-idf/blob/v5.4.1/components/esp_system/panic.c#L243-L245), to `esp_panic_handler_feed_wdts`, see [here](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_system/panic.c#L288-L290), specifically in [this commit](https://github.com/espressif/esp-idf/commit/cd887ef59a7b966a7f431754aaec6ee653849d77)), and thus this PR introduces that same change into our wrapper.

### Testing

My [previously described method](https://github.com/micropython/micropython/pull/14086#issuecomment-2014549743) for triggering a crash no longer works, so here's an updated version:

```python
from io import IOBase
class CrashingUART(IOBase):
    IRQ_RXIDLE = 0
    def irq(self, handler, trigger, hard=False):
        pass
from network import PPP
ppp = PPP(CrashingUART())
ppp.active(True)
ppp.connect()
```

This results in the following output:

```
A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

MPY version : v1.26.0-preview-278-g9f0024b31c on 2025-06-30
IDF version : v5.4.2
Machine     : <custom board> with ESP32S3

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x420246fb  PS      : 0x00060030  A0      : 0x82024e68  A1      : 0x3fcbea20
A2      : 0x00000010  A3      : 0x00000000  A4      : 0x3fcbeb14  A5      : 0x3c1dd0a0
A6      : 0x00000002  A7      : 0x00000001  A8      : 0x820246fb  A9      : 0x3fcbea00
A10     : 0x00000000  A11     : 0x0000000e  A12     : 0x0000000f  A13     : 0x00000002
A14     : 0x00000001  A15     : 0x00000200  SAR     : 0x00000002  EXCCAUSE: 0x0000001c
EXCVADDR: 0x00000008  LBEG    : 0x40056f5c  LEND    : 0x40056f72  LCOUNT  : 0x00000000


Backtrace: 0x420246f8:0x3fcbea20 0x42024e65:0x3fcbea60 0x42027f96:0x3fcbea80 0x4202ff34:0x3fcbeb30 0x42030263:0x3fcbeb80 0x42058cbe:0x3fcbeba0 0x42058d09:0x3fcbebe0 0x4210c9f9:0x3fcbec00 0x4204710d:0x3fcbec30 0x420173ed:0x3fcbec60 0x4201756a:0x3fcbec80 0x4210c195:0x3fcbecb0 0x42020f2f:0x3fcbecd0 0x42020f8b:0x3fcbed00 0x4201e75b:0x3fcbed20 0x42016fd9:0x3fcbed40 0x420172d9:0x3fcbed60 0x42016e51:0x3fcbed80 0x420a38e3:0x3fcbeda0 0x4200987d:0x3fcbedc0
```

Decoded backtrace:

```
0x420246f8: gc_alloc at /micropython/py/gc.c:771
0x42024e65: m_malloc_maybe at /micropython/py/malloc.c:100
0x42027f96: mp_obj_new_exception_msg_vlist at /micropython/py/objexcept.c:479
0x4202ff34: mp_raise_msg_varg at /micropython/py/runtime.c:1727
0x42030263: mp_load_method at /micropython/py/runtime.c:1264 (discriminator 1)
 (inlined by) mp_load_method at /micropython/py/runtime.c:1235 (discriminator 1)
0x42058cbe: iobase_read_write at /micropython/py/modio.c:58
0x42058d09: iobase_write at /micropython/py/modio.c:79
0x4210c9f9: mp_stream_rw at /micropython/py/stream.c:58
0x4204710d: network_ppp_output_callback at /micropython/ports/esp32/network_ppp.c:279
0x420173ed: pppos_output_last at /esp-idf/components/lwip/lwip/src/netif/ppp/pppos.c:917
0x4201756a: pppos_write at /esp-idf/components/lwip/lwip/src/netif/ppp/pppos.c:242
0x4210c195: ppp_write at /esp-idf/components/lwip/lwip/src/netif/ppp/ppp.c:1006
0x42020f2f: fsm_sconfreq at /esp-idf/components/lwip/lwip/src/netif/ppp/fsm.c:757
0x42020f8b: fsm_lowerup at /esp-idf/components/lwip/lwip/src/netif/ppp/fsm.c:102
 (inlined by) fsm_lowerup at /esp-idf/components/lwip/lwip/src/netif/ppp/fsm.c:91
0x4201e75b: lcp_lowerup at /esp-idf/components/lwip/lwip/src/netif/ppp/lcp.c:475
0x42016fd9: ppp_start at /esp-idf/components/lwip/lwip/src/netif/ppp/ppp.c:753
0x420172d9: pppos_connect at /esp-idf/components/lwip/lwip/src/netif/ppp/pppos.c:342
0x42016e51: ppp_do_connect at /esp-idf/components/lwip/lwip/src/netif/ppp/ppp.c:465
 (inlined by) ppp_connect at /esp-idf/components/lwip/lwip/src/netif/ppp/ppp.c:286
0x420a38e3: pppapi_do_ppp_connect at /esp-idf/components/lwip/lwip/src/netif/ppp/pppapi.c:277
0x4200987d: tcpip_thread_handle_msg at /esp-idf/components/lwip/lwip/src/api/tcpip.c:166
 (inlined by) tcpip_thread at /esp-idf/components/lwip/lwip/src/api/tcpip.c:148
```

