### PR TITLE
mpremote/mp_errno: Fix errno.ENOTBLK error on Windows.

### DIFF
--- a/tools/mpremote/mpremote/mp_errno.py
+++ b/tools/mpremote/mpremote/mp_errno.py
@@ -1,4 +1,5 @@
 import errno
+import platform
 
 # This table maps numeric values defined by `py/mperrno.h` to host errno code.
 MP_ERRNO_TABLE = {
@@ -16,7 +17,6 @@ MP_ERRNO_TABLE = {
     12: errno.ENOMEM,
     13: errno.EACCES,
     14: errno.EFAULT,
-    15: errno.ENOTBLK,
     16: errno.EBUSY,
     17: errno.EEXIST,
     18: errno.EXDEV,
@@ -51,3 +51,5 @@ MP_ERRNO_TABLE = {
     115: errno.EINPROGRESS,
     125: errno.ECANCELED,
 }
+if platform.system() != "Windows":
+    MP_ERRNO_TABLE[15] = errno.ENOTBLK


### PR DESCRIPTION
### Summary
not all errors defined in stdlib `errno` are available on Windows.
Specifically `errno.ENOTBLK` is not.
Not 100% sure about availability of all other codes across platforms either, so would be good if someone can confirm that MacOS has no problems either.


This was not caught in CI, as there is no CI , nor tests for mpremote on Windows.

closes: https://github.com/micropython/micropython/issues/17773

### Testing
Manual testing on Windows 11 and WSL2.

