### PR TITLE
Fix more operations that can return small ints

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -528,9 +528,9 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%f\n", mpz_as_float(&mpz));
 
         // convert a large integer value (stored in a mpz) to mp_uint_t and to ll;
-        mp_obj_t obj_bigint = mp_obj_new_int_from_uint((mp_uint_t)0xdeadbeef);
+        mp_obj_t obj_bigint = mp_obj_new_int_from_ull((unsigned long long)0xdeadbeef);
         mp_printf(&mp_plat_print, "%x\n", (int)mp_obj_get_uint(obj_bigint));
-        obj_bigint = mp_obj_new_int_from_ll(0xc0ffee777c0ffeell);
+        obj_bigint = mp_obj_new_bigint_from_ll(0xc0ffee777c0ffeell);
         long long value_ll = mp_obj_get_ll(obj_bigint);
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
 
@@ -542,7 +542,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
 
         // convert a smaller integer value to mp_uint_t and to ll
-        obj_bigint = mp_obj_new_int_from_uint(0xc0ffee);
+        obj_bigint = mp_obj_new_int_from_ull(0xc0ffeeull);
         mp_printf(&mp_plat_print, "%x\n", (int)mp_obj_get_uint(obj_bigint));
         value_ll = mp_obj_get_ll(obj_bigint);
         mp_printf(&mp_plat_print, "%x%08x\n", (uint32_t)(value_ll >> 32), (uint32_t)value_ll);
@@ -569,7 +569,7 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%d\n", (int)mp_obj_int_get_uint_checked(MP_OBJ_NEW_SMALL_INT(1)));
 
         // mp_obj_int_get_uint_checked with non-negative big-int
-        mp_printf(&mp_plat_print, "%d\n", (int)mp_obj_int_get_uint_checked(mp_obj_new_int_from_ll(2)));
+        mp_printf(&mp_plat_print, "%d\n", (int)mp_obj_int_get_uint_checked(mp_obj_new_bigint_from_ll(2)));
 
         // mp_obj_int_get_uint_checked with negative small-int (should raise exception)
         nlr_buf_t nlr;
@@ -582,7 +582,7 @@ static mp_obj_t extra_coverage(void) {
 
         // mp_obj_int_get_uint_checked with negative big-int (should raise exception)
         if (nlr_push(&nlr) == 0) {
-            mp_obj_int_get_uint_checked(mp_obj_new_int_from_ll(-2));
+            mp_obj_int_get_uint_checked(mp_obj_new_bigint_from_ll(-2));
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
@@ -854,12 +854,12 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_bool(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_bool(mp_const_none));
 
         // mp_obj_is_integer accepts ints and booleans
-        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_integer(mp_obj_new_int_from_ll(1)));
+        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_integer(mp_obj_new_bigint_from_ll(1)));
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(mp_const_true), mp_obj_is_integer(mp_const_false));
         mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_integer(mp_obj_new_str_from_cstr("1")), mp_obj_is_integer(mp_const_none));
 
         // mp_obj_is_int accepts small int and object ints
-        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_int(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_int(mp_obj_new_int_from_ll(1)));
+        mp_printf(&mp_plat_print, "%d %d\n", mp_obj_is_int(MP_OBJ_NEW_SMALL_INT(1)), mp_obj_is_int(mp_obj_new_bigint_from_ll(1)));
     }
 
     // Legacy stackctrl.h API, this has been replaced by cstack.h

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1658,6 +1658,7 @@ mp_float_t mpz_as_float(const mpz_t *i) {
 }
 #endif
 
+// assumes the value is nonzero (micropython always uses small ints for zero)
 // assumes enough space in str as calculated by mp_int_format_size
 // base must be between 2 and 32 inclusive
 // returns length of string, not including null byte
