### PR TITLE
tools/ci.sh: Test building all natmod examples with all ARM-M archs.

### DIFF
--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -39,6 +39,11 @@ endif
 # Use our own errno implementation if Picolibc is used
 CFLAGS += -D__PICOLIBC_ERRNO_FUNCTION=__errno
 
+ifeq ($(ARCH),armv6m)
+# Link with libgcc.a for division helper functions
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk
 
 # btree needs gnu99 defined

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -10,6 +10,11 @@ SRC = deflate.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH ?= x64
 
+ifeq ($(ARCH),armv6m)
+# Link with libgcc.a for division helper functions
+LINK_RUNTIME = 1
+endif
+
 ifeq ($(ARCH),xtensa)
 # Link with libm.a and libgcc.a from the toolchain
 LINK_RUNTIME = 1

--- a/examples/natmod/framebuf/Makefile
+++ b/examples/natmod/framebuf/Makefile
@@ -10,6 +10,11 @@ SRC = framebuf.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin)
 ARCH ?= x64
 
+ifeq ($(ARCH),armv6m)
+# Link with libgcc.a for division helper functions
+LINK_RUNTIME = 1
+endif
+
 ifeq ($(ARCH),xtensa)
 MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
 endif

--- a/examples/natmod/re/Makefile
+++ b/examples/natmod/re/Makefile
@@ -10,4 +10,9 @@ SRC = re.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc)
 ARCH = x64
 
+ifeq ($(ARCH),armv6m)
+# Link with libgcc.a for division helper functions
+LINK_RUNTIME = 1
+endif
+
 include $(MPY_DIR)/py/dynruntime.mk

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -196,7 +196,7 @@ test_natmod: $(BUILD)/firmware.elf
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && \
 		for natmod in btree deflate framebuf heapq random_basic re; do \
-		./run-natmodtests.py -p -d execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" extmod/$$natmod*.py; \
+		./run-natmodtests.py -p -d execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_EXTRA) extmod/$$natmod*.py; \
 		done
 
 $(BUILD)/firmware.elf: $(LDSCRIPT) $(OBJ)

--- a/ports/qemu/README.md
+++ b/ports/qemu/README.md
@@ -112,8 +112,8 @@ Extra make options
 
 The following options can be specified on the `make` command line:
 - `CFLAGS_EXTRA`: pass in extra flags for the compiler.
-- `RUN_TESTS_EXTRA`: pass in extra flags for `run-tests.py` when invoked via
-  `make test`.
+- `RUN_TESTS_EXTRA`: pass in extra flags for `run-tests.py` and `run-natmodtests.py`
+  when invoked via `make test` or `make test_natmod`.
 - `QEMU_DEBUG=1`: when running qemu (via `repl`, `run` or `test` target), qemu
   will block until a debugger is connected.  By default it waits for a gdb connection
   on TCP port 1234.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -346,9 +346,15 @@ function ci_qemu_build_arm_thumb {
     ci_qemu_build_arm_prepare
     make ${MAKEOPTS} -C ports/qemu test_full
 
-    # Test building and running native .mpy with armv7m architecture.
+    # Test building native .mpy with all ARM-M architectures.
+    ci_native_mpy_modules_build armv6m
     ci_native_mpy_modules_build armv7m
-    make ${MAKEOPTS} -C ports/qemu test_natmod
+    ci_native_mpy_modules_build armv7emsp
+    ci_native_mpy_modules_build armv7emdp
+
+    # Test running native .mpy with armv6m and armv7m architectures.
+    make ${MAKEOPTS} -C ports/qemu test_natmod RUN_TESTS_EXTRA="--arch armv6m"
+    make ${MAKEOPTS} -C ports/qemu test_natmod RUN_TESTS_EXTRA="--arch armv7m"
 }
 
 function ci_qemu_build_rv32 {
@@ -442,10 +448,6 @@ function ci_stm32_pyb_build {
     make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBV10 CFLAGS_EXTRA='-DMBOOT_FSLOAD=1 -DMBOOT_VFS_LFS2=1'
     make ${MAKEOPTS} -C ports/stm32/mboot BOARD=PYBD_SF6
     make ${MAKEOPTS} -C ports/stm32/mboot BOARD=STM32F769DISC CFLAGS_EXTRA='-DMBOOT_ADDRESS_SPACE_64BIT=1 -DMBOOT_SDCARD_ADDR=0x100000000ULL -DMBOOT_SDCARD_BYTE_SIZE=0x400000000ULL -DMBOOT_FSLOAD=1 -DMBOOT_VFS_FAT=1'
-
-    # Test building native .mpy with armv7emsp architecture.
-    git submodule update --init lib/berkeley-db-1.xx
-    ci_native_mpy_modules_build armv7emsp
 }
 
 function ci_stm32_nucleo_build {


### PR DESCRIPTION
### Summary

This adds a few more tests to CI, to build all natmod examples with all possible ARM-M architectures.

### Testing

To be tested by CI.

