### PR TITLE
tools/mpremote: Add metadata file and new subcommands for mip

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -243,7 +243,7 @@ def argparse_mip():
     cmd_parser.add_argument("command", nargs=1, help="mip command (e.g. install)")
     cmd_parser.add_argument(
         "packages",
-        nargs="+",
+        nargs="*",
         help="list package specifications, e.g. name, name@version, github:org/repo, github:org/repo@branch, gitlab:org/repo, gitlab:org/repo@branch",
     )
     return cmd_parser

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -5,8 +5,8 @@
 import urllib.error
 import urllib.request
 import json
-import tempfile
-import os
+import re
+import hashlib
 import os.path
 
 from .commands import CommandError, show_progress_bar
@@ -44,7 +44,7 @@ def _check_exists(transport, path, short_hash):
 
 
 def _rewrite_url(url, branch=None):
-    if not branch:
+    if not branch or branch == "latest":
         branch = "HEAD"
     if url.startswith("github:"):
         url = url[7:].split("/")
@@ -73,7 +73,7 @@ def _rewrite_url(url, branch=None):
     return url
 
 
-def _download_file(transport, url, dest):
+def _download_file(transport, url, dest, package_info, target):
     if url.startswith(allowed_mip_url_prefixes):
         try:
             with urllib.request.urlopen(url) as src:
@@ -97,9 +97,19 @@ def _download_file(transport, url, dest):
     print("Installing:", dest)
     _ensure_path_exists(transport, dest)
     transport.fs_writefile(dest, data, progress_callback=show_progress_bar)
+    assert dest.startswith(target)
+    relative_dest = dest[len(target) :].lstrip("/")
+    if "files" not in package_info:
+        # this step is postponed in order to get "files" as last entry of the package info
+        package_info["files"] = []
+    package_info["files"].append(
+        {"path": relative_dest, "sha256": hashlib.sha256(data).hexdigest()}
+    )
 
 
-def _install_json(transport, package_json_url, index, target, version, mpy):
+def _install_json(
+    transport, package_json_url, index, target, version, mpy, package_info, target_info
+):
     base_url = ""
     if package_json_url.startswith(allowed_mip_url_prefixes):
         try:
@@ -122,28 +132,70 @@ def _install_json(transport, package_json_url, index, target, version, mpy):
         base_url = os.path.dirname(package_json_url)
     else:
         raise CommandError(f"Invalid url for package: {package_json_url}")
+
+    if package_json_url.startswith(index):
+        package_info["index"] = index
+        reported_version = package_json.get("version")
+        # Note that the reliability of the reported version is guaranteed only in case of index packages.
+        # Even if a GitHub repo has corresponding tag, its other commits (between releases)
+        # may also contain the same reported version.
+        if reported_version is not None:
+            package_info["resolved_version"] = reported_version
+    package_info["metadata"] = package_json
+
     for target_path, short_hash in package_json.get("hashes", ()):
         fs_target_path = target + "/" + target_path
         if _check_exists(transport, fs_target_path, short_hash):
             print("Exists:", fs_target_path)
         else:
             file_url = f"{index}/file/{short_hash[:2]}/{short_hash}"
-            _download_file(transport, file_url, fs_target_path)
+            _download_file(transport, file_url, fs_target_path, package_info, target)
     for target_path, url in package_json.get("urls", ()):
         fs_target_path = target + "/" + target_path
         if base_url and not url.startswith(allowed_mip_url_prefixes):
             url = f"{base_url}/{url}"  # Relative URLs
-        _download_file(transport, _rewrite_url(url, version), fs_target_path)
+        _download_file(transport, _rewrite_url(url, version), fs_target_path, package_info, target)
     for dep, dep_version in package_json.get("deps", ()):
-        _install_package(transport, dep, index, target, dep_version, mpy)
+        _install_package(transport, dep, index, target, dep_version, mpy, target_info)
+
+    if "files" not in package_info:
+        # make sure "files" is always present
+        package_info["files"] = []
 
 
-def _install_package(transport, package, index, target, version, mpy):
+def _install_package(transport, package, index, target, version, mpy, target_info):
+    installed_version = _get_installed_version(package, target_info)
+    if installed_version is not None:
+        if _installed_version_matches_requirement(installed_version, version):
+            print(f"Version {installed_version} of {package} is already installed")
+            return
+        else:
+            _uninstall_package(transport, package, target, target_info)
+
+    if version is None:
+        version = "latest"
+
+    package_info = {
+        "requested_version": version,
+    }
+    package = _normalize_package_specifier(package)
+    target_info["packages"][package] = package_info
+
     if package.startswith(allowed_mip_url_prefixes):
+        if package.startswith("github:") or package.startswith("gitlab:"):
+            resolved_version = _try_resolve_version_as_git_reference(package, version)
+            if resolved_version is not None:
+                package_info["resolved_version"] = resolved_version
+                version = resolved_version
         if package.endswith(".py") or package.endswith(".mpy"):
             print(f"Downloading {package} to {target}")
