### PR TITLE
rp2: Add binary info for ROMFS.

### DIFF
--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -98,6 +98,18 @@ bi_decl(bi_block_device(
     BINARY_INFO_BLOCK_DEV_FLAG_WRITE |
     BINARY_INFO_BLOCK_DEV_FLAG_PT_UNKNOWN));
 
+#if MICROPY_HW_ROMFS_BYTES
+// Tag the ROMFS partition in the binary
+bi_decl(bi_block_device(
+    BINARY_INFO_TAG_MICROPYTHON,
+    "ROMFS",
+    XIP_BASE + MICROPY_HW_ROMFS_BASE,
+    MICROPY_HW_ROMFS_BYTES,
+    NULL,
+    BINARY_INFO_BLOCK_DEV_FLAG_READ |
+    BINARY_INFO_BLOCK_DEV_FLAG_PT_UNKNOWN));
+#endif
+
 // This is a workaround to pico-sdk #2201: https://github.com/raspberrypi/pico-sdk/issues/2201
 // which means the multicore_lockout_victim_is_initialized returns true even after core1 is reset.
 static bool use_multicore_lockout(void) {


### PR DESCRIPTION
This describes the ROMFS location and size in Pico SDK's binary declaration format, so it can be read from a .uf2 file for use with various tools (specifically my CI UF2 wrangling).

Changes the [py_decl](https://github.com/gadgetoid/py_decl) output from:

```
/py_decl.py --to-json build-RPI_PICO2/firmware.uf2
<snip>
    "BlockDevice": [
        {
            "name": "MicroPython",
            "address": 269746176,
            "size": 2883584,
            "flags": 3
        }
    ],
<snip>
```

to:

```
/py_decl.py --to-json build-RPI_PICO2/firmware.uf2
<snip>
    "BlockDevice": [
        {
            "name": "ROMFS",
            "address": 269484032,
            "size": 262144,
            "flags": 1
        },
        {
            "name": "MicroPython",
            "address": 269746176,
            "size": 2883584,
            "flags": 3
        }
    ],
<snip>
```