### PR TITLE
py: Add MICROPY_PY_STRUCT_UNSAFE_TYPECODES.

### DIFF
--- a/py/binary.c
+++ b/py/binary.c
@@ -69,11 +69,13 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
                 case 'Q':
                     size = 8;
                     break;
+                #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
                 case 'P':
                 case 'O':
                 case 'S':
                     size = sizeof(void *);
                     break;
+                #endif
                 case 'e':
                     size = 2;
                     break;
@@ -119,12 +121,14 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
                     align = alignof(long long);
                     size = sizeof(long long);
                     break;
+                #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
                 case 'P':
                 case 'O':
                 case 'S':
                     align = alignof(void *);
                     size = sizeof(void *);
                     break;
+                #endif
                 case 'e':
                     align = 2;
                     size = 2;
@@ -280,12 +284,14 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
         case 'd':
             return mp_obj_new_float_from_d(((double *)p)[index]);
         #endif
-        // Extension to CPython: array of objects
+            // Extension to CPython: array of objects
+        #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
         case 'O':
             return ((mp_obj_t *)p)[index];
         // Extension to CPython: array of pointers
         case 'P':
             return mp_obj_new_int((mp_int_t)(uintptr_t)((void **)p)[index]);
+        #endif
     }
     return MP_OBJ_NEW_SMALL_INT(val);
 }
@@ -334,9 +340,9 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
 
     long long val = mp_binary_get_int(size, is_signed(val_type), (struct_type == '>'), p);
 
-    if (val_type == 'O') {
+    if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == 'O') {
         return (mp_obj_t)(mp_uint_t)val;
-    } else if (val_type == 'S') {
+    } else if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == 'S') {
         const char *s_val = (const char *)(uintptr_t)(mp_uint_t)val;
         return mp_obj_new_str_from_cstr(s_val);
     #if MICROPY_PY_BUILTINS_FLOAT
@@ -407,9 +413,11 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
 
     mp_uint_t val;
     switch (val_type) {
+        #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
         case 'O':
             val = (mp_uint_t)val_in;
             break;
+        #endif
         #if MICROPY_PY_BUILTINS_FLOAT
         case 'e':
             val = mp_encode_half_float(mp_obj_get_float_to_f(val_in));
@@ -474,10 +482,12 @@ void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_
             ((double *)p)[index] = mp_obj_get_float_to_d(val_in);
             break;
         #endif
+        #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
         // Extension to CPython: array of objects
         case 'O':
             ((mp_obj_t *)p)[index] = val_in;
             break;
+        #endif
         default:
             #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
             if (mp_obj_is_exact_type(val_in, &mp_type_int)) {
@@ -534,9 +544,11 @@ void mp_binary_set_val_array_from_int(char typecode, void *p, size_t index, mp_i
             ((double *)p)[index] = (double)val;
             break;
         #endif
-        // Extension to CPython: array of pointers
+            // Extension to CPython: array of pointers
+        #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
         case 'P':
             ((void **)p)[index] = (void *)(uintptr_t)val;
             break;
+        #endif
     }
 }

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1601,6 +1601,13 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_STRUCT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
 #endif
 
+// Whether struct module provides unsafe and non-standard typecodes O, P, S.
+// These typecodes are not in CPython and can cause crashes by accessing arbitrary
+// memory.
+#ifndef MICROPY_PY_STRUCT_UNSAFE_TYPECODES
+#define MICROPY_PY_STRUCT_UNSAFE_TYPECODES (1)
+#endif
+
 // Whether to provide "sys" module
 #ifndef MICROPY_PY_SYS
 #define MICROPY_PY_SYS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)


### PR DESCRIPTION
### Summary

This adds a compile-time flag to disable some "unsafe" and non-standard typecodes in struct, array & related modules.

The typecodes "P", "O", and "S" can allow unchecked access to arbitrary memory. This is undesired in the context of fuzzing, so it's useful to specifically disable these codes.

The typecodes are also not part of CPython, and as such CircuitPython has disabled them for years.

This item is from a list prepared by @dhalbert and reviewed by @jimmo about a year ago of CircuitPython changes that might be worth offering upstream to MicroPython. The implementation is not taken from CircuitPython because I reimplemented it in the context of fuzzing instead of finding the right commit to cherry-pick.

### Testing

Locally I have tested this in builds intended to run under a fuzzer. No CI build tests with this setting changed from its default (which is enabled, leading to no behavioral change compared to the status quo)