### PR TITLE
py: Make math and cmath modules extensible.

### DIFF
--- a/py/modcmath.c
+++ b/py/modcmath.c
@@ -149,6 +149,6 @@ const mp_obj_module_t mp_module_cmath = {
     .globals = (mp_obj_dict_t *)&mp_module_cmath_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_cmath, mp_module_cmath);
+MP_REGISTER_EXTENSIBLE_MODULE(MP_QSTR_cmath, mp_module_cmath);
 
 #endif // MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_BUILTINS_COMPLEX && MICROPY_PY_CMATH

--- a/py/modmath.c
+++ b/py/modmath.c
@@ -450,6 +450,6 @@ const mp_obj_module_t mp_module_math = {
     .globals = (mp_obj_dict_t *)&mp_module_math_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_math, mp_module_math);
+MP_REGISTER_EXTENSIBLE_MODULE(MP_QSTR_math, mp_module_math);
 
 #endif // MICROPY_PY_BUILTINS_FLOAT && MICROPY_PY_MATH


### PR DESCRIPTION
### Summary

Change math and cmath module registration from normal to extensible. This way users can extend the modules to add any missing functions.

At Pybricks, we actually want this to be able to import `umath` for backwards compatibility purposes, but this seems like something that would be useful for other users as well since they will likely expect these modules to be extensible like most other standard library modules are in MicroPython.

### Testing

We tested this in Pybricks where we were able to import `umath` to get the `math` module.

### Trade-offs and Alternatives

We'll see if there is any code size change. Alternative would be for Pybricks to keep carrying this patch in their fork.