### PR TITLE
Fix mpprintf argument type errors

### DIFF
--- a/examples/usercmodule/cexample/examplemodule.c
+++ b/examples/usercmodule/cexample/examplemodule.c
@@ -86,12 +86,12 @@ static void example_AdvancedTimer_print(const mp_print_t *print, mp_obj_t self_i
     mp_uint_t elapsed = mp_obj_get_int(example_Timer_time(self_in));
 
     // We'll make all representations print at least the class name.
-    mp_printf(print, "%q()", MP_QSTR_AdvancedTimer);
+    mp_printf(print, "%q()", (qstr)MP_QSTR_AdvancedTimer);
 
     // Decide what else to print based on print kind.
     if (kind == PRINT_STR) {
         // For __str__, let's attempt to make it more readable.
-        mp_printf(print, "  # created %d seconds ago", elapsed / 1000);
+        mp_printf(print, "  # created %d seconds ago", (int)(elapsed / 1000));
     }
 }
 

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -907,7 +907,7 @@ static const mp_obj_type_t lwip_socket_type;
 
 static void lwip_socket_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     lwip_socket_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<socket state=%d timeout=%d incoming=", self->state, self->timeout);
+    mp_printf(print, "<socket state=%d timeout=" UINT_FMT " incoming=", self->state, self->timeout);
     if (self->type == MOD_NETWORK_SOCK_STREAM) {
         mp_printf(print, "%p off=%d>", self->incoming.tcp.pbuf, self->recv_offset);
     } else {

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -155,9 +155,6 @@
 #define MICROPY_MAKE_POINTER_CALLABLE(p)            ((void *)((mp_uint_t)(p) | 1))
 #define MP_SSIZE_MAX                                (0x7FFFFFFF)
 
-#define UINT_FMT                                    "%u"
-#define INT_FMT                                     "%d"
-
 typedef int32_t mp_int_t;                           // must be pointer size
 typedef unsigned int mp_uint_t;                     // must be pointer size
 typedef long mp_off_t;

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -326,9 +326,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 #define MICROPY_WRAP_MP_SCHED_EXCEPTION(f) IRAM_ATTR f
 #define MICROPY_WRAP_MP_SCHED_KEYBOARD_INTERRUPT(f) IRAM_ATTR f
 
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
-
 typedef int32_t mp_int_t; // must be pointer size
 typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -150,9 +150,6 @@
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
-
 typedef int32_t mp_int_t; // must be pointer size
 typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -335,8 +335,6 @@ void *nrf_native_code_commit(void *, unsigned int, void *);
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
 #define HEX2_FMT "%02x"
 
 typedef int mp_int_t; // must be pointer size

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -77,8 +77,6 @@
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
 
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 

--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -96,6 +96,7 @@
 // This port is 64-bit
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
+#define HEX_FMT "%lx"
 typedef signed long mp_int_t; // must be pointer size
 typedef unsigned long mp_uint_t; // must be pointer size
 

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -72,6 +72,7 @@
 
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
+#define HEX_FMT "%lx"
 
 typedef int32_t mp_int_t; // must be pointer size
 typedef uint32_t mp_uint_t; // must be pointer size

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -234,8 +234,6 @@
 
 // Assume that if we already defined the obj repr then we also defined these items
 #ifndef MICROPY_OBJ_REPR
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 #endif

--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-giga-r1-wifi"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-#define UINT_FMT                    "%u"
-#define INT_FMT                     "%d"
 typedef int mp_int_t;               // must be pointer size
 typedef unsigned int mp_uint_t;     // must be pointer size
 

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-nicla-vision"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-#define UINT_FMT                    "%u"
-#define INT_FMT                     "%d"
 typedef int mp_int_t;               // must be pointer size
 typedef unsigned int mp_uint_t;     // must be pointer size
 

--- a/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-opta"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-#define UINT_FMT                    "%u"
-#define INT_FMT                     "%d"
 typedef int mp_int_t;               // must be pointer size
 typedef unsigned int mp_uint_t;     // must be pointer size
 

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-portenta-h7"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-#define UINT_FMT                    "%u"
-#define INT_FMT                     "%d"
 typedef int mp_int_t;               // must be pointer size
 typedef unsigned int mp_uint_t;     // must be pointer size
 

--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -760,7 +760,7 @@ static mp_obj_t extint_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 
 static void extint_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     extint_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<ExtInt line=%u>", self->line);
+    mp_printf(print, "<ExtInt line=%u>", (int)self->line);
 }
 
 static const mp_rom_map_elem_t extint_locals_dict_table[] = {

--- a/ports/stm32/led.c
+++ b/ports/stm32/led.c
@@ -305,7 +305,7 @@ void led_debug(int n, int delay) {
 
 void led_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_led_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "LED(%u)", self->led_id);
+    mp_printf(print, "LED(%u)", (int)self->led_id);
 }
 
 /// \classmethod \constructor(id)

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -93,7 +93,7 @@ static void mp_machine_uart_print(const mp_print_t *print, mp_obj_t self_in, mp_
         #endif
         {
             mp_printf(print, "UART(%u, baudrate=%u, bits=%u, parity=",
-                self->uart_id, uart_get_baudrate(self), bits);
+                self->uart_id, uart_get_baudrate(self), (int)bits);
         }
         if (!(cr1 & USART_CR1_PCE)) {
             mp_print_str(print, "None");

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -230,8 +230,6 @@ extern const struct _mp_obj_type_t network_lan_type;
 
 // Assume that if we already defined the obj repr then we also defined these items
 #ifndef MICROPY_OBJ_REPR
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned int mp_uint_t; // must be pointer size
 #endif

--- a/ports/stm32/mpconfigport_nanbox.h
+++ b/ports/stm32/mpconfigport_nanbox.h
@@ -36,6 +36,7 @@
 // Types needed for nan-boxing
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
+#define HEX_FMT "%llx"
 typedef int64_t mp_int_t;
 typedef uint64_t mp_uint_t;
 

--- a/ports/stm32/pin.c
+++ b/ports/stm32/pin.c
@@ -232,7 +232,7 @@ static void pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
             mp_uint_t af_idx = pin_get_af(self);
             const pin_af_obj_t *af_obj = pin_find_af_by_index(self, af_idx);
             if (af_obj == NULL) {
-                mp_printf(print, ", alt=%d)", af_idx);
+                mp_printf(print, ", alt=%d)", (int)af_idx);
             } else {
                 mp_printf(print, ", alt=Pin.%q)", af_obj->name);
             }

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -499,7 +499,7 @@ static uint32_t compute_dtg_from_ticks(mp_int_t ticks) {
 
 // Given the 8-bit value stored in the DTG field of the BDTR register, compute
 // the number of ticks.
-static mp_int_t compute_ticks_from_dtg(uint32_t dtg) {
+static unsigned compute_ticks_from_dtg(uint32_t dtg) {
     if ((dtg & 0x80) == 0) {
         return dtg & 0x7F;
     }

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -171,13 +171,13 @@ static void pairheap_test(size_t nops, int *ops) {
         if (mp_pairheap_is_empty(pairheap_lt, heap)) {
             mp_printf(&mp_plat_print, " -");
         } else {
-            mp_printf(&mp_plat_print, " %d", mp_pairheap_peek(pairheap_lt, heap) - &node[0]);
+            mp_printf(&mp_plat_print, " %d", (int)(mp_pairheap_peek(pairheap_lt, heap) - &node[0]));
             ;
         }
     }
     mp_printf(&mp_plat_print, "\npop all:");
     while (!mp_pairheap_is_empty(pairheap_lt, heap)) {
-        mp_printf(&mp_plat_print, " %d", mp_pairheap_peek(pairheap_lt, heap) - &node[0]);
+        mp_printf(&mp_plat_print, " %d", (int)(mp_pairheap_peek(pairheap_lt, heap) - &node[0]));
         ;
         heap = mp_pairheap_pop(pairheap_lt, heap);
     }
@@ -274,7 +274,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%p\n", gc_realloc(p, 0, false));
 
         // calling gc_nbytes with a non-heap pointer
-        mp_printf(&mp_plat_print, "%p\n", gc_nbytes(NULL));
+        mp_printf(&mp_plat_print, "%d\n", (int)gc_nbytes(NULL));
     }
 
     // GC initialisation and allocation stress test, to check the logic behind ALLOC_TABLE_GAP_BYTE
@@ -335,7 +335,7 @@ static mp_obj_t extra_coverage(void) {
                 }
                 ptrs[i][j] = j;
             }
-            mp_printf(&mp_plat_print, "%d %d\n", i, all_zero);
+            mp_printf(&mp_plat_print, "%d %d\n", (int)i, (int)all_zero);
 
             // hide the pointer from the GC and collect
             ptrs[i] = FLIP_POINTER(ptrs[i]);
@@ -351,7 +351,7 @@ static mp_obj_t extra_coverage(void) {
                     break;
                 }
             }
-            mp_printf(&mp_plat_print, "%d %d\n", i, correct_contents);
+            mp_printf(&mp_plat_print, "%d %d\n", (int)i, (int)correct_contents);
         }
 
         // free the memory blocks
