### PR TITLE
tests/run-tests.py: Auto detect whether the target has threading and the GIL or not.

### DIFF
--- a/docs/library/sys.rst
+++ b/docs/library/sys.rst
@@ -77,6 +77,8 @@ Constants
    * *_mpy* - supported mpy file-format version (optional attribute)
    * *_build* - string that can help identify the configuration that
      MicroPython was built with
+   * *_thread* - optional string attribute, exists if the target has threading
+     and is either "GIL" or "unsafe"
 
    This object is the recommended way to distinguish MicroPython from other
    Python implementations (note that it still may not exist in the very
@@ -94,6 +96,14 @@ Constants
      name, for example ``'standard'``.
    * On microcontroller targets, the first element is the board name and the second
      element (if present) is the board variant, for example ``'RPI_PICO2-RISCV'``
+
+   The *_thread* entry was added in version 1.26.0 and if it exists then the
+   target has the ``_thread`` module.  If the target enables the GIL (global
+   interpreter lock) then this attribute is ``"GIL"``.  Otherwise the attribute
+   is ``"unsafe"`` and the target has threading but does not enable the GIL,
+   and mutable Python objects (such as `bytearray`, `list` and `dict`) that are
+   shared amongst threads must be protected explicitly by locks such as
+   ``_thread.allocate_lock``.
 
    .. admonition:: Difference to CPython
       :class: attention

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -259,7 +259,6 @@ test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 test_full_no_native: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -d thread
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) -d basics float micropython
 	cat $(TOP)/tests/basics/0prelim.py | ./$(BUILD)/$(PROG) | grep -q 'abc'
 

