### PR TITLE
extmod/modtime: Move tuple creation to common localtime implementation.

### DIFF
--- a/extmod/modtime.c
+++ b/extmod/modtime.c
@@ -53,26 +53,26 @@
 // - weekday is 0-6 for Mon-Sun
 // - yearday is 1-366
 static mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
+    timeutils_struct_time_t tm;
     if (n_args == 0 || args[0] == mp_const_none) {
         // Get current date and time.
-        return mp_time_localtime_get();
+        mp_time_localtime_get(&tm);
     } else {
         // Convert given seconds to tuple.
         mp_timestamp_t seconds = timeutils_obj_get_timestamp(args[0]);
-        timeutils_struct_time_t tm;
         timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
-        mp_obj_t tuple[8] = {
-            tuple[0] = mp_obj_new_int(tm.tm_year),
-            tuple[1] = mp_obj_new_int(tm.tm_mon),
-            tuple[2] = mp_obj_new_int(tm.tm_mday),
-            tuple[3] = mp_obj_new_int(tm.tm_hour),
-            tuple[4] = mp_obj_new_int(tm.tm_min),
-            tuple[5] = mp_obj_new_int(tm.tm_sec),
-            tuple[6] = mp_obj_new_int(tm.tm_wday),
-            tuple[7] = mp_obj_new_int(tm.tm_yday),
-        };
-        return mp_obj_new_tuple(8, tuple);
     }
+    mp_obj_t tuple[8] = {
+        mp_obj_new_int(tm.tm_year),
+        mp_obj_new_int(tm.tm_mon),
+        mp_obj_new_int(tm.tm_mday),
+        mp_obj_new_int(tm.tm_hour),
+        mp_obj_new_int(tm.tm_min),
+        mp_obj_new_int(tm.tm_sec),
+        mp_obj_new_int(tm.tm_wday),
+        mp_obj_new_int(tm.tm_yday),
+    };
+    return mp_obj_new_tuple(8, tuple);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_time_localtime_obj, 0, 1, time_localtime);
 

--- a/ports/cc3200/mods/modtime.c
+++ b/ports/cc3200/mods/modtime.c
@@ -29,23 +29,10 @@
 #include "shared/timeutils/timeutils.h"
 #include "pybrtc.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
-    timeutils_struct_time_t tm;
-
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     // get the seconds from the RTC
-    timeutils_seconds_since_2000_to_struct_time(pyb_rtc_get_seconds(), &tm);
-    mp_obj_t tuple[8] = {
-            mp_obj_new_int(tm.tm_year),
-            mp_obj_new_int(tm.tm_mon),
-            mp_obj_new_int(tm.tm_mday),
-            mp_obj_new_int(tm.tm_hour),
-            mp_obj_new_int(tm.tm_min),
-            mp_obj_new_int(tm.tm_sec),
-            mp_obj_new_int(tm.tm_wday),
-            mp_obj_new_int(tm.tm_yday)
-    };
-    return mp_obj_new_tuple(8, tuple);
+    timeutils_seconds_since_2000_to_struct_time(pyb_rtc_get_seconds(), tm);
 }
 
 // Returns the number of seconds, as an integer, since the Epoch.

--- a/ports/esp32/modtime.c
+++ b/ports/esp32/modtime.c
@@ -31,23 +31,11 @@
 #include "py/obj.h"
 #include "shared/timeutils/timeutils.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    timeutils_struct_time_t tm;
-    timeutils_seconds_since_epoch_to_struct_time(tv.tv_sec, &tm);
-    mp_obj_t tuple[8] = {
-        tuple[0] = mp_obj_new_int(tm.tm_year),
-        tuple[1] = mp_obj_new_int(tm.tm_mon),
-        tuple[2] = mp_obj_new_int(tm.tm_mday),
-        tuple[3] = mp_obj_new_int(tm.tm_hour),
-        tuple[4] = mp_obj_new_int(tm.tm_min),
-        tuple[5] = mp_obj_new_int(tm.tm_sec),
-        tuple[6] = mp_obj_new_int(tm.tm_wday),
-        tuple[7] = mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    timeutils_seconds_since_epoch_to_struct_time(tv.tv_sec, tm);
 }
 
 // Return the number of seconds since the Epoch.

--- a/ports/esp8266/modtime.c
+++ b/ports/esp8266/modtime.c
@@ -29,22 +29,10 @@
 #include "shared/timeutils/timeutils.h"
 #include "modmachine.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     mp_uint_t seconds = pyb_rtc_get_us_since_epoch() / 1000u / 1000u;
