### PR TITLE
examples/rp2/pio_uart_rx: Fix error running example.

### DIFF
--- a/examples/rp2/pio_uart_rx.py
+++ b/examples/rp2/pio_uart_rx.py
@@ -23,7 +23,7 @@ PIO_RX_PIN = Pin(3, Pin.IN, Pin.PULL_UP)
 @asm_pio(
     autopush=True,
     push_thresh=8,
-    in_shiftdir=rp2.PIO.SHIFT_RIGHT,
+    in_shiftdir=PIO.SHIFT_RIGHT,
     fifo_join=PIO.JOIN_RX,
 )
 def uart_rx_mini():
@@ -42,7 +42,7 @@ def uart_rx_mini():
 
 
 @asm_pio(
-    in_shiftdir=rp2.PIO.SHIFT_RIGHT,
+    in_shiftdir=PIO.SHIFT_RIGHT,
 )
 def uart_rx():
     # fmt: off


### PR DESCRIPTION
Running the unmodified `pio_uart_rx` example by uploading the file and importing it doesn't succeed, and instead emits a NameError at line 26.

Discovered while using this and other examples to help verify #16851.

With this fix, and the specified jumper between GPIO4 and GPIO3, this example runs successfully on both my PicoW and my Pico2.