### PR TITLE
longlong: Add sanitizer builds, fix revealed problems.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -148,6 +148,34 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
+  longlong_sanitize_address:
+    runs-on: ubuntu-22.04 # use 22.04 to get python2, and libffi-dev:i386
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: source tools/ci.sh && ci_unix_32bit_setup
+    - name: Build
+      run: source tools/ci.sh && ci_unix_longlong_sanitize_address_build
+    - name: Run main test suite
+      run: source tools/ci.sh && ci_unix_longlong_sanitize_address_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
+  longlong_sanitize_undefined:
+    runs-on: ubuntu-22.04 # use 22.04 to get python2, and libffi-dev:i386
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install packages
+      run: source tools/ci.sh && ci_unix_32bit_setup
+    - name: Build
+      run: source tools/ci.sh && ci_unix_longlong_sanitize_undefined_build
+    - name: Run main test suite
+      run: source tools/ci.sh && ci_unix_longlong_sanitize_undefined_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
   float:
     runs-on: ubuntu-latest
     steps:

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -199,10 +199,11 @@ static bool mp_native_yield_from(mp_obj_t gen, mp_obj_t send_value, mp_obj_t *re
     nlr_buf_t nlr_buf;
     mp_obj_t throw_value = *ret_value;
     if (nlr_push(&nlr_buf) == 0) {
+        mp_obj_t to_send = send_value;
         if (throw_value != MP_OBJ_NULL) {
-            send_value = MP_OBJ_NULL;
+            to_send = MP_OBJ_NULL;
         }
-        ret_kind = mp_resume(gen, send_value, throw_value, ret_value);
+        ret_kind = mp_resume(gen, to_send, throw_value, ret_value);
         nlr_pop();
     } else {
         ret_kind = MP_VM_RETURN_EXCEPTION;

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -172,6 +172,9 @@ struct _nlr_jump_callback_node_t {
 // For this case it is safe to call nlr_push_tail() first.
 #define nlr_push(buf) (nlr_push_tail(buf), setjmp((buf)->jmpbuf))
 #else
+#if defined(__SANITIZE_ADDRESS__)
+__attribute((returns_twice))
+#endif
 unsigned int nlr_push(nlr_buf_t *);
 #endif
 

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -212,9 +212,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
                 // negative shift not allowed
                 mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
             }
-            result = lhs_val << (int)rhs_val;
-            // Left-shifting of negative values is implementation defined in C, but assume compiler
-            // will give us typical 2s complement behaviour unless the value overflows
+            result = lhs_val * (1ll << (int)rhs_val);
             overflow = rhs_val > 0 && ((lhs_val >= 0 && result < lhs_val) || (lhs_val < 0 && result > lhs_val));
             break;
         case MP_BINARY_OP_RSHIFT:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -509,13 +509,11 @@ CI_UNIX_OPTS_QEMU_RISCV64=(
 )
 
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
-    VARIANT=coverage
     CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
     LDFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
 )
 
 CI_UNIX_OPTS_SANITIZE_UNDEFINED=(
-    VARIANT=coverage
     CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
     LDFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
 )
@@ -695,6 +693,22 @@ function ci_unix_nanbox_run_tests {
     ci_unix_run_tests_full_no_native_helper nanbox PYTHON=python2.7
 }
 
+function ci_unix_longlong_sanitize_address_build {
+    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
+}
+
+function ci_unix_longlong_sanitize_address_run_tests {
+    ci_unix_run_tests_full_helper longlong "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
+}
+
+function ci_unix_longlong_sanitize_undefined_build {
+    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+}
+
+function ci_unix_longlong_sanitize_undefined_run_tests {
+    ci_unix_run_tests_full_helper longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+}
+
 function ci_unix_longlong_build {
     ci_unix_build_helper VARIANT=longlong
 }
@@ -752,7 +766,7 @@ function ci_unix_settrace_stackless_run_tests {
 function ci_unix_sanitize_undefined_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix submodules
-    make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
     ci_unix_build_ffi_lib_helper gcc
 }
 
@@ -763,7 +777,7 @@ function ci_unix_sanitize_undefined_run_tests {
 function ci_unix_sanitize_address_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix submodules
-    make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
     ci_unix_build_ffi_lib_helper gcc
 }
 


### PR DESCRIPTION
### Summary

I decided to try the longlong build under the sanitizers. This exposed a pair of problems:
 * A line, already commented to explain undefined integer overflow behavior, did in fact produce a diagnostic
 * The address sanitizer produced spurious results on 32-bit x86 builds when raising exceptions.

### Testing

I built the branch locally with the sanitizers until it passed.

### Trade-offs and Alternatives

It's odd that the fixed version of left shift doesn't produce a diagnostic, because there is still an overflowing operation (now a multiplication, previously a shift). Is the sanitizer deliberately not checking this kind of overflow, or is recognizing a specific overflow check pattern in the following line? I was not able to find any documentation about this, and the documentation seemed to imply that -fsanitize=signed-integer-overflow was enabled by -fsanitize=undefined; explicitly enabling it made no difference.

It's unclear *why* adding the `returns_twice` qualification to `nlr_push` helps the sanitizer to function properly, but it's true that `nlr_push` *should* have this annotation. Hence, maybe it should be enabled whenever the compiler supports it? (any plausible gcc & clang versions, probably)