### PR TITLE
docs/esp32: Use new esptool syntax.

### DIFF
--- a/docs/esp8266/tutorial/intro.rst
+++ b/docs/esp8266/tutorial/intro.rst
@@ -97,11 +97,11 @@ to the documentation for your board to see its recommendations.
 
 Using esptool.py you can erase the flash with the command::
 
-    esptool.py --port /dev/ttyUSB0 erase_flash
+    esptool.py --port /dev/ttyUSB0 erase-flash
 
 And then deploy the new firmware using::
 
-    esptool.py --port /dev/ttyUSB0 --baud 460800 write_flash --flash_size=detect 0 esp8266-20170108-v1.8.7.bin
+    esptool.py --port /dev/ttyUSB0 --baud 460800 write-flash --flash-size=detect 0 esp8266-20170108-v1.8.7.bin
 
 You might need to change the "port" setting to something else relevant for your
 PC.  You may also need to reduce the baudrate if you get errors when flashing
@@ -114,7 +114,7 @@ a NodeMCU board) you may need to manually set a compatible
 You'd usually pick the fastest option that is compatible with your device, but
 the ``-fm dout`` option (the slowest option) should have the best compatibility::
 
-    esptool.py --port /dev/ttyUSB0 --baud 460800 write_flash --flash_size=detect -fm dout 0 esp8266-20170108-v1.8.7.bin
+    esptool.py --port /dev/ttyUSB0 --baud 460800 write-flash --flash-size=detect -fm dout 0 esp8266-20170108-v1.8.7.bin
 
 If the above commands run without error then MicroPython should be installed on
 your board!
@@ -178,12 +178,12 @@ after it, here are troubleshooting recommendations:
 
     pip install esptool==1.0.1
 
-  This version doesn't support ``--flash_size=detect`` option, so you will
+  This version doesn't support ``--flash-size=detect`` option, so you will
   need to specify FlashROM size explicitly (in megabits). It also requires
   Python 2.7, so you may need to use ``pip2`` instead of ``pip`` in the
   command above.
 
-* The ``--flash_size`` option in the commands above is mandatory. Omitting
+* The ``--flash-size`` option in the commands above is mandatory. Omitting
   it will lead to a corrupted firmware.
 
 * To catch incorrect flash content (e.g. from a defective sector on a chip),

--- a/ports/esp32/boards/deploy.md
+++ b/ports/esp32/boards/deploy.md
@@ -29,7 +29,7 @@ esptool.py --port PORTNAME erase_flash
 Then deploy the firmware to the board, starting at address {deploy_options[flash_offset]}:
 
 ```bash
-esptool.py --baud 460800 write_flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
+esptool.py --baud 460800 write-flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
 ```
 
 Replace `ESP32_BOARD_NAME-DATE-VERSION.bin` with the `.bin` file downloaded from this page.
@@ -38,7 +38,7 @@ As above, if `esptool.py` can't automatically detect the serial port
 then you can pass it explicitly on the command line instead. For example:
 
 ```bash
-esptool.py --port PORTNAME --baud 460800 write_flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
+esptool.py --port PORTNAME --baud 460800 write-flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
 ```
 
 ### Troubleshooting

--- a/ports/esp32/boards/deploy_nativeusb.md
+++ b/ports/esp32/boards/deploy_nativeusb.md
@@ -29,7 +29,7 @@ esptool.py --port PORTNAME erase_flash
 Then deploy the firmware to the board, starting at address {deploy_options[flash_offset]}:
 
 ```bash
-esptool.py write_flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
+esptool.py write-flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
 ```
 
 Replace `ESP32_BOARD_NAME-DATE-VERSION.bin` with the `.bin` file downloaded from this page.
@@ -38,7 +38,7 @@ As above, if `esptool.py` can't automatically detect the serial port
 then you can pass it explicitly on the command line instead. For example:
 
 ```bash
-esptool.py --port PORTNAME write_flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
+esptool.py --port PORTNAME write-flash {deploy_options[flash_offset]} ESP32_BOARD_NAME-DATE-VERSION.bin
 ```
 
 ### Troubleshooting

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -199,11 +199,11 @@ FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
 
 deploy: $(FWBIN)
 	$(ECHO) "Writing $< to the board"
-	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write-flash --verify --flash-size=$(FLASH_SIZE) --flash-mode=$(FLASH_MODE) 0 $<
 
 erase:
 	$(ECHO) "Erase flash"
-	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) erase_flash
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) erase-flash
 
 reset:
 	echo -e "\r\nimport machine; machine.reset()\r\n" >$(PORT)

--- a/ports/esp8266/README.md
+++ b/ports/esp8266/README.md
@@ -126,7 +126,7 @@ If you install MicroPython to your module for the first time, or after
 installing any other firmware, you should erase flash completely:
 
 ```bash
-$ esptool.py --port /dev/ttyXXX erase_flash
+$ esptool.py --port /dev/ttyXXX erase-flash
 ```
 
 Erasing the flash is also useful as a troubleshooting measure, if a module doesn't


### PR DESCRIPTION
### Summary

This updates references `esptool` arguments to use kebab-case (`write-flash`) instead of snake_case (`write_flash`). The latter seems deprecated and shows warnings.

```bash
$ esptool write_flash
Warning: Deprecated: Command 'write_flash' is deprecated. Use 'write-flash' instead.
esptool v5.0.1
```
