### PR TITLE
asyncio: slight optimizations for `run_until_complete` and `sleep_ms`

### DIFF
--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -3,6 +3,7 @@
 
 from time import ticks_ms as ticks, ticks_diff, ticks_add
 import sys, select
+from select import POLLIN, POLLOUT
 
 # Import TaskQueue and Task, preferring built-in C code over Python code
 try:
@@ -66,6 +67,9 @@ def sleep(t):
 ################################################################################
 # Queue and poller for stream IO
 
+nPOLLIN = ~POLLIN
+nPOLLOUT = ~POLLOUT
+
 
 class IOQueue:
     def __init__(self):
@@ -77,13 +81,13 @@ class IOQueue:
             entry = [None, None, s]
             entry[idx] = cur_task
             self.map[id(s)] = entry
-            self.poller.register(s, select.POLLIN if idx == 0 else select.POLLOUT)
+            self.poller.register(s, POLLIN if idx == 0 else POLLOUT)
         else:
             sm = self.map[id(s)]
             assert sm[idx] is None
             assert sm[1 - idx] is not None
             sm[idx] = cur_task
-            self.poller.modify(s, select.POLLIN | select.POLLOUT)
+            self.poller.modify(s, POLLIN | POLLOUT)
         # Link task to this IOQueue so it can be removed if needed
         cur_task.data = self
 
@@ -114,20 +118,20 @@ class IOQueue:
         for s, ev in self.poller.ipoll(dt):
             sm = self.map[id(s)]
             # print('poll', s, sm, ev)
-            if ev & ~select.POLLOUT and sm[0] is not None:
+            if ev & nPOLLOUT and sm[0] is not None:
                 # POLLIN or error
                 _task_queue.push(sm[0])
                 sm[0] = None
-            if ev & ~select.POLLIN and sm[1] is not None:
+            if ev & nPOLLIN and sm[1] is not None:
                 # POLLOUT or error
                 _task_queue.push(sm[1])
                 sm[1] = None
             if sm[0] is None and sm[1] is None:
                 self._dequeue(s)
             elif sm[0] is None:
-                self.poller.modify(s, select.POLLOUT)
+                self.poller.modify(s, POLLOUT)
             else:
-                self.poller.modify(s, select.POLLIN)
+                self.poller.modify(s, POLLIN)
 
 
 ################################################################################
@@ -153,12 +157,15 @@ def run_until_complete(main_task=None):
     global cur_task
     excs_all = (CancelledError, Exception)  # To prevent heap allocation in loop
     excs_stop = (CancelledError, StopIteration)  # To prevent heap allocation in loop
+    queue_peek = _task_queue.peek
+    queue_pop = _task_queue.pop
+    wait_io_event = _io_queue.wait_io_event
     while True:
         # Wait until the head of _task_queue is ready to run
         dt = 1
         while dt > 0:
             dt = -1
-            t = _task_queue.peek()
+            t = queue_peek()
             if t:
                 # A task waiting on _task_queue; "ph_key" is time to schedule task at
                 dt = max(0, ticks_diff(t.ph_key, ticks()))
@@ -167,10 +174,10 @@ def run_until_complete(main_task=None):
                 cur_task = None
                 return
             # print('(poll {})'.format(dt), len(_io_queue.map))
-            _io_queue.wait_io_event(dt)
+            wait_io_event(dt)
 
         # Get next task to run and continue it
-        t = _task_queue.pop()
+        t = queue_pop()
         cur_task = t
         try:
             # Continue running the coroutine, it's responsible for rescheduling itself


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This is aimed at improving the loop timing of the asyncio core loop. It makes a few small optimizations to the core and realizes about a 20% impact in overall performance.

  - In the IO poll method, the POLLIN and POLLOUT constants are looked up in the local module context rather than in the `select` module when used.
  - In `sleep_ms`, `max` is not used for each call. Instead, an `if` expression handles the case when `t` is negative.
  - In `run_until_complete`, a call to `max` is avoided
  - In `run_until_complete` the methods for the task and IO queues are only looked up once.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I ran two tests on three platforms. Source code is given below. The tight-loop just runs a single task as quickly as possible. The second task uses a ThreadSafeFlag to run two tasks as quickly as possible but requires IO polling between the tasks.

| test       | platform                      | base (v1.25.0) | PR     | Change |
|------------|-------------------------------|----------------|--------|--------|
| tight-loop | unix (ubuntu 22.04 on Mac M2) | 1.65us         | 1.26us | +23.6% |
|            | mimxrt (Teensy 4.1)           | 47us           | 42us   | +10.6% |
|            | rp2 (W5100S EVB PICO @ 125MHz)| 554us          | 495us  | +10.6% |
| io-poll    | unix                          | 2982us         | 3004us | -0.7%  |
|            | mimxrt                        | 253us          | 222us  | +12.2% |
|            | rp2                           | 2107us         | 1972us | +6.4%  |

tight-loop test
```python
import asyncio

async def count():
    global counter
    while True:
        await asyncio.sleep_ms(0)
        counter += 1

try:
    counter = 0
    asyncio.run(asyncio.wait_for(count(), timeout=2))
finally:
    print(counter, 2e6/counter)
```

io-poll test
```python
import asyncio

flag = asyncio.ThreadSafeFlag()
async def sender():
    while True:
        flag.set()
        await asyncio.sleep_ms(0)

async def recv():
    global counter
    while True:
        await flag.wait()
        counter += 1

counter = 0
try:
    asyncio.create_task(sender())
    asyncio.run(asyncio.wait_for(recv(), timeout=2))
finally:
    if counter:
        print(counter, 2e6/counter)
```

