### PR TITLE
objint_mpz: Fix pow3(1,2,0).

### DIFF
--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -356,9 +356,10 @@ static mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
 mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
     if (!mp_obj_is_int(base) || !mp_obj_is_int(exponent) || !mp_obj_is_int(modulus)) {
         mp_raise_TypeError(MP_ERROR_TEXT("pow() with 3 arguments requires integers"));
+    } else if (modulus == MP_OBJ_NEW_SMALL_INT(0)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("divide by zero"));
     } else {
-        mp_obj_t result = mp_obj_new_int_from_ull(0); // Use the _from_ull version as this forces an mpz int
-        mp_obj_int_t *res_p = (mp_obj_int_t *)MP_OBJ_TO_PTR(result);
+        mp_obj_int_t *res_p = mp_obj_int_new_mpz();
 
         mpz_t l_temp, r_temp, m_temp;
         mpz_t *lhs = mp_mpz_for_int(base,     &l_temp);
@@ -376,7 +377,7 @@ mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
         if (mod == &m_temp) {
             mpz_deinit(mod);
         }
-        return result;
+        return MP_OBJ_FROM_PTR(res_p);
     }
 }
 #endif

--- a/tests/basics/builtin_pow3_intbig.py
+++ b/tests/basics/builtin_pow3_intbig.py
@@ -20,3 +20,7 @@ print(hex(pow(2, x-1, x))) # Should be 1, since x is prime
 print(hex(pow(y, x-1, x))) # Should be 1, since x is prime
 print(hex(pow(y, y-1, x))) # Should be a 'big value'
 print(hex(pow(y, y-1, y))) # Should be a 'big value'
+try:
+    print(pow(1,2,0))
+except ValueError:
+    print("ValueError")


### PR DESCRIPTION
### Summary

This finding is based on fuzzing micropython. I manually minimized the test case it provided.

### Testing

A fuzzer found a crash in 3-arg pow where the 3rd argument was zero. I added a test case for it, and fixed it.

### Trade-offs and Alternatives

I initially wanted to throw ZeroDivisionError and re-use the error string but I now throw ValueError with a string that matches CPython (3.11.2)