### PR TITLE
unix/make: Fix 32bit libffi path.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -167,11 +167,7 @@ ifeq ($(MICROPY_STANDALONE),1)
 GIT_SUBMODULES += lib/libffi
 DEPLIBS += libffi
 LIBFFI_CFLAGS := -I$(shell ls -1d $(BUILD)/lib/libffi/include)
- ifeq ($(MICROPY_FORCE_32BIT),1)
-  LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib32/libffi.a
- else
   LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib/libffi.a
- endif
 else
 # Use system version of libffi.
 LIBFFI_CFLAGS := $(shell pkg-config --cflags libffi)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This fixes libffi.a link error when building 32bit standalone UNIX port on Ubuntu 22.04:

```sh
$ make -C ports/unix MICROPY_STANDALONE=1 MICROPY_FORCE_32BIT=1 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++ deplibs
$ make -C ports/unix MICROPY_STANDALONE=1 MICROPY_FORCE_32BIT=1 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++
...
LINK build-standard/micropython
/usr/lib/gcc-cross/i686-linux-gnu/11/../../../../i686-linux-gnu/bin/ld: cannot find build-standard/lib/libffi/out/lib32/libffi.a: No such file or directory
collect2: error: ld returned 1 exit status
```

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Checked on Ubuntu 22.04 like:

```sh
$ make -C ports/unix MICROPY_STANDALONE=1 MICROPY_FORCE_32BIT=1 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++ deplibs
$ make -C ports/unix MICROPY_STANDALONE=1 MICROPY_FORCE_32BIT=1 CC=i686-linux-gnu-gcc CXX=i686-linux-gnu-g++
...
LINK build-standard/micropython
   text      data       bss       dec       hex   filename
 743657     35968      2788    782413     bf04d   build-standard/micropython
$ file ports/unix/build-standard/micropython
ports/unix/build-standard/micropython: ELF 32-bit LSB pie executable, Intel 80386, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux.so.2, BuildID[sha1]=3c107769fefd7b467ca0b095ad1c6d28b1702826, for GNU/Linux 3.2.0, stripped
$ ldd ports/unix/build-standard/micropython
     linux-gate.so.1 (0xf7f7b000)
     libm.so.6 => /lib/i386-linux-gnu/libm.so.6 (0xf7d8f000)
     libc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7a00000)
     /lib/ld-linux.so.2 (0xf7f7d000)
```

