### PR TITLE
py/asmthumb: Don't corrupt base register in large offset store.

### DIFF
--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -492,8 +492,10 @@ void asm_thumb_store_reg_reg_offset(asm_thumb_t *as, uint reg_src, uint reg_base
         asm_thumb_op32(as, (OP_LDR_STR_W_HI(operation_size, reg_base) | OP_STR_W), OP_LDR_STR_W_LO(reg_src, (offset << operation_size)));
     } else {
         // Must use the generic sequence
+        asm_thumb_op16(as, OP_PUSH_RLIST(1 << reg_base));
         asm_thumb_add_reg_reg_offset(as, reg_base, reg_base, offset - 31, operation_size);
         asm_thumb_op16(as, ((OP_LDR_STR_TABLE[operation_size] | OP_STR) << 11) | (31 << 6) | (reg_base << 3) | reg_src);
+        asm_thumb_op16(as, OP_POP_RLIST(1 << reg_base));
     }
 }
 

--- a/tests/micropython/viper_ptr16_store_boundary_intbig.py
+++ b/tests/micropython/viper_ptr16_store_boundary_intbig.py
@@ -3,7 +3,9 @@
 SET_TEMPLATE = """
 @micropython.viper
 def set{off}(dest: ptr16):
+    saved = dest
     dest[{off}] = {val}
+    assert int(saved) == int(dest)
 set{off}(buffer)
 print(hex(get_index(buffer, {off})))
 """
@@ -15,7 +17,9 @@ MASK = (1 << (8 * SIZE)) - 1
 
 @micropython.viper
 def set_index(dest: ptr16, i: int, val: uint):
+    saved = dest
     dest[i] = val
+    assert int(saved) == int(dest)
 
 
 def get_index(src, i):

--- a/tests/micropython/viper_ptr32_store_boundary_intbig.py
+++ b/tests/micropython/viper_ptr32_store_boundary_intbig.py
@@ -3,7 +3,9 @@
 SET_TEMPLATE = """
 @micropython.viper
 def set{off}(dest: ptr32):
+    saved = dest
     dest[{off}] = {val}
+    assert int(saved) == int(dest)
 set{off}(buffer)
 print(hex(get_index(buffer, {off})))
 """
@@ -15,7 +17,9 @@ MASK = (1 << (8 * SIZE)) - 1
 
 @micropython.viper
 def set_index(dest: ptr32, i: int, val: uint):
+    saved = dest
     dest[i] = val
+    assert int(saved) == int(dest)
 
 
 def get_index(src, i):

--- a/tests/micropython/viper_ptr8_store_boundary_intbig.py
+++ b/tests/micropython/viper_ptr8_store_boundary_intbig.py
@@ -3,7 +3,9 @@
 SET_TEMPLATE = """
 @micropython.viper
 def set{off}(dest: ptr8):
+    saved = dest
     dest[{off}] = {val}
+    assert int(saved) == int(dest)
 set{off}(buffer)
 print(hex(get_index(buffer, {off})))
 """
@@ -15,7 +17,9 @@ MASK = (1 << (8 * SIZE)) - 1
 
 @micropython.viper
 def set_index(dest: ptr8, i: int, val: uint):
+    saved = dest
     dest[i] = val
+    assert int(dest) == int(saved)
 
 
 def get_index(src: ptr8, i: int):


### PR DESCRIPTION
### Summary

On rp2, I discovered that viper stores offset from a register variable were clobbering that variable:

```python
@micropython.viper
def test():
  x = ptr8(ba)
  print(hex(uint(x)))
  x[0x1000] = 0
  # The register x has now been clobbered, incremented by 0x1000 - 31.
  # It gets corrupted only if the index/offset is >= 1 << 10.
  print(hex(uint(x)))
ba = bytearray(0x2000)
test()
```

@agatti kindly pointed me at `asm_thumb_store_reg_reg_offset()`. It turns out this modifies the base register when storing with a large offset which triggers the generic path. If a variable lives in that register, this corrupts it.

Fix this by saving the base register on the stack before modifying it. (I tried using REG_TEMP2 which would be faster but this turned out to collide with the generated code.)

### Testing

The existing viper ptr8, ptr16 and ptr32 tests all pass, and the second commit adds assertions to the viper store boundary tests to verify the base register is not corrupted during the store.