### PR TITLE
fix: Update LoRa pin definitions for RAK11300/RAK11310

### DIFF
--- a/ports/rp2/boards/RAK11300/.gitkeep
+++ b/ports/rp2/boards/RAK11300/.gitkeep
@@ -1,0 +1,2 @@
+# This is a dummy file to ensure directory creation.
+# It can be removed later if desired.

--- a/ports/rp2/boards/RAK11300/board.json
+++ b/ports/rp2/boards/RAK11300/board.json
@@ -1,0 +1,21 @@
+{
+    "deploy": [
+        "../../deploy.md"
+    ],
+    "docs": "https://docs.rakwireless.com/Product-Categories/WisDuo/RAK11300-Module/Overview/",
+    "features": [
+        "RP2040 MCU",
+        "SX1262 LoRa Transceiver",
+        "Dual-core Arm Cortex-M0+",
+        "External Flash (assumed 2MB, verify)",
+        "USB-C (if applicable, or header for USB)"
+    ],
+    "images": [
+        "RAK11300.jpg"
+    ],
+    "mcu": "rp2040",
+    "product": "RAK11300 WisDuo LPWAN Module",
+    "thumbnail": "RAK11300_thumbnail.jpg",
+    "url": "https://store.rakwireless.com/products/wisduo-lpwan-module-rak11300",
+    "vendor": "RAKwireless"
+}

--- a/ports/rp2/boards/RAK11300/mpconfigboard.cmake
+++ b/ports/rp2/boards/RAK11300/mpconfigboard.cmake
@@ -1,0 +1,14 @@
+# CMake config for RAKwireless RAK11300
+
+# Set PICO_BOARD to a generic value known by the SDK,
+# as RAK11300 is a custom board not defined in the SDK itself.
+set(PICO_BOARD pico)
+
+# Nothing specific here for now, add board-specific compile definitions
+# or source files if needed in the future.
+
+# Example for adding a board-specific C file:
+# list(APPEND BOARD_SRC board.c)
+
+# Example for setting a board-specific definition:
+# add_definitions(-DMY_CUSTOM_BOARD_FEATURE=1)

--- a/ports/rp2/boards/RAK11300/mpconfigboard.h
+++ b/ports/rp2/boards/RAK11300/mpconfigboard.h
@@ -1,0 +1,48 @@
+// RAK11300 specific configurations
+
+#define MICROPY_HW_BOARD_NAME          "RAKwireless RAK11300"
+#define MICROPY_HW_MCU_NAME            "rp2040"
+
+// Flash size: Assuming 2MB. Please verify from official datasheet if possible.
+#define MICROPY_HW_FLASH_STORAGE_BYTES (2 * 1024 * 1024)
+
+// USB VID/PID: Using Raspberry Pi Pico defaults.
+// RAKwireless may have its own VID, but it's not readily available.
+#define MICROPY_HW_USB_VID (0x2E8A)
+#define MICROPY_HW_USB_PID (0x0005) // Pico PID
+
+// On-board SX1262 LoRa chip connections (User Updated Pinout)
+#define MICROPY_HW_SX1262_SPI_ID    1    // SPI1
+#define MICROPY_HW_SX1262_SPI_SCK   10   // GPIO10 (LORA_CLK)
+#define MICROPY_HW_SX1262_SPI_MOSI  11   // GPIO11 (LORA_MOSI)
+#define MICROPY_HW_SX1262_SPI_MISO  12   // GPIO12 (LORA_MISO)
+#define MICROPY_HW_SX1262_NSS       13   // GPIO13 (LORA_CS)
+#define MICROPY_HW_SX1262_NRESET    14   // GPIO14 (LORA_RST)
+#define MICROPY_HW_SX1262_DIO1      29   // GPIO29 (LORA_IRQ) - Note: ADC capable pin
+#define MICROPY_HW_SX1262_BUSY      15   // GPIO15 (LORA_GPIO, assumed BUSY)
+
+// Power Enable for SX1262 module
+#define MICROPY_HW_SX1262_PWR_EN    25   // GPIO25 (LORA_POWER_EN)
+
+// Default UART / I2C assignments (can be overridden in user code)
+// UART0
+#define MICROPY_HW_UART0_TX  (0)
+#define MICROPY_HW_UART0_RX  (1)
+// UART1
+// #define MICROPY_HW_UART1_TX (4) // Example, if needed
+// #define MICROPY_HW_UART1_RX (5) // Example, if needed
+
+// I2C0
+#define MICROPY_HW_I2C0_SCL (5)
+#define MICROPY_HW_I2C0_SDA (4)
+// I2C1
+// #define MICROPY_HW_I2C1_SCL (3) // Example, if needed
+// #define MICROPY_HW_I2C1_SDA (2) // Example, if needed
+
+// SPI0
+// #define MICROPY_HW_SPI0_SCK  (6) // Example
+// #define MICROPY_HW_SPI0_MOSI (7) // Example
+// #define MICROPY_HW_SPI0_MISO (4) // Example (often shares pins with I2C)
+
+// No specific user LED defined from available info. Add if known:
+// #define MICROPY_HW_LED_STATUS      (pin_GPx)

