### PR TITLE
tools/mpremote/config: Add environment-variable and .env-style config options.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -108,7 +108,7 @@ The full list of supported commands are:
   **Note:** Instead of using the ``connect`` command, there are several
   :ref:`pre-defined shortcuts <mpremote_shortcuts>` for common device paths. For
   example the ``a0`` shortcut command is equivalent to
-  ``connect /dev/ttyACM0`` (Linux), or ``c0`` for ``COM0`` (Windows).
+  ``connect /dev/ttyACM0`` (Linux), or ``c1`` for ``COM1`` (Windows).
 
   **Note:** The ``auto`` option will only detect USB serial ports, i.e. a serial
   port that has an associated USB VID/PID (i.e. CDC/ACM or FTDI-style
@@ -487,9 +487,16 @@ Shortcuts can be defined using the macro system.  Built-in shortcuts are:
 
 - ``cat``, ``edit``, ``ls``, ``cp``, ``rm``, ``mkdir``, ``rmdir``, ``touch``: Aliases for ``fs <sub-command>``
 
-Additional shortcuts can be defined by in user-configuration files, which is
-located at ``.config/mpremote/config.py``. This file should define a
-dictionary named ``commands``. The keys of this dictionary are the shortcuts
+Additional shortcuts can be defined by in the user configuration file ``mpremote/config.py``, located in
+the User Configuration Directory. 
+The correct location for each OS is determined using the ``platformdirs`` module.
+
+This is typically:
+  # ``$XDG_CONFIG_HOME/mpremote/config.py``
+  # ``$HOME/.config/mpremote/config.py``
+  # ``$env:LOCALAPPDATA/mpremote/config.py``
+  
+The ``config.py``` file should define a dictionary named ``commands``. The keys of this dictionary are the shortcuts
 and the values are either a string or a list-of-strings:
 
 .. code-block:: python3

--- a/tools/mpremote/mpremote/config.py
+++ b/tools/mpremote/mpremote/config.py
@@ -14,22 +14,20 @@ def cwd_as(path):
 
 def load_script(prog: str) -> dict:
     """Executes the ~/.config/mpremote/config.py configuration script to derive a configuration."""
+    import platformdirs
+
     config = {
         'commands': {},
     }
-    # Get config file name.
-    path = os.getenv("XDG_CONFIG_HOME")
-    if path is None:
-        path = os.getenv("HOME")
-        if path is None:
-            return config
-        path = os.path.join(path, ".config")
-    path = os.path.join(path, prog)
+    path = platformdirs.user_config_dir(appname=prog, appauthor=False)
     config_file = os.path.join(path, "config.py")
 
-    # Check if config file exists.
     if not os.path.exists(config_file):
         return config
+
+    # pass in the config path so that the config file can use it
+    config["config_path"] = path
+    config["__file__"] = config_file
 
     # Exec the config file in its directory.
     with open(config_file) as f:

--- a/tools/mpremote/mpremote/config.py
+++ b/tools/mpremote/mpremote/config.py
@@ -1,0 +1,45 @@
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def cwd_as(path):
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+
+
+def load_script(prog: str) -> dict:
+    """Executes the ~/.config/mpremote/config.py configuration script to derive a configuration."""
+    config = {
+        'commands': {},
+    }
+    # Get config file name.
+    path = os.getenv("XDG_CONFIG_HOME")
+    if path is None:
+        path = os.getenv("HOME")
+        if path is None:
+            return config
+        path = os.path.join(path, ".config")
+    path = os.path.join(path, prog)
+    config_file = os.path.join(path, "config.py")
+
+    # Check if config file exists.
+    if not os.path.exists(config_file):
+        return config
+
+    # Exec the config file in its directory.
+    with open(config_file) as f:
+        config_data = f.read()
+    with cwd_as(path):
+        exec(config_data, config)
+
+    return config
+
+
+class Config:
+    def __init__(self, prog='mpremote'):
+        self.__dict__.update(load_script(prog))

--- a/tools/mpremote/mpremote/config.py
+++ b/tools/mpremote/mpremote/config.py
@@ -40,6 +40,17 @@ def load_script(prog: str) -> dict:
     return config
 
 
+def load_dotenv(prog: str) -> dict:
+    """Searches up the directory tree for a file called '.mpremote' and parses it with .env syntax."""
+    import dotenv
+
+    path = dotenv.find_dotenv(f'.{prog}', usecwd=True)
+    if path is None:
+        return {}
+
+    return dotenv.dotenv_values(path)
+
+
 def load_environ(prog: str) -> dict:
     """Filters environment variables for and strips off their 'MPREMOTE_' prefix,
     and processes 'MPREMOTE_CMD_' prefixed vars into command-specific config entries.
@@ -64,4 +75,5 @@ def load_environ(prog: str) -> dict:
 class Config:
     def __init__(self, prog='mpremote'):
         self.__dict__.update(load_script(prog))
+        self.__dict__.update(load_dotenv(prog))
         self.__dict__.update(load_environ(prog))

--- a/tools/mpremote/mpremote/config.py
+++ b/tools/mpremote/mpremote/config.py
@@ -40,6 +40,28 @@ def load_script(prog: str) -> dict:
     return config
 
 
+def load_environ(prog: str) -> dict:
+    """Filters environment variables for and strips off their 'MPREMOTE_' prefix,
+    and processes 'MPREMOTE_CMD_' prefixed vars into command-specific config entries.
+    """
+    env_prefix = prog.upper() + '_'
+    cmd_prefix = env_prefix + 'CMD_'
+
+    config = {}
+    commands = {}
+
+    for k in os.environ.keys():
+        if k.startswith(cmd_prefix):
+            commands[k.removeprefix(cmd_prefix).lower()] = os.environ[k]
+        elif k.startswith(env_prefix):
+            config[k.removeprefix(env_prefix).lower()] = os.environ[k]
+
+    if commands:
+        config['commands'] = commands
+    return config
+
+
 class Config:
     def __init__(self, prog='mpremote'):
         self.__dict__.update(load_script(prog))
+        self.__dict__.update(load_environ(prog))

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -22,6 +22,7 @@ import os, sys, time
 from collections.abc import Mapping
 from textwrap import dedent
 
+from .config import Config
 from .commands import (
     CommandError,
     do_connect,
@@ -434,33 +435,7 @@ for port_num in range(4):
 
 
 def load_user_config():
-    # Create empty config object.
-    config = __build_class__(lambda: None, "Config")()
-    config.commands = {}
-
-    # Get config file name.
-    path = os.getenv("XDG_CONFIG_HOME")
-    if path is None:
-        path = os.getenv("HOME")
-        if path is None:
-            return config
-        path = os.path.join(path, ".config")
-    path = os.path.join(path, _PROG)
-    config_file = os.path.join(path, "config.py")
-
-    # Check if config file exists.
-    if not os.path.exists(config_file):
-        return config
-
-    # Exec the config file in its directory.
-    with open(config_file) as f:
-        config_data = f.read()
-    prev_cwd = os.getcwd()
-    os.chdir(path)
-    exec(config_data, config.__dict__)
-    os.chdir(prev_cwd)
-
-    return config
+    return Config(_PROG)
 
 
 def prepare_command_expansions(config):

--- a/tools/mpremote/requirements.txt
+++ b/tools/mpremote/requirements.txt
@@ -1,2 +1,3 @@
 pyserial >= 3.3
 importlib_metadata >= 1.4; python_version < "3.8"
+python-dotenv >= 1.0.1

--- a/tools/mpremote/requirements.txt
+++ b/tools/mpremote/requirements.txt
@@ -1,3 +1,4 @@
 pyserial >= 3.3
 importlib_metadata >= 1.4; python_version < "3.8"
 python-dotenv >= 1.0.1
+platformdirs >= 4.3.7


### PR DESCRIPTION
### Summary

This PR factors out mpremote's configuration code into a separate file, and adds the ability to specify that configuration from two other sources: environment variables with the `MPREMOTE_` prefix, and/or a dotenv-style configuration file called `.mpremote` in the user's current directory or one of its parents.

My own motivation for wanting environment-variable control here is ease of automation. In heavily-scripted and especially containerized environments, environment variables are generally easier to work with than configuration files. This will help pave the way for e.g. a future CI/CD task for running the mpremote test suite.

The dotenv configuration mechanism is another common configuration method I found while researching existing python libraries for combining and dispatching to available file-based and environment-variable-based configuration methods. I ended up not finding a tool that could process the `MPREMOTE_` and `MPREMOTE_CMD_` environment-variable prefixes together the way I'd have liked, but I had the dotenv-style loader working already by that point. It adds a convenient way to specify project-specific mpremote configurations to be automatically used when running mpremote in the context of that specific project.

This was inspired by discussion on #17485, and also incorporates a not-entirely-trivial rebase of #9573 to include @Josverl's fixes to the current `config.py` issues on Windows.

### Testing

Not yet done; we're at least at "works on my machine", but I've not yet gone through testing every combinations of configuration sources across multiple applicable environments.

Part of testing this will also need to be ensuring that all available settings are tested, to make sure the testing process has been sensitive to e.g. a need to add some sort of explicit type conversion processing (to the environment-variable loading, or at the site where the relevant config item is used). Since I'll have to go through that anyway I'll also make sure all of those options have documentation.

### Trade-offs and Alternatives

More opinionated philosophies like [The Twelve-Factor App](https://12factor.net/config) suggest that environment variables should be the _only_ configuration mechanism. Some of its reasoning in favor of environment variables might be worth reading, but I don't agree with the conclusion that the current `config.py` mechanism ought to be dropped.

It _might_ still be better to drop the dotenv-style, to avoid proliferating too many ways a user could get tangled in stupid "where even _is_ the damn config file" style headaches, and avoid an obligation to maintain support for it; though I think the usability it adds outweighs that.