+            fs_target_path = target + "/" + package.rsplit("/")[-1]
             _download_file(
-                transport, _rewrite_url(package, version), target + "/" + package.rsplit("/")[-1]
+                transport,
+                _rewrite_url(package, version),
+                fs_target_path,
+                package_info,
+                target,
             )
             return
         else:
@@ -155,8 +207,6 @@ def _install_package(transport, package, index, target, version, mpy):
     elif package.endswith(".json"):
         pass
     else:
-        if not version:
-            version = "latest"
         print(f"Installing {package} ({version}) from {index} to {target}")
 
         mpy_version = "py"
@@ -166,14 +216,213 @@ def _install_package(transport, package, index, target, version, mpy):
 
         package = f"{index}/package/{mpy_version}/{package}/{version}.json"
 
-    _install_json(transport, package, index, target, version, mpy)
+    _install_json(transport, package, index, target, version, mpy, package_info, target_info)
+
+
+def _list_packages(args, target_info):
+    for key, entry in target_info["packages"].items():
+        print(key, end="")
+
+        version = entry.get("resolved_version", entry.get("requested_version")) or "latest"
+        if version != "latest":
+            print(f"@{version}", end="")
+
+        index = entry.get("index")
+        if index is not None and index != _PACKAGE_INDEX:
+            print(f" from {index}")
+
+        print()
+
+
+def _uninstall_package(transport, package, target, target_info):
+    target = target.rstrip("/")
+    dirs_to_check = []
+    package = _normalize_package_specifier(package)
+    if package not in target_info["packages"]:
+        raise CommandError(f"mip: package '{package}' not found")
+
+    package_info = target_info["packages"][package]
+
+    print(f"Uninstalling {package} from {target}")
+    for file in package_info["files"]:
+        full_path = target + "/" + file["path"]
+        print("Uninstalling:", full_path)
+        if transport.fs_exists(full_path):
+            transport.fs_rmfile(full_path)
+            parent_dir = full_path.rsplit("/", maxsplit=1)[0]
+            if parent_dir not in dirs_to_check:
+                dirs_to_check.append(parent_dir)
+
+    # remove directories, which became empty because of this uninstall (except target)
+    while dirs_to_check:
+        dir_to_check = dirs_to_check.pop(0)
+        if dir_to_check != target and not transport.fs_listdir(dir_to_check):
+            print("Removing empty directory:", dir_to_check)
+            transport.fs_rmdir(dir_to_check)
+            parent_dir = dir_to_check.rsplit("/", maxsplit=1)[0]
+            if parent_dir not in dirs_to_check and parent_dir != target:
+                dirs_to_check.append(parent_dir)
+
+    del target_info["packages"][package]
+
+
+def _get_installed_version(package, target_info):
+    spec = target_info["packages"].get(_normalize_package_specifier(package), None)
+    if spec is not None:
+        return spec.get("resolved_version", spec["requested_version"])
+
+    return None
+
+
+def _installed_version_matches_requirement(installed_version, requirement):
+    if requirement == "latest":
+        # explicit "latest" always requires re-install
+        return False
+
+    return requirement is None or installed_version == requirement
+
+
+def _get_target_info_path(args):
+    return args.target.rstrip("/") + "/mip-packages.json"
+
+
+def _normalize_package_specifier(package):
+    if package.endswith(".json") and os.path.isfile(package):
+        return os.path.normpath(os.path.abspath(package))
+
+    package_json_url_suffix = "/package.json"
+    if package.startswith(allowed_mip_url_prefixes) and package.endswith(package_json_url_suffix):
+        return package[: -len(package_json_url_suffix)]
+
+    # TODO: What to do with trailing slashes?g
+
+    if ":" not in package:
+        # index package
+        # TODO: is this right?
+        return re.sub(r"[-_.]+", "-", package.lower()).strip("-")
+
+    return package
+
+
+def _load_target_info(state, args):
+    path = _get_target_info_path(args)
+    if state.transport.fs_exists(path):
+        return json.loads(state.transport.fs_readfile(path).decode("utf-8"))
+    else:
+        return {"packages": {}}
+
+
+def _save_target_info(state, args, target_info, pretty=False):
+    if pretty:
+        json_str = json.dumps(target_info, indent=2)
+    else:
+        json_str = json.dumps(target_info)
+
+    state.transport.fs_writefile(_get_target_info_path(args), json_str.encode("utf-8"))
+
+
+def _try_resolve_version_as_git_reference(package, version):
+    if version in ["latest", None]:
+        git_ref = "HEAD"
+    else:
+        git_ref = version
+
+    if package.startswith("github:"):
+        host = "https://github.com"
+        org, project = package[7:].split("/")[:2]
+    elif package.startswith("gitlab:"):
+        host = "https://gitlab.com"
+        org, project = package[7:].split("/")[:2]
+    else:
+        raise ValueError("Unexpected package reference: " + package)
+
+    repo_url = f"{host}/{org}/{project}.git"
+
+    tags, heads = _fetch_git_refs(repo_url)
+    if git_ref in tags:
+        return git_ref
+
+    if git_ref in heads:
+        return heads[git_ref]
+
+    if re.fullmatch("[0-9a-fA-F]{7,40}", git_ref):
+        # looks like commit hash
+        return git_ref
+
+    return heads.get(git_ref, None)
+
+
+def _fetch_git_refs(repo_url):
+    """
+    Returns two dictionaries mapping tags to commit hashes and branches (including pseudo-branch HEAD) to commit hashes
+    """
+    assert repo_url.endswith(".git")
+
+    req = urllib.request.Request(
+        repo_url + "/info/refs?service=git-upload-pack",
+        headers={"User-Agent": "python-ref-resolver/0.2"},
+    )
+    data = urllib.request.urlopen(req, timeout=15).read()
+
+    def pkt_lines(raw: bytes):
+        i = 0
+        while i < len(raw):
+            n = int(raw[i : i + 4], 16)
+            i += 4
+            if n == 0:  # flush
+                continue
+            yield raw[i : i + n - 4].rstrip(b"\r\n")
+            i += n - 4
+
+    tags = {}
+    heads = {}
+
+    for pl in pkt_lines(data):
+        if pl.startswith(b"#"):  # “# service=…”
+            continue
+
+        sha, rest = pl.split(b" ", 1)
+        name, *cap = rest.split(b"\0", 1)
+        name = name.decode()
+        sha = sha.decode()
+
+        if name.endswith("^{}"):  # peeled helper line
+            continue
+        elif name == "HEAD":
+            heads[name] = sha
+        elif name.startswith("refs/tags/"):
+            tags[name[10:]] = sha
+        elif name.startswith("refs/heads/"):
+            heads[name[11:]] = sha
+
+    return tags, heads
 
 
 def do_mip(state, args):
     state.did_action()
 
