### PR TITLE
webassembly/objpyproxy: Avoid throwing on implicit symbols access.

### DIFF
--- a/tests/ports/webassembly/py_proxy_get.mjs
+++ b/tests/ports/webassembly/py_proxy_get.mjs
@@ -1,0 +1,14 @@
+// Test `<py-obj> get <attr>` on the JavaScript side, which tests PyProxy.get.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+mp.runPython(`
+x = {"a": 1}
+`);
+
+const x = mp.globals.get("x");
+console.log(x.a === 1);
+console.log(x.b === undefined);
+console.log(typeof x[Symbol.iterator] === "function");
+console.log(x[Symbol.toStringTag] === undefined);
+console.log(x.then === undefined);

--- a/tests/ports/webassembly/py_proxy_get.mjs.exp
+++ b/tests/ports/webassembly/py_proxy_get.mjs.exp
@@ -1,0 +1,5 @@
+true
+true
+true
+true
+true


### PR DESCRIPTION
### Summary

This MR fixes https://github.com/micropython/micropython/issues/17657 by guarding against implicit unknown symbols accessed directly by specific JS native APIs.


### Testing

Added a new `get` proxy trap focused test that would throw otherwise with current MicroPython when `Object.prototype.toString.call(pyProxy)` happens, returning `null` just like the `then` case would for any symbol that is not `Symbol.iterator`.

### Trade-offs and Alternatives

The `typeof` operator is the fastest check JS offers for primitive types so there are not many side-effects or trafe-offs in here, just better runtime handling of unexpected symbol access that both 3rd party libraries or native JS APIs would regularly perform.

The only alternative approach is to return `undefined` which could be returned for `then` case too but neither of these actually matter as both `then` and `Symbol.toStringTag` or others are implicit via `Reflect` so that returning `null` is still OK, yet if anyone checks strictly against `undefined` that might fail but it's a very edge/uncommon use case to consider, so that changes in here are minimal.

