### PR TITLE
tests: add support for native-specific .exp test output files

### DIFF
--- a/tests/basics/sys_tracebacklimit.py.native.exp
+++ b/tests/basics/sys_tracebacklimit.py.native.exp
@@ -1,0 +1,22 @@
+ValueError: value
+
+limit 4
+ValueError: value
+
+limit 3
+ValueError: value
+
+limit 2
+ValueError: value
+
+limit 1
+ValueError: value
+
+limit 0
+ValueError: value
+
+limit -1
+ValueError: value
+
+True
+False

--- a/tests/micropython/emg_exc.py.native.exp
+++ b/tests/micropython/emg_exc.py.native.exp
@@ -1,0 +1,2 @@
+ValueError: 1
+

--- a/tests/micropython/heapalloc_traceback.py.native.exp
+++ b/tests/micropython/heapalloc_traceback.py.native.exp
@@ -1,0 +1,3 @@
+StopIteration
+StopIteration: 
+

--- a/tests/micropython/opt_level_lineno.py
+++ b/tests/micropython/opt_level_lineno.py
@@ -3,4 +3,15 @@ import micropython as micropython
 # check that level 3 doesn't store line numbers
 # the expected output is that any line is printed as "line 1"
 micropython.opt_level(3)
-exec("try:\n xyz\nexcept NameError as er:\n import sys\n sys.print_exception(er)")
+
+# force bytecode emitter, because native emitter doesn't store line numbers
+exec("""
+@micropython.bytecode
+def f():
+    try:
+        xyz
+    except NameError as er:
+        import sys
+        sys.print_exception(er)
+f()
+""")

--- a/tests/micropython/opt_level_lineno.py.exp
+++ b/tests/micropython/opt_level_lineno.py.exp
@@ -1,3 +1,3 @@
 Traceback (most recent call last):
-  File "<string>", line 1, in <module>
+  File "<string>", line 1, in f
 NameError: name 'xyz' isn't defined

--- a/tests/misc/print_exception.py
+++ b/tests/misc/print_exception.py
@@ -71,7 +71,7 @@ try:
     except Exception as e:
         print("reraise")
         print_exc(e)
-        raise
+        raise e
 except Exception as e:
     print("caught")
     print_exc(e)

--- a/tests/misc/print_exception.py.native.exp
+++ b/tests/misc/print_exception.py.native.exp
@@ -1,0 +1,18 @@
+caught
+Exception: msg
+
+caught
+Exception: fail
+
+finally
+caught
+Exception: fail
+
+reraise
+Exception: fail
+
+caught
+Exception: fail
+
+AttributeError: 'function' object has no attribute 'X'
+

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -131,7 +131,6 @@ emitter_tests_to_skip = {
         "misc/print_exception.py",
         "micropython/emg_exc.py",
         "micropython/heapalloc_traceback.py",
-        "micropython/opt_level_lineno.py",
         "thread/thread_exc2.py",
         # These require stack-allocated slice optimisation.
         "micropython/heapalloc_slice.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -994,7 +994,11 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             # Expected output is result of running unittest.
             output_expected = None
         else:
-            test_file_expected = test_file + ".exp"
+            # Prefer emitter-specific expected output.
+            test_file_expected = test_file + "." + args.emit + ".exp"
+            if not os.path.isfile(test_file_expected):
+                # Fall back to generic expected output.
+                test_file_expected = test_file + ".exp"
             if os.path.isfile(test_file_expected):
                 # Expected output given by a file, so read that in.
                 with open(test_file_expected, "rb") as f:
@@ -1202,8 +1206,8 @@ def main():
 {test_directory_description}
 
 When running tests, run-tests.py compares the MicroPython output of the test with the output
-produced by running the test through CPython unless a <test>.exp file is found, in which
-case it is used as comparison.
+produced by running the test through CPython unless a <test>.exp file is found (or a
+<test>.native.exp file when using the native emitter), in which case it is used as comparison.
 
 If a test fails, run-tests.py produces a pair of <test>.out and <test>.exp files in the result
 directory with the MicroPython output and the expectations, respectively.

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -126,12 +126,6 @@ emitter_tests_to_skip = {
         "basics/unboundlocal.py",
         # These require "raise from".
         "basics/exception_chain.py",
-        # These require proper traceback info.
-        "basics/sys_tracebacklimit.py",
-        "misc/print_exception.py",
-        "micropython/emg_exc.py",
-        "micropython/heapalloc_traceback.py",
-        "thread/thread_exc2.py",
         # These require stack-allocated slice optimisation.
         "micropython/heapalloc_slice.py",
         # These require running the scheduler.

--- a/tests/thread/thread_exc2.py.native.exp
+++ b/tests/thread/thread_exc2.py.native.exp
@@ -1,0 +1,3 @@
+Unhandled exception in thread started by <function thread_entry at 0x\[0-9a-f\]\+>
+ValueError: 
+done


### PR DESCRIPTION
### Summary

There are currently a few tests that are excluded when using the native emitter because they test printing of exception tracebacks, which includes line numbers.  And the native emitter doesn't store line numbers, so gets these tests wrong.

But we'd still like to run these tests using the native emitter, because they test useful things even if the line number info is not in the traceback (eg that threads which crash print out their exception).

This PR adds support for native-specific .exp files, which are of the form `<test>.py.exp.native`.  If such an .exp file exists then it take precedence over any normal `<test>.py.exp` file.  (Actually, the implementation is general enough that it also supports `<test>py.exp.bytecode` as well, if bytecode ever needs a specific exp file.)

In this PR:
- support for `run-tests.py` to look for `<test>.py.exp.native` files (a very simple change)
- adding of a few such .exp.native files to tests that need them
- remove excluded native tests from `run-tests.py`
- tweak a few other tests so they can run with the native emitter

### Testing

Tested locally on PYBD_SF6, RPI_PICO2_W, ESP32 and unix port.  There were no regressions, and the new tests (now no longer excluded) pass with the native emitter.

Will also be tested by CI.

### Trade-offs and Alternatives

- Could change the test so it doesn't rely on line numbers, but that really defeats the purpose of some of these tests, which aim to test line numbering.
- Could make the .exp have special regex pattern matching, but again that would mean the actual line number for the bytecode emitter is not tested.
- Could make the native emitter support line numbers in tracebacks... but that's very difficult!

