### PR TITLE
tests: Require SSL certificate file to be available for test to run.

### DIFF
--- a/tests/multi_net/asyncio_tls_server_client.py
+++ b/tests/multi_net/asyncio_tls_server_client.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 async def handle_connection(reader, writer):
     data = await reader.read(100)

--- a/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 async def handle_connection(reader, writer):
     print("handle connection")

--- a/tests/multi_net/asyncio_tls_server_client_readline.py
+++ b/tests/multi_net/asyncio_tls_server_client_readline.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 async def handle_connection(reader, writer):
     data = await reader.readline()

--- a/tests/multi_net/asyncio_tls_server_client_verify_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_verify_error.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 async def handle_connection(reader, writer):
     print("handle connection")

--- a/tests/multi_net/ssl_cert_ec.py
+++ b/tests/multi_net/ssl_cert_ec.py
@@ -13,13 +13,6 @@ PORT = 8000
 certfile = "ec_cert.der"
 keyfile = "ec_key.der"
 
-try:
-    os.stat(certfile)
-    os.stat(keyfile)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 with open(certfile, "rb") as cf:
     cert = cadata = cf.read()
 

--- a/tests/multi_net/ssl_cert_rsa.py
+++ b/tests/multi_net/ssl_cert_rsa.py
@@ -13,13 +13,6 @@ PORT = 8000
 certfile = "rsa_cert.der"
 keyfile = "rsa_key.der"
 
-try:
-    os.stat(certfile)
-    os.stat(keyfile)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 with open(certfile, "rb") as cf:
     cert = cadata = cf.read()
 

--- a/tests/multi_net/sslcontext_check_hostname_error.py
+++ b/tests/multi_net/sslcontext_check_hostname_error.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 # Server
 def instance0():

--- a/tests/multi_net/sslcontext_getpeercert.py
+++ b/tests/multi_net/sslcontext_getpeercert.py
@@ -15,13 +15,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 # Server
 def instance0():

--- a/tests/multi_net/sslcontext_server_client_files.py
+++ b/tests/multi_net/sslcontext_server_client_files.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 # Server
 def instance0():

--- a/tests/multi_net/sslcontext_verify_error.py
+++ b/tests/multi_net/sslcontext_verify_error.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 # Server
 def instance0():

--- a/tests/multi_net/sslcontext_verify_time_error.py
+++ b/tests/multi_net/sslcontext_verify_time_error.py
@@ -14,13 +14,6 @@ PORT = 8000
 cert = cafile = "expired_cert.der"
 key = "ec_key.der"
 
-try:
-    os.stat(cafile)
-    os.stat(key)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 
 # Server
 def instance0():

--- a/tests/net_inet/asyncio_tls_open_connection_readline.py
+++ b/tests/net_inet/asyncio_tls_open_connection_readline.py
@@ -20,12 +20,6 @@ import asyncio
 
 ca_cert_chain = "isrg.der"
 
-try:
-    os.stat(ca_cert_chain)
-except OSError:
-    print("SKIP")
-    raise SystemExit
-
 with open(ca_cert_chain, "rb") as ca:
     cadata = ca.read()
 

--- a/tests/net_inet/test_sslcontext_client.py
+++ b/tests/net_inet/test_sslcontext_client.py
@@ -13,11 +13,6 @@ import ssl
 # $ openssl x509 -in mpycert.pem -out mpycert.der -outform DER
 
 ca_cert_chain = "mpycert.der"
-try:
-    os.stat(ca_cert_chain)
-except OSError:
-    print("SKIP")
-    raise SystemExit
 
 
 def main(use_stream=True):


### PR DESCRIPTION
### Summary

Previously, any test needing an SSL certificate file would automatically skip if the file could not be found.  But that makes it too easy to accidentally skip tests.

Instead, change it so that the test fails if the certificate file doesn't exist.  That matches, for example, the fact that the test fails if networking (LAN, WiFi) is not active.

### Testing

Tested on the unix port (files always available, passes), and PYBD_SF6 with and without the files on the local filesystem.  It fails without them, passes with them.

### Trade-offs and Alternatives

IMO this is a good improvement, it simplifies the test and makes it impossible to accidentally skip it.  But it does require users to copy the files across first (as mentioned in the test README).
