### PR TITLE
objrange: Allow return of non-small ints.

### DIFF
--- a/py/objrange.c
+++ b/py/objrange.c
@@ -41,9 +41,9 @@ typedef struct _mp_obj_range_it_t {
 static mp_obj_t range_it_iternext(mp_obj_t o_in) {
     mp_obj_range_it_t *o = MP_OBJ_TO_PTR(o_in);
     if ((o->step > 0 && o->cur < o->stop) || (o->step < 0 && o->cur > o->stop)) {
-        mp_obj_t o_out = MP_OBJ_NEW_SMALL_INT(o->cur);
+        mp_int_t cur = o->cur;
         o->cur += o->step;
-        return o_out;
+        return mp_obj_new_int(cur);
     } else {
         return MP_OBJ_STOP_ITERATION;
     }
@@ -132,7 +132,7 @@ static mp_obj_t range_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
         case MP_UNARY_OP_BOOL:
             return mp_obj_new_bool(len > 0);
         case MP_UNARY_OP_LEN:
-            return MP_OBJ_NEW_SMALL_INT(len);
+            return mp_obj_new_int(len);
         default:
             return MP_OBJ_NULL;      // op not supported
     }
@@ -173,7 +173,7 @@ static mp_obj_t range_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
         }
         #endif
         size_t index_val = mp_get_index(self->base.type, len, index, false);
-        return MP_OBJ_NEW_SMALL_INT(self->start + index_val * self->step);
+        return mp_obj_new_int(self->start + index_val * self->step);
     } else {
         return MP_OBJ_NULL; // op not supported
     }

--- a/tests/basics/builtin_range_maxsize.py
+++ b/tests/basics/builtin_range_maxsize.py
@@ -1,0 +1,38 @@
+try:
+    from sys import maxsize
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Test the range builtin at extreme values. (https://github.com/micropython/micropython/issues/17684)
+#
+# This is written using asserts instead of prints because the value of `maxsize` differs.
+#
+# Numbers & counts right up against the max of mp_int_t also cause overflows, such as
+# objrange.c:115:14: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'
+# so just avoid them for the purposes of this test.
+
+r = range(-maxsize+1, -1)
+assert r.start == -maxsize +1
+assert r.stop == -1
+assert r[0] == -maxsize + 1
+assert r[1] == -maxsize + 2
+assert r[-1] == -2
+assert r[-2] == -3
+
+ir = iter(r)
+assert next(ir) == -maxsize + 1
+assert next(ir) == -maxsize + 2
+
+r = range(0, maxsize-1)
+assert len(r) == maxsize-1
+assert r.stop == maxsize-1
+
+r = range(maxsize, 0, -1)
+assert len(r) == maxsize
+assert r.start == maxsize
+assert r[0] == maxsize
+assert r[1] == maxsize-1
+ir = iter(r)
+assert next(ir) == maxsize
+assert next(ir) == maxsize-1

--- a/tests/cpydiff/types_range_limits.py
+++ b/tests/cpydiff/types_range_limits.py
@@ -1,0 +1,26 @@
+"""
+categories: Types,range
+description: Range objects with large start or stop arguments misbehave.
+cause: Intermediate calculations overflow the C mp_int_t type
+workaround: Avoid using such ranges
+"""
+
+from sys import maxsize
+
+# A range including `maxsize-1` cannot be created
+try:
+    print(range(-maxsize - 1, 0))
+except OverflowError:
+    print("OverflowError")
+
+# A range with `stop-start` exceeding sys.maxsize has incorrect len(), while CPython cannot calculate len().
+try:
+    print(len(range(-maxsize, maxsize)))
+except OverflowError:
+    print("OverflowError")
+
+# A range with `stop-start` exceeding sys.maxsize has incorrect len()
+try:
+    print(len(range(-maxsize, maxsize, maxsize)))
+except OverflowError:
+    print("OverflowError")


### PR DESCRIPTION

### Summary

Closes #17684.

### Testing

I wrote new tests & ran the unix coverage tests locally.

### Trade-offs and Alternatives

Given that values between the "small int" range and "machine int" range never worked with range(), maybe non "small int"
range() arguments should be rejected instead. However, this would be a bit contradictory as you expect to have ranges with elements up to `sys.maxsize` at least.