### PR TITLE
py/asmthumb: Don't corrupt base register in large offset store.

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -491,9 +491,11 @@ void asm_thumb_store_reg_reg_offset(asm_thumb_t *as, uint reg_src, uint reg_base
         // Can use T3 encoding
         asm_thumb_op32(as, (OP_LDR_STR_W_HI(operation_size, reg_base) | OP_STR_W), OP_LDR_STR_W_LO(reg_src, (offset << operation_size)));
     } else {
-        // Must use the generic sequence
-        asm_thumb_add_reg_reg_offset(as, reg_base, reg_base, offset - 31, operation_size);
-        asm_thumb_op16(as, ((OP_LDR_STR_TABLE[operation_size] | OP_STR) << 11) | (31 << 6) | (reg_base << 3) | reg_src);
+        // Must use the generic sequence. It is safe to use R2 (REG_TEMP2)
+        // here because that is only used by emit_native_rot_three(), which
+        // can't call us with a large enough offset to end up in this branch.
+        asm_thumb_add_reg_reg_offset(as, ASM_THUMB_REG_R2, reg_base, offset - 31, operation_size);
+        asm_thumb_op16(as, ((OP_LDR_STR_TABLE[operation_size] | OP_STR) << 11) | (31 << 6) | (ASM_THUMB_REG_R2 << 3) | reg_src);
     }
 }
 


### PR DESCRIPTION
### Summary

On rp2, I discovered that viper stores offset from a register variable were clobbering that variable:
```python
@micropython.viper
def test():
  x = ptr8(ba)
  print(hex(uint(x)))
  x[0x1000] = 0
  # The register x has now been clobbered, incremented by 0x1000 - 31.
  # It gets corrupted only if the index/offset is >= 1 << 10.
  print(hex(uint(x)))
ba = bytearray(0x2000)
test()
```

@agatti kindly pointed me at `asm_thumb_store_reg_reg_offset()`. It turns out this modifies the base register when storing with a large offset which triggers the generic path. If a variable lives in that register, this corrupts it. This patch fixes this by using R2 (REG_TEMP2) instead.

The only VM opcode which uses REG_TEMP2 is `emit_native_rot_three()`, which only calls `ASM_STORE_REG_REG()` via `emit_access_stack()` with an offset of free = start + size - pos for the stack. This should never be large enough to trigger the generic path which clobbers REG_TEMP2.

The rv32 emitter uses REG_TEMP2 in `asm_rv32_emit_store_reg_reg_offset()` already, with the same justification: values of the free stack capacity are too small to trigger the affected large offset path.

However...

### Testing

...before extending the existing store boundary tests to check for unwanted modification of the base registers, I double-checked them against this commit. It turns out to break them!

```
FAILURE /home/root/mp/tests/results/micropython_viper_ptr32_store_boundary_intbig.py
--- /home/root/mp/tests/results/micropython_viper_ptr32_store_boundary_intbig.py.exp    2025-07-27 13:03:13.618624946 +0100
+++ /home/root/mp/tests/results/micropython_viper_ptr32_store_boundary_intbig.py.out    2025-07-27 13:03:13.618759975 +0100
@@ -17,4 +17,4 @@
 0x10111213 0x11121314 0x12131415
 0x13141516
 0x14151617
-0x15161718
+0x20012b54

FAILURE /home/root/mp/tests/results/micropython_viper_ptr16_store_boundary_intbig.py
--- /home/root/mp/tests/results/micropython_viper_ptr16_store_boundary_intbig.py.exp    2025-07-27 13:04:43.689570377 +0100
+++ /home/root/mp/tests/results/micropython_viper_ptr16_store_boundary_intbig.py.out    2025-07-27 13:04:43.689900357 +0100
@@ -17,4 +17,4 @@
 0x1213 0x1314 0x1415
 0x1516
 0x1617
-0x1718
+0x2ae2

FAILURE /home/root/mp/tests/results/micropython_viper_ptr8_store_boundary_intbig.py
--- /home/root/mp/tests/results/micropython_viper_ptr8_store_boundary_intbig.py.exp     2025-07-27 13:34:04.778117813 +0100
+++ /home/root/mp/tests/results/micropython_viper_ptr8_store_boundary_intbig.py.out     2025-07-27 13:34:04.778436804 +0100
@@ -17,4 +17,4 @@
 0x13 0x14 0x15
 0x16
 0x17
-0x18
+0x61
```

I prodded a bit further, and have the following simple repro of the problem:

```python
>>> b = bytearray(5000)
>>> @micropython.viper
... def test():
...     x = ptr8(b)
...     x[0x1000]=123
...
>>> test()
>>> b[4096]
17
>>> sum(b)
17
```

So maybe there's a problem with using R2 after all @agatti - it looks like the correct location always gets written, but with the wrong value? (Strangely, it *didn't* break my more complicated test case that I used as a first quick check. I must have got lucky.) I've left this as a draft for now while I stare at it a bit more!