### PR TITLE
webassembly/objpyproxy: Avoid throwing on symbols or iterator.

### DIFF
--- a/ports/webassembly/objpyproxy.js
+++ b/ports/webassembly/objpyproxy.js
@@ -148,6 +148,12 @@ const py_proxy_handler = {
         };
     },
     has(target, prop) {
+        // avoid throwing on `Symbol() in proxy` checks
+        if (typeof prop !== "string") {
+            // returns true only on iterator because other
+            // symbols are not considered in the `get` trap
+            return prop === Symbol.iterator;
+        }
         return Module.ccall(
             "proxy_c_to_js_has_attr",
             "number",

--- a/tests/ports/webassembly/py_proxy_has.mjs
+++ b/tests/ports/webassembly/py_proxy_has.mjs
@@ -9,3 +9,5 @@ x = []
 const x = mp.globals.get("x");
 console.log("no_exist" in x);
 console.log("sort" in x);
+console.log(Symbol.toStringTag in x);
+console.log(Symbol.iterator in x);

--- a/tests/ports/webassembly/py_proxy_has.mjs.exp
+++ b/tests/ports/webassembly/py_proxy_has.mjs.exp
@@ -1,2 +1,4 @@
 false
 true
+false
+true


### PR DESCRIPTION
Not only our latest stack uses internally symbols to brand check its own proxies, there are various 3rd party libraries that might perform similar checks and you also have:

```js
if (prop === Symbol.iterator) ...
```

in your `get` trap but a check before such as:

```js
if (Symbol.iterator in ref) ...
```

would fail with an error that states that a string was expected but a symbol was received.

This MR would like to fix the situation for at least known symbols you also handle internally.

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