-    timeutils_struct_time_t tm;
-    timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
-    mp_obj_t tuple[8] = {
-        tuple[0] = mp_obj_new_int(tm.tm_year),
-        tuple[1] = mp_obj_new_int(tm.tm_mon),
-        tuple[2] = mp_obj_new_int(tm.tm_mday),
-        tuple[3] = mp_obj_new_int(tm.tm_hour),
-        tuple[4] = mp_obj_new_int(tm.tm_min),
-        tuple[5] = mp_obj_new_int(tm.tm_sec),
-        tuple[6] = mp_obj_new_int(tm.tm_wday),
-        tuple[7] = mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    timeutils_seconds_since_epoch_to_struct_time(seconds, tm);
 }
 
 // Returns the number of seconds, as an integer, since the Epoch.

--- a/ports/mimxrt/modtime.c
+++ b/ports/mimxrt/modtime.c
@@ -29,22 +29,19 @@
 #include "shared/timeutils/timeutils.h"
 #include "fsl_snvs_lp.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     // Get current date and time.
     snvs_lp_srtc_datetime_t t;
     SNVS_LP_SRTC_GetDatetime(SNVS, &t);
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(t.year),
-        mp_obj_new_int(t.month),
-        mp_obj_new_int(t.day),
-        mp_obj_new_int(t.hour),
-        mp_obj_new_int(t.minute),
-        mp_obj_new_int(t.second),
-        mp_obj_new_int(timeutils_calc_weekday(t.year, t.month, t.day)),
-        mp_obj_new_int(timeutils_year_day(t.year, t.month, t.day)),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    tm->tm_year = t.year;
+    tm->tm_mon = t.month;
+    tm->tm_mday = t.day;
+    tm->tm_hour = t.hour;
+    tm->tm_min = t.minute;
+    tm->tm_sec = t.second;
+    tm->tm_wday = timeutils_calc_weekday(t.year, t.month, t.day);
+    tm->tm_yday = timeutils_year_day(t.year, t.month, t.day);
 }
 
 // Return the number of seconds since the Epoch.

--- a/ports/renesas-ra/modtime.c
+++ b/ports/renesas-ra/modtime.c
@@ -28,23 +28,20 @@
 #include "shared/timeutils/timeutils.h"
 #include "rtc.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     // get current date and time
     rtc_init_finalise();
     ra_rtc_t time;
     ra_rtc_get_time(&time);
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(time.year),
-        mp_obj_new_int(time.month),
-        mp_obj_new_int(time.date),
-        mp_obj_new_int(time.hour),
-        mp_obj_new_int(time.minute),
-        mp_obj_new_int(time.second),
-        mp_obj_new_int(time.weekday - 1),
-        mp_obj_new_int(timeutils_year_day(time.year, time.month, time.date)),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    tm->tm_year = time.year;
+    tm->tm_mon = time.month;
+    tm->tm_mday = time.date;
+    tm->tm_hour = time.hour;
+    tm->tm_min = time.minute;
+    tm->tm_sec = time.second;
+    tm->tm_wday = time.weekday - 1;
+    tm->tm_yday = timeutils_year_day(time.year, time.month, time.date);
 }
 
 // Returns the number of seconds, as an integer, since the Epoch.

--- a/ports/rp2/modtime.c
+++ b/ports/rp2/modtime.c
@@ -28,23 +28,11 @@
 #include "shared/timeutils/timeutils.h"
 #include "pico/aon_timer.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     struct timespec ts;
     aon_timer_get_time(&ts);
-    timeutils_struct_time_t tm;
-    timeutils_seconds_since_epoch_to_struct_time(ts.tv_sec, &tm);
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(tm.tm_year),
-        mp_obj_new_int(tm.tm_mon),
-        mp_obj_new_int(tm.tm_mday),
-        mp_obj_new_int(tm.tm_hour),
-        mp_obj_new_int(tm.tm_min),
-        mp_obj_new_int(tm.tm_sec),
-        mp_obj_new_int(tm.tm_wday),
-        mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    timeutils_seconds_since_epoch_to_struct_time(ts.tv_sec, tm);
 }
 
 // Return the number of seconds since the Epoch.

