### PR TITLE
rp2/mpnetworkport: Deregister all sys timeouts when netif is removed.

### DIFF
--- a/extmod/lwip-include/lwipopts_common.h
+++ b/extmod/lwip-include/lwipopts_common.h
@@ -28,6 +28,9 @@
 
 #include "py/mpconfig.h"
 
+// This is needed to access `next_timeout` via `sys_timeouts_get_next_timeout()`.
+#define LWIP_TESTMODE                   1
+
 // This sys-arch protection is not needed.
 // Ports either protect lwIP code with flags, or run it at PendSV priority.
 #define SYS_ARCH_DECL_PROTECT(lev) do { } while (0)

--- a/extmod/modnetwork.h
+++ b/extmod/modnetwork.h
@@ -82,6 +82,9 @@ extern const struct _mp_obj_type_t mp_network_ppp_lwip_type;
 #endif
 
 struct netif;
+
+void sys_untimeout_all_with_arg(void *arg);
+
 void mod_network_lwip_init(void);
 void mod_network_lwip_poll_wrapper(uint32_t ticks_ms);
 mp_obj_t mod_network_nic_ifconfig(struct netif *netif, size_t n_args, const mp_obj_t *args);

--- a/extmod/network_lwip.c
+++ b/extmod/network_lwip.c
@@ -52,6 +52,19 @@ int mp_mod_network_prefer_dns_use_ip_version = 4;
 
 // Implementations of network methods that can be used by any interface.
 
+// This follows sys_untimeout but removes all timeouts with the given argument.
+void sys_untimeout_all_with_arg(void *arg) {
+    for (struct sys_timeo **t = sys_timeouts_get_next_timeout(); *t != NULL;) {
+        if ((*t)->arg == arg) {
+            struct sys_timeo *next = (*t)->next;
+            memp_free(MEMP_SYS_TIMEOUT, *t);
+            *t = next;
+        } else {
+            t = &(*t)->next;
+        }
+    }
+}
+
 // This function provides the implementation of nic.ifconfig, is deprecated and will be removed.
 // Use network.ipconfig and nic.ipconfig instead.
 mp_obj_t mod_network_nic_ifconfig(struct netif *netif, size_t n_args, const mp_obj_t *args) {

--- a/ports/rp2/mpnetworkport.c
+++ b/ports/rp2/mpnetworkport.c
@@ -30,6 +30,7 @@
 
 #if MICROPY_PY_LWIP
 
+#include "extmod/modnetwork.h"
 #include "shared/runtime/softtimer.h"
 #include "lwip/netif.h"
 #include "lwip/timeouts.h"
@@ -182,6 +183,10 @@ static void mp_network_netif_status_cb(struct netif *netif, netif_nsc_reason_t r
         && mp_network_soft_timer.mode == SOFT_TIMER_MODE_ONE_SHOT) {
         mp_network_soft_timer.mode = SOFT_TIMER_MODE_PERIODIC;
         soft_timer_reinsert(&mp_network_soft_timer, LWIP_TICK_RATE_MS);
+    }
+
+    if (reason == LWIP_NSC_NETIF_REMOVED) {
+        sys_untimeout_all_with_arg(netif);
     }
 }
 


### PR DESCRIPTION
### Summary

When mDNS is active on a netif it registers a lot of timeouts, namely:
    
        mdns_probe_and_announce
        mdns_handle_tc_question
    
        mdns_multicast_probe_timeout_reset_ipv4
        mdns_multicast_timeout_25ttl_reset_ipv4
        mdns_multicast_timeout_reset_ipv4
        mdns_send_multicast_msg_delayed_ipv4
        mdns_send_unicast_msg_delayed_ipv4
    
        mdns_multicast_probe_timeout_reset_ipv6
        mdns_multicast_timeout_25ttl_reset_ipv6
        mdns_multicast_timeout_reset_ipv6
        mdns_send_multicast_msg_delayed_ipv6
        mdns_send_unicast_msg_delayed_ipv6

These may still be active after a netif is removed, and if they are called they will find that the mDNS state pointer in the netif is NULL and they will crash.

These functions could be explicitly removed using `sys_untimeout()`, but `mdns_handle_tc_question()` is static so it's not possible to access it.  Instead use the new `sys_untimeout_all_with_arg()` helper to deregister all timeout callbacks when a netif is removed.

Fixes issue #17621.

### Testing

Tested with RPI_PICO_W firmware, running the test from #17621.  It's been running for over 100 cycles without any issue (prior to the fix it would crash within 10 cycles).

### Trade-offs and Alternatives

There's also `LWIP_NETIF_REMOVE_CALLBACK` which is a more lightweight way to do something when a netif is removed.  But `LWIP_NETIF_EXT_STATUS_CALLBACK` is already enabled so easier to use that.

This fix needs to be generalised to all ports that use lwIP, but for now I just wanted something minimal that works and is easy to review / reason about.

Note that we could probably use `LWIP_NETIF_EXT_STATUS_CALLBACK` instead of the hooks `CYW43_CB_TCPIP_INIT_EXTRA` and `CYW43_CB_TCPIP_DEINIT_EXTRA`, but that's also for follow-up work.
