### PR TITLE
ports/zephyr: Add mp_hal_stdio_poll().

### DIFF
--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -67,3 +67,11 @@ void zephyr_getchar_init(void) {
     // All NULLs because we're interested only in the callback above
     uart_register_input(NULL, NULL, NULL);
 }
+
+bool zephyr_getchar_is_ready(void) {
+    // Check if there is data in the ring buffer
+    unsigned int key = irq_lock();
+    bool ret = (i_get != i_put);
+    irq_unlock(key);
+    return ret;
+}

--- a/ports/zephyr/src/zephyr_getchar.h
+++ b/ports/zephyr/src/zephyr_getchar.h
@@ -18,3 +18,4 @@
 
 void zephyr_getchar_init(void);
 int zephyr_getchar(void);
+bool zephyr_getchar_is_ready(void);


### PR DESCRIPTION
This PR adds `mp_hal_stdio_poll()` to the Zephyr port.
This is required to make input() work.

### Summary

I'm making a Zephyr MicroPython port for the XIAO BLE NRF52840 SENSE board, and discovered that `upysh`'s `newfile`
command required having `input()` working. Getting this working required adding `mp_hal_stdio_poll()` to the port.

### Testing

I tested this on my XIAO BLE NRF52840 SENSE board, and was able to use `newfile` and the builtin `input()` successfully.
