### PR TITLE
shared/tinyusb: Fix build errors with CDC support disabled.

### DIFF
--- a/ports/esp32/usb.c
+++ b/ports/esp32/usb.c
@@ -28,15 +28,15 @@
 #include "py/mphal.h"
 #include "usb.h"
 
-#if MICROPY_HW_USB_CDC
-#include "esp_rom_gpio.h"
+#if MICROPY_HW_ENABLE_USBDEV
+
 #include "esp_mac.h"
+#include "esp_rom_gpio.h"
 #include "esp_private/usb_phy.h"
 
 #include "shared/tinyusb/mp_usbd.h"
 
 static usb_phy_handle_t phy_hdl;
-
 
 void usb_init(void) {
     // ref: https://github.com/espressif/esp-usb/blob/4b6a798d0bed444fff48147c8dcdbbd038e92892/device/esp_tinyusb/tinyusb.c
@@ -77,4 +77,4 @@ void mp_usbd_port_get_serial_number(char *serial_buf) {
     mp_usbd_hex_str(serial_buf, mac, sizeof(mac));
 }
 
-#endif // MICROPY_HW_USB_CDC
+#endif // MICROPY_HW_ENABLE_USBDEV

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -47,7 +47,9 @@ ringbuf_t stdin_ringbuf = {stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0, 
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
+    #if MICROPY_HW_USB_CDC
     ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
+    #endif
     #if MICROPY_PY_OS_DUPTERM
     ret |= mp_os_dupterm_poll(poll_flags);
     #endif
@@ -56,7 +58,9 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
+        #if MICROPY_HW_USB_CDC
         mp_usbd_cdc_poll_interfaces(0);
+        #endif
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
@@ -74,11 +78,13 @@ int mp_hal_stdin_rx_chr(void) {
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     mp_uint_t ret = len;
     bool did_write = false;
+    #if MICROPY_HW_USB_CDC
     mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
     if (cdc_res > 0) {
         did_write = true;
         ret = MIN(cdc_res, ret);
     }
+    #endif
     #if MICROPY_PY_OS_DUPTERM
     int dupterm_res = mp_os_dupterm_tx_strn(str, len);
     if (dupterm_res >= 0) {

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -50,7 +50,7 @@
 static uint64_t time_us_64_offset_from_epoch;
 #endif
 
-#if MICROPY_HW_ENABLE_UART_REPL || MICROPY_HW_USB_CDC
+#if MICROPY_HW_ENABLE_UART_REPL || MICROPY_HW_USB_CDC || MICROPY_PY_OS_DUPTERM_NOTIFY
 
 #ifndef MICROPY_HW_STDIN_BUFFER_LEN
 #define MICROPY_HW_STDIN_BUFFER_LEN 512
@@ -83,11 +83,12 @@ int mp_hal_stdin_rx_chr(void) {
         #if MICROPY_HW_USB_CDC
         mp_usbd_cdc_poll_interfaces(0);
         #endif
-
+        #if MICROPY_HW_USB_CDC || MICROPY_HW_ENABLE_UART_REPL || MICROPY_PY_OS_DUPTERM_NOTIFY
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
         }
+        #endif
         #if MICROPY_PY_OS_DUPTERM
         int dupterm_c = mp_os_dupterm_rx_chr();
         if (dupterm_c >= 0) {

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -120,7 +120,9 @@ uint64_t mp_hal_ticks_us_64(void) {
 
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
     uintptr_t ret = 0;
+    #if MICROPY_HW_USB_CDC
     ret |= mp_usbd_cdc_poll_interfaces(poll_flags);
+    #endif
     #if MICROPY_PY_OS_DUPTERM
     ret |= mp_os_dupterm_poll(poll_flags);
     #endif
@@ -129,8 +131,9 @@ uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
 
 int mp_hal_stdin_rx_chr(void) {
     for (;;) {
-
+        #if MICROPY_HW_USB_CDC
         mp_usbd_cdc_poll_interfaces(0);
+        #endif
         int c = ringbuf_get(&stdin_ringbuf);
         if (c != -1) {
             return c;
@@ -149,11 +152,13 @@ int mp_hal_stdin_rx_chr(void) {
 mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
     mp_uint_t ret = len;
     bool did_write = false;
+    #if MICROPY_HW_USB_CDC
     mp_uint_t cdc_res = mp_usbd_cdc_tx_strn(str, len);
     if (cdc_res > 0) {
         did_write = true;
         ret = MIN(cdc_res, ret);
     }
+    #endif
     #if MICROPY_PY_OS_DUPTERM
     int dupterm_res = mp_os_dupterm_tx_strn(str, len);
     if (dupterm_res >= 0) {

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -38,13 +38,16 @@
 #ifndef NO_QSTR
 #include "tusb.h"
 #include "device/dcd.h"
+#include "class/cdc/cdc_device.h"
 #endif
 
 // Initialise TinyUSB device.
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
+    #if MICROPY_HW_USB_CDC
     tud_cdc_configure_fifo_t cfg = { .rx_persistent = 0, .tx_persistent = 1 };
     tud_cdc_configure_fifo(&cfg);
+    #endif
 }
 
 // Run the TinyUSB device task

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -267,9 +267,11 @@ static uint16_t runtime_dev_open(uint8_t rhport, tusb_desc_interface_t const *it
     }
 
     // If TinyUSB built-in drivers are enabled, don't claim any interface in the built-in range
+    #if USBD_ITF_BUILTIN_MAX > 0
     if (mp_usb_device_builtin_enabled(usbd) && itf_desc->bInterfaceNumber < USBD_ITF_BUILTIN_MAX) {
         return 0;
     }
+    #endif
 
     // Determine the total descriptor length of the interface(s) we are going to claim
     uint8_t assoc_itf_count = _runtime_dev_count_itfs(itf_desc);


### PR DESCRIPTION
### Summary

This PR makes it possible to build selected MicroPython ports that would have USB support enabled but CDC support disabled as well (whilst keeping MSC support for example).

The original code does support such a configuration but missed a few spots where build errors would arise.  These changes fix the remaining issues, fixing also warnings caused by the changes needed to make the build succeed (like unused variables and so on).

### Testing

This was checked by building the ESP32-S3 firmware with `MICROPY_HW_USB_CDC` set to 0, and then making sure the build process would succeed with that flag set back to 1.  I also have another (unreleased) port where this behaviour was originally discovered and then fixed.

### Trade-offs and Alternatives

There shouldn't be any impact, as these changes only affect a specific configuration whilst leaving the rest of the codebase as it is otherwise.