### PR TITLE
zephyr/machine_pin: Configure OUT pin also as input so it's readable.

### DIFF
--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -270,7 +270,7 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
 
     // class constants
     { MP_ROM_QSTR(MP_QSTR_IN),        MP_ROM_INT(GPIO_INPUT) },
-    { MP_ROM_QSTR(MP_QSTR_OUT),       MP_ROM_INT(GPIO_OUTPUT) },
+    { MP_ROM_QSTR(MP_QSTR_OUT),       MP_ROM_INT(GPIO_OUTPUT | GPIO_INPUT) },
     { MP_ROM_QSTR(MP_QSTR_PULL_UP),   MP_ROM_INT(GPIO_PULL_UP) },
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN), MP_ROM_INT(GPIO_PULL_DOWN) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_RISING), MP_ROM_INT(GPIO_INT_EDGE_RISING) },


### PR DESCRIPTION
### Summary

Zephyr allows setting both GPIO_OUTPUT and GPIO_INPUT on a pin, which means it's an output pin that can have its current value read.

Fixes issue #17596.

### Testing

Tested with `bbc_microbit_v2` and `nucleo_wb55rg` board definitions.  Both allow reading an output pin:
```
from machine import Pin
p = Pin(("gpioa", 0), Pin.OUT)
print(p())
p(1)
print(p())
p(0)
print(p())
```
Note: `nucleo_wb55rg` already works without this change, but `bbc_microbit_v2` requires the change.