### PR TITLE
`embed`: Fix `alloca` include for Windows.

### DIFF
--- a/ports/embed/port/mpconfigport_common.h
+++ b/ports/embed/port/mpconfigport_common.h
@@ -34,8 +34,13 @@ typedef long mp_off_t;
 
 // Need to provide a declaration/definition of alloca()
 #if defined(__FreeBSD__) || defined(__NetBSD__)
+// BSD
 #include <stdlib.h>
+#elif defined(_WIN32)
+// Windows
+#include <malloc.h>
 #else
+// Other OS
 #include <alloca.h>
 #endif
 


### PR DESCRIPTION
### Summary

When building the embedded port on MinGW-w64, I receive the following error:

```
fatal error: alloca.h: No such file or directory
```

MinGW-w64 (used on [MSYS2](https://www.msys2.org/)) doesn't include `alloca.h`, but `alloca()` is provided via `malloc.h` instead. This PR allows the build on this system. 

This fix needs be applied on other Windows build systems.

**Note:** A similar problem affected BSD in the past (see: https://github.com/micropython/micropython/pull/13360).

### Testing

We are using MicroPython through [KallistiOS](https://github.com/KallistiOS/), a library for developing on Sega Dreamcast, and more specifically a port in KallistiOS ([kos-ports](https://github.com/KallistiOS/kos-ports/)). Previously, it was impossible to compile this port with MinGW-w64 (the foundation of the [DreamSDK](https://github.com/dreamsdk/) environment), thanks to this fix, compilation is now possible and the problem is fixed.

<img width="721" height="412" alt="image" src="https://github.com/user-attachments/assets/87d4624d-a68a-4c1c-8a1a-6eabcbc72d6b" />

See: https://github.com/KallistiOS/kos-ports/issues/112





