### PR TITLE
renesas-ra/mpconfigport: Enable MICROPY_TIME_SUPPORT_Y1969_AND_BEFORE.

### DIFF
--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -99,6 +99,7 @@
 #ifndef MICROPY_FLOAT_IMPL // can be configured by each board via mpconfigboard.mk
 #define MICROPY_FLOAT_IMPL          (MICROPY_FLOAT_IMPL_FLOAT)
 #endif
+#define MICROPY_TIME_SUPPORT_Y1969_AND_BEFORE (1)
 #define MICROPY_USE_INTERNAL_ERRNO  (1)
 #define MICROPY_SCHEDULER_DEPTH     (8)
 #define MICROPY_SCHEDULER_STATIC_NODES (1)


### PR DESCRIPTION
### Summary

This setting was missed in df05caea6c6437a8b4756ec502a5e6210f4b6256.  It's needed for this port to pass its `tests/ports/renesas-ra/modtime.py` test.

### Testing

Tested on EK_RA6M2, running the test suite.  `tests/ports/renesas-ra/modtime.py` now passes.