### PR TITLE
mpy-cross: Fix output to stdout on Windows.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -24,6 +24,11 @@
  * THE SOFTWARE.
  */
 
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -92,7 +97,28 @@ static int compile_and_save(const char *file, const char *output_file, const cha
 
         if ((output_file != NULL && strcmp(output_file, "-") == 0) ||
             (output_file == NULL && strcmp(file, "-") == 0)) {
+            // Windows defaults stdout to text mode which will corrupt the MPY
+            // output. Change it to binary mode to avoid this.
+            #ifdef _WIN32
+            fflush(stdout);
+            _setmode(fileno(stdout), _O_BINARY);
+
+            nlr_buf_t nlr2;
+            if (nlr_push(&nlr2) == 0) {
+                mp_raw_code_save(&cm, (mp_print_t *)&mp_stdout_print);
+                nlr_pop();
+
+                // Restore the original mode in case we have to print unhandled exceptions
+                fflush(stdout);
+                _setmode(fileno(stdout), _O_TEXT);
+            } else {
+                fflush(stdout);
+                _setmode(fileno(stdout), _O_TEXT);
+                nlr_jump(nlr2.ret_val);
+            }
+            #else
             mp_raw_code_save(&cm, (mp_print_t *)&mp_stdout_print);
+            #endif
         } else {
             vstr_t vstr;
             vstr_init(&vstr, 16);


### PR DESCRIPTION

### Summary

Set stdout to binary mode on Windows to avoid corruption of MPY output.

By default, Windows uses text mode for stdout which will convert any newline byte (\n) to a carriage return + newline (\r\n) pair. This can corrupt the MPY output if the MPY contains any 0x0A byte.


### Testing

I didn't see a way to test this using our existing test framework. But I have made a test in the python-mpy-cross project I maintain.

Failing test before the fix: https://github.com/pybricks/python-mpy-cross/actions/runs/16865780805/job/47772458449#step:4:538

Passing test after the fix: https://github.com/pybricks/python-mpy-cross/actions/runs/16866365087/job/47773824320#step:4:863

Test source: https://github.com/pybricks/python-mpy-cross/blob/f376b412573a0c8c825abc300c5e36a716a85f98/tests/test_mpy_cross.py#L40-L50

