### PR TITLE
Fix potential vulnerable clone function

### DIFF
--- a/ports/cc3200/FreeRTOS/Source/queue.c
+++ b/ports/cc3200/FreeRTOS/Source/queue.c
@@ -403,6 +403,9 @@ Queue_t * const pxQueue = ( Queue_t * ) xQueue;
 			xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
 		}
 
+		/* Check for addition overflow. */
+		configASSERT( ( sizeof( Queue_t ) + xQueueSizeInBytes ) >  xQueueSizeInBytes );
+
 		pxNewQueue = ( Queue_t * ) pvPortMalloc( sizeof( Queue_t ) + xQueueSizeInBytes );
 
 		if( pxNewQueue != NULL )


### PR DESCRIPTION
Hi Development Team,

I identified a potential integer overflow in a clone function xQueueGenericCreate() in `ports/cc3200/FreeRTOS/Source/queue.c` sourced from [FreeRTOS/FreeRTOS-Kernel](https://github.com/FreeRTOS/FreeRTOS-Kernel). This issue, originally reported in [CVE-2021-31571](https://nvd.nist.gov/vuln/detail/CVE-2021-31571), was resolved in the repository via this commit https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/47338393f1f79558f6144213409f09f81d7c4837.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!

