### PR TITLE
tools/ci.sh: Change averaging to 1 for run-perfbench.py test.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -538,7 +538,7 @@ function ci_unix_run_tests_helper {
 function ci_unix_run_tests_full_extra {
     micropython=$1
     (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=$micropython ./run-multitests.py multi_net/*.py)
-    (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=$micropython ./run-perfbench.py 1000 1000)
+    (cd tests && MICROPY_CPYTHON3=python3 MICROPY_MICROPYTHON=$micropython ./run-perfbench.py --average 1 1000 1000)
 }
 
 function ci_unix_run_tests_full_no_native_helper {


### PR DESCRIPTION
### Summary

The `run-perfbench.py` test is run as part of CI, but the actual performance results are not used.  Rather, the test is just testing that all the performance tests run correctly.

So there's no need to run with the default averaging of 8 (which runs each test 8 times and takes the average time for the performance result) which can take a lot of time for slower builds, eg unix sanitize, settrace and stackless builds.

This commit changes the averaging to just 1.

### Testing

CI will test this.

Edit: here are the new times taken for the slower CI jobs (improved due to this PR), the time taken for the "run main test suite part":
- unix settrace_stackless: was 2m:50s now 1m:15s
- unix sanitize_address: was 3m:40s now 1m:40s
- unix sanitize_undefined: was 5m:10s now 1m:50s

That's a lot faster, and doesn't reduce test coverage.