### PR TITLE
esp32: Fix UART rxidle and machine.Timer on ESP32-C2,C6

### DIFF
--- a/ports/esp32/machine_timer.h
+++ b/ports/esp32/machine_timer.h
@@ -34,13 +34,6 @@
 #include "hal/timer_ll.h"
 #include "soc/timer_periph.h"
 
-#define TIMER_DIVIDER  8
-
-// TIMER_BASE_CLK is normally 80MHz. TIMER_DIVIDER ought to divide this exactly
-#define TIMER_SCALE    (APB_CLK_FREQ / TIMER_DIVIDER)
-
-#define TIMER_FLAGS    0
-
 typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
 
@@ -63,5 +56,7 @@ typedef struct _machine_timer_obj_t {
 machine_timer_obj_t *machine_timer_create(mp_uint_t timer);
 void machine_timer_enable(machine_timer_obj_t *self);
 void machine_timer_disable(machine_timer_obj_t *self);
+
+uint32_t machine_timer_freq_hz(void);
 
 #endif // MICROPY_INCLUDED_ESP32_MACHINE_TIMER_H

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -58,7 +58,7 @@
 #define UART_IRQ_RXIDLE (0x1000)
 #define UART_IRQ_BREAK (1 << UART_BREAK)
 #define MP_UART_ALLOWED_FLAGS (UART_IRQ_RX | UART_IRQ_RXIDLE | UART_IRQ_BREAK)
-#define RXIDLE_TIMER_MIN (5000)  // 500 us
+#define RXIDLE_TIMER_MIN (machine_timer_freq_hz() * 5 / 10000) // 500us minimum rxidle time
 #define UART_QUEUE_SIZE (3)
 
 enum {
@@ -535,7 +535,7 @@ static void uart_irq_configure_timer(machine_uart_obj_t *self, mp_uint_t trigger
         self->mp_irq_obj->ishard = false;
         uint32_t baudrate;
         uart_get_baudrate(self->uart_num, &baudrate);
-        mp_int_t period = TIMER_SCALE * 20 / baudrate + 1;
+        mp_int_t period = machine_timer_freq_hz() * 20 / baudrate + 1;
         if (period < RXIDLE_TIMER_MIN) {
             period = RXIDLE_TIMER_MIN;
         }


### PR DESCRIPTION
### Summary

* Fixes a regression in ESP32-C6 when updating to IDF v5.4.1 - the 80MHz PLL is no longer enabled by default, so the RXIDLE UART interrupt never fires. Found via `tests/extmod_hardware/machine_uart_irq_rxidle.py`.
* Adds a related fix, which is that the ESP32 `machine.Timer` implementation assumed the default timer source clock was the APB clock but it's a different clock on some chips, leading to incorrect timer periods (ESP32-C2 used 26MHz but should be 40MHz, ESP32-C6 used 40MHz but should be 80MHz).

### Testing

* Ran the `extmod_hardware/machine_uart_*.py` tests on ESP32-C2,C3,C6,S2 and original. All passing now.
* Ran a homemade periodic 1 second `machine.Timer` test on ESP32-C2,C6 and S2. Verified incorrect tick period on C2 and C6 that is fixed with this PR. Will submit a proper unit test for this, later.

(Note: Some of these tests were run on the first version of this PR. I re-ran the latest version on C2, C6 and original ESP32.)

### Trade-offs and Alternatives

* Calling `esp_clk_tree_src_get_freq_hz()` to get a constant clock frequency seems inelegant compared to calculating it at compile time, but this isn't called very often (initially I thought it was being called from the ISR, which made it seem worse, but it's not!)

*This work was funded through GitHub sponsors*