### PR TITLE
rp2/modmachine: Do not use deprecated XOSC_MHZ.

### DIFF
--- a/ports/rp2/clocks_extra.c
+++ b/ports/rp2/clocks_extra.c
@@ -83,8 +83,8 @@ void runtime_init_clocks_optional_usb(bool init_usb) {
     clock_configure(clk_ref,
         CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC,
         0,             // No aux mux
-        XOSC_KHZ * KHZ,
-        XOSC_KHZ * KHZ);
+        XOSC_HZ,
+        XOSC_HZ);
 
     /// \tag::configure_clk_sys[]
     // CLK SYS = PLL SYS (usually) 125MHz / 1 = 125MHz

--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -163,8 +163,6 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         }
     }
 
-    const uint32_t xosc_hz = XOSC_MHZ * 1000000;
-
     uint32_t my_interrupts = MICROPY_BEGIN_ATOMIC_SECTION();
     #if MICROPY_PY_NETWORK_CYW43
     if (cyw43_poll_is_pending()) {
@@ -200,18 +198,18 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     #endif
 
     // CLK_REF = XOSC
-    clock_configure(clk_ref, CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC, 0, xosc_hz, xosc_hz);
+    clock_configure(clk_ref, CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC, 0, XOSC_HZ, XOSC_HZ);
 
     // CLK_SYS = CLK_REF
-    clock_configure(clk_sys, CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLK_REF, 0, xosc_hz, xosc_hz);
+    clock_configure(clk_sys, CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLK_REF, 0, XOSC_HZ, XOSC_HZ);
 
     // CLK_RTC = XOSC / 256
     #if PICO_RP2040
-    clock_configure(clk_rtc, 0, CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_XOSC_CLKSRC, xosc_hz, xosc_hz / 256);
+    clock_configure(clk_rtc, 0, CLOCKS_CLK_RTC_CTRL_AUXSRC_VALUE_XOSC_CLKSRC, XOSC_HZ, XOSC_HZ / 256);
     #endif
 
     // CLK_PERI = CLK_SYS
-    clock_configure(clk_peri, 0, CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS, xosc_hz, xosc_hz);
+    clock_configure(clk_peri, 0, CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS, XOSC_HZ, XOSC_HZ);
 
     // Disable PLLs.
     pll_deinit(pll_sys);


### PR DESCRIPTION
### Summary

I replaced the crystal on a `W5500_EVB_PICO` board by a custom clock source which is not 12 MHz. Therefore I need to configure the SYS and USB PLL with custom dividers. The script `vcocalc.py` is used to calculate the needed values and to generate the compiler definitions that need to be added to cmake. 

But when using such custom defines the `XOSC_MHZ` is not defined and the build fails. 


### Testing

I tested this change while compiling for a `W5500_EVB_PICO` board with custom PLL settings as described above.


