### PR TITLE
py/mphal: Add header for size_t.

### DIFF
--- a/py/mphal.h
+++ b/py/mphal.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_PY_MPHAL_H
 
 #include <stdint.h>
+#include <stddef.h>
 #include "py/mpconfig.h"
 
 #ifdef MICROPY_MPHALPORT_H


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This adds `#include <stddef.h>` for definition of `size_t` to solve compilation issue encountered with NuttX integration:

```
py/mphal.h:59:50: error: unknown type name 'size_t'
   59 | mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len);
      |                                                  ^~~~~~
py/mphal.h:34:1: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'
```

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Checked with NuttX integration on QEMU riscv.
