### PR TITLE
docs/library/os: Document dupterm_notify function.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,7 @@ Building the documentation locally
 If you're making changes to the documentation, you may want to build the
 documentation locally so that you can preview your changes.
 
-Install Sphinx, and optionally (for the RTD-styling), sphinx_rtd_theme,
-preferably in a virtualenv:
+Install Sphinx and sphinx_rtd_theme, preferably in a virtualenv:
 
      pip install sphinx
      pip install sphinx_rtd_theme

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,21 @@ In `micropython/docs`, build the docs:
 
 You'll find the index page at `micropython/docs/build/html/index.html`.
 
+Documentation autobuild
+-----------------------
+
+For a more convenient development experience, you can use `sphinx-autobuild`
+to automatically rebuild and serve the documentation when you make changes:
+
+    pip install sphinx-autobuild
+
+Then run from the `micropython/docs` directory:
+
+    sphinx-autobuild . build/html
+
+This will start a local web server (typically at `http://127.0.0.1:8000`)
+and automatically rebuild the documentation whenever you save changes to the source files.
+
 Having readthedocs.org build the documentation
 ----------------------------------------------
 

--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -133,6 +133,37 @@ Terminal redirection and duplication
 
    The function returns the previous stream-like object in the given slot.
 
+.. function:: dupterm_notify(obj_in, /)
+
+    Notify the MicroPython REPL that input is available on a stream-like object
+    previously registered via `os.dupterm()`.
+
+    This function should be called by custom stream implementations (e.g., UART,
+    Bluetooth, or other non-USB REPL streams) to inform the REPL that input is
+    ready to be read. Proper use ensures that special characters such as
+    Ctrl+C (used to trigger KeyboardInterrupt) are processed promptly by the
+    REPL, enabling expected interruption behavior for user code.
+
+    The *obj_in* parameter is ignored by `os.dupterm_notify()`, but is required to allow calling
+    dupterm_notify from an interrupt handler such as `UART.irq()`.
+
+    Example:
+
+    .. code-block:: python
+
+        from machine import UART
+        import os
+        uart = UART(0)
+        os.dupterm(uart, 0)
+        uart.irq(os.dupterm_notify, machine.UART.IRQ_RX)
+
+    .. note::
+        If the ``dupterm_notify()`` function is not called, input from the custom stream
+        may not be detected or processed until the next REPL poll, potentially delaying
+        KeyboardInterrupts or other control signals.
+        This is especially important for UART, Bluetooth and other
+        non-standard REPL connections, where automatic notification is not guaranteed.
+
 Filesystem mounting
 -------------------
 


### PR DESCRIPTION
### Summary

Add documentation for `os.dupterm_notify()`
Based on the information in 

https://github.com/micropython/micropython/issues/17732
and 
https://github.com/micropython/micropython/issues/17732
and the source code.

### Testing

n/a

