### PR TITLE
stm32: Fix 12bit DAC issue on STM32H5.

### DIFF
--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -174,7 +174,7 @@ static void dac_start_dma(uint32_t dac_channel, const dma_descr_t *dma_descr, ui
         // For STM32G4, DAC registers have to be accessed by words (32-bit).
         dma_align = DMA_MDATAALIGN_BYTE | DMA_PDATAALIGN_WORD;
         #elif defined(STM32H5)
-        dma_align = 0;
+        dma_align = DMA_SRC_DATAWIDTH_BYTE | DMA_DEST_DATAWIDTH_WORD;
         #else
         dma_align = DMA_MDATAALIGN_BYTE | DMA_PDATAALIGN_BYTE;
         #endif
@@ -183,7 +183,7 @@ static void dac_start_dma(uint32_t dac_channel, const dma_descr_t *dma_descr, ui
         // For STM32G4, DAC registers have to be accessed by words (32-bit).
         dma_align = DMA_MDATAALIGN_HALFWORD | DMA_PDATAALIGN_WORD;
         #elif defined(STM32H5)
-        dma_align = 0;
+        dma_align = DMA_SRC_DATAWIDTH_HALFWORD | DMA_DEST_DATAWIDTH_WORD;
         #else
         dma_align = DMA_MDATAALIGN_HALFWORD | DMA_PDATAALIGN_HALFWORD;
         #endif
@@ -490,7 +490,10 @@ mp_obj_t pyb_dac_write_timed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
         align = DAC_ALIGN_8B_R;
     } else {
         align = DAC_ALIGN_12B_R;
+        // For STM32H5, the length is the amount of data to be transferred from source to destination in bytes.
+        #if !defined(STM32H5)
         bufinfo.len /= 2;
+        #endif
     }
 
     dac_start_dma(self->dac_channel, tx_dma_descr, args[2].u_int, self->bits, align, bufinfo.len, bufinfo.buf);

--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -1737,10 +1737,10 @@ void dma_nohal_init(const dma_descr_t *descr, uint32_t config) {
     dma->CCR = init->Priority;
 
     uint32_t ctr1reg = 0;
-    ctr1reg |= init->SrcDataWidth;
+    ctr1reg |= config & DMA_CTR1_SDW_LOG2_Msk;
     ctr1reg |= init->SrcInc;
     ctr1reg |= (((init->SrcBurstLength - 1) << DMA_CTR1_SBL_1_Pos)) & DMA_CTR1_SBL_1_Msk;
-    ctr1reg |= init->DestDataWidth;
+    ctr1reg |= config & DMA_CTR1_DDW_LOG2_Msk;
     ctr1reg |= init->DestInc;
     ctr1reg |= (((init->DestBurstLength - 1) << DMA_CTR1_DBL_1_Pos)) & DMA_CTR1_DBL_1_Msk;
 

--- a/ports/stm32/dma.h
+++ b/ports/stm32/dma.h
@@ -33,7 +33,7 @@ typedef struct _dma_descr_t dma_descr_t;
 #if defined(STM32H5)
 // STM32H5 GPDMA doesn't feature circular mode directly, so define doesn't exist in
 // stm32 driver header. Define it here to make users like DAC driver happy.
-#define DMA_CIRCULAR 0x00000001
+#define DMA_CIRCULAR 0x20000000
 #endif
 
 #if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32G0) || defined(STM32H5) || defined(STM32H7)


### PR DESCRIPTION
### Summary

The following code does not work with NUCLEO-H563ZI.
```python
import math
from array import array
from pyb import DAC

# create a buffer containing a sine-wave, using half-word samples
buf = array('H', 2048 + int(2047 * math.sin(2 * math.pi * i / 128)) for i in range(128))

# output the sine-wave at 400Hz
dac = DAC(2, bits=12)
dac.write_timed(buf, 400 * len(buf), mode=DAC.CIRCULAR)
```

For STM32H5, DMA parameter should set:
 * Actual DMA source datawidth to CTR1.
 * The length is the amount of data to be transferred from source to destiniation in bytes. to use 12bit DAC.

Also, this PR modifies the definition of `DMA_CIRCULAR` for STM32H5 to prevent conflict with data width specification.

### Testing

Tested code above with NUCLEO-H563ZI.
Also, DAC with 8bit still works after applying this PR.

### Trade-offs and Alternatives

The value of `DAC_CIRCULAR` is changed:
from
```shell
>>> hex(DAC.CIRTUCLAR)
'0x1'
```
to
```shell
>>> hex(DAC.CIRCULAR)
'0x20000000'
```

Indeed, it won't be a problem because users do not need to be aware of value of `DAC.CIRCULAR` in most cases.