### PR TITLE
py/misc: Add explicit dependency on py/mpconfig.h.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_PY_MISC_H
 #define MICROPY_INCLUDED_PY_MISC_H
 
+#include "py/mpconfig.h"
+
 // a mini library of useful types and functions
 
 /** types *******************************************************/


### PR DESCRIPTION
### Summary

Macros in misc.h depend on values defined by including mpconfig.h (i.e. the checks for `MICROPY_ROM_TEXT_COMPRESSION`)

This PR makes the relationship explicit. Noticed while trying to restructure #17735.

*This work was funded through GitHub Sponsors.*