### PR TITLE
various: Don't allow creation of invalid UTF8 strings or identifiers

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2461,7 +2461,7 @@ mp_obj_t mp_obj_new_bytes_iterator(mp_obj_t str, mp_obj_iter_buf_t *iter_buf) {
 }
 
 #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-static bool mp_utf8_check(const byte *p, size_t len) {
+bool mp_utf8_check(const byte *p, size_t len) {
     uint8_t need = 0;
     const byte *end = p + len;
     for (; p < end; p++) {

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -2251,6 +2251,7 @@ mp_obj_t mp_obj_new_str_via_qstr(const char *data, size_t len) {
 static mp_obj_t mp_obj_new_str_type_from_vstr(const mp_obj_type_t *type, vstr_t *vstr) {
     // if not a bytes object, look if a qstr with this data already exists
     if (type == &mp_type_str) {
+        mp_utf8_require((byte *)vstr->buf, vstr->len);
         qstr q = qstr_find_strn(vstr->buf, vstr->len);
         if (q != MP_QSTRnull) {
             vstr_clear(vstr);

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -122,9 +122,13 @@ extern const mp_obj_dict_t mp_obj_array_locals_dict;
 #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
 // Throws an exception if string content is not UTF-8
 void mp_utf8_require(const byte *p, size_t len);
+bool mp_utf8_check(const byte *p, size_t len);
 #else
 // If unicode strings are not enabled, or the check is explicitly disabled, it's a no-op
 static inline void mp_utf8_require(const byte *p, size_t len) {
+}
+static inline bool mp_utf8_check(const byte *p, size_t len) {
+    return true;
 }
 #endif
 

--- a/py/objstr.h
+++ b/py/objstr.h
@@ -119,4 +119,13 @@ extern const mp_obj_dict_t mp_obj_bytearray_locals_dict;
 extern const mp_obj_dict_t mp_obj_array_locals_dict;
 #endif
 
+#if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+// Throws an exception if string content is not UTF-8
+void mp_utf8_require(const byte *p, size_t len);
+#else
+// If unicode strings are not enabled, or the check is explicitly disabled, it's a no-op
+static inline void mp_utf8_require(const byte *p, size_t len) {
+}
+#endif
+
 #endif // MICROPY_INCLUDED_PY_OBJSTR_H

--- a/py/parse.c
+++ b/py/parse.c
@@ -598,6 +598,11 @@ static mp_parse_node_t make_node_const_object_optimised(parser_t *parser, size_t
 static void push_result_token(parser_t *parser, uint8_t rule_id) {
     mp_parse_node_t pn;
     mp_lexer_t *lex = parser->lexer;
+    if (lex->tok_kind == MP_TOKEN_NAME || lex->tok_kind == MP_TOKEN_STRING) {
+        if (!mp_utf8_check((byte *)lex->vstr.buf, lex->vstr.len)) {
+            mp_raise_msg(&mp_type_SyntaxError, NULL);
+        }
+    }
     if (lex->tok_kind == MP_TOKEN_NAME) {
         qstr id = qstr_from_strn(lex->vstr.buf, lex->vstr.len);
         #if MICROPY_COMP_CONST

--- a/py/unicode.c
+++ b/py/unicode.c
@@ -177,35 +177,3 @@ mp_uint_t unichar_xdigit_value(unichar c) {
     }
     return n;
 }
-
-#if MICROPY_PY_BUILTINS_STR_UNICODE
-
-bool utf8_check(const byte *p, size_t len) {
-    uint8_t need = 0;
-    const byte *end = p + len;
-    for (; p < end; p++) {
-        byte c = *p;
-        if (need) {
-            if (UTF8_IS_CONT(c)) {
-                need--;
-            } else {
-                // mismatch
-                return 0;
-            }
-        } else {
-            if (c >= 0xc0) {
-                if (c >= 0xf8) {
-                    // mismatch
-                    return 0;
-                }
-                need = (0xe5 >> ((c >> 3) & 0x6)) & 3;
-            } else if (c >= 0x80) {
-                // mismatch
-                return 0;
-            }
-        }
-    }
-    return need == 0; // no pending fragments allowed
-}
-
-#endif

--- a/py/unicode.h
+++ b/py/unicode.h
@@ -30,6 +30,5 @@
 #include "py/misc.h"
 
 mp_uint_t utf8_ptr_to_index(const byte *s, const byte *ptr);
-bool utf8_check(const byte *p, size_t len);
 
 #endif // MICROPY_INCLUDED_PY_UNICODE_H

--- a/tests/cpydiff/types_str_formatuni.py
+++ b/tests/cpydiff/types_str_formatuni.py
@@ -1,0 +1,28 @@
+"""
+categories: Types,str
+description: MicroPython cannot format non-ASCII characters with %c or {:c}
+cause: To reduce code size, MicroPython does not implement this feature
+workaround: Use %s or {:s} together with chr()
+"""
+
+# note: UTF-8 code point 233 is latin small letter e with acute
+try:
+    print("{:c}".format(233))
+except Exception as e:
+    print(type(e).__name__)
+
+try:
+    print("%c" % 233)
+except Exception as e:
+    print(type(e).__name__)
+
+try:
+    print("%c" % chr(233))
+except Exception as e:
+    print(type(e).__name__)
+
+print()
+print("Compatible alternatives:")
+
+print("{:s}".format(chr(233)))
+print("%s" % chr(233))

--- a/tests/unicode/unicode_parser.py
+++ b/tests/unicode/unicode_parser.py
@@ -1,0 +1,22 @@
+# test invalid UTF-8 string via eval
+try:
+    eval(b"'ab\xa1'")
+except SyntaxError:
+    print("Exception")
+try:
+    eval(b"'ab\xf8'")
+except SyntaxError:
+    print("Exception")
+try:
+    eval(bytearray(b"'ab\xc0a'"))
+except SyntaxError:
+    print("Exception")
+try:
+    eval(b"'\xf0\xe0\xed\xe8'")
+except SyntaxError:
+    print("Exception")
+
+try:
+    exec(b"b\xff = 1")
+except SyntaxError:
+    print("Exception")


### PR DESCRIPTION

### Summary

Fuzz testing found that it was possible to create invalid UTF-8 strings when the program input was not UTF-8. This could occur because a disk file was not UTF-8, or because a byte string passed to eval()/exec() was not UTF-8.

Besides leading to the problems that the introduction of `utf8_check` was intended to fix (#9044), the fuzzer found an actual crash when the first byte was `\xff` and the string was used as an exception argument (#17855).

I also noticed that the check could be generalized a little to avoid constructing non-UTF-8 identifiers, which could also lead to problems.

I re-organized the code to pay for the size cost of the new check in the lexer.

### Testing

I added a new test, using `eval()` and `exec()` of byte strings, to ensure that these cases are caught by the lexer.

### Trade-offs and Alternatives

Could check that the whole code buffer is UTF-8 instead.