### PR TITLE
Fix incomplete implementation of readonly for VfsPosix

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -160,10 +160,21 @@ static mp_obj_t vfs_posix_umount(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(vfs_posix_umount_obj, vfs_posix_umount);
 
+static bool vfs_posix_is_readonly(mp_obj_vfs_posix_t *self) {
+    return self->readonly;
+}
+
+static void vfs_posix_require_writable(mp_obj_t self_in) {
+    mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
+    if (vfs_posix_is_readonly(self)) {
+        mp_raise_OSError(MP_EROFS);
+    }
+}
+
 static mp_obj_t vfs_posix_open(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mode_in) {
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
     const char *mode = mp_obj_str_get_str(mode_in);
-    if (self->readonly
+    if (vfs_posix_is_readonly(self)
         && (strchr(mode, 'w') != NULL || strchr(mode, 'a') != NULL || strchr(mode, '+') != NULL)) {
         mp_raise_OSError(MP_EROFS);
     }
@@ -303,6 +314,7 @@ typedef struct _mp_obj_listdir_t {
 } mp_obj_listdir_t;
 
 static mp_obj_t vfs_posix_mkdir(mp_obj_t self_in, mp_obj_t path_in) {
+    vfs_posix_require_writable(self_in);
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
     const char *path = vfs_posix_get_path_str(self, path_in);
     MP_THREAD_GIL_EXIT();
@@ -320,11 +332,13 @@ static mp_obj_t vfs_posix_mkdir(mp_obj_t self_in, mp_obj_t path_in) {
 static MP_DEFINE_CONST_FUN_OBJ_2(vfs_posix_mkdir_obj, vfs_posix_mkdir);
 
 static mp_obj_t vfs_posix_remove(mp_obj_t self_in, mp_obj_t path_in) {
+    vfs_posix_require_writable(self_in);
     return vfs_posix_fun1_helper(self_in, path_in, unlink);
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(vfs_posix_remove_obj, vfs_posix_remove);
 
 static mp_obj_t vfs_posix_rename(mp_obj_t self_in, mp_obj_t old_path_in, mp_obj_t new_path_in) {
+    vfs_posix_require_writable(self_in);
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
     const char *old_path = vfs_posix_get_path_str(self, old_path_in);
     const char *new_path = vfs_posix_get_path_str(self, new_path_in);
@@ -339,6 +353,7 @@ static mp_obj_t vfs_posix_rename(mp_obj_t self_in, mp_obj_t old_path_in, mp_obj_
 static MP_DEFINE_CONST_FUN_OBJ_3(vfs_posix_rename_obj, vfs_posix_rename);
 
 static mp_obj_t vfs_posix_rmdir(mp_obj_t self_in, mp_obj_t path_in) {
+    vfs_posix_require_writable(self_in);
     return vfs_posix_fun1_helper(self_in, path_in, rmdir);
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(vfs_posix_rmdir_obj, vfs_posix_rmdir);

--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -137,7 +137,7 @@ static mp_obj_t vfs_posix_make_new(const mp_obj_type_t *type, size_t n_args, siz
         vstr_add_char(&vfs->root, '/');
     }
     vfs->root_len = vfs->root.len;
-    vfs->readonly = false;
+    vfs->readonly = !MICROPY_VFS_POSIX_WRITABLE;
 
     return MP_OBJ_FROM_PTR(vfs);
 }
@@ -160,8 +160,8 @@ static mp_obj_t vfs_posix_umount(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(vfs_posix_umount_obj, vfs_posix_umount);
 
-static bool vfs_posix_is_readonly(mp_obj_vfs_posix_t *self) {
-    return self->readonly;
+static inline bool vfs_posix_is_readonly(mp_obj_vfs_posix_t *self) {
+    return !MICROPY_VFS_POSIX_WRITABLE || self->readonly;
 }
 
 static void vfs_posix_require_writable(mp_obj_t self_in) {

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1084,6 +1084,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_VFS_POSIX (0)
 #endif
 
+// Whether to include support for writable POSIX filesystems.
+#ifndef MICROPY_VFS_POSIX_WRITABLE
+#define MICROPY_VFS_POSIX_WRITABLE (1)
+#endif
+
 // Support for VFS FAT component, to mount a FAT filesystem within VFS
 #ifndef MICROPY_VFS_FAT
 #define MICROPY_VFS_FAT (0)

--- a/tests/extmod/vfs_posix_readonly.py
+++ b/tests/extmod/vfs_posix_readonly.py
@@ -1,0 +1,99 @@
+# Test for VfsPosix
+
+try:
+    import gc, os, vfs, errno
+
+    vfs.VfsPosix
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# We need a directory for testing that doesn't already exist.
+# Skip the test if it does exist.
+temp_dir = "micropy_readonly_test_dir"
+try:
+    os.stat(temp_dir)
+    raise SystemExit("Target directory {} exists".format(temp_dir))
+except OSError:
+    pass
+
+# mkdir (skip test if whole filesystem is readonly)
+try:
+    os.mkdir(temp_dir)
+except OSError as e:
+    if e.errno == errno.EROFS:
+        print("SKIP")
+        raise SystemExit
+
+fs_factory = lambda: vfs.VfsPosix(temp_dir)
+
+# mount
+fs = fs_factory()
+vfs.mount(fs, "/vfs")
+
+with open("/vfs/file", "w") as f:
+    f.write("content")
+
+# test reading works
+with open("/vfs/file") as f:
+    print("file:", f.read())
+
+os.mkdir("/vfs/emptydir")
+
+# umount
+vfs.umount("/vfs")
+
+# mount read-only
+fs = fs_factory()
+vfs.mount(fs, "/vfs", readonly=True)
+
+# test reading works
+with open("/vfs/file") as f:
+    print("file 2:", f.read())
+
+# test writing fails
+try:
+    with open("/vfs/test_write", "w"):
+        pass
+    print("opened")
+except OSError as er:
+    print(repr(er))
+
+# test removing fails
+try:
+    os.unlink("/vfs/file")
+    print("unlinked")
+except OSError as er:
+    print(repr(er))
+
+# test renaming fails
+try:
+    os.rename("/vfs/file2", "/vfs/renamed")
+    print("renamed")
+except OSError as er:
+    print(repr(er))
+
+# test removing directory fails
+try:
+    os.rmdir("/vfs/emptydir")
+    print("rmdir'd")
+except OSError as er:
+    print(repr(er))
+
+# test creating directory fails
+try:
+    os.mkdir("/vfs/emptydir2")
+    print("mkdir'd")
+except OSError as er:
+    print(repr(er))
+
+# umount
+vfs.umount("/vfs")
+
+fs = fs_factory()
+vfs.mount(fs, "/vfs")
+
+os.rmdir("/vfs/emptydir")
+os.unlink("/vfs/file")
+
+os.rmdir(temp_dir)

--- a/tests/extmod/vfs_posix_readonly.py
+++ b/tests/extmod/vfs_posix_readonly.py
@@ -10,7 +10,7 @@ except (ImportError, AttributeError):
 
 # We need a directory for testing that doesn't already exist.
 # Skip the test if it does exist.
-temp_dir = "micropy_readonly_test_dir"
+temp_dir = "vfs_posix_readonly_test_dir"
 try:
     os.stat(temp_dir)
     raise SystemExit("Target directory {} exists".format(temp_dir))

--- a/tests/extmod/vfs_posix_readonly.py.exp
+++ b/tests/extmod/vfs_posix_readonly.py.exp
@@ -1,0 +1,7 @@
+file: content
+file 2: content
+OSError(30,)
+OSError(30,)
+OSError(30,)
+OSError(30,)
+OSError(30,)


### PR DESCRIPTION
### Summary

I noticed that operations such as unlink could be performed on a nominally read-only VfsPosix.

Fix all these operations, and then add a compile-time configuration option MICROPY_VFS_POSIX_WRITABLE. Disabling this option ensures that a VfsPosix instance is *ALWAYS* read-only. This may be useful when fuzzing micropython, which can [otherwise make modifications to the host filesystem](https://emergent.unpythonic.net/01522108310).

### Testing

I added a new test for VfsPosix read-only mode.

## Trade-offs and Alternatives

Initially, I structured the test as an importable module so that other filesystems could potentially re-use the same test code; however, most(all?) other filesystems are based on block devices, and I don't think they have the same problems with needing to add readonly checks in each code path since they just ensure the block write function cannot be called. It also turns out ci_webassembly_run_tests failed due to inability to import the auxiliary file, so I went with the one-file implementation after all.