@@ -449,7 +449,7 @@ static mp_obj_t extra_coverage(void) {
         // create a bytearray via mp_obj_new_bytearray
         mp_buffer_info_t bufinfo;
         mp_get_buffer_raise(mp_obj_new_bytearray(4, "data"), &bufinfo, MP_BUFFER_RW);
-        mp_printf(&mp_plat_print, "%.*s\n", bufinfo.len, bufinfo.buf);
+        mp_printf(&mp_plat_print, "%.*s\n", (int)bufinfo.len, bufinfo.buf);
     }
 
     // mpz
@@ -516,11 +516,11 @@ static mp_obj_t extra_coverage(void) {
 
         // hash the zero mpz integer
         mpz_set_from_int(&mpz, 0);
-        mp_printf(&mp_plat_print, "%d\n", mpz_hash(&mpz));
+        mp_printf(&mp_plat_print, "%d\n", (int)mpz_hash(&mpz));
 
         // convert the mpz zero integer to int
         mp_printf(&mp_plat_print, "%d\n", mpz_as_int_checked(&mpz, &value_signed));
-        mp_printf(&mp_plat_print, "%d\n", value_signed);
+        mp_printf(&mp_plat_print, "%d\n", (int)value_signed);
 
         // mpz_set_from_float with 0 as argument
         mpz_set_from_float(&mpz, 0);
@@ -562,7 +562,7 @@ static mp_obj_t extra_coverage(void) {
         mp_call_function_2_protected(MP_OBJ_FROM_PTR(&mp_builtin_divmod_obj), mp_obj_new_str_from_cstr("abc"), mp_obj_new_str_from_cstr("abc"));
 
         // mp_obj_int_get_checked with mp_obj_int_t that has a value that is a small integer
-        mp_printf(&mp_plat_print, "%d\n", mp_obj_int_get_checked(MP_OBJ_FROM_PTR(mp_obj_int_new_mpz())));
+        mp_printf(&mp_plat_print, "%d\n", (int)mp_obj_int_get_checked(MP_OBJ_FROM_PTR(mp_obj_int_new_mpz())));
 
         // mp_obj_int_get_uint_checked with non-negative small-int
         mp_printf(&mp_plat_print, "%d\n", (int)mp_obj_int_get_uint_checked(MP_OBJ_NEW_SMALL_INT(1)));
@@ -674,7 +674,7 @@ static mp_obj_t extra_coverage(void) {
         #endif
 
         mp_vm_return_kind_t ret = mp_execute_bytecode(code_state, MP_OBJ_NULL);
-        mp_printf(&mp_plat_print, "%d %d\n", ret, mp_obj_get_type(code_state->state[0]) == &mp_type_NotImplementedError);
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ret, mp_obj_get_type(code_state->state[0]) == &mp_type_NotImplementedError);
     }
 
     // scheduler
@@ -754,36 +754,36 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "# ringbuf\n");
 
         // Single-byte put/get with empty ringbuf.
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         ringbuf_put(&ringbuf, 22);
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         mp_printf(&mp_plat_print, "%d\n", ringbuf_get(&ringbuf));
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
 
         // Two-byte put/get with empty ringbuf.
         ringbuf_put16(&ringbuf, 0xaa55);
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         mp_printf(&mp_plat_print, "%04x\n", ringbuf_get16(&ringbuf));
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
 
         // Two-byte put with full ringbuf.
         for (int i = 0; i < 99; ++i) {
             ringbuf_put(&ringbuf, i);
         }
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         mp_printf(&mp_plat_print, "%d\n", ringbuf_put16(&ringbuf, 0x11bb));
         // Two-byte put with one byte free.
         ringbuf_get(&ringbuf);
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         mp_printf(&mp_plat_print, "%d\n", ringbuf_put16(&ringbuf, 0x3377));
         ringbuf_get(&ringbuf);
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
         mp_printf(&mp_plat_print, "%d\n", ringbuf_put16(&ringbuf, 0xcc99));
         for (int i = 0; i < 97; ++i) {
             ringbuf_get(&ringbuf);
         }
         mp_printf(&mp_plat_print, "%04x\n", ringbuf_get16(&ringbuf));
