### PR TITLE
tests/run-tests.py: Consider tests ending in _async.py as async tests.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -886,7 +886,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         is_bytearray = test_name.startswith("bytearray") or test_name.endswith("_bytearray")
         is_set_type = test_name.startswith(("set_", "frozenset")) or test_name.endswith("_set")
         is_slice = test_name.find("slice") != -1 or test_name in misc_slice_tests
-        is_async = test_name.startswith(("async_", "asyncio_"))
+        is_async = test_name.startswith(("async_", "asyncio_")) or test_name.endswith("_async")
         is_const = test_name.startswith("const")
         is_io_module = test_name.startswith("io_")
         is_fstring = test_name.startswith("string_fstring")


### PR DESCRIPTION
### Summary

The test `micropython/ringio_async.py` is a test that requires async keyword support, and will fail with SyntaxError on targets that don't support async/await.  Really it should be skipped on such targets, and this commit makes sure that's the case.

### Testing

Tested that the test `micropython/ringio_async.py` would previously fail on a zephyr board, but now it is correctly skipped.

Verified that that test still run under the unix port (ie not skipped).