### PR TITLE
stm32: Add DAC feature for STM32G0.

### DIFF
--- a/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
@@ -5,7 +5,7 @@
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_ENABLE_RNG       (0)
 #define MICROPY_HW_ENABLE_RTC       (1)
-#define MICROPY_HW_ENABLE_DAC       (0)
+#define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_USB       (0) // can be enabled if USB cable connected to PA11/PA12
 #define MICROPY_PY_PYB_LEGACY       (0)
 

--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -97,7 +97,7 @@ static uint32_t TIMx_Config(mp_obj_t timer) {
     // work out the trigger channel (only certain ones are supported)
     if (tim->Instance == TIM2) {
         return DAC_TRIGGER_T2_TRGO;
-    #if defined(TIM4)
+    #if defined(TIM4) && defined(DAC_TRIGGER_T4_TRGO) // G0B1 doesn't have this
     } else if (tim->Instance == TIM4) {
         return DAC_TRIGGER_T4_TRGO;
     #endif

--- a/ports/stm32/dma.c
+++ b/ports/stm32/dma.c
@@ -1657,7 +1657,7 @@ static void dma_idle_handler(uint32_t tick) {
 }
 #endif
 
-#if defined(STM32F0) || defined(STM32G4) || defined(STM32L0) || defined(STM32L1) || defined(STM32L4)
+#if defined(STM32F0) || defined(STM32G0) || defined(STM32G4) || defined(STM32L0) || defined(STM32L1) || defined(STM32L4)
 
 void dma_nohal_init(const dma_descr_t *descr, uint32_t config) {
     DMA_Channel_TypeDef *dma = descr->instance;
@@ -1680,7 +1680,7 @@ void dma_nohal_init(const dma_descr_t *descr, uint32_t config) {
     } else {
         __HAL_DMA2_REMAP(descr->sub_instance);
     }
-    #elif defined(STM32G4)
+    #elif defined(STM32G0) || defined(STM32G4)
     uint32_t *dmamux_ctrl = (void *)(DMAMUX1_Channel0_BASE + 0x04 * descr->id);
     *dmamux_ctrl = (*dmamux_ctrl & ~(0x7f)) | descr->sub_instance;
     #elif defined(STM32L1)
@@ -1807,7 +1807,7 @@ void dma_nohal_start(const dma_descr_t *descr, uint32_t src_addr, uint32_t dst_a
     dma->CCR |= DMA_CCR_EN;
 }
 
-#elif defined(STM32G0) || defined(STM32N6) || defined(STM32WB) || defined(STM32WL)
+#elif defined(STM32N6) || defined(STM32WB) || defined(STM32WL)
 
 // These functions are currently not implemented or needed for this MCU.
 


### PR DESCRIPTION
### Summary

This PR adds DAC feature for STM32G0.
`DAC.write()` and `DAC.write_timed()` is now available.

### Testing

The following code works with NUCLEO-G01BRE.
A sine wave is output via PA4 when ch=1, PA5 when ch=2.

```python
import math
from pyb import DAC

ch = 1

# create a buffer containing a sine-wave
buf = bytearray(100)
for i in range(len(buf)):
    buf[i] = 128 + int(127 * math.sin(2 * math.pi * i / len(buf)))

# output the sine-wave at 600Hz
dac = DAC(ch, bits=8)
dac.write_timed(buf, 600 * len(buf), mode=DAC.CIRCULAR)
```

```python
import math
from array import array
from pyb import DAC

ch = 2

# create a buffer containing a sine-wave, using half-word samples
buf = array('H', 2048 + int(2047 * math.sin(2 * math.pi * i / 128)) for i in range(128))

# output the sine-wave at 400Hz
dac = DAC(ch, bits=12)
dac.write_timed(buf, 400 * len(buf), mode=DAC.CIRCULAR)
```


### Trade-offs and Alternatives

This PR increases code size by 1800 Bytes.

Before:
```
   text	   data	    bss	    dec	    hex	filename
 297528	    108	   4004	 301640	  49a48	build-NUCLEO_G0B1RE/firmware.elf
```
After:
```
   text	   data	    bss	    dec	    hex	filename
 299312	    108	   4020	 303440	  4a150	build-NUCLEO_G0B1RE/firmware.elf
```
 

