### PR TITLE
vfs_reader: Check that open() resulted in a file-like object.

### DIFF
--- a/extmod/modopenamp_remoteproc_store.c
+++ b/extmod/modopenamp_remoteproc_store.c
@@ -76,6 +76,7 @@ static int openamp_remoteproc_store_open(void *store, const char *path, const vo
 
     openamp_remoteproc_filestore_t *fstore = store;
     fstore->file = mp_vfs_open(MP_ARRAY_SIZE(args), args, (mp_map_t *)&mp_const_empty_map);
+    (void)mp_get_stream_raise(fstore->file, MP_STREAM_OP_READ);
 
     int error = 0;
     mp_uint_t bytes = mp_stream_read_exactly(fstore->file, fstore->buf, RPROC_FILE_STORE_BUF_SIZE, &error);

--- a/extmod/vfs_reader.c
+++ b/extmod/vfs_reader.c
@@ -83,7 +83,7 @@ void mp_reader_new_file(mp_reader_t *reader, qstr filename) {
     };
     mp_obj_t file = mp_vfs_open(MP_ARRAY_SIZE(args), &args[0], (mp_map_t *)&mp_const_empty_map);
 
-    const mp_stream_p_t *stream_p = mp_get_stream(file);
+    const mp_stream_p_t *stream_p = mp_get_stream_raise(file, MP_STREAM_OP_READ);
     int errcode = 0;
 
     #if MICROPY_VFS_ROM

--- a/tests/micropython/builtin_execfile.py
+++ b/tests/micropython/builtin_execfile.py
@@ -75,3 +75,24 @@ except TypeError:
 
 # Unmount the VFS object.
 vfs.umount(fs)
+
+
+class EvilFilesystem:
+    def mount(self, readonly, mkfs):
+        print("mount", readonly, mkfs)
+
+    def umount(self):
+        print("umount")
+
+    def open(self, file, mode):
+        return None
+
+
+fs = EvilFilesystem()
+vfs.mount(fs, "/test_mnt")
+try:
+    execfile("/test_mnt/test.py")
+    print("ExecFile succeeded")
+except OSError:
+    print("OSError")
+vfs.umount(fs)

--- a/tests/micropython/builtin_execfile.py.exp
+++ b/tests/micropython/builtin_execfile.py.exp
@@ -5,3 +5,6 @@ open /test.py rb
 123
 TypeError
 umount
+mount False False
+OSError
+umount


### PR DESCRIPTION
### Summary

Check that open() results in a file-like object, preventing crashes in callers to `mp_reader_new_file` when an object that is "not actually a file" is returned. This includes, for example, `execfile`.

Closes: #17841

### Testing

I added a test derived from the reproducer in #17841.

### Trade-offs and Alternatives
The code can only ensure that the object's type defines a protocol slot. Due to protocol confusion, a variant of the original crasher that returned e.g., a machine.Pin instance could still lead to a crash. (#17852)