--- a/ports/rp2/boards/RAK11300/pins.csv
+++ b/ports/rp2/boards/RAK11300/pins.csv
@@ -1,0 +1,44 @@
+# Pin definitions for RAKwireless RAK11300
+# Format: PIN_NAME,GPIO_NUMBER
+
+# SX1262 LoRa Module Pins (User Updated Pinout)
+LORA_CLK,GPIO10
+LORA_MOSI,GPIO11
+LORA_MISO,GPIO12
+LORA_NSS,GPIO13  # Chip Select
+LORA_NRESET,GPIO14 # Reset
+LORA_DIO1,GPIO29   # IRQ
+LORA_BUSY,GPIO15   # Assumed BUSY from LORA_GPIO
+LORA_PWR_EN,GPIO25 # Power Enable
+
+# Default UART0
+UART0_TX,GPIO0
+UART0_RX,GPIO1
+
+# Default I2C0
+I2C0_SCL,GPIO5
+I2C0_SDA,GPIO4
+
+# Standard SPI0 (if exposed and different from LoRa SPI)
+# SPI0_SCK,GPIOx
+# SPI0_MOSI,GPIOx
+# SPI0_MISO,GPIOx
+# SPI0_CS,GPIOx
+
+# User LED (if any)
+# LED,GPIOx
+
+# General Purpose IOs (examples, map according to actual board pinout if available)
+# IO0,GPIO0
+# IO1,GPIO1
+# ...
+# IO25,GPIO25
+# IO26,GPIO26
+# IO27,GPIO27
+# IO28,GPIO28
+# IO29,GPIO29
+# RUN,RUN
+# ADC_VBAT,GPIO29 # Or whichever ADC pin is used for battery monitoring, if any
+# SWCLK,SWCLK
+# SWDIO,SWDIO
+# RESET,RUN

--- a/ports/rp2/boards/RAK11310/.gitkeep
+++ b/ports/rp2/boards/RAK11310/.gitkeep
@@ -1,0 +1,2 @@
+# This is a dummy file to ensure directory creation.
+# It can be removed later if desired.

--- a/ports/rp2/boards/RAK11310/board.json
+++ b/ports/rp2/boards/RAK11310/board.json
@@ -1,0 +1,21 @@
+{
+    "deploy": [
+        "../../deploy.md"
+    ],
+    "docs": "https://docs.rakwireless.com/Product-Categories/WisDuo/RAK11300-Module/Overview/",
+    "features": [
+        "RP2040 MCU",
+        "SX1262 LoRa Transceiver",
+        "Dual-core Arm Cortex-M0+",
+        "External Flash (assumed 2MB, verify)",
+        "Stamp Module Form Factor"
+    ],
+    "images": [
+        "RAK11310.jpg"
+    ],
+    "mcu": "rp2040",
+    "product": "RAK11310 WisDuo LPWAN Module (Stamp)",
+    "thumbnail": "RAK11310_thumbnail.jpg",
+    "url": "https://store.rakwireless.com/products/wisduo-lpwan-module-rak11300?variant=42643166232774",
+    "vendor": "RAKwireless"
+}

--- a/ports/rp2/boards/RAK11310/mpconfigboard.cmake
+++ b/ports/rp2/boards/RAK11310/mpconfigboard.cmake
@@ -1,0 +1,14 @@
+# CMake config for RAKwireless RAK11310
+
+# Set PICO_BOARD to a generic value known by the SDK,
+# as RAK11310 is a custom board not defined in the SDK itself.
+set(PICO_BOARD pico)
+
+# Nothing specific here for now, add board-specific compile definitions
+# or source files if needed in the future.
+
+# Example for adding a board-specific C file:
+# list(APPEND BOARD_SRC board.c)
+
+# Example for setting a board-specific definition:
+# add_definitions(-DMY_CUSTOM_BOARD_FEATURE=1)

