### PR TITLE
py/objtype: Add support for __set_name__. (no-self-modification version)

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1124,7 +1124,7 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_FUNCTION_ATTRS_CODE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_FULL_FEATURES)
 #endif
 
-// Whether to support the descriptors __get__, __set__, __delete__
+// Whether to support the descriptors __get__, __set__, __delete__, __set_name__
 // This costs some code size and makes load/store/delete of instance
 // attributes slower for the classes that use this feature
 #ifndef MICROPY_PY_DESCRIPTORS

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -1242,6 +1242,8 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
     }
 
     #if MICROPY_PY_DESCRIPTORS
+    locals_map->is_fixed = 1; // prevent modify-while-write of __set_name__
+
     // call __set_name__ on all entries (especially descriptors)
     for (size_t i = 0; i < locals_map->alloc; i++) {
         if (mp_map_slot_is_filled(locals_map, i)) {
@@ -1256,6 +1258,8 @@ mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) 
             }
         }
     }
+
+    locals_map->is_fixed = 0; // would be finalizer, but class isn't returned anyway
     #endif
 
     return MP_OBJ_FROM_PTR(o);

--- a/tests/basics/class_descriptor.py
+++ b/tests/basics/class_descriptor.py
@@ -1,21 +1,27 @@
 class Descriptor:
     def __get__(self, obj, cls):
-        print('get')
+        print("get")
         print(type(obj) is Main)
         print(cls is Main)
-        return 'result'
+        return "result"
 
     def __set__(self, obj, val):
-        print('set')
+        print("set")
         print(type(obj) is Main)
         print(val)
 
     def __delete__(self, obj):
-        print('delete')
+        print("delete")
         print(type(obj) is Main)
+
+    def __set_name__(self, owner, name):
+        print("set_name", name)
+        print(owner.__name__ == "Main")
+
 
 class Main:
     Forward = Descriptor()
+
 
 m = Main()
 try:
@@ -26,15 +32,15 @@ except AttributeError:
     raise SystemExit
 
 r = m.Forward
-if 'Descriptor' in repr(r.__class__):
+if "Descriptor" in repr(r.__class__):
     # Target doesn't support descriptors.
-    print('SKIP')
+    print("SKIP")
     raise SystemExit
 
 # Test assignment and deletion.
 
 print(r)
-m.Forward = 'a'
+m.Forward = "a"
 del m.Forward
 
 # Test that lookup of descriptors like __get__ are not passed into __getattr__.

--- a/tests/basics/class_descriptor_setname.py
+++ b/tests/basics/class_descriptor_setname.py
@@ -1,0 +1,68 @@
+
+set_name_called = False
+
+class Descriptor:
+    def __set_name__(self, owner, name):
+        global set_name_called
+        set_name_called = True
+
+class TestClass:
+    Forward = Descriptor()
+
+if not set_name_called:
+    print("SKIP")
+    raise SystemExit
+
+
+# Make sure classes get unfrozen after the __set_name__ phase
+
+try:
+    TestClass.x = 5
+    print(TestClass.x)
+except AttributeError:
+    print("AttributeError")
+
+
+# Test accesses to owner class.
+
+
+class GetSibling:
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name + "_sib"))
+
+
+class GetSiblingTest:
+    desc = GetSibling()
+    desc_sib = 111
+
+
+t110 = GetSiblingTest()
+
+
+class GetSelf:
+    x = 211
+
+    def __set_name__(self, owner, name):
+        print(getattr(owner, name).x)
+
+
+class GetSelfTest:
+    desc = GetSelf()
+
+
+t210 = GetSelfTest()
+
+
+# Test exception behavior
+
+
+class Raise:
+    def __set_name__(self, owner, name):
+        raise Exception()
+
+
+try:
+    class RaiseTest:
+        desc = Raise()
+except Exception as e:
+    print("Exception")

--- a/tests/basics/class_descriptor_setname1.py
+++ b/tests/basics/class_descriptor_setname1.py
@@ -1,0 +1,91 @@
+
+set_name_called = False
+
+class Descriptor:
+    def __set_name__(self, owner, name):
+        global set_name_called
+        set_name_called = True
+
+class TestClass:
+    Forward = Descriptor()
+
+if not set_name_called:
+    print("SKIP")
+    raise SystemExit
+
+
+# Test mutations of owner class.
+
+
+class SetSibling:
+    def __set_name__(self, owner, name):
+        setattr(owner, name + "_sib", 121)
+
+
+try:
+    class SetSiblingTest:
+        desc = SetSibling()
+        
+except AttributeError:
+    print("AttributeError")
+else:
+    t120 = SetSiblingTest()
+    print(t120.desc_sib)
+
+
+class DelSibling:
+    def __set_name__(self, owner, name):
+        delattr(owner, name + "_sib")
+
+
+try:
+    class DelSiblingTest:
+        desc = DelSibling()
+        desc_sib = 131
+
+except AttributeError:
+    print("AttributeError")
+else:
+    t130 = DelSiblingTest()
+
+    try:
+        print(t130.desc_sib)
+    except AttributeError:
+        print("(deleted)")
+
+
+
+class SetSelf:
+    def __set_name__(self, owner, name):
+        setattr(owner, name, 221)
+
+
+try:
+    class SetSelfTest:
+        desc = SetSelf()
+
+except AttributeError:
+    print("AttributeError")
+else:
+    t220 = SetSelfTest()
+    print(t220.desc)
+
+
+class DelSelf:
+    def __set_name__(self, owner, name):
+        delattr(owner, name)
+
+
+try:
+    class DelSelfTest:
+        desc = DelSelf()
+
+except AttributeError:
+    print("AttributeError")
+else:
+    t230 = DelSelfTest()
+
+    try:
+        print(t230.desc)
+    except AttributeError:
+        print("(deleted)")

--- a/tests/basics/class_descriptor_setname1.py.exp
+++ b/tests/basics/class_descriptor_setname1.py.exp
@@ -1,0 +1,4 @@
+AttributeError
+AttributeError
+AttributeError
+AttributeError


### PR DESCRIPTION
### Summary

This PR implements the feature described in https://github.com/micropython/micropython/issues/15501, adding support for the `__set_name__` data model method.

In particular, this implementation leverages the existing `is_fixed` flag bit on micropython's flag type to avoid the potential modify-while-iterating hazard in the simplest possible way, i.e. by preventing `__set_name__` from modifying the owner class.

### Testing

This PR includes and passes the unit test originally submitted in https://github.com/micropython/micropython/pull/15500 to verify the feature's absence, as well as additional tests to specifically verify that attempting to mutate the descriptor's owner triggers an error.

### Trade-offs and Alternatives

This is the least powerful of the four ways I've tried implementing this (just allowing the hazard in #15503, or copying a list of calls to make in #16806, or making a private copy of the dict in #16816), as the ability for a descriptor to add siblings or transparently delete or replace itself isn't an especially-rarely-used functionality in descriptor-heavy code.

The functionality in question can, though, for the most part be replaced by inheriting the owner class from a suitable parent class with an `__init_subclass__` method that handles this on behalf of its descriptors. This will need to be documented as a cpydiff workaround, though that can only really be considered a workaround once we have actual `__init_subclass__` (#15511) or at least documented workarounds to that method's nonfunctionality (#16786).

As an alternative, maybe this PR could be combined with either #16806 or #16816 with a feature flag that defaults to this minimal 'disallow modifying the owner' implementation, but can be set for platforms/applications where the full cost of making the extra copies is tolerable?