### PR TITLE
esp32: update IDF to 5.4.2

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -31,7 +31,7 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v5.2, v5.2.2, v5.3, v5.4 and v5.4.1.
+Currently MicroPython supports v5.2, v5.2.2, v5.3, v5.4, v5.4.1 and v5.4.2.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).
@@ -49,10 +49,10 @@ The steps to take are summarised below.
 To check out a copy of the IDF use git clone:
 
 ```bash
-$ git clone -b v5.4.1 --recursive https://github.com/espressif/esp-idf.git
+$ git clone -b v5.4.2 --recursive https://github.com/espressif/esp-idf.git
 ```
 
-You can replace `v5.4.1` with any other supported version.
+You can replace `v5.4.2` with any other supported version.
 (You don't need a full recursive clone; see the `ci_esp32_setup` function in
 `tools/ci.sh` in this repository for more detailed set-up commands.)
 
@@ -61,7 +61,7 @@ MicroPython and update the submodules using:
 
 ```bash
 $ cd esp-idf
-$ git checkout v5.4.1
+$ git checkout v5.4.2
 $ git submodule update --init --recursive
 ```
 

--- a/ports/esp32/tools/metrics_esp32.py
+++ b/ports/esp32/tools/metrics_esp32.py
@@ -37,7 +37,7 @@ import sys
 import subprocess
 from dataclasses import dataclass
 
-IDF_VERS = ("v5.4.1",)
+IDF_VERS = ("v5.4.2",)
 
 BUILDS = (
     ("ESP32_GENERIC", ""),

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -169,7 +169,7 @@ function ci_cc3200_build {
 # ports/esp32
 
 # GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
-IDF_VER=v5.4.1
+IDF_VER=v5.4.2
 PYTHON=$(command -v python3 2> /dev/null)
 PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
 


### PR DESCRIPTION
### Summary

This PR updates the esp32 port to use IDF 5.4.2 (instead of 5.4.1).

The CI will now use IDF 5.4.2, and the README recommends this as the officially supported version.  Downloads will also use the new version.

Thanks to @projectgus, here is a summary of the change in firmware size and RAM usage moving from 5.4.1 to 5.4.2:

| BOARD | BOARD_VARIANT | IDF Version | Binary Size | Static IRAM Size | Static DRAM Size |
|-------|---------------|-------------|-------------|------------------|------------------|
| ESP32_GENERIC |  | v5.4.1 | 1656557 | 117286 | 56136 |
|  |  | v5.4.2 | 1658709 | 116894 | 53948 |
| ESP32_GENERIC | D2WD | v5.4.1 | 1371197 | 111174 | 55840 |
|  |  | v5.4.2 | 1372697 | 110714 | 53616 |
| ESP32_GENERIC | SPIRAM | v5.4.1 | 1481400 | 116430 | 56264 |
|  |  | v5.4.2 | 1482900 | 115998 | 54068 |
| ESP32_GENERIC_S3 |  | v5.4.1 | 1635902 | 16383 | 143295 |
|  |  | v5.4.2 | 1645006 | 16383 | 142059 |
| ESP32_GENERIC_S3 | SPIRAM_OCT | v5.4.1 | 1639314 | 16383 | 146727 |
|  |  | v5.4.2 | 1648446 | 16383 | 145519 |

Comparing with 5.4.1, firmware size is up by about 1.5k on ESP32 and 9k on ESP32-S3.  But IRAM usage (of the IDF) is down by about 500 byte on ESP32 and DRAM usage is down by about 20k on ESP32 and 10k on ESP32-S3.

### Testing

I ran the full test suite (Python, .mpy, native, hardware, BLE, WiFi) on ESP32, ESP32-S2, ESP32-S3 and ESP32-C3.  I did not see any regressions.

However, I did see a change in BLE event behaviour which makes `tests/multi_bluetooth/ble_mtu.py` and `tests/multi_bluetooth/ble_mtu_peripheral.py` now fail on ESP32 with IDF 5.4.2.  The change in behaviour is that MTU_EXCHANGE events can now occur *before* CENTRAL_CONNECT/PERIPHERAL_CONNECT events.  That seems a bit strange, because the MTU exchange occurs after the connection.  And looking at the timing of the events there is exactly 100ms between them, ie MTU_EXCHANGE fires and then exactly 100ms later CENTRAL_CONNECT/PERIPHERAL_CONNECT fires.

I don't know if this is a bug in (Espressif's) NimBLE, a subtle change in scheduling with still valid behaviour, an intended change, a change allowed under the BLE spec, or something else.  But I doubt we can fix that (easily) on our side and so in order to move forward with updating to IDF 5.4.2 I have adjusted the relevant tests so they can pass (basically, the test just needs to wait a bit between doing the connect and doing the MTU exchange, so the other side sees the original/correct ordering of events).

I have tested the modified tests on PYBD_SF6, RPI_PICO_W, ESP32 (IDF 5.4.1 and IDF 5.4.2) and ESP32-S3 (IDF 5.4.1 and IDF 5.4.2).  They pass.

### Trade-offs and Alternatives

- We need to keep up with IDF releases, so there's not much alternative.  And this is only a patch release update, so really shouldn't have many semantic changes.
- Instead of trying to hunt down why the BLE event ordering has changed, I just opted to tweak the test.