-        mp_printf(&mp_plat_print, "%d %d\n", ringbuf_free(&ringbuf), ringbuf_avail(&ringbuf));
+        mp_printf(&mp_plat_print, "%d %d\n", (int)ringbuf_free(&ringbuf), (int)ringbuf_avail(&ringbuf));
 
         // Two-byte put with wrap around on first byte:
         ringbuf.iput = 0;

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -212,9 +212,9 @@ static mp_obj_t extra_coverage(void) {
             mp_printf(&mp_plat_print, "%llu\n", ULLONG_MAX); // unsigned long long
         } else {
             // fake for platforms without narrower mp_int_t
-            mp_printf(&mp_plat_print, "7fffffffffffffff\n", LLONG_MAX);
-            mp_printf(&mp_plat_print, "7FFFFFFFFFFFFFFF\n", LLONG_MAX);
-            mp_printf(&mp_plat_print, "18446744073709551615\n", ULLONG_MAX);
+            mp_printf(&mp_plat_print, "7fffffffffffffff\n");
+            mp_printf(&mp_plat_print, "7FFFFFFFFFFFFFFF\n");
+            mp_printf(&mp_plat_print, "18446744073709551615\n");
         }
         mp_printf(&mp_plat_print, "%p\n", (void *)0x789f); // pointer
         mp_printf(&mp_plat_print, "%P\n", (void *)0x789f); // pointer uppercase

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -528,7 +528,7 @@ static mp_obj_t extra_coverage(void) {
 
         // convert a large integer value (stored in a mpz) to mp_uint_t and to ll;
         mp_obj_t obj_bigint = mp_obj_new_int_from_uint((mp_uint_t)0xdeadbeef);
-        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        mp_printf(&mp_plat_print, "%x\n", (int)mp_obj_get_uint(obj_bigint));
         obj_bigint = mp_obj_new_int_from_ll(0xc0ffee777c0ffeell);
         long long value_ll = mp_obj_get_ll(obj_bigint);
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
@@ -536,13 +536,13 @@ static mp_obj_t extra_coverage(void) {
         // convert a large integer value (stored via a struct object) to uint and to ll
         // `deadbeef` global is an uctypes.struct defined by extra_coverage.py
         obj_bigint = mp_load_global(MP_QSTR_deadbeef);
-        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        mp_printf(&mp_plat_print, "%x\n", (int)mp_obj_get_uint(obj_bigint));
         value_ll = mp_obj_get_ll(obj_bigint);
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
 
         // convert a smaller integer value to mp_uint_t and to ll
         obj_bigint = mp_obj_new_int_from_uint(0xc0ffee);
-        mp_printf(&mp_plat_print, "%x\n", mp_obj_get_uint(obj_bigint));
+        mp_printf(&mp_plat_print, "%x\n", (int)mp_obj_get_uint(obj_bigint));
         value_ll = mp_obj_get_ll(obj_bigint);
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
     }

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -218,7 +218,7 @@ static mp_obj_t extra_coverage(void) {
         }
         mp_printf(&mp_plat_print, "%p\n", (void *)0x789f); // pointer
         mp_printf(&mp_plat_print, "%P\n", (void *)0x789f); // pointer uppercase
-        mp_printf(&mp_plat_print, "%.2s %.3s '%4.4s' '%5.5q' '%.3q'\n", "abc", "abc", "abc", MP_QSTR_True, MP_QSTR_True); // fixed string precision
+        mp_printf(&mp_plat_print, "%.2s %.3s '%4.4s' '%5.5q' '%.3q'\n", "abc", "abc", "abc", (qstr)MP_QSTR_True, (qstr)MP_QSTR_True); // fixed string precision
         mp_printf(&mp_plat_print, "%.*s\n", -1, "abc"); // negative string precision
         mp_printf(&mp_plat_print, "%b %b\n", 0, 1); // bools
         #ifndef NDEBUG

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -230,7 +230,12 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%u\n", 0x80000000); // should print unsigned
         mp_printf(&mp_plat_print, "%x\n", 0x8000000f); // should print unsigned
         mp_printf(&mp_plat_print, "%X\n", 0x8000000f); // should print unsigned
-        mp_printf(&mp_plat_print, "abc\n%"); // string ends in middle of format specifier
+        // note: storing the string in a variable is enough to prevent the
+        // format string checker from checking this format string. Otherwise,
+        // it would be a compile time diagnostic under the format string
+        // checker.
+        const char msg[] = "abc\n%";
+        mp_printf(&mp_plat_print, msg); // string ends in middle of format specifier
         mp_printf(&mp_plat_print, "%%\n"); // literal % character
         mp_printf(&mp_plat_print, ".%-3s.\n", "a"); // left adjust
 

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -203,7 +203,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "# mp_printf\n");
         mp_printf(&mp_plat_print, "%d %+d % d\n", -123, 123, 123); // sign
         mp_printf(&mp_plat_print, "%05d\n", -123); // negative number with zero padding