@@ -1666,20 +1667,11 @@ size_t mpz_as_str_inpl(const mpz_t *i, unsigned int base, const char *prefix, ch
     assert(2 <= base && base <= 32);
 
     size_t ilen = i->len;
+    assert(ilen);
 
     int n_comma = (base == 10) ? 3 : 4;
 
     char *s = str;
-    if (ilen == 0) {
-        if (prefix) {
-            while (*prefix) {
-                *s++ = *prefix++;
-            }
-        }
-        *s++ = '0';
-        *s = '\0';
-        return s - str;
-    }
 
     // make a copy of mpz digits, so we can do the div/mod calculation
     mpz_dig_t *dig = m_new(mpz_dig_t, ilen);

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1658,15 +1658,6 @@ mp_float_t mpz_as_float(const mpz_t *i) {
 }
 #endif
 
-#if 0
-this function is unused
-char *mpz_as_str(const mpz_t *i, unsigned int base) {
-    char *s = m_new(char, mp_int_format_size(mpz_max_num_bits(i), base, NULL, '\0'));
-    mpz_as_str_inpl(i, base, NULL, 'a', '\0', s);
-    return s;
-}
-#endif
-
 // assumes enough space in str as calculated by mp_int_format_size
 // base must be between 2 and 32 inclusive
 // returns length of string, not including null byte

--- a/py/obj.h
+++ b/py/obj.h
@@ -996,8 +996,9 @@ mp_obj_t mp_obj_new_cell(mp_obj_t obj);
 mp_obj_t mp_obj_new_int(mp_int_t value);
 mp_obj_t mp_obj_new_int_from_uint(mp_uint_t value);
 mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, unsigned int base);
-mp_obj_t mp_obj_new_int_from_ll(long long val); // this must return a multi-precision integer object (or raise an overflow exception)
-mp_obj_t mp_obj_new_int_from_ull(unsigned long long val); // this must return a multi-precision integer object (or raise an overflow exception)
+mp_obj_t mp_obj_new_int_from_ll(long long val); // returns a small int if value fits
+mp_obj_t mp_obj_new_int_from_ull(unsigned long long val); // returns a small int if value fits
+mp_obj_t mp_obj_new_bigint_from_ll(long long val); // this must return a multi-precision integer object (or raise an overflow exception)
 mp_obj_t mp_obj_new_str(const char *data, size_t len); // will check utf-8 (raises UnicodeError)
 mp_obj_t mp_obj_new_str_from_cstr(const char *str); // // accepts null-terminated string, will check utf-8 (raises UnicodeError)
 mp_obj_t mp_obj_new_str_via_qstr(const char *data, size_t len); // input data must be valid utf-8

--- a/py/objint.c
+++ b/py/objint.c
@@ -332,7 +332,13 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
 
 // This is called only with strings whose value doesn't fit in SMALL_INT
 mp_obj_t mp_obj_new_int_from_str_len(const char **str, size_t len, bool neg, unsigned int base) {
-    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("long int not supported in this build"));
+    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("small int overflow"));
+    return mp_const_none;
+}
+
+// This is called when an integer larger than a SMALL_INT is needed (although val might still fit in a SMALL_INT)
+mp_obj_t mp_obj_new_bigint_from_ll(long long val) {
+    mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("small int overflow"));
     return mp_const_none;
 }
 

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -298,14 +298,18 @@ mp_obj_t mp_obj_new_int_from_uint(mp_uint_t value) {
     return mp_obj_new_int_from_ll(value);
 }
 
+mp_obj_t mp_obj_new_bigint_from_ll(long long val) {
+    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
+    o->val = val;
+    return MP_OBJ_FROM_PTR(o);
+}
+
 mp_obj_t mp_obj_new_int_from_ll(long long val) {
     if ((long long)(mp_int_t)val == val && MP_SMALL_INT_FITS(val)) {
         return MP_OBJ_NEW_SMALL_INT(val);
     }
 
-    mp_obj_int_t *o = mp_obj_malloc(mp_obj_int_t, &mp_type_int);
-    o->val = val;
-    return MP_OBJ_FROM_PTR(o);
+    return mp_obj_new_bigint_from_ll(val);
 }
 
 mp_obj_t mp_obj_new_int_from_ull(unsigned long long val) {

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -316,7 +316,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
                 }
                 mp_obj_int_t *quo = mp_obj_int_new_mpz();
                 mpz_divmod_inpl(&quo->mpz, &res->mpz, zlhs, zrhs);
