### PR TITLE
github/workflows: Add a CI job to build ESP32-C2 and ESP32-C6 boards, and disable I2CTarget on ESP32C6

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -25,6 +25,7 @@ jobs:
         ci_func:  # names are functions in ci.sh
           - esp32_build_cmod_spiram_s2
           - esp32_build_s3_c3
+          - esp32_build_c2_c6
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -140,7 +140,8 @@
 #define MICROPY_PY_MACHINE_I2C              (1)
 #define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 // I2C target hardware is limited on ESP32 (eg read event comes after the read) so we only support newer SoCs.
-#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32)
+// ESP32C6 does not have enough flash space so also disable it on that SoC.
+#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32 && !CONFIG_IDF_TARGET_ESP32C6)
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/esp32/machine_i2c_target.c"
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX   (2)
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -214,6 +214,13 @@ function ci_esp32_build_s3_c3 {
     make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C3
 }
 
+function ci_esp32_build_c2_c6 {
+    ci_esp32_build_common
+
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C2
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C6
+}
+
 ########################################################################################
 # ports/esp8266
 


### PR DESCRIPTION
### Summary

Build C2 and C6 in CI so that all six supported SoCs are built by CI.

We can see that the C6 build fails because it runs out of flash.  Need to disable I2CTarget (at least for now, can try to reclaim some flash later on).

### Testing

Tested by CI.