-        mp_printf(&mp_plat_print, "%ld\n", 123); // long
+        mp_printf(&mp_plat_print, "%ld\n", 123l); // long
         mp_printf(&mp_plat_print, "%lx\n", 0x123fl); // long hex
         mp_printf(&mp_plat_print, "%lX\n", 0x123fl); // capital long hex
         if (sizeof(mp_int_t) == 8) {

--- a/ports/unix/variants/nanbox/mpconfigvariant.h
+++ b/ports/unix/variants/nanbox/mpconfigvariant.h
@@ -48,3 +48,4 @@ typedef int64_t mp_int_t;
 typedef uint64_t mp_uint_t;
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
+#define HEX_FMT "%llx"

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -107,8 +107,6 @@
 // different targets may be defined in different ways - either as int
 // or as long. This requires different printf formatting specifiers
 // to print such value. So, we avoid int32_t and use int directly.
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
 typedef int mp_int_t; // must be pointer size
 typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -135,7 +135,7 @@ static void mp_help_print_obj(const mp_obj_t obj) {
     // try to print something sensible about the given object
     mp_print_str(MP_PYTHON_PRINTER, "object ");
     mp_obj_print(obj, PRINT_STR);
-    mp_printf(MP_PYTHON_PRINTER, " is of type %q\n", type->name);
+    mp_printf(MP_PYTHON_PRINTER, " is of type %q\n", (qstr)type->name);
 
     mp_map_t *map = NULL;
     if (type == &mp_type_module) {

--- a/py/gc.c
+++ b/py/gc.c
@@ -1202,7 +1202,7 @@ void gc_dump_alloc_table(const mp_print_t *print) {
                     }
                     if (bl2 - bl >= 2 * DUMP_BYTES_PER_LINE) {
                         // there are at least 2 lines containing only free blocks, so abbreviate their printing
-                        mp_printf(print, "\n       (%u lines all free)", (uint)(bl2 - bl) / DUMP_BYTES_PER_LINE);
+                        mp_printf(print, "\n       (%u lines all free)", (uint)((bl2 - bl) / DUMP_BYTES_PER_LINE));
                         bl = bl2 & (~(DUMP_BYTES_PER_LINE - 1));
                         if (bl >= area->gc_alloc_table_byte_len * BLOCKS_PER_ATB) {
                             // got to end of heap

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -98,7 +98,7 @@ static mp_obj_t mp_micropython_qstr_info(size_t n_args, const mp_obj_t *args) {
     size_t n_pool, n_qstr, n_str_data_bytes, n_total_bytes;
     qstr_pool_info(&n_pool, &n_qstr, &n_str_data_bytes, &n_total_bytes);
     mp_printf(&mp_plat_print, "qstr pool: n_pool=%u, n_qstr=%u, n_str_data_bytes=%u, n_total_bytes=%u\n",
-        n_pool, n_qstr, n_str_data_bytes, n_total_bytes);
+        (uint)n_pool, (uint)n_qstr, (uint)n_str_data_bytes, (uint)n_total_bytes);
     if (n_args == 1) {
         // arg given means dump qstr data
         qstr_dump_data();

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2177,13 +2177,16 @@ typedef time_t mp_timestamp_t;
 // Archs where mp_int_t == long, long != int
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
+#define HEX_FMT "%lx"
 #elif defined(_WIN64)
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
+#define HEX_FMT "%llx"
 #else
 // Archs where mp_int_t == int
 #define UINT_FMT "%u"
 #define INT_FMT "%d"
+#define HEX_FMT "%x"
 #endif
 #endif // INT_FMT
 

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -530,7 +530,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
                 char fmt_chr = *fmt;
                 mp_uint_t val;
                 if (fmt_chr == 'p' || fmt_chr == 'P') {
-                    val = va_arg(args, intptr_t);
+                    val = va_arg(args, uintptr_t);
                 }
                 #if SUPPORT_LL_FORMAT
                 else if (long_long_arg) {

--- a/py/obj.c
+++ b/py/obj.c
@@ -128,7 +128,7 @@ void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t
     if (MP_OBJ_TYPE_HAS_SLOT(type, print)) {
         MP_OBJ_TYPE_GET_SLOT(type, print)((mp_print_t *)print, o_in, kind);
     } else {
-        mp_printf(print, "<%q>", type->name);
+        mp_printf(print, "<%q>", (qstr)type->name);
     }
 }
 

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -30,7 +30,7 @@
 static void cell_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_cell_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_printf(print, "<cell %p ", o->obj);
+    mp_printf(print, "<cell " HEX_FMT " ", (mp_uint_t)o->obj);
     if (o->obj == MP_OBJ_NULL) {
         mp_print_str(print, "(nil)");
     } else {

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -84,7 +84,7 @@ static void dict_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_
         #endif
     }
     if (MICROPY_PY_COLLECTIONS_ORDEREDDICT && self->base.type != &mp_type_dict && kind != PRINT_JSON) {
-        mp_printf(print, "%q(", self->base.type->name);
+        mp_printf(print, "%q(", (qstr)self->base.type->name);
     }
     mp_print_str(print, "{");
     size_t cur = 0;

--- a/py/objnamedtuple.c
+++ b/py/objnamedtuple.c
@@ -63,7 +63,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(namedtuple_asdict_obj, namedtuple_asdict);
 static void namedtuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_namedtuple_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_printf(print, "%q", o->tuple.base.type->name);
+    mp_printf(print, "%q", (qstr)o->tuple.base.type->name);
     const qstr *fields = ((mp_obj_namedtuple_type_t *)o->tuple.base.type)->fields;
     mp_obj_attrtuple_print_helper(print, fields, &o->tuple);
 }

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -977,7 +977,7 @@ static bool check_for_special_accessors(mp_obj_t key, mp_obj_t value) {
 static void type_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<class '%q'>", self->name);
+    mp_printf(print, "<class '%q'>", (qstr)self->name);
 }
 
 static mp_obj_t type_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/shared/netutils/trace.c
+++ b/shared/netutils/trace.c
@@ -56,7 +56,7 @@ static const char *ethertype_str(uint16_t type) {
 }
 
 void netutils_ethernet_trace(const mp_print_t *print, size_t len, const uint8_t *buf, unsigned int flags) {
-    mp_printf(print, "[% 8d] ETH%cX len=%u", mp_hal_ticks_ms(), flags & NETUTILS_TRACE_IS_TX ? 'T' : 'R', len);
+    mp_printf(print, "[% 8u] ETH%cX len=%u", (unsigned)mp_hal_ticks_ms(), flags & NETUTILS_TRACE_IS_TX ? 'T' : 'R', len);
     mp_printf(print, " dst=%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]);
     mp_printf(print, " src=%02x:%02x:%02x:%02x:%02x:%02x", buf[6], buf[7], buf[8], buf[9], buf[10], buf[11]);
 


### PR DESCRIPTION
### Summary

I have developed a gcc plugin for checking mp_printf format strings vs argument types at compile time. https://github.com/micropython/micropython/pull/17556 is the fixes plus the checker, while this PR is only the fixes.

### Testing

I added tests to the coverage build for stuff I felt was not yet adequately covered.