### PR TITLE
ports/stm32: Extend STM32H5 DMA use.

### DIFF
--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -735,9 +735,13 @@ const dma_descr_t dma_SPI_1_RX = { GPDMA1_Channel0, GPDMA1_REQUEST_SPI1_RX, dma_
 const dma_descr_t dma_SPI_1_TX = { GPDMA1_Channel1, GPDMA1_REQUEST_SPI1_TX, dma_id_1, &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_2_RX = { GPDMA1_Channel2, GPDMA1_REQUEST_SPI2_RX, dma_id_2, &dma_init_struct_spi_i2c };
 const dma_descr_t dma_SPI_2_TX = { GPDMA1_Channel3, GPDMA1_REQUEST_SPI2_TX, dma_id_3, &dma_init_struct_spi_i2c };
+const dma_descr_t dma_SPI_3_RX = { GPDMA1_Channel4, GPDMA1_REQUEST_SPI3_RX, dma_id_4, &dma_init_struct_spi_i2c };
+const dma_descr_t dma_SPI_3_TX = { GPDMA1_Channel5, GPDMA1_REQUEST_SPI3_TX, dma_id_5, &dma_init_struct_spi_i2c };
+const dma_descr_t dma_SPI_4_RX = { GPDMA1_Channel6, GPDMA1_REQUEST_SPI4_RX, dma_id_6, &dma_init_struct_spi_i2c };
+const dma_descr_t dma_SPI_4_TX = { GPDMA1_Channel7, GPDMA1_REQUEST_SPI4_TX, dma_id_7, &dma_init_struct_spi_i2c };
 #if MICROPY_HW_ENABLE_DAC
-const dma_descr_t dma_DAC_1_TX = { GPDMA1_Channel4, GPDMA1_REQUEST_DAC1_CH1, dma_id_4, &dma_init_struct_dac };
-const dma_descr_t dma_DAC_2_TX = { GPDMA1_Channel5, GPDMA1_REQUEST_DAC1_CH2, dma_id_5, &dma_init_struct_dac };
+const dma_descr_t dma_DAC_1_TX = { GPDMA2_Channel0, GPDMA1_REQUEST_DAC1_CH1, dma_id_8, &dma_init_struct_dac };
+const dma_descr_t dma_DAC_2_TX = { GPDMA2_Channel1, GPDMA1_REQUEST_DAC1_CH2, dma_id_9, &dma_init_struct_dac };
 #endif
 
 static const uint8_t dma_irqn[NSTREAM] = {


### PR DESCRIPTION
### Summary

Attempting to configure SPI3 and SPI4 for the STM32H5 used to fail with a linker error, something like:

```bash
[snip]
...undefined reference to `dma_SPI_4_TX'
```

An example of valid configuration that was failing:
```diff
diff --git a/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h b/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
index 1e802eda5..9585ade03 100644
--- a/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
@@ -62,6 +62,10 @@
 #define MICROPY_HW_SPI1_MISO                (pin_G9) // Arduino Connector CN7-Pin12 (D12)
 #define MICROPY_HW_SPI1_MOSI                (pin_B5) // Arduino Connector CN7-Pin14 (D11)

+#define MICROPY_HW_SPI4_SCK
+#define MICROPY_HW_SPI4_MISO
+#define MICROPY_HW_SPI4_MOSI
+
 // USRSW is pulled low. Pressing the button makes the input go high.
 #define MICROPY_HW_USRSW_PIN                (pin_C13)
 #define MICROPY_HW_USRSW_PULL               (GPIO_NOPULL)
```

This patch resolves that, ensuring that appropriate DMA channels are assigned to those SPI resources.

### Testing

Tested SPI3 and SPI4 against a SPI peripheral ([MAX14915](https://www.analog.com/en/products/max14915.html)). Also validated correct pin behaviour under a DSO.

I _haven't_ tested if power use is higher due to more channels being employed.

### Trade-offs and Alternatives

This patch does use more DMA channels. The H5 has two DMA resources, each with 8 channels. Two are needed for a bidirectional SPI channel (one each for Rx and Tx) so a whole DMA resource - 8 channels - are used to cover SPI1-4. An additional 2x channels of the second DMA resource may also be used if DAC is used. 

Currently the DMA channels are statically assigned in MicroPython; an alternative would be to provide an abstraction for DMA channels and allow them to be assigned more dynamically. However, that would be a more complex implementation and difficult to provide a cross-port design.