### PR TITLE
ci: Enable UBSan for 'longlong' builds in CI, add stack size for sanitizer builds.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -54,6 +54,7 @@
 #include "extmod/vfs_posix.h"
 #include "genhdr/mpversion.h"
 #include "input.h"
+#include "stack_size.h"
 
 // Command line options, with their defaults
 static bool compile_only = false;
@@ -479,11 +480,7 @@ int main(int argc, char **argv) {
     #endif
 
     // Define a reasonable stack limit to detect stack overflow.
-    mp_uint_t stack_size = 40000 * (sizeof(void *) / 4);
-    #if defined(__arm__) && !defined(__thumb2__)
-    // ARM (non-Thumb) architectures require more stack.
-    stack_size *= 2;
-    #endif
+    mp_uint_t stack_size = 40000 * UNIX_STACK_MULTIPLIER;
 
     // We should capture stack top ASAP after start, and it should be
     // captured guaranteedly before any other stack variables are allocated.

--- a/ports/unix/mpthreadport.c
+++ b/ports/unix/mpthreadport.c
@@ -31,6 +31,7 @@
 #include "py/runtime.h"
 #include "py/mpthread.h"
 #include "py/gc.h"
+#include "stack_size.h"
 
 #if MICROPY_PY_THREAD
 
@@ -244,9 +245,9 @@ void mp_thread_start(void) {
 }
 
 mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
-    // default stack size is 8k machine-words
+    // default stack size
     if (*stack_size == 0) {
-        *stack_size = 8192 * sizeof(void *);
+        *stack_size = 32768 * UNIX_STACK_MULTIPLIER;
     }
 
     // minimum stack size is set by pthreads

--- a/ports/unix/stack_size.h
+++ b/ports/unix/stack_size.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Angus Gratton
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_UNIX_STACK_SIZE_H
+#define MICROPY_INCLUDED_UNIX_STACK_SIZE_H
+
+#include "py/misc.h"
+
+// Define scaling factors for the stack size (also applies to main thread)
+#ifndef UNIX_STACK_MULTIPLIER
+
+#if defined(__arm__) && !defined(__thumb2__)
+// ARM (non-Thumb) architectures require more stack.
+#define UNIX_STACK_MUL_ARM 2
+#else
+#define UNIX_STACK_MUL_ARM 1
+#endif
+
+#if MP_SANITIZER_BUILD
+// Sanitizer features consume significant stack in some cases
+// This multiplier can probably be removed when using GCC 12 or newer.
+#define UNIX_STACK_MUL_SANITIZERS 4
+#else
+#define UNIX_STACK_MUL_SANITIZERS 1
+#endif
+
+// Double the stack size for 64-bit builds, plus additional scaling
+#define UNIX_STACK_MULTIPLIER ((sizeof(void *) / 4) * UNIX_STACK_MUL_ARM * UNIX_STACK_MUL_SANITIZERS)
+
+#endif // UNIX_STACK_MULTIPLIER
+
+#endif // MICROPY_INCLUDED_UNIX_STACK_SIZE_H

--- a/py/misc.h
+++ b/py/misc.h
@@ -43,6 +43,11 @@ typedef unsigned int uint;
 #ifndef __has_builtin
 #define __has_builtin(x) (0)
 #endif
+#ifndef __has_feature
+// This macro is supported by Clang and gcc>=14
+#define __has_feature(x) (0)
+#endif
+
 
 /** generic ops *************************************************/
 
@@ -536,6 +541,25 @@ inline static bool mp_sub_ll_overflow(long long int lhs, long long int rhs, long
 
     return overflow;
 }
+#endif
+
+
+// Helper macros for detecting if sanitizers are enabled
+//
+// Use sparingly, not for masking issues reported by sanitizers!
+//
+// Can be detected automatically in Clang and gcc>=14, need to be
+// set manually otherwise.
+#ifndef MP_UBSAN
+#define MP_UBSAN __has_feature(undefined_behavior_sanitizer)
+#endif
+
+#ifndef MP_ASAN
+#define MP_ASAN __has_feature(address_sanitizer)
+#endif
+
+#ifndef MP_SANITIZER_BUILD
+#define MP_SANITIZER_BUILD (MP_UBSAN || MP_ASAN)
 #endif
 
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -518,13 +518,11 @@ CI_UNIX_OPTS_QEMU_RISCV64=(
 )
 
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
-    VARIANT=coverage
     CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
     LDFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
 )
 
 CI_UNIX_OPTS_SANITIZE_UNDEFINED=(
-    VARIANT=coverage
     CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
     LDFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
 )
