### PR TITLE
zephyr: Read erase block size from dts instead of using fixed value.

### DIFF
--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -112,7 +112,9 @@ static void vfs_init(void) {
     mount_point_str = "/sd";
     path_lib_qstr = MP_QSTR__slash_sd_slash_lib;
     #elif defined(CONFIG_FLASH_MAP) && FIXED_PARTITION_EXISTS(storage_partition)
-    int block_size = DT_PROP(DT_GPARENT(DT_NODELABEL(storage_partition)), erase_block_size);
+    #define STORAGE_DEVICE   DT_GPARENT(DT_NODELABEL(storage_partition))
+    #define ERASE_BLOCK_SIZE COND_CODE_1(DT_NODE_HAS_PROP(STORAGE_DEVICE, erase_block_size), (DT_PROP(STORAGE_DEVICE, erase_block_size)), (4096))
+    int block_size = ERASE_BLOCK_SIZE;
     mp_obj_t args[] = { MP_OBJ_NEW_SMALL_INT(FIXED_PARTITION_ID(storage_partition)), MP_OBJ_NEW_SMALL_INT(block_size) };
     bdev = MP_OBJ_TYPE_GET_SLOT(&zephyr_flash_area_type, make_new)(&zephyr_flash_area_type, ARRAY_SIZE(args), 0, args);
     mount_point_str = "/flash";

--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -112,7 +112,8 @@ static void vfs_init(void) {
     mount_point_str = "/sd";
     path_lib_qstr = MP_QSTR__slash_sd_slash_lib;
     #elif defined(CONFIG_FLASH_MAP) && FIXED_PARTITION_EXISTS(storage_partition)
-    mp_obj_t args[] = { MP_OBJ_NEW_SMALL_INT(FIXED_PARTITION_ID(storage_partition)), MP_OBJ_NEW_SMALL_INT(4096) };
+    int block_size = DT_PROP(DT_GPARENT(DT_NODELABEL(storage_partition)), erase_block_size);
+    mp_obj_t args[] = { MP_OBJ_NEW_SMALL_INT(FIXED_PARTITION_ID(storage_partition)), MP_OBJ_NEW_SMALL_INT(block_size) };
     bdev = MP_OBJ_TYPE_GET_SLOT(&zephyr_flash_area_type, make_new)(&zephyr_flash_area_type, ARRAY_SIZE(args), 0, args);
     mount_point_str = "/flash";
     path_lib_qstr = MP_QSTR__slash_flash_slash_lib;


### PR DESCRIPTION
### Summary

On my Apollo3 board, which is supported by Zephyr, I can create a filesystem in flash but cannot get Micropython automount to work.

I've tracked the issue down to the fact that not all boards use the 4096 byte erase block size  that MP is assuming in `vfs_init()`. 

My patch extracts the correct configuration value directly from the devicetree, so it should work out of the box for every Zephyr board (with a flash).

### Testing

With my modification filesystem automount works correctly for my board, which needs 8192 as erase block size as specified in the devicetree configuration.

I've checked with a script, and AFAICT all Zephyr boards with a `zephyr,flash` compatible node have the required property explicitly defined in the devicetree.