### PR TITLE
nrf/drivers/bluetooth: Change soft-device download URL to self hosted.

### DIFF
--- a/ports/nrf/drivers/bluetooth/download_ble_stack.sh
+++ b/ports/nrf/drivers/bluetooth/download_ble_stack.sh
@@ -10,12 +10,9 @@ function download_s110_nrf51_8_0_0
 
     mkdir -p $1/s110_nrf51_8.0.0
     cd $1/s110_nrf51_8.0.0
-    wget --post-data="fileName=DeviceDownload&ids=DBBEB2467E4A4EBCB791C2E7BE3FC7A8" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
-    mv MedialibraryZipDownload2 temp.zip
-    unzip -u temp.zip
+    wget https://micropython.org/resources/nrf-soft-device/s110nrf51800.zip
     unzip -u s110nrf51800.zip
     rm s110nrf51800.zip
-    rm temp.zip
     cd -
 }
 
@@ -29,12 +26,9 @@ function download_s132_nrf52_6_1_1
 
     mkdir -p $1/s132_nrf52_6.1.1
     cd $1/s132_nrf52_6.1.1
-    wget --post-data="fileName=DeviceDownload&ids=3AB3E86666FE4361A4A3B7E0D1CBB9B9" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
-    mv MedialibraryZipDownload2 temp.zip
-    unzip -u temp.zip
+    wget https://micropython.org/resources/nrf-soft-device/s132nrf52611.zip
     unzip -u s132nrf52611.zip
     rm s132nrf52611.zip
-    rm temp.zip
     cd -
 }
 
@@ -48,12 +42,9 @@ function download_s140_nrf52_6_1_1
 
     mkdir -p $1/s140_nrf52_6.1.1
     cd $1/s140_nrf52_6.1.1
-    wget --post-data="fileName=DeviceDownload&ids=CE89BA7633C540AFA48AB88E934DBF05" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
-    mv MedialibraryZipDownload2 temp.zip
-    unzip -u temp.zip
+    wget https://micropython.org/resources/nrf-soft-device/s140nrf52611.zip
     unzip -u s140nrf52611.zip
     rm s140nrf52611.zip
-    rm temp.zip
     cd -
 }
 
@@ -67,12 +58,9 @@ function download_s140_nrf52_7_3_0
 
     mkdir -p $1/s140_nrf52_7.3.0
     cd $1/s140_nrf52_7.3.0
-    wget --post-data="fileName=DeviceDownload&ids=59452FDD13BA46EEAD0810A57359F294" https://www.nordicsemi.com/api/sitecore/Products/MedialibraryZipDownload2
-    mv MedialibraryZipDownload2 temp.zip
-    unzip -u temp.zip
+    wget https://micropython.org/resources/nrf-soft-device/s140_nrf52_7.3.0.zip
     unzip -u s140_nrf52_7.3.0.zip
     rm s140_nrf52_7.3.0.zip
-    rm temp.zip
     cd -
 }
 


### PR DESCRIPTION
### Summary

The existing URLs have started to return a HTTP 403, breaking CI, among other things.  The simplest way around this is to host the files at micropython.org, and point to them from the download script.

The soft-device files have been retrieved from:
- https://www.nordicsemi.com/Products/Development-software/s110/download
- https://www.nordicsemi.com/Products/Development-software/s132/download
- https://www.nordicsemi.com/Products/Development-software/s140/download

### Testing

Tested locally.  Will also be tested by CI.

### Trade-offs and Alternatives

There may be a URL maintained by Nordic (eg on GitHub) for these files, but it seems the most robust thing to do is self-host them.