### PR TITLE
Enable I2S for ESP32C6 (ESP32_GENERIC_C6)

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.h
@@ -2,8 +2,5 @@
 
 #define MICROPY_HW_BOARD_NAME               "ESP32C6 module"
 #define MICROPY_HW_MCU_NAME                 "ESP32C6"
-
-#define MICROPY_PY_MACHINE_I2S              (0)
-
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)


### PR DESCRIPTION
### Summary

The ESP32_GENERIC_C6 firmware doesn't support I2S. This PR enables I2S support.

Fixes: https://github.com/orgs/micropython/discussions/17151

### Testing

![image](https://github.com/user-attachments/assets/0b7a10a2-01c3-40e5-806f-f2b5ad42a898)

The I2S import works but I'm yet to test that the audio actually works. But, according to @steve1780 who also custom built the firmware it worked for him: https://github.com/orgs/micropython/discussions/17151#discussioncomment-12925674