### PR TITLE
 examples/bluetooth/ble_advertising.py: fix decoding of UUID32

### DIFF
--- a/docs/library/bluetooth.rst
+++ b/docs/library/bluetooth.rst
@@ -764,4 +764,5 @@ Constructor
     The **value** can be either:
 
     - A 16-bit integer. e.g. ``0x2908``.
+    - An object with the buffer protocol and that is 2, 4 or 16 bytes long, e.g. ``b'\x08\x29'``.
     - A 128-bit UUID string. e.g. ``'6E400001-B5A3-F393-E0A9-E50E24DCCA9E'``.

--- a/examples/bluetooth/ble_advertising.py
+++ b/examples/bluetooth/ble_advertising.py
@@ -79,12 +79,9 @@ def decode_name(payload):
 
 def decode_services(payload):
     services = []
-    for u in decode_field(payload, _ADV_TYPE_UUID16_COMPLETE):
-        services.append(bluetooth.UUID(struct.unpack("<h", u)[0]))
-    for u in decode_field(payload, _ADV_TYPE_UUID32_COMPLETE):
-        services.append(bluetooth.UUID(struct.unpack("<d", u)[0]))
-    for u in decode_field(payload, _ADV_TYPE_UUID128_COMPLETE):
-        services.append(bluetooth.UUID(u))
+    for code in (_ADV_TYPE_UUID16_COMPLETE, _ADV_TYPE_UUID32_COMPLETE, _ADV_TYPE_UUID128_COMPLETE):
+        for u in decode_field(payload, code):
+            services.append(bluetooth.UUID(u))
     return services
 
 


### PR DESCRIPTION
### Summary

This fixes a long-standing bug in the BLE example, the part that decodes UUIDs.

The bug was reported here: https://github.com/raspberrypi/pico-micropython-examples/issues/86

I also updated the relevant part of the documentation, about how UUIDs are constructed. 

### Testing

Tested with the following script:
```py
import bluetooth
import ble_advertising

for uuid in (
    0x1234,
    b'\x34\x12',
    b'\x78\x56\x34\x12',
    b'1234567812345678',
    '6E400001-B5A3-F393-E0A9-E50E24DCCA9E',
):
    adv = ble_advertising.advertising_payload(name="test", services=[bluetooth.UUID(uuid)])
    try:
        print(ble_advertising.decode_services(adv))
    except Exception as er:
        print(er)
```

Prior to this fix the output was:
```
[UUID(0x1234)]
[UUID(0x1234)]
buffer too small
[UUID('38373635-3433-3231-3837-363534333231')]
[UUID('6e400001-b5a3-f393-e0a9-e50e24dcca9e')]
```
With the fix, the output is:
```
[UUID(0x1234)]
[UUID(0x1234)]
[UUID(0x12345678)]
[UUID('38373635-3433-3231-3837-363534333231')]
[UUID('6e400001-b5a3-f393-e0a9-e50e24dcca9e')]
```
### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

