### PR TITLE
tests/extmod: Close UDP timely.

### DIFF
--- a/tests/extmod/select_poll_udp.py
+++ b/tests/extmod/select_poll_udp.py
@@ -29,3 +29,5 @@ print(poll.poll(0)[0][1] == select.POLLOUT)
 if hasattr(select, "select"):
     r, w, e = select.select([s], [], [], 0)
     assert not r and not w and not e
+
+s.close()

--- a/tests/extmod/socket_udp_nonblock.py
+++ b/tests/extmod/socket_udp_nonblock.py
@@ -19,3 +19,5 @@ try:
     s.recv(1)
 except OSError as er:
     print("EAGAIN:", er.errno == errno.EAGAIN)
+
+s.close()


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This adds call to release UDP port timely so that to reuse it  in other tests. Otherwise, one could face issue like https://github.com/orgs/micropython/discussions/17623.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Tested with VARIANT coverage of UNIX port on Ubuntu 22.04.

