### PR TITLE
mpremote: Improve ESPxx board detection and user configuration. 

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -42,6 +42,7 @@ from .commands import (
 )
 from .mip import do_mip
 from .repl import do_repl
+from .transport_serial import add_user_esp_detection
 
 _PROG = "mpremote"
 
@@ -560,6 +561,7 @@ class State:
 def main():
     config = load_user_config()
     prepare_command_expansions(config)
+    add_user_esp_detection(config)
 
     remaining_args = sys.argv[1:]
     state = State()


### PR DESCRIPTION
### Summary

With modern ESPxxx boards switching to native USB , and less reliance on 3rd party UART drivers I think it is a good time to implement a better detection if a device is likely to have an MCU of the ESP32 or ESP8266 femilies

This PR adds: 
- a list of VIDs-PIDs that require "ESP-Handling" on Windows.
- this list can be extended through the mpremote configuration file 
when connecting to a decices port on Windows - mpremote can check if it needs ESP-Handling - and then act accordingly
if / when needed new vids/pids can be added to the default list via PRs, and included in the next release
personal / interim changes can be done by editing the mpremote config file.

In this draft the detection is based on a list of 4-tuples, 
Current implementation only used the VID and PID to identify , 
the vendor could be used if if there is a need to extend matches.

The list of VIDs and PIDs has been gathered through 
- inspection and testing of some devices
- documentation research on the internet 

**user configuration:**

the user configuration allows to **add** additional PID/VIDs.
currently overriding the built-in list is not implemented 

```py 
#config.py - mpremote configuration file 

esp_detection = [
    # chipset , VID, PID, Vendor
    ("CP2102 / CP2104", 0x10C4, 0xEA60, "Silicon Labs"),
    ( "foobar" , 0xFFFFF, 0xFFFFF, "Unknown")
]
```

### Testing

Manual testing can be done by attaching devices and running the following script:

```py
from mpremote.transport_serial import is_esp_device
import serial.tools.list_ports

ports = serial.tools.list_ports.comports()
for port in ports:
    if port.vid is None:
        continue
    print(f"{port.device} {port.vid:04x}:{port.pid:04x} {port.description} - {"ESP device" if is_esp_device(port.device) else "Non-ESP device"}")
```

Positive identification of: 

- [x] Espressif USB-CDC   
    - COM8 303a:1001 USB Serial Device (COM8) - ESP device. - ESP32-C3
    - COM18 303a:1001 USB Serial Device (COM18) - ESP32-C3 Mini device
    - COM21 303a:4001 USB Serial Device (COM21) - ESP device - ESP32-S3
    - COM14 303a:4001 USB Serial Device (COM14) - ESP device - ESP32-S2
- [x] CP2102 / CP2104 
  - COM17 4292:60000 Silicon Labs CP210x USB to UART Bridge (COM17) - ESP32 device
- [x] CP210x 
  - COM9 10c4:ea60 Silicon Labs CP210x USB to UART Bridge (COM9) - ESP8266 device
  - COM23 10c4:ea60 Silicon Labs CP210x USB to UART Bridge (COM23) - ESP32 device
- [x] CH340K - COM15 1a86:7522 USB-SERIAL CH340K (COM15) - ESP-C3 UART device
- [ ] FT232R / FTDI - 
- [x] CH340 
  - COM5 1a86:7523 USB-SERIAL CH340 (COM5) - ESP8266 device
  - COM5 1a86:7523 USB-SERIAL CH340 (COM5) - ESP8266 device 
- [ ] CH341 - 
- [ ] Prolific PL2303 - 
- [ ] Microchip MCP2200 - 
- [ ] CH9102 / CH9102F - 
- [ ] Pycom -

not detected as ESPxx device.

- [x] rpi pico/picow
- [x] rpi pico2 
  - COM26 2e8a:0005 USB Serial Device (COM26) - Non-ESP device
- [x] pimorino pico lipo 
- [x] PYBDv1.1 
   - COM24 f055:9800 USB Serial Device (COM24) - Non-ESP device
- [x] NRF5240 
  - COM25 239a:8029 USB Serial Device (COM25) - Non-ESP device 
- [ ] Micro:bit v1
  - COM27 0d28:0204 USB Serial Device (COM27) - Non-ESP device
- [ ] to test more 

### Trade-offs and Alternatives

**VID/PID versus Vendor name**
Up to now the determination was done just based on the Vendor name.
See https://github.com/micropython/micropython/issues/9659

**Cherry-picking**
This PR contains a few cherry-picked commits from other PRs that are required to allow this PR to work.
They should be automatically dropped when this PR is rebased before merging.


Signed-off-by: Jos Verlinde <Jos_Verlinde@hotmail.com>
