### PR TITLE
py/parse: Remove explicit checks for invalid folding operations.

### DIFF
--- a/py/parse.c
+++ b/py/parse.c
@@ -771,12 +771,6 @@ static bool fold_constants(parser_t *parser, uint8_t rule_id, size_t num_args) {
             if (!mp_parse_node_get_number_maybe(pn, &arg1)) {
                 return false;
             }
-            #if !MICROPY_COMP_CONST_FLOAT
-            if (op == MP_BINARY_OP_POWER && mp_obj_int_sign(arg1) < 0) {
-                // ** can't have negative rhs
-                return false;
-            }
-            #endif
             if (!binary_op_maybe(op, arg0, arg1, &arg0)) {
                 return false;
             }
@@ -796,16 +790,6 @@ static bool fold_constants(parser_t *parser, uint8_t rule_id, size_t num_args) {
                 return false;
             }
             mp_token_kind_t tok = MP_PARSE_NODE_LEAF_ARG(peek_result(parser, i));
-            if (tok == MP_TOKEN_OP_AT) {
-                // Can't fold @
-                return false;
-            }
-            #if !MICROPY_COMP_CONST_FLOAT
-            if (tok == MP_TOKEN_OP_SLASH) {
-                // Can't fold /
-                return false;
-            }
-            #endif
             mp_binary_op_t op = MP_BINARY_OP_LSHIFT + (tok - MP_TOKEN_OP_DBL_LESS);
             if (!binary_op_maybe(op, arg0, arg1, &arg0)) {
                 return false;


### PR DESCRIPTION
### Summary

They are instead checked by `binary_op_maybe()`, which catches exceptions for invalid int/float operations.

This is a follow-up to 69ead7d98ef30df3b6bd4485633490e80fca1718 / #16666.

### Testing

Tested with the unix port, with floats disabled.

The following do not raise exceptions (as expected) because the folding is not done:
```py
compile("1/2","file","eval")
compile("1**-2","file","eval")
compile("1@2","file","eval")
```

Then I validated that the bytecode has the explicit operator calls:
```
$ micropython -v -v -v
...
>>> (1+2)@4
File <stdin>, code block '<module>' (descriptor: 7f0d487eed80, bytecode @7f0d487eeca0 13 bytes)
Raw bytecode (code_info_size=3, bytecode_size=10):
 10 02 01 11 02 83 84 f5 34 01 59 51 63
arg names:
(N_STATE 3)
(N_EXC_STACK 0)
  bc=0 line=1
00 LOAD_NAME __repl_print__
02 LOAD_CONST_SMALL_INT 3
03 LOAD_CONST_SMALL_INT 4
04 BINARY_OP 30 __matmul__
05 CALL_FUNCTION n=1 nkw=0
07 POP_TOP
08 LOAD_CONST_NONE
09 RETURN_VALUE
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported types for __matmul__: 'int', 'int'
```
You can see that the `(1+2)` is folded but not the `@` operator, which is then evaluated at runtime.  And also:
```
>>> 1**(-2)
File <stdin>, code block '<module>' (descriptor: 7f0d487eef00, bytecode @7f0d487eee80 13 bytes)
Raw bytecode (code_info_size=3, bytecode_size=10):
 10 02 01 11 02 81 7e f9 34 01 59 51 63
arg names:
(N_STATE 3)
(N_EXC_STACK 0)
  bc=0 line=1
00 LOAD_NAME __repl_print__
02 LOAD_CONST_SMALL_INT 1
03 LOAD_CONST_SMALL_INT -2
04 BINARY_OP 34 __pow__
05 CALL_FUNCTION n=1 nkw=0
07 POP_TOP
08 LOAD_CONST_NONE
09 RETURN_VALUE
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: negative power with no float support
>>> 1/2
File <stdin>, code block '<module>' (descriptor: 7f0d487ef300, bytecode @7f0d487ef120 13 bytes)
Raw bytecode (code_info_size=3, bytecode_size=10):
 10 02 01 11 02 81 82 f7 34 01 59 51 63
arg names:
(N_STATE 3)
(N_EXC_STACK 0)
  bc=0 line=1
00 LOAD_NAME __repl_print__
02 LOAD_CONST_SMALL_INT 1
03 LOAD_CONST_SMALL_INT 2
04 BINARY_OP 32 __truediv__
05 CALL_FUNCTION n=1 nkw=0
07 POP_TOP
08 LOAD_CONST_NONE
09 RETURN_VALUE
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported types for __truediv__: 'int', 'int'
```

### Trade-offs and Alternatives

This means the test is delegated to `binary_op_maybe()`, making the check for invalid folding operations a little slower.  But it saves code size and it's rare that the user does invalid binary operations on literal numbers.