-    if args.command[0] == "install":
+    if args.command[0] in ["install", "list", "uninstall"]:
         state.ensure_raw_repl()
+
+        if args.target is None:
+            state.transport.exec("import sys")
+            lib_paths = [
+                p
+                for p in state.transport.eval("sys.path")
+                if not p.startswith("/rom") and p.endswith("/lib")
+            ]
+            if lib_paths and lib_paths[0]:
+                args.target = lib_paths[0]
+            else:
+                raise CommandError("Unable to find lib dir in sys.path, use --target to override")
+
+        target_info = _load_target_info(state, args)
+    else:
+        raise CommandError(f"mip: '{args.command[0]}' is not a command")
+
+    if args.command[0] == "install":
+        if not args.packages:
+            raise CommandError("mip: install requires one or more package arguments")
 
         for package in args.packages:
             version = None
@@ -184,20 +433,6 @@ def do_mip(state, args):
 
             if args.index is None:
                 args.index = _PACKAGE_INDEX
-
-            if args.target is None:
-                state.transport.exec("import sys")
-                lib_paths = [
-                    p
-                    for p in state.transport.eval("sys.path")
-                    if not p.startswith("/rom") and p.endswith("/lib")
-                ]
-                if lib_paths and lib_paths[0]:
-                    args.target = lib_paths[0]
-                else:
-                    raise CommandError(
-                        "Unable to find lib dir in sys.path, use --target to override"
-                    )
 
             if args.mpy is None:
                 args.mpy = True
@@ -210,10 +445,31 @@ def do_mip(state, args):
                     args.target,
                     version,
                     args.mpy,
+                    target_info,
                 )
             except CommandError:
                 print("Package may be partially installed")
                 raise
             print("Done")
-    else:
-        raise CommandError(f"mip: '{args.command[0]}' is not a command")
+
+        _save_target_info(state, args, target_info)
+
+    elif args.command[0] == "list":
+        if args.packages:
+            raise CommandError("mip: list does not take package arguments")
+        _list_packages(args, target_info)
+
+    elif args.command[0] == "uninstall":
+        if not args.packages:
+            raise CommandError("mip: uninstall requires one or more package arguments")
+
+        for package in args.packages:
+            print("Uninstall", package)
+            _uninstall_package(state.transport, package, args.target, target_info)
+        if target_info["packages"] == {}:
+            target_info_path = _get_target_info_path(args)
+            if state.transport.fs_exists(target_info_path):
+                print("Removing empty", target_info_path)
+                state.transport.fs_rmfile(target_info_path)
+        else:
+            _save_target_info(state, args, target_info)


### PR DESCRIPTION
### Summary

1. Make `mpremote mip install` create or update a metadata file containing installation details
2. Use this impormation to implement `mpremote mip list` and `mpremote mip uninstall`.

### Testing

I tested on a Raspberry Pi Pico. I'll perform more thorough testing if the maintainers express their interest in this idea.

### Trade-offs and Alternatives

The discussion has been started at https://github.com/orgs/micropython/discussions/17534
