### PR TITLE
py/objcode: Remove co_lnotab from v2 preview.

### DIFF
--- a/py/objcode.c
+++ b/py/objcode.c
@@ -69,6 +69,7 @@ static mp_obj_tuple_t *code_consts(const mp_module_context_t *context, const mp_
     return consts;
 }
 
+#if !MICROPY_PREVIEW_VERSION_2
 static mp_obj_t raw_code_lnotab(const mp_raw_code_t *rc) {
     // const mp_bytecode_prelude_t *prelude = &rc->prelude;
     uint start = 0;
@@ -106,6 +107,7 @@ static mp_obj_t raw_code_lnotab(const mp_raw_code_t *rc) {
     m_del(byte, buffer, buffer_size);
     return o;
 }
+#endif
 
 static mp_obj_t code_colines_iter(mp_obj_t);
 static mp_obj_t code_colines_next(mp_obj_t);
@@ -198,12 +200,14 @@ static void code_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         case MP_QSTR_co_names:
             dest[0] = MP_OBJ_FROM_PTR(o->dict_locals);
             break;
+        #if !MICROPY_PREVIEW_VERSION_2
         case MP_QSTR_co_lnotab:
             if (!o->lnotab) {
                 o->lnotab = raw_code_lnotab(rc);
             }
             dest[0] = o->lnotab;
             break;
+        #endif
         case MP_QSTR_co_lines:
             dest[0] = MP_OBJ_FROM_PTR(&code_colines_obj);
             dest[1] = self_in;

--- a/tests/basics/fun_code_full.py
+++ b/tests/basics/fun_code_full.py
@@ -6,12 +6,6 @@ except AttributeError:
     print("SKIP")
     raise SystemExit
 
-try:
-    import warnings
-    warnings.simplefilter("ignore") # ignore deprecation warning about co_lnotab
-except ImportError:
-    pass
-
 def f(x, y):
     a = x + y
     b = x - y
@@ -25,7 +19,6 @@ print(code.co_filename.rsplit('/')[-1]) # same terminal filename but might be di
 print(type(code.co_firstlineno)) # both ints (but mpy points to first line inside, cpy points to declaration)
 print(code.co_name)
 print(iter(code.co_names) is not None) # both iterable (but mpy returns dict with names as keys, cpy only the names; and not necessarily the same set)
-print(type(code.co_lnotab)) # both bytes
 
 co_lines = code.co_lines()
 

--- a/tests/basics/fun_code_lnotab.py
+++ b/tests/basics/fun_code_lnotab.py
@@ -1,0 +1,34 @@
+# Test deprecation of co_lnotab
+
+try:
+    (lambda: 0).__code__.co_code
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+
+import unittest
+import sys
+
+
+mpy_is_v2 = getattr(sys.implementation, '_v2', False)
+
+
+def f():
+    pass
+
+
+class Test(unittest.TestCase):
+
+    @unittest.skipIf(mpy_is_v2, "Removed in MicroPython v2 and later.")
+    def test_co_lnotab_exists(self):
+        self.assertIsInstance(f.__code__.co_lnotab, bytes)
+
+    @unittest.skipUnless(mpy_is_v2, "Not removed before MicroPython v2.")
+    def test_co_lnotab_removed(self):
+        with self.assertRaises(AttributeError):
+            f.__code__.co_lnotab
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Starting in CPython 3.12, accessing the `co_lnotab` attribute on code objects results in a deprecation message; and in theory, attempting to use it will be an AttributeError in CPython 3.15. Likewise, the corresponding provision in [PEP-626](https://peps.python.org/pep-0626/#backwards-compatibility) states that "the co_lnotab attribute will be deprecated in 3.10 and removed in 3.12."

Once #16989 is merged (to implement the `co_lines` method that `co_lnotab` is being removed in favor of), Micropython should follow suit to deprecate and remove `co_lnotab` from our v2 previews (and eventually, the Micropython 2.0 release).

This PR does this, adding `MICROPY_PREVIEW_VERSION_2` macro gates to the `co_lnotab` attr entry and corresponding function implementation.

### Testing

This PR adds a new set of automated test cases to validate the v2 removal and pre-v2 non-removal of `co_lnotab`, replacing a test from #16989 that only applies to pre-v2.
I've run these tests and verified correct behavior on both v2-preview and non-preview settrace builds of the unix port.

### Trade-offs and Alternatives

Aside from the expected compatibility break with v2 preview, there are no downsides to this. This is a strict improvement to code size on settrace builds, and should have no effect on standard builds.

