### PR TITLE
tests: remove working cpydiff for float rounding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     paths:
       - docs/**
+      - py/**
+      - tests/cpydiff/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,5 +21,7 @@ jobs:
     - uses: actions/setup-python@v5
     - name: Install Python packages
       run: pip install -r docs/requirements.txt
+    - name: Build unix port
+      run: source tools/ci.sh && ci_unix_build_helper
     - name: Build docs
       run: make -C docs/ html

--- a/tests/cpydiff/types_float_rounding.py
+++ b/tests/cpydiff/types_float_rounding.py
@@ -1,8 +1,0 @@
-"""
-categories: Types,float
-description: uPy and CPython outputs formats may differ
-cause: Unknown
-workaround: Unknown
-"""
-
-print("%.1g" % -9.9)


### PR DESCRIPTION
### Summary

In #17444 float formatting was improved, which made `tests/cpydiff/types_float_rounding.py` now behave the same in MicroPython as in CPython.

But the CI did not pick this up.  So tweak the workflow and delete that cpydiff test.

### Testing

To be tested by CI.