### PR TITLE
py/makeversionhdr.py: Always abbreviate Git hashes to same length.

### DIFF
--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -31,7 +31,16 @@ def get_version_info_from_git(repo_path):
     # Note: git describe doesn't work if no tag is available
     try:
         git_tag = subprocess.check_output(
-            ["git", "describe", "--tags", "--dirty", "--always", "--match", "v[1-9].*"],
+            [
+                "git",
+                "describe",
+                "--tags",
+                "--dirty",
+                "--always",
+                "--match",
+                "v[1-9].*",
+                "--abbrev=10",
+            ],
             cwd=repo_path,
             stderr=subprocess.STDOUT,
             universal_newlines=True,


### PR DESCRIPTION
### Summary

The Git hash is embedded in the version number. The hash is abbreviated by Git. This commit changes the length of the Git hash abbreviation to a fixed number, so that the length of the version string no longer varies based on external factors.

Made this change because builds of the same MicroPython commit on multiple machines were sometimes giving a version string with different lengths. This change may also help the code size report to be more consistent, because it will less often be impacted by random changes in the version string length, at the cost of *always* being a few bytes longer.

### Testing

By default Git chooses the length "based on the approximate number of packed objects in your repository" ([man page](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreabbrev)). This was causing the version string length to be unstable depending on how big your local repository is.

At the moment of writing, the `master` branch on GitHub contains 17463 commits. Based on the statistics from my own repository, I set the value to 10, which is one higher than the highest value I saw required for a unique commit abbreviation in my local repository checkout:

```sh
$ git rev-list --all | wc -l
38059
$ git rev-list --all | xargs -P0 -I{} sh -c 'git rev-parse --short=4 {} | tr -cd 0-9a-f | wc -m' | sort -n | uniq -c
    345 4
  28172 5
   8855 6
    652 7
     33 8
      2 9
```

### Trade-offs and Alternatives

Alternative is to not do this. Then we don't get the consistency benefits, but will keep semi-randomly saving a few bytes for years to come (until the default gets increased by the Git heuristic).

Note that Git will still use more characters if it required to make the hash unique. So all this setting does is increase the minimum slightly; Git will still use a longer hash if it already knows about another commit with the same abbreviation.

We can always safely increase this number later should the need arise.

Note: Presumably the users with the largest repositories are the core maintainers, so perhaps they could check the statistics for their repository and report if they think a length of 10 is the right choice.