-                mp_obj_t tuple[2] = {MP_OBJ_FROM_PTR(quo), MP_OBJ_FROM_PTR(res)};
+                mp_obj_t tuple[2] = {mp_int_maybe_narrow(quo), mp_int_maybe_narrow(res)};
                 return mp_obj_new_tuple(2, tuple);
             }
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -456,7 +456,7 @@ mp_obj_t MICROPY_WRAP_MP_BINARY_OP(mp_binary_op)(mp_binary_op_t op, mp_obj_t lhs
                                || lhs_val > (MP_SMALL_INT_MAX >> rhs_val)
                                || lhs_val < (MP_SMALL_INT_MIN >> rhs_val)) {
                         // left-shift will overflow, so use higher precision integer
-                        lhs = mp_obj_new_int_from_ll(lhs_val);
+                        lhs = mp_obj_new_bigint_from_ll(lhs_val);
                         goto generic_binary_op;
                     } else {
                         // use standard precision
@@ -492,7 +492,7 @@ mp_obj_t MICROPY_WRAP_MP_BINARY_OP(mp_binary_op)(mp_binary_op_t op, mp_obj_t lhs
                     mp_int_t int_res;
                     if (mp_mul_mp_int_t_overflow(lhs_val, rhs_val, &int_res)) {
                         // use higher precision
-                        lhs = mp_obj_new_int_from_ll(lhs_val);
+                        lhs = mp_obj_new_bigint_from_ll(lhs_val);
                         goto generic_binary_op;
                     } else {
                         // use standard precision
@@ -558,7 +558,7 @@ mp_obj_t MICROPY_WRAP_MP_BINARY_OP(mp_binary_op)(mp_binary_op_t op, mp_obj_t lhs
 
                 power_overflow:
                     // use higher precision
-                    lhs = mp_obj_new_int_from_ll(MP_OBJ_SMALL_INT_VALUE(lhs));
+                    lhs = mp_obj_new_bigint_from_ll(MP_OBJ_SMALL_INT_VALUE(lhs));
                     goto generic_binary_op;
 
                 case MP_BINARY_OP_DIVMOD: {
@@ -588,7 +588,7 @@ mp_obj_t MICROPY_WRAP_MP_BINARY_OP(mp_binary_op)(mp_binary_op_t op, mp_obj_t lhs
             if (MP_SMALL_INT_FITS(lhs_val)) {
                 return MP_OBJ_NEW_SMALL_INT(lhs_val);
             } else {
-                return mp_obj_new_int_from_ll(lhs_val);
+                return mp_obj_new_bigint_from_ll(lhs_val);
             }
         #if MICROPY_PY_BUILTINS_FLOAT
         } else if (mp_obj_is_float(rhs)) {

--- a/tests/micropython/smallint_intbig.py
+++ b/tests/micropython/smallint_intbig.py
@@ -1,0 +1,16 @@
+import struct
+import array
+
+zero = 0
+i = struct.unpack("Q", b"\0" * 8)[0]
+print(i is zero)
+i = struct.unpack("q", b"\0" * 8)[0]
+print(i is zero)
+
+i = array.array("Q", [0])[0]
+print(i is zero)
+i = array.array("q", [0])[0]
+print(i is zero)
+
+i = pow(3, 3, 3)
+print(i is zero)


### PR DESCRIPTION
### Summary

#17730 identified some code paths that could still return long ints when small ints would suffice. Fix them.

### Testing

I wrote a new test based on sites that called new_int_from_{u,}ll, including the case I'd noticed of pow3 (already reported in #9531 as well).

### Trade-offs and Alternatives

I haven't seen the code size change summary yet, but this is likely to increase code size. I'm open to suggestions about how to reduce the increase.

Making the new `long_from` functions always return longs, and changing the existing `new_int_from` functions to return ints when possible is just one alternative. Another alternative would be to add calls to `mp_int_maybe_narrow` in paths that used `new_int_from`, but this seemed like the worse alternative, with more added code.