### PR TITLE
stm32: Fix DAC issue for MCUs those have D-Cache.

### DIFF
--- a/ports/stm32/dac.c
+++ b/ports/stm32/dac.c
@@ -485,6 +485,9 @@ mp_obj_t pyb_dac_write_timed(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
     #endif
     }
 
+    // To prevent invalid dac output, clean D-cache before starting dma.
+    MP_HAL_CLEAN_DCACHE(bufinfo.buf, bufinfo.len);
+
     uint32_t align;
     if (self->bits == 8) {
         align = DAC_ALIGN_8B_R;


### PR DESCRIPTION
### Summary

The following code does not work with NUCLEO-F767ZI.
Incorrect wave may be output on PA4. STM32H7 has same issue.
```python
import math
from pyb import DAC

# create a buffer containing a sine-wave
buf = bytearray(100)
for i in range(len(buf)):
    buf[i] = 128 + int(127 * math.sin(2 * math.pi * i / len(buf)))

# output the sine-wave at 600Hz
dac = DAC(1, bits=8)
dac.write_timed(buf, 600 * len(buf), mode=DAC.CIRCULAR)
```

For MCUs which has D-Cache (such as STM32F7, STM32H7), clean D-cache before starting DMA.
For more details, please refer follwing document:
https://www.st.com/resource/en/application_note/DM00272913.pdf

This PR cleans D-cache before starting DMA.


### Testing

Tested code above with:
* NUCLEO-F767ZI (STM32F767ZI)
* WeAct H743VI (STM32H743VI, PR: #17766) 

-> Both boards output wave as expected.
