### PR TITLE
rp2: on RP2350 configure jmp pins as input if they are in isolation mode

### DIFF
--- a/docs/library/rp2.StateMachine.rst
+++ b/docs/library/rp2.StateMachine.rst
@@ -58,6 +58,11 @@ Methods
     - *pull_thresh* is the threshold in bits before auto-pull or conditional
       re-pulling is triggered.
 
+    Note: pins used for *in_base* need to be configured manually for input (or
+    otherwise) so that the PIO can see the desired signal (they could be input
+    pins, output pins, or connected to a different peripheral).  The *jmp_pin*
+    can also be configured manually, but by default will be an input pin.
+
 .. method:: StateMachine.active([value])
 
     Gets or sets whether the state machine is currently running.

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -683,8 +683,10 @@ static mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     }
 
     // Configure jmp pin, if needed.
+    int jmp_pin = -1;
     if (args[ARG_jmp_pin].u_obj != mp_const_none) {
-        sm_config_set_jmp_pin(&config, mp_hal_get_pin_obj(args[ARG_jmp_pin].u_obj));
+        jmp_pin = mp_hal_get_pin_obj(args[ARG_jmp_pin].u_obj);
+        sm_config_set_jmp_pin(&config, jmp_pin);
     }
 
     // Configure sideset pin, if needed.
@@ -716,6 +718,18 @@ static mp_obj_t rp2_state_machine_init_helper(const rp2_state_machine_obj_t *sel
     if (set_config.base >= 0) {
         asm_pio_init_gpio(self->pio, self->sm, &set_config);
     }
+    #if !PICO_RP2040
+    if (jmp_pin >= 0) {
+        // On RP2350 pins by default have their isolation enabled.  This means they will
+        // not work as input to a PIO without further configuration.  That's different to
+        // RP2040 where pins can work as PIO input from a reset.  To make RP2350 have
+        // similar behaviour as RP2040, configure the jmp pin for PIO use if it's isolation
+        // is enabled (which means it's probably unconfigured from reset).
+        if (pads_bank0_hw->io[jmp_pin] & PADS_BANK0_GPIO0_ISO_BITS) {
+            pio_gpio_init(self->pio, jmp_pin);
+        }
+    }
+    #endif
     if (sideset_config.base >= 0) {
         asm_pio_init_gpio(self->pio, self->sm, &sideset_config);
     }


### PR DESCRIPTION
### Summary

On RP2350, enable PIO jmp pins as input if they haven't already been configured.  This allows them to work as input pins to the PIO.  Otherwise the pin remains in isolation mode from reset and doesn't work as expected, in particular code that works on RP2040 does not work on RP2350.

Resolves issue #17047.

### Testing

Tested with the code in #17047.  Without the fix here the test fails (as described there).  With the fix, it passes.

### Trade-offs and Alternatives

The alternative would be to just document this.  But I think a little bit of code to help things work "out of the box" makes it easier for users.