### PR TITLE
stm32: Add machine.ADC implementation for STM32L1.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -416,7 +416,7 @@ static void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) 
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel)) {
         sConfig.SamplingTime = ADC_SAMPLETIME_384CYCLES;
     } else {
-        sConfig.SamplingTime = ADC_SAMPLETIME_384CYCLES;
+        sConfig.SamplingTime = ADC_SAMPLETIME_16CYCLES;
     }
     #elif defined(STM32G0)
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel)) {


### PR DESCRIPTION
### Summary

machine.ADC needs implementation for each platform.
This PR adds implementation for STM32L1.


### Testing

Tested whether machine.ADC works with NUCLEO-L152RE.
```python
from machine import ADC

# Internal temperature sensor
adc=ADC(ADC.CORE_TEMP)
adc.read_u16()

# Internal Vrefint
adc=ADC(ADC.CORE_VREF)
adc.read_u16()
```

### Trade-offs and Alternatives

There is no negative impact because this change affects only for STM32L1.