--- a/ports/samd/modtime.c
+++ b/ports/samd/modtime.c
@@ -30,23 +30,11 @@
 
 static uint64_t time_us_64_offset_from_epoch;
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
-    timeutils_struct_time_t tm;
-    rtc_gettime(&tm);
-    tm.tm_wday = timeutils_calc_weekday(tm.tm_year, tm.tm_mon, tm.tm_mday);
-    tm.tm_yday = timeutils_year_day(tm.tm_year, tm.tm_mon, tm.tm_mday);
-    mp_obj_t tuple[8] = {
-        tuple[0] = mp_obj_new_int(tm.tm_year),
-        tuple[1] = mp_obj_new_int(tm.tm_mon),
-        tuple[2] = mp_obj_new_int(tm.tm_mday),
-        tuple[3] = mp_obj_new_int(tm.tm_hour),
-        tuple[4] = mp_obj_new_int(tm.tm_min),
-        tuple[5] = mp_obj_new_int(tm.tm_sec),
-        tuple[6] = mp_obj_new_int(tm.tm_wday),
-        tuple[7] = mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
+    rtc_gettime(tm);
+    tm->tm_wday = timeutils_calc_weekday(tm->tm_year, tm->tm_mon, tm->tm_mday);
+    tm->tm_yday = timeutils_year_day(tm->tm_year, tm->tm_mon, tm->tm_mday);
 }
 
 // Returns the number of seconds, as an integer, since the Epoch.

--- a/ports/stm32/modtime.c
+++ b/ports/stm32/modtime.c
@@ -28,8 +28,8 @@
 #include "shared/timeutils/timeutils.h"
 #include "rtc.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     // get current date and time
     // note: need to call get time then get date to correctly access the registers
     rtc_init_finalise();
@@ -37,17 +37,14 @@ static mp_obj_t mp_time_localtime_get(void) {
     RTC_TimeTypeDef time;
     HAL_RTC_GetTime(&RTCHandle, &time, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&RTCHandle, &date, RTC_FORMAT_BIN);
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(2000 + date.Year),
-        mp_obj_new_int(date.Month),
-        mp_obj_new_int(date.Date),
-        mp_obj_new_int(time.Hours),
-        mp_obj_new_int(time.Minutes),
-        mp_obj_new_int(time.Seconds),
-        mp_obj_new_int(date.WeekDay - 1),
-        mp_obj_new_int(timeutils_year_day(2000 + date.Year, date.Month, date.Date)),
-    };
-    return mp_obj_new_tuple(8, tuple);
+    tm->tm_year = 2000 + date.Year;
+    tm->tm_mon = date.Month;
+    tm->tm_mday = date.Date;
+    tm->tm_hour = time.Hours;
+    tm->tm_min = time.Minutes;
+    tm->tm_sec = time.Seconds;
+    tm->tm_wday = date.WeekDay - 1;
+    tm->tm_yday = timeutils_year_day(tm->tm_year, date.Month, date.Date);
 }
 
 // Returns the number of seconds, as an integer, since 1/1/2000.

--- a/ports/webassembly/modtime.c
+++ b/ports/webassembly/modtime.c
@@ -28,21 +28,9 @@
 #include "shared/timeutils/timeutils.h"
 #include "library.h"
 
-// Return the localtime as an 8-tuple.
-static mp_obj_t mp_time_localtime_get(void) {
-    timeutils_struct_time_t tm;
-    timeutils_seconds_since_epoch_to_struct_time(mp_hal_time_ms() / 1000, &tm);
-    mp_obj_t tuple[8] = {
-        mp_obj_new_int(tm.tm_year),
-        mp_obj_new_int(tm.tm_mon),
-        mp_obj_new_int(tm.tm_mday),
-        mp_obj_new_int(tm.tm_hour),
-        mp_obj_new_int(tm.tm_min),
-        mp_obj_new_int(tm.tm_sec),
-        mp_obj_new_int(tm.tm_wday),
-        mp_obj_new_int(tm.tm_yday),
-    };
-    return mp_obj_new_tuple(8, tuple);
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
+    timeutils_seconds_since_epoch_to_struct_time(mp_hal_time_ms() / 1000, tm);
 }
 
 // Returns the number of seconds, as a float, since the Epoch.


### PR DESCRIPTION
### Summary

This factors code out of the ports and into the common `time.localtime` implementation in `extmod/modtime.c`.  That helps to reduce code duplication, prevent errors in implementation, and hopefully reduce code size.

### Testing

Tested on PYBD_SF6, running the test suite (which includes tests for `localtime()`).  It passes.

CI will test the unix port.

### Trade-offs and Alternatives

This is a code refactoring, I don't see any downsides to it.

