### PR TITLE
tests/run-tests.py: Use TEST_TIMEOUT as timeout for bare-metal tests.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -15,7 +15,7 @@ from multiprocessing.pool import ThreadPool
 import threading
 import tempfile
 
-# Maximum time to run a PC-based test, in seconds.
+# Maximum time to run a single test, in seconds.
 TEST_TIMEOUT = float(os.environ.get('MICROPY_TEST_TIMEOUT', 30))
 
 # See stackoverflow.com/questions/2632199: __file__ nor sys.argv[0]
@@ -333,7 +333,7 @@ def run_script_on_remote_target(pyb, args, test_file, is_special):
     try:
         had_crash = False
         pyb.enter_raw_repl()
-        output_mupy = pyb.exec_(script)
+        output_mupy = pyb.exec_(script, timeout=TEST_TIMEOUT)
     except pyboard.PyboardError as e:
         had_crash = True
         if not is_special and e.args[0] == "exception":

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -530,8 +530,8 @@ class Pyboard:
             return ret
 
     # In Python3, call as pyboard.exec(), see the setattr call below.
-    def exec_(self, command, data_consumer=None):
-        ret, ret_err = self.exec_raw(command, data_consumer=data_consumer)
+    def exec_(self, command, timeout=10, data_consumer=None):
+        ret, ret_err = self.exec_raw(command, timeout, data_consumer)
         if ret_err:
             raise PyboardError("exception", ret, ret_err)
         return ret


### PR DESCRIPTION
### Summary

This TEST_TIMEOUT parameter is already used for PC-based tests (eg unix and webassembly ports), and it makes sense for it to be used for bare-metal ports as well.  That way the timeout is configurable for all targets.

Because this increases the default timeout from 10s to 30s, this fixes some long-running tests that would previously fail due to a timeout such as `thread/stress_aes.py` on ESP32.

### Testing

Tested with ESP32_GENERIC firmware.  The `thread/stress_aes.py` test now passes (previously it would fail due to timeout).