### PR TITLE
py/asmrv32: Make lt/le comparisons emitter shorter.

### DIFF
--- a/py/asmrv32.c
+++ b/py/asmrv32.c
@@ -573,12 +573,8 @@ void asm_rv32_meta_comparison_ne(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2
 }
 
 void asm_rv32_meta_comparison_lt(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t rd, bool unsigned_comparison) {
-    // slt(u) rd, rs1, rs2
-    if (unsigned_comparison) {
-        asm_rv32_opcode_sltu(state, rd, rs1, rs2);
-    } else {
-        asm_rv32_opcode_slt(state, rd, rs1, rs2);
-    }
+    // slt|sltu rd, rs1, rs2
+    asm_rv32_emit_word_opcode(state, RV32_ENCODE_TYPE_R(0x33, (0x02 | (unsigned_comparison ? 1 : 0)), 0x00, rd, rs1, rs2));
 }
 
 void asm_rv32_meta_comparison_le(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t rd, bool unsigned_comparison) {
@@ -588,11 +584,7 @@ void asm_rv32_meta_comparison_le(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2
     // ...                 ; PC + 8
     asm_rv32_opcode_cli(state, rd, 1);
     asm_rv32_opcode_beq(state, rs1, rs2, 8);
-    if (unsigned_comparison) {
-        asm_rv32_opcode_sltu(state, rd, rs1, rs2);
-    } else {
-        asm_rv32_opcode_slt(state, rd, rs1, rs2);
-    }
+    asm_rv32_meta_comparison_lt(state, rs1, rs2, rd, unsigned_comparison);
 }
 
 #endif // MICROPY_EMIT_RV32


### PR DESCRIPTION
### Summary

This PR simplifies the *emitter* code (not the *emitted* code) in charge of generating opcodes performing less-than and less-than-or-equal comparisons.

By rewriting the `SLT`/`SLTU` opcode generator (handling less-than comparisons) and de-inlining the less-than comparison generator call in the less-than-or-equal generator, the QEMU's output binary is 78 bytes smaller (measurement taken when building on a CI-like environment).

### Testing

Besides the usual manual tests run on QEMU's VIRT_RV32 board, CI's QEMU tests for RV32 were executed successfully by GitHub's test runner from its original code branch.