### PR TITLE
core: Add MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC.

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2336,4 +2336,23 @@ typedef time_t mp_timestamp_t;
 #define MP_WARN_CAT(x) (NULL)
 #endif
 
+// If true, use __builtin_mul_overflow (a gcc intrinsic supported by clang) for
+// overflow checking when multiplying two small ints. Otherwise, use a portable
+// algorithm.
+//
+// Most MCUs have a 32x32->64 bit multiply instruction, in which case the
+// intrinsic is likely to be faster and generate smaller code. The main exception is
+// cortex-m0 with __ARM_ARCH_ISA_THUMB == 1.
+//
+// The intrinsic is in GCC starting with version 5.
+#ifndef MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC
+#if defined(__ARM_ARCH_ISA_THUMB) && (__GNUC__ >= 5)
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (__ARM_ARCH_ISA_THUMB >= 2)
+#elif (__GNUC__ >= 5)
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (1)
+#else
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (0)
+#endif
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MPCONFIG_H

--- a/py/parsenum.c
+++ b/py/parsenum.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 
 #include "py/runtime.h"
+#include "py/misc.h"
 #include "py/parsenumbase.h"
 #include "py/parsenum.h"
 #include "py/smallint.h"
@@ -52,7 +53,7 @@ static MP_NORETURN void raise_exc(mp_obj_t exc, mp_lexer_t *lex) {
 // to bigint parsing if supported)
 typedef mp_int_t parsed_int_t;
 
-#define PARSED_INT_MUL_OVERFLOW mp_small_int_mul_overflow
+#define PARSED_INT_MUL_OVERFLOW mp_mul_mp_int_t_overflow
 #define PARSED_INT_FITS MP_SMALL_INT_FITS
 #else
 // In the special case where bigint support is long long, we save code size by

--- a/py/runtime_utils.c
+++ b/py/runtime_utils.c
@@ -50,3 +50,63 @@ mp_obj_t mp_call_function_2_protected(mp_obj_t fun, mp_obj_t arg1, mp_obj_t arg2
         return MP_OBJ_NULL;
     }
 }
+
+#if !MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC
+bool mp_mul_ll_overflow(long long int x, long long int y, long long int *res) {
+    bool overflow;
+
+    // Check for multiply overflow; see CERT INT32-C
+    if (x > 0) { // x is positive
+        if (y > 0) { // x and y are positive
+            overflow = (x > (LLONG_MAX / y));
+        } else { // x positive, y nonpositive
+            overflow = (y < (LLONG_MIN / x));
+        } // x positive, y nonpositive
+    } else { // x is nonpositive
+        if (y > 0) { // x is nonpositive, y is positive
+            overflow = (x < (LLONG_MIN / y));
+        } else { // x and y are nonpositive
+            overflow = (x != 0 && y < (LLONG_MAX / x));
+        } // End if x and y are nonpositive
+    } // End if x is nonpositive
+
+    if (!overflow) {
+        *res = x * y;
+    }
+
+    return overflow;
+}
+
+#define MP_UINT_MAX (~(mp_uint_t)0)
+#define MP_INT_MAX ((mp_int_t)(MP_UINT_MAX >> 1))
+#define MP_INT_MIN (-MP_INT_MAX - 1)
+
+bool mp_mul_mp_int_t_overflow(mp_int_t x, mp_int_t y, mp_int_t *res) {
+    // Check for multiply overflow; see CERT INT32-C
+    if (x > 0) { // x is positive
+        if (y > 0) { // x and y are positive
+            if (x > (MP_INT_MAX / y)) {
+                return true;
+            }
+        } else { // x positive, y nonpositive
+            if (y < (MP_INT_MIN / x)) {
+                return true;
+            }
+        } // x positive, y nonpositive
+    } else { // x is nonpositive
+        if (y > 0) { // x is nonpositive, y is positive
+            if (x < (MP_INT_MIN / y)) {
+                return true;
+            }
+        } else { // x and y are nonpositive
+            if (x != 0 && y < (MP_INT_MAX / x)) {
+                return true;
+            }
+        } // End if x and y are nonpositive
+    } // End if x is nonpositive
+
+    // Result doesn't overflow
+    *res = x * y;
+    return false;
+}
+#endif

--- a/py/smallint.c
+++ b/py/smallint.c
@@ -26,35 +26,6 @@
 
 #include "py/smallint.h"
 
-bool mp_small_int_mul_overflow(mp_int_t x, mp_int_t y, mp_int_t *res) {
-    // Check for multiply overflow; see CERT INT32-C
-    if (x > 0) { // x is positive
-        if (y > 0) { // x and y are positive
-            if (x > (MP_SMALL_INT_MAX / y)) {
-                return true;
-            }
-        } else { // x positive, y nonpositive
-            if (y < (MP_SMALL_INT_MIN / x)) {
-                return true;
-            }
-        } // x positive, y nonpositive
-    } else { // x is nonpositive
-        if (y > 0) { // x is nonpositive, y is positive
-            if (x < (MP_SMALL_INT_MIN / y)) {
-                return true;
-            }
-        } else { // x and y are nonpositive
-            if (x != 0 && y < (MP_SMALL_INT_MAX / x)) {
-                return true;
-            }
-        } // End if x and y are nonpositive
-    } // End if x is nonpositive
-
-    // Result doesn't overflow
-    *res = x * y;
-    return false;
-}
-
 mp_int_t mp_small_int_modulo(mp_int_t dividend, mp_int_t divisor) {
     // Python specs require that mod has same sign as second operand
     dividend %= divisor;

--- a/py/smallint.h
+++ b/py/smallint.h
@@ -68,10 +68,6 @@
 // The number of bits in a MP_SMALL_INT including the sign bit.
 #define MP_SMALL_INT_BITS (MP_IMAX_BITS(MP_SMALL_INT_MAX) + 1)
 
-// Multiply two small ints.
-// If returns false, the correct result is stored in 'res'
-// If returns true, the multiplication would have overflowed. 'res' is unchanged.
-bool mp_small_int_mul_overflow(mp_int_t x, mp_int_t y, mp_int_t *res);
 mp_int_t mp_small_int_modulo(mp_int_t dividend, mp_int_t divisor);
 mp_int_t mp_small_int_floor_divide(mp_int_t num, mp_int_t denom);
 


### PR DESCRIPTION
And enable it on platforms where I am aware an efficient 32x32->64 bit multiply instruction exists.

### Summary

In the discussion of #17734 I became aware there was some existing use of the builtin overflow intrinsics, particularly for the longlong build.

This PR tests using it in place of `mp_small_int_mul_overflow`.

### Testing

I ran the testsuite locally (64-bit standard build). However, I don't know if the testsuite adequately checks multiplications "at the boundary" of the short integer range.

I also did some investigating and found a check for riscv, x86/x86_64, and arm that seems to capture the "is there a suitable multiply instruction". A check for xtensa is missing but could be beneficial.

I think there might be a modest performance benefit (avoiding multiple divisions per multiplication) but I did not attempt to measure it.

### Trade-offs and Alternatives

In an earlier iteration, the structure of int*int multiply in mp_binary_op ended up more complicated than needed, because I was still trying to use "small int overflow" in some places and "c type mul overflow" in others in a misguided attempt to keep the change minimal. That's no longer the case.