### PR TITLE
ci: Always call `apt-get update` before `apt-get install`.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -13,11 +13,13 @@ ulimit -n 1024
 # general helper functions
 
 function ci_gcc_arm_setup {
+    sudo apt-get update
     sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi
     arm-none-eabi-gcc --version
 }
 
 function ci_gcc_riscv_setup {
+    sudo apt-get update
     sudo apt-get install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
     riscv64-unknown-elf-gcc --version
 }
@@ -35,6 +37,7 @@ function ci_picotool_setup {
 # c code formatting
 
 function ci_c_code_formatting_setup {
+    sudo apt-get update
     sudo apt-get install uncrustify
     uncrustify --version
 }
@@ -703,6 +706,7 @@ function ci_unix_float_run_tests {
 }
 
 function ci_unix_clang_setup {
+    sudo apt-get update
     sudo apt-get install clang
     clang --version
 }
@@ -839,6 +843,7 @@ function ci_unix_qemu_riscv64_run_tests {
 # ports/windows
 
 function ci_windows_setup {
+    sudo apt-get update
     sudo apt-get install gcc-mingw-w64
 }
 


### PR DESCRIPTION
### Summary

I saw a recent build failure in build_renesas_ra_board. It appears to be the case that a security update for this package was recently issued by ubuntu for CVE-2025-4565 and the buggy version is no longer on package servers. However, it is still referred to by the cached apt metadata in the GitHub runners. [temporary log](https://github.com/jepler/circuitpython/actions/runs/16203266104/job/45747302942#logs)

```
Err:3 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libprotoc32t64 amd64 3.21.12-8.2ubuntu0.1
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/protobuf/libprotoc32t64_3.21.12-8.2ubuntu0.1_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
```

I added apt-get update there, and audited for other sites in ci.sh where it might be necessary.

### Testing

It'll need to run through CI. It would be a good idea to check that no builds are running `apt-get update` twice, because that costs a few seconds.