### PR TITLE
mpremote: fix esp usb reset

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -40,6 +40,8 @@ from errno import EPERM
 from .console import VT_ENABLED
 from .transport import TransportError, TransportExecError, Transport
 
+VID_ESPRESSIF = 0x303A  # Espressif Incorporated
+
 
 class SerialTransport(Transport):
     fs_hook_mount = "/remote"  # MUST match the mount point in fs_hook_code
@@ -71,7 +73,10 @@ class SerialTransport(Transport):
                     self.serial = serial.Serial(**serial_kwargs)
                     self.serial.port = device
                     portinfo = list(serial.tools.list_ports.grep(device))  # type: ignore
-                    if portinfo and portinfo[0].manufacturer != "Microsoft":
+                    if portinfo and (
+                        getattr(portinfo[0], "vid", 0) == VID_ESPRESSIF
+                        or getattr(portinfo[0], "manufacturer", "") != "Microsoft"
+                    ):
                         # ESP8266/ESP32 boards use RTS/CTS for flashing and boot mode selection.
                         # DTR False: to avoid using the reset button will hang the MCU in bootloader mode
                         # RTS False: to prevent pulses on rts on serial.close() that would POWERON_RESET an ESPxx


### PR DESCRIPTION
### Summary

Detection of ESP-XX devices was based on just the names of the USB driver name.
and did not account for the switch of the newer ESP-xx devices to USB-CDC.
On Windows this caused unwanted/unneeded resets as the DTR/RTS signals are also used for automatic device reset over USB-CDC as reported by @crackwitz in https://github.com/micropython/micropython/issues/9659#issuecomment-3124704572.

This PR uses the Espressif registered VID : 0x303A to detect USB-CDC ports ,
to enable the same DTR/RTS settings as used on the UART-USB connection.

Also improved the robustness of the code using `getattr()`

Depends on : #17775

### Testing
Manual testing on Windows and WSL2

| device| platform| USB-CDC| UART|
|--------|--------|--------|--------|
| Win11 | ESP32-C3| ✅| ✅|
| WSL2-Ubuntu | ESP32-C3| ✅| ✅|
| Win11 | ESP32-C2| ✅ | n/a |
| WSL2-Ubuntu| ESP32-C2| ✅ | n/a |
| Win11 | rp2040| n/a |  ✅ | 
| Win11 | ESP32-S3| ✅| ✅|
| WSL2-Ubuntu | ESP32-S3| ✅| ✅|

### Trade-offs and Alternatives

Detection of the ESPxx devices via the USB-CDC VID is more deterministic than `getattr(portinfo[0], "manufacturer", "") != "Microsoft"`, and will cover most of not all Espressif boards.

One possible drawback is that if/when other board manufacturers register their own VIDs for devices powered by an ESP32 - and access over USB-CDC that they will be exposed to unexpected resets. 
