### PR TITLE
docs: Fix method links in btree.rst

### DIFF
--- a/docs/library/btree.rst
+++ b/docs/library/btree.rst
@@ -151,10 +151,10 @@ Constants
 
 .. data:: INCL
 
-   A flag for `keys()`, `values()`, `items()` methods to specify that
+   A flag for :meth:`btree.keys`, :meth:`btree.values`, :meth:`btree.items` methods to specify that
    scanning should be inclusive of the end key.
 
 .. data:: DESC
 
-   A flag for `keys()`, `values()`, `items()` methods to specify that
+   A flag for :meth:`btree.keys`, :meth:`btree.values`, :meth:`btree.items` methods to specify that
    scanning should be in descending direction of keys.


### PR DESCRIPTION
### Summary
This pull request renames the values attribute in the btree module to resolve a name conflict.

The issue came up when building the documentation with Sphinx, where btree.values conflicted with string.templatelib.Template.values, causing the build to fail.

This change was originally part of my work in PR #17557. As suggested by @AJMansfield in the review comments, I've moved it into its own separate pull request to keep the changes focused and unrelated to the t-string support.

### Testing
I have confirmed that with this change, the documentation now builds successfully using Sphinx without any errors.

Since this change is limited to resolving a documentation build issue, it has no impact on the runtime code or any board-specific functionality.