### PR TITLE
py/objint_longlong: Fix overflow check in mp_obj_int_get_checked.

### DIFF
--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -308,8 +308,17 @@ mp_int_t mp_obj_int_get_truncated(mp_const_obj_t self_in) {
 }
 
 mp_int_t mp_obj_int_get_checked(mp_const_obj_t self_in) {
-    // TODO: Check overflow
-    return mp_obj_int_get_truncated(self_in);
+    if (mp_obj_is_small_int(self_in)) {
+        return MP_OBJ_SMALL_INT_VALUE(self_in);
+    } else {
+        const mp_obj_int_t *self = self_in;
+        long long value = self->val;
+        mp_int_t truncated = (mp_int_t)value;
+        if ((long long)truncated == value) {
+            return truncated;
+        }
+    }
+    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("overflow converting long int to machine word"));
 }
 
 mp_uint_t mp_obj_int_get_uint_checked(mp_const_obj_t self_in) {

--- a/tests/basics/int_64_basics.py
+++ b/tests/basics/int_64_basics.py
@@ -125,6 +125,22 @@ else:
 x = 1 << 62
 print('a' * (x + 4 - x))
 
+# test overflow check in mp_obj_get_int_maybe
+x = 1 << 32
+r = None
+try:
+    r = range(0, x)
+except OverflowError:
+    # 32-bit target, correctly handled the overflow of x
+    print("ok")
+if r is not None:
+    if len(r) == x:
+        # 64-bit target, everything is just a small-int
+        print("ok")
+    else:
+        # 32-bit target that did not handle the overflow of x
+        print("unhandled overflow")
+
 # negative shifts are invalid
 try:
     print((1 << 48) >> -4)


### PR DESCRIPTION
### Summary

This is to fix an outstanding TODO. The test cases is using a range expression, as this is available all builds, but `mp_obj_get_int` is used by various extmod where an overflow is more likely to occur.

### Testing

The code is pretty simple, and has been tested on unix/longlong varient.
An test case has been added in CI tests.

### Trade-offs and Alternatives

I am not sure that this exception is likely to occur in the MicroPython core code ,unless the Python code includes a serious bug. Therefore, the extra code size might not be worthwhile for everyone. However, there are many hardware extensions that use this function, and in those cases, the likelihood of an overflow is much higher.