--- a/ports/rp2/boards/RAK11310/mpconfigboard.h
+++ b/ports/rp2/boards/RAK11310/mpconfigboard.h
@@ -1,0 +1,38 @@
+// RAK11310 specific configurations
+
+#define MICROPY_HW_BOARD_NAME          "RAKwireless RAK11310" // Changed
+#define MICROPY_HW_MCU_NAME            "rp2040"
+
+// Flash size: Assuming 2MB. Please verify from official datasheet if possible.
+// Assumed to be same as RAK11300.
+#define MICROPY_HW_FLASH_STORAGE_BYTES (2 * 1024 * 1024)
+
+// USB VID/PID: Using Raspberry Pi Pico defaults.
+// RAKwireless may have its own VID, but it's not readily available.
+// Assumed to be same as RAK11300.
+#define MICROPY_HW_USB_VID (0x2E8A)
+#define MICROPY_HW_USB_PID (0x0005) // Pico PID
+
+// On-board SX1262 LoRa chip connections (User Updated Pinout, identical to RAK11300)
+#define MICROPY_HW_SX1262_SPI_ID    1    // SPI1
+#define MICROPY_HW_SX1262_SPI_SCK   10   // GPIO10 (LORA_CLK)
+#define MICROPY_HW_SX1262_SPI_MOSI  11   // GPIO11 (LORA_MOSI)
+#define MICROPY_HW_SX1262_SPI_MISO  12   // GPIO12 (LORA_MISO)
+#define MICROPY_HW_SX1262_NSS       13   // GPIO13 (LORA_CS)
+#define MICROPY_HW_SX1262_NRESET    14   // GPIO14 (LORA_RST)
+#define MICROPY_HW_SX1262_DIO1      29   // GPIO29 (LORA_IRQ) - Note: ADC capable pin
+#define MICROPY_HW_SX1262_BUSY      15   // GPIO15 (LORA_GPIO, assumed BUSY)
+
+// Power Enable for SX1262 module (Identical to RAK11300)
+#define MICROPY_HW_SX1262_PWR_EN    25   // GPIO25 (LORA_POWER_EN)
+
+// Default UART / I2C assignments (Identical to RAK11300)
+// UART0
+#define MICROPY_HW_UART0_TX  (0)
+#define MICROPY_HW_UART0_RX  (1)
+// I2C0
+#define MICROPY_HW_I2C0_SCL (5)
+#define MICROPY_HW_I2C0_SDA (4)
+
+// No specific user LED defined from available info. Add if known:
+// #define MICROPY_HW_LED_STATUS      (pin_GPx)

--- a/ports/rp2/boards/RAK11310/pins.csv
+++ b/ports/rp2/boards/RAK11310/pins.csv
@@ -1,0 +1,39 @@
+# Pin definitions for RAKwireless RAK11310
+# Format: PIN_NAME,GPIO_NUMBER
+# Assumed to be identical to RAK11300 for core peripherals.
+
+# SX1262 LoRa Module Pins (User Updated Pinout)
+LORA_CLK,GPIO10
+LORA_MOSI,GPIO11
+LORA_MISO,GPIO12
+LORA_NSS,GPIO13  # Chip Select
+LORA_NRESET,GPIO14 # Reset
+LORA_DIO1,GPIO29   # IRQ
+LORA_BUSY,GPIO15   # Assumed BUSY from LORA_GPIO
+LORA_PWR_EN,GPIO25 # Power Enable
+
+# Default UART0
+UART0_TX,GPIO0
+UART0_RX,GPIO1
+
+# Default I2C0
+I2C0_SCL,GPIO5
+I2C0_SDA,GPIO4
+
+# Standard SPI0 (if exposed and different from LoRa SPI)
+# SPI0_SCK,GPIOx
+# SPI0_MOSI,GPIOx
+# SPI0_MISO,GPIOx
+# SPI0_CS,GPIOx
+
+# User LED (if any)
+# LED,GPIOx
+
+# General Purpose IOs (examples, map according to actual board pinout if available)
+# IO0,GPIO0
+# ...
+# RUN,RUN
+# ADC_VBAT,GPIO29
+# SWCLK,SWCLK
+# SWDIO,SWDIO
+# RESET,RUN


### PR DESCRIPTION
This commit corrects the SX1262 LoRa module pin definitions for the RAK11300 and RAK11310 board ports based on user-provided information.

The updated pins are:
- SPI SCK: GPIO10 (was GPIO18)
- SPI MOSI: GPIO11 (was GPIO19)
- SPI MISO: GPIO12 (was GPIO20)
- NSS (CS): GPIO13 (was GPIO17)
- NRESET (RST): GPIO14 (was GPIO22)
- DIO1 (IRQ): GPIO29 (was GPIO23)
- BUSY: GPIO15 (was GPIO21, LORA_GPIO now mapped to BUSY)
- PWR_EN: GPIO25 (was ANT_SW_PWR, renamed for clarity)

The SPI peripheral remains SPI1. These changes apply to both mpconfigboard.h and pins.csv files for both boards.

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

