### PR TITLE
map: Always hash the object in mp_map_lookup.

### DIFF
--- a/tests/basics/ordereddict_unhashable.py
+++ b/tests/basics/ordereddict_unhashable.py
@@ -1,0 +1,21 @@
+try:
+    from collections import OrderedDict
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+d = OrderedDict()
+
+# ordered dict must reject nonhashable items, including slices
+# This test operates with a .exp file because Python 3.12 made slice objects
+# hashable.
+try:
+    d[:'a'] = 123
+except:
+    print("exception")
+
+try:
+    d[[]] = 123
+except:
+    print("exception")
+print(len(d))

--- a/tests/basics/ordereddict_unhashable.py.exp
+++ b/tests/basics/ordereddict_unhashable.py.exp
@@ -1,0 +1,3 @@
+exception
+exception
+0

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -758,6 +758,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         "memoryview1",
         "memoryview_gc",
         "object1",
+        "ordereddict_unhashable",
         "python34",
         "string_format_modulo",
         "struct_endian",


### PR DESCRIPTION


### Summary

Fuzzing produced a crash in OrderedDict which reduced to the following:
```
from collections import OrderedDict
x = OrderedDict()
x[: 'a'] = 1
x['b'] = 2
```

This occurs because, as an optimization, the key is not hashed when searching an OrderedDict, so an unhashable key can be stored. Even worse, the slice in this case is from `build_slice_stack_allocated` so by the time the 2nd indexing operation is being performed, it's nonsense instead of a Python object.

### Testing

I added a test for this and ran the testsuite locally.

### Trade-offs and Alternatives

This might slightly lower the performance of OrderedDict objects because before this change they avoided hashing the keys at all. However, I'm not aware of a way to check whether an object is hashable short of actually hashing it.