--- a/py/modsys.c
+++ b/py/modsys.c
@@ -103,6 +103,18 @@ static const MP_DEFINE_STR_OBJ(mp_sys_implementation__build_obj, MICROPY_BOARD_B
 #define SYS_IMPLEMENTATION_ELEMS__BUILD
 #endif
 
+#if MICROPY_PY_THREAD
+#if MICROPY_PY_THREAD_GIL
+#define SYS_IMPLEMENTATION_ELEMS__THREAD \
+    , MP_ROM_QSTR(MP_QSTR_GIL)
+#else
+#define SYS_IMPLEMENTATION_ELEMS__THREAD \
+    , MP_ROM_QSTR(MP_QSTR_unsafe)
+#endif
+#else
+#define SYS_IMPLEMENTATION_ELEMS__THREAD
+#endif
+
 #if MICROPY_PREVIEW_VERSION_2
 #define SYS_IMPLEMENTATION_ELEMS__V2 \
     , MP_ROM_TRUE
@@ -120,6 +132,9 @@ static const qstr impl_fields[] = {
     #if defined(MICROPY_BOARD_BUILD_NAME)
     MP_QSTR__build,
     #endif
+    #if MICROPY_PY_THREAD
+    MP_QSTR__thread,
+    #endif
     #if MICROPY_PREVIEW_VERSION_2
     MP_QSTR__v2,
     #endif
@@ -127,20 +142,21 @@ static const qstr impl_fields[] = {
 static MP_DEFINE_ATTRTUPLE(
     mp_sys_implementation_obj,
     impl_fields,
-    3 + MICROPY_PERSISTENT_CODE_LOAD + MICROPY_BOARD_BUILD + MICROPY_PREVIEW_VERSION_2,
+    3 + MICROPY_PERSISTENT_CODE_LOAD + MICROPY_BOARD_BUILD + MICROPY_PY_THREAD + MICROPY_PREVIEW_VERSION_2,
     SYS_IMPLEMENTATION_ELEMS_BASE
     SYS_IMPLEMENTATION_ELEMS__MPY
     SYS_IMPLEMENTATION_ELEMS__BUILD
+    SYS_IMPLEMENTATION_ELEMS__THREAD
     SYS_IMPLEMENTATION_ELEMS__V2
     );
 #else
 static const mp_rom_obj_tuple_t mp_sys_implementation_obj = {
     {&mp_type_tuple},
     3 + MICROPY_PERSISTENT_CODE_LOAD,
-    // Do not include SYS_IMPLEMENTATION_ELEMS__BUILD or SYS_IMPLEMENTATION_ELEMS__V2
-    // because SYS_IMPLEMENTATION_ELEMS__MPY may be empty if
+    // Do not include SYS_IMPLEMENTATION_ELEMS__BUILD, SYS_IMPLEMENTATION_ELEMS__THREAD
+    // or SYS_IMPLEMENTATION_ELEMS__V2 because SYS_IMPLEMENTATION_ELEMS__MPY may be empty if
     // MICROPY_PERSISTENT_CODE_LOAD is disabled, which means they'll share
-    // the same index. Cannot query _build or _v2 if MICROPY_PY_ATTRTUPLE is
+    // the same index. Cannot query _build, _thread or _v2 if MICROPY_PY_ATTRTUPLE is
     // disabled.
     {
         SYS_IMPLEMENTATION_ELEMS_BASE

--- a/tests/basics/sys1.py
+++ b/tests/basics/sys1.py
@@ -30,6 +30,12 @@ else:
     # Effectively skip subtests
     print(str)
 
+if hasattr(sys.implementation, '_thread'):
+    print(sys.implementation._thread in ("GIL", "unsafe"))
+else:
+    # Effectively skip subtests
+    print(True)
+
 try:
     print(sys.intern('micropython') == 'micropython')
     has_intern = True

--- a/tests/extmod/select_poll_eintr.py
+++ b/tests/extmod/select_poll_eintr.py
@@ -33,6 +33,14 @@ def thread_main():
     print("thread gc end")
 
 
+# Pre-allocate global variables here so the global dict is not resized by the main
+# thread while the secondary thread runs.  This is a workaround for the bug described
+# in https://github.com/micropython/micropython/pull/11604
+poller = None
+t0 = None
+result = None
+dt_ms = None
+
 # Start a thread to interrupt the main thread during its call to poll.
 lock = _thread.allocate_lock()
 lock.acquire()

--- a/tests/feature_check/target_info.py
+++ b/tests/feature_check/target_info.py
@@ -20,4 +20,6 @@ arch = [
     "xtensawin",
     "rv32imc",
 ][sys_mpy >> 10]
-print(platform, arch)
+thread = getattr(sys.implementation, "_thread", None)
+
+print(platform, arch, thread)

--- a/tests/thread/stress_aes.py
+++ b/tests/thread/stress_aes.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
         n_thread = 2
         n_loop = 2
     else:
-        n_thread = 20
+        n_thread = 10
         n_loop = 5
     for i in range(n_thread):
         _thread.start_new_thread(thread_entry, (n_loop,))

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -720,7 +720,8 @@ function ci_unix_stackless_clang_build {
 }
 
 function ci_unix_stackless_clang_run_tests {
-    ci_unix_run_tests_helper CC=clang
+    # Timeout needs to be increased for thread/stress_aes.py test.
+    MICROPY_TEST_TIMEOUT=90 ci_unix_run_tests_helper CC=clang
 }
 
 function ci_unix_float_clang_build {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -801,8 +801,9 @@ function ci_unix_qemu_mips_build {
 function ci_unix_qemu_mips_run_tests {
     # Issues with MIPS tests:
     # - thread/stress_aes.py takes around 50 seconds
+    # - thread/stress_recurse.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py)
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'thread/stress_recurse.py')
 }
 
 function ci_unix_qemu_arm_setup {
@@ -823,8 +824,9 @@ function ci_unix_qemu_arm_run_tests {
     # Issues with ARM tests:
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
     # - thread/stress_aes.py takes around 70 seconds
+    # - thread/stress_recurse.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py|thread/stress_recurse.py')
 }
 
 function ci_unix_qemu_riscv64_setup {
@@ -844,8 +846,9 @@ function ci_unix_qemu_riscv64_build {
 function ci_unix_qemu_riscv64_run_tests {
     # Issues with RISCV-64 tests:
     # - thread/stress_aes.py takes around 140 seconds
+    # - thread/stress_recurse.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py)
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py --exclude 'thread/stress_recurse.py')
 }
 
 ########################################################################################

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -797,8 +797,10 @@ function ci_unix_qemu_mips_build {
 }
 
 function ci_unix_qemu_mips_run_tests {
+    # Issues with MIPS tests:
+    # - thread/stress_aes.py takes around 50 seconds
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py)
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py)
 }
 
 function ci_unix_qemu_arm_setup {
@@ -818,8 +820,9 @@ function ci_unix_qemu_arm_build {
 function ci_unix_qemu_arm_run_tests {
     # Issues with ARM tests:
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
+    # - thread/stress_aes.py takes around 70 seconds
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py --exclude 'vfs_posix.*\.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py')
 }
 
 function ci_unix_qemu_riscv64_setup {
@@ -837,8 +840,10 @@ function ci_unix_qemu_riscv64_build {
 }
 
 function ci_unix_qemu_riscv64_run_tests {
+    # Issues with RISCV-64 tests:
+    # - thread/stress_aes.py takes around 140 seconds
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py)
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py)
 }
 
 ########################################################################################

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -780,7 +780,8 @@ function ci_unix_macos_run_tests {
     # Issues with macOS tests:
     # - float_parse and float_parse_doubleprec parse/print floats out by a few mantissa bits
     # - ffi_callback crashes for an unknown reason
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython ./run-tests.py --exclude '(float_parse|float_parse_doubleprec|ffi_callback).py')
+    # - thread/stress_heap.py is flaky
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython ./run-tests.py --exclude '(float_parse|float_parse_doubleprec|ffi_callback|thread/stress_heap).py')
 }
 
 function ci_unix_qemu_mips_setup {


### PR DESCRIPTION
### Summary

This PR makes the following changes to the test runner and CI:
- detect if the target has the `_thread` module and, if so, add the threading tests to the set of tests to run
- if the target has threading, detect if the target has the GIL enabled or not, and use that information to exclude thread mutating tests if the GIL is disabled
- work around threading bug in `tests/extmod/select_poll_eintr.py` test
- make `tests/thread/stress_aes.py` test do less work on stackless threading builds, so it finishes before the test timeout limit
- increase test timeout for unix qemu test runs
- skip some threading tests on macOS and on unix qemu

Currently the information whether a port has the GIL is hard-coded: unix/PC targets and the rp2 port are considered to be GIL-less, and all other targets have the GIL enabled (if they have threading enabled).  With the change here, some code is run to detect the GIL.  That uses the fact that native code won't bounce the GIL and can hog it, and times how long code runs.

Overall the changes here mean that the threading tests are run in many more configurations:
- on the unix port with the native emitter
- on the unix port with single precision float
- on the unix port with stackless mode enabled
- on the unix port using clang as a compiler
- on unix qemu, the architectures MIPS, ARM and RISCV-64
- on macOS
 
### Testing

Tested locally on the unix port, esp32 and rp2.  Let's also see how the CI works.

### Trade-offs and Alternatives

This uses a tricky technique to determine GIL/non-GIL.  An alternative would be to add some indication in a function whether the GIL is enabled, eg `sys.implementation._thread_info`.  But that will increase code size.