@@ -699,7 +697,7 @@ function ci_unix_nanbox_run_tests {
 }
 
 function ci_unix_longlong_build {
-    ci_unix_build_helper VARIANT=longlong
+    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
 }
 
 function ci_unix_longlong_run_tests {
@@ -765,23 +763,23 @@ function ci_unix_settrace_stackless_run_tests {
 function ci_unix_sanitize_undefined_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix submodules
-    make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
     ci_unix_build_ffi_lib_helper gcc
 }
 
 function ci_unix_sanitize_undefined_run_tests {
-    MICROPY_TEST_TIMEOUT=60 ci_unix_run_tests_full_helper coverage "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+    MICROPY_TEST_TIMEOUT=60 ci_unix_run_tests_full_helper coverage VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
 }
 
 function ci_unix_sanitize_address_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/unix submodules
-    make ${MAKEOPTS} -C ports/unix "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
     ci_unix_build_ffi_lib_helper gcc
 }
 
 function ci_unix_sanitize_address_run_tests {
-    MICROPY_TEST_TIMEOUT=60 ci_unix_run_tests_full_helper coverage "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
+    MICROPY_TEST_TIMEOUT=60 ci_unix_run_tests_full_helper coverage VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
 }
 
 function ci_unix_macos_build {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -518,12 +518,14 @@ CI_UNIX_OPTS_QEMU_RISCV64=(
 )
 
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
-    CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
+    # Macro MP_ASAN allows detecting ASan on gcc<=13
+    CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -DMP_ASAN=1"
     LDFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
 )
 
 CI_UNIX_OPTS_SANITIZE_UNDEFINED=(
-    CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
+    # Macro MP_UBSAN allows detecting UBSan on gcc<=13
+    CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute -DMP_UBSAN=1"
     LDFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
 )
 


### PR DESCRIPTION
### Summary

* Spun out from #17734 - enable UBSan in CI as suggested by @jepler 
* Scale up the unix port stack sizes substantially when sanitizers are enabled. The size of some MicroPython C stack frames with UBSan and GCC 12 (as used in CI) appears to be quite high. Whatever causes this seems to be fixed in later GCC.
* To support uniform scaling of stack sizes, added some macros to apply the same stack size multiplier to both the main thread and the default thread stack size on unix port. Previously the unix port main thread stack was doubled on ARM builds but the default thread stack size was not, now they are both doubled (and the same macros are used when sanitizers are enabled).
* Added a custom MicroPython macro to mark if sanitizers are enabled. As far as I can tell there's no way to programmatically detect if sanitizers are enabled on gcc<14, the other macros are all Clang-only.
* Rewrote the scaling mechanism for the `stress/recurse_iternext.py` test, as this test fails on sanitizer builds with the increased stack. (Sanitizer build stack usage is only increased due to certain C function calls, but this test - I think - consumes stack in a way which isn't impacted by sanitizers so it can now handle many more iterations compared to a standard build). This took a while to find a good approach, but what's there seems more accurate than the previous heuristic and doesn't take noticeably more time to execute.

### Testing

* Tested in CI and by running CI functions locally with an ubuntu-22.04 container and with my local newer GCC.
* Re-ran the updated `stress/recurse_iternext.py` test on unix port with and without sanitizers, esp32 port with SPIRAM, and esp8266 port.

### Trade-offs and Alternatives

* Could leave UBSan disabled in CI for the 'longlong' variant, but (as demonstrated) it is useful to find bugs.

*This work was funded through GitHub Sponsors*