### PR TITLE
esp32/network_ppp: Bugfixes for deadlocks and crashes when disconnecting.

### DIFF
--- a/extmod/network_ppp_lwip.c
+++ b/extmod/network_ppp_lwip.c
@@ -119,17 +119,18 @@ static mp_obj_t network_ppp_make_new(const mp_obj_type_t *type, size_t n_args, s
 
 static mp_obj_t network_ppp___del__(mp_obj_t self_in) {
     network_ppp_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    if (self->state >= STATE_ACTIVE) {
-        if (self->state >= STATE_ERROR) {
-            // Still connected over the stream.
-            // Force the connection to close, with nocarrier=1.
-            self->state = STATE_INACTIVE;
-            ppp_close(self->pcb, 1);
-        }
-        network_ppp_stream_uart_irq_disable(self);
+
+    network_ppp_stream_uart_irq_disable(self);
+    if (self->state >= STATE_ERROR) {
+        // Still connected over the stream.
+        // Force the connection to close, with nocarrier=1.
+        ppp_close(self->pcb, 1);
+    } else if (self->state >= STATE_ACTIVE) {
         // Free PPP PCB and reset state.
+        if (ppp_free(self->pcb) != ERR_OK) {
+            mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("ppp_free failed"));
+        }
         self->state = STATE_INACTIVE;
-        ppp_free(self->pcb);
         self->pcb = NULL;
     }
     return mp_const_none;

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -68,8 +68,6 @@ typedef struct _network_ppp_obj_t {
 
 const mp_obj_type_t esp_network_ppp_lwip_type;
 
-static mp_obj_t network_ppp___del__(mp_obj_t self_in);
-
 static void network_ppp_stream_uart_irq_disable(network_ppp_obj_t *self) {
     if (self->stream == mp_const_none) {
         return;
@@ -94,8 +92,15 @@ static void network_ppp_status_cb(ppp_pcb *pcb, int err_code, void *ctx) {
                 // only need to free the PPP PCB, not close it.
                 self->state = STATE_ACTIVE;
             }
+            network_ppp_stream_uart_irq_disable(self);
             // Clean up the PPP PCB.
-            network_ppp___del__(MP_OBJ_FROM_PTR(self));
+            // Note: Because we use pppapi_close instead of ppp_close, this
+            // callback will run on the lwIP tcpip_thread, thus to prevent a
+            // deadlock we must use the non-threadsafe function here.
+            if (ppp_free(pcb) == ERR_OK) {
+                self->state = STATE_INACTIVE;
+                self->pcb = NULL;
+            }
             break;
         default:
             self->state = STATE_ERROR;

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -163,7 +163,7 @@ static mp_obj_t network_ppp_poll(size_t n_args, const mp_obj_t *args) {
         }
         mp_printf(&mp_plat_print, ")\n");
         #endif
-        pppos_input(self->pcb, (u8_t *)buf, len);
+        pppos_input_tcpip(self->pcb, (u8_t *)buf, len);
         total_len += len;
     }
 


### PR DESCRIPTION
### Summary

A follow-up to #17138 in which I reworked the ESP32 PPP implementation to be closer to the extmod implementation.

In that PR it was mentioned that:

> PPP is quite hard to get right and modems can be very finicky. So it's great now that the code running on esp32 boards is also (indirectly) testing the extmod code, and vice versa

Well, I found three issues on the ESP32. Two of them are specific to the ESP32 and it's use of a thread-safe API, and I think one of them (the PCB cleanup) also is probably also wrong in the extmod version.

The three fixes (each a separate commit):

#### Use thread-safe API for PPPoS input

The ESP32 port uses the thread-safe API, but in the previous PR the PPP input function was accidentally changed to use the non-safe API. It happens to work fine, but the correct way is to use the thread-safe API as we do elsewhere in the implementation (and did before this change was accidentally introduced).

(extmod doesn't use the thread-safe API so isn't affected.)

#### Use non-thread-safe API inside status callback

The status callback runs on the lwIP `tcpip_thread`, and thus on the ESP32 we must use the non-thread-safe API because the thread-safe API would cause a deadlock (because it would wait on that same `tcpip_thread` to first finish executing the status callback).

(extmod doesn't use the thread-safe API so isn't affected, other than a change that doesn't change any functionally but keeps the two files as similar as possible when diffing them.)

#### Correctly clean up PPP PCB after close

If PPP is still connected, freeing the PCB will fail ([see lwIP code here](https://github.com/lwip-tcpip/lwip/blob/3013e1fc191a20f7a4333f445aa5c815dd051e22/src/netif/ppp/ppp.c#L400-L402)) and thus instead we should trigger a disconnect and wait for the lwIP callback to actually free the PCB.

When PPP is not connected we should check if the freeing failed, warn the user if so, and only mark the connection as inactive if not.

When all this happens during garbage collection the best case is that the PPP connection is already dead, which means the callback will be called immediately and cleanup will happen correctly. The worst case is that the connection is still alive, thus we are unable to free the PCB (lwIP won't let us) and it remains referenced in the `netif_list`, meaning a use-after-free happens later when lwIP traverses that linked list.

While this change does not fully fix the garbage collection case, on the ESP32 port specifically it *does* improve how the `PPP.active(False)` method behaves: It no longer immediately tries to free (and fails), but instead triggers a disconnect and lets the cleanup happen correctly through the status callback. (extmod doesn't have the `.active()` method.)

### Testing

I've so far only tested this on the ESP32 port, by repeatedly connecting/disconnecting/deleting, and checking via GDB that the `netif_list` did not get corrupted anymore. As for other ports: I did not test them, but am fairly confident the change makes sense; as the linked code from the exact lwIP submodule used by extmod shows the `ppp_free` function indeed can fail and thus the change to handle it in the callback seems correct.