### PR TITLE
alif: implement `machine.RTC.datetime`, enable remaining time functions, and implement littlefs, FAT and mbedTLS time

### DIFF
--- a/ports/alif/fatfs_port.c
+++ b/ports/alif/fatfs_port.c
@@ -24,15 +24,12 @@
  * THE SOFTWARE.
  */
 
+#include "py/mphal.h"
+#include "shared/timeutils/timeutils.h"
 #include "lib/oofatfs/ff.h"
 
 DWORD get_fattime(void) {
-    // TODO
-    int year = 2024;
-    int month = 1;
-    int day = 1;
-    int hour = 0;
-    int min = 0;
-    int sec = 0;
-    return ((year - 1980) << 25) | (month << 21) | (day << 16) | (hour << 11) | (min << 5) | (sec / 2);
+    timeutils_struct_time_t tm;
+    timeutils_seconds_since_epoch_to_struct_time(mp_hal_time_get(NULL), &tm);
+    return ((tm.tm_year - 1980) << 25) | ((tm.tm_mon) << 21) | ((tm.tm_mday) << 16) | ((tm.tm_hour) << 11) | ((tm.tm_min) << 5) | (tm.tm_sec / 2);
 }

--- a/ports/alif/machine_rtc.c
+++ b/ports/alif/machine_rtc.c
@@ -28,8 +28,19 @@
 #include "py/mphal.h"
 #include "py/mperrno.h"
 #include "extmod/modmachine.h"
+#include "shared/timeutils/timeutils.h"
 #include "rtc.h"
 #include "sys_ctrl_rtc.h"
+
+// The LPRTC (low-power real-time counter) is a 32-bit counter with a 16-bit prescaler,
+// and usually clocked by a 32768Hz clock source.  To get a large date range of around
+// 136 years, the prescaler is set to 32768 and so the counter clocks at 1Hz.  Then the
+// counter counts the number of seconds since the 1970 Epoch.  The prescaler is used to
+// get the subseconds which are then converted to microseconds.
+//
+// The combined counter+prescaler counts starting at 0 from the year 1970 up to the year
+// 2106, with a resolution of 30.52 microseconds.
+#define LPRTC_PRESCALER_SETTING (32768)
 
 typedef struct _machine_rtc_obj_t {
     mp_obj_base_t base;
@@ -44,23 +55,96 @@ void LPRTC_IRQHandler(void) {
     lprtc_interrupt_disable(machine_rtc.rtc);
 }
 
+// Returns the number of seconds and microseconds since the Epoch.
+uint32_t mp_hal_time_get(uint32_t *microseconds) {
+    uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    uint32_t count = lprtc_get_count(machine_rtc.rtc);
+    if (microseconds == NULL) {
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
+        return count;
+    }
+    uint32_t prescaler = machine_rtc.rtc->LPRTC_CPCVR;
+    uint32_t count2 = lprtc_get_count(machine_rtc.rtc);
+    if (count != count2) {
+        // The counter incremented during sampling of the prescaler, so resample the prescaler.
+        prescaler = machine_rtc.rtc->LPRTC_CPCVR;
+    }
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    // Compute the microseconds from the up-counting prescaler value.
+    MP_STATIC_ASSERT(LPRTC_PRESCALER_SETTING == 32768);
+    *microseconds = 15625UL * prescaler / 512UL;
+
+    return count2;
+}
+
 static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     const machine_rtc_obj_t *self = &machine_rtc;
 
     // Check arguments.
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
 
-    enable_lprtc_clk();
-    lprtc_prescaler_disable(self->rtc);
-    lprtc_counter_wrap_disable(self->rtc);
     lprtc_interrupt_disable(self->rtc);
     lprtc_interrupt_unmask(self->rtc);
+
+    // Initialise the LPRTC if it's not already enabled.
+    if (!((VBAT->RTC_CLK_EN & RTC_CLK_ENABLE)
+          && (self->rtc->LPRTC_CCR & CCR_LPRTC_EN)
+          && (self->rtc->LPRTC_CPSR == LPRTC_PRESCALER_SETTING))) {
+        enable_lprtc_clk();
+        self->rtc->LPRTC_CCR = 0;
+        lprtc_load_prescaler(self->rtc, LPRTC_PRESCALER_SETTING);
+        lprtc_load_count(self->rtc, 0);
+        self->rtc->LPRTC_CCR = CCR_LPRTC_PSCLR_EN | CCR_LPRTC_EN;
+    }
 
     NVIC_SetPriority(LPRTC_IRQ_IRQn, IRQ_PRI_RTC);
     NVIC_ClearPendingIRQ(LPRTC_IRQ_IRQn);
     NVIC_EnableIRQ(LPRTC_IRQ_IRQn);
+
     return MP_OBJ_FROM_PTR(self);
 }
+
+static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
+    if (n_args == 1) {
+        // Get datetime.
+        uint32_t microseconds;
+        mp_timestamp_t s = mp_hal_time_get(&microseconds);
+        timeutils_struct_time_t tm;
+        timeutils_seconds_since_epoch_to_struct_time(s, &tm);
+        mp_obj_t tuple[8] = {
+            mp_obj_new_int(tm.tm_year),
+            mp_obj_new_int(tm.tm_mon),
+            mp_obj_new_int(tm.tm_mday),
+            mp_obj_new_int(tm.tm_wday),
+            mp_obj_new_int(tm.tm_hour),
+            mp_obj_new_int(tm.tm_min),
+            mp_obj_new_int(tm.tm_sec),
+            mp_obj_new_int(microseconds),
+        };
+        return mp_obj_new_tuple(8, tuple);
+    } else {
+        // Set datetime.
+        mp_obj_t *items;
+        mp_obj_get_array_fixed_n(args[1], 8, &items);
+        timeutils_struct_time_t tm = {
+            .tm_year = mp_obj_get_int(items[0]),
+            .tm_mon = mp_obj_get_int(items[1]),
+            .tm_mday = mp_obj_get_int(items[2]),
+            .tm_hour = mp_obj_get_int(items[4]),
+            .tm_min = mp_obj_get_int(items[5]),
+            .tm_sec = mp_obj_get_int(items[6]),
+        };
+        mp_timestamp_t s = timeutils_seconds_since_epoch(tm.tm_year, tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+        // Disable then re-enable the LPRTC so that the prescaler counter resets to 0.
+        machine_rtc.rtc->LPRTC_CCR = 0;
+        lprtc_load_count(machine_rtc.rtc, s);
+        machine_rtc.rtc->LPRTC_CCR = CCR_LPRTC_PSCLR_EN | CCR_LPRTC_EN;
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
 static mp_obj_t machine_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_id, ARG_time, ARG_repeat };
@@ -80,13 +164,18 @@ static mp_obj_t machine_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_ma
     if (mp_obj_is_int(args[ARG_time].u_obj)) {
         uint32_t seconds = mp_obj_get_int(args[1].u_obj) / 1000;
 
-        lprtc_counter_disable(self->rtc);
-        lprtc_load_count(self->rtc, 1);
-        lprtc_load_counter_match_register(self->rtc, seconds * 32768);
+        // Make sure we are guaranteed an interrupt:
+        // - if seconds = 0 it won't fire
+        // - if seconds = 1 it may miss if the counter rolls over just after it's read
+        // - if seconds >= 2 then it will always fire (when read/written close enough)
+        seconds = MAX(2, seconds);
 
+        // Configure the counter match as atomically as possible.
+        uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
         lprtc_interrupt_ack(self->rtc);
+        lprtc_load_counter_match_register(self->rtc, lprtc_get_count(self->rtc) + seconds);
         lprtc_interrupt_enable(self->rtc);
-        lprtc_counter_enable(self->rtc);
+        MICROPY_END_ATOMIC_SECTION(atomic_state);
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid argument(s)"));
     }
@@ -96,6 +185,7 @@ static mp_obj_t machine_rtc_alarm(size_t n_args, const mp_obj_t *pos_args, mp_ma
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_rtc_alarm_obj, 1, machine_rtc_alarm);
 
 static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
     { MP_ROM_QSTR(MP_QSTR_alarm), MP_ROM_PTR(&machine_rtc_alarm_obj) },
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);

--- a/ports/alif/mbedtls/mbedtls_port.c
+++ b/ports/alif/mbedtls/mbedtls_port.c
@@ -24,14 +24,9 @@
  * THE SOFTWARE.
  */
 
-#include "py/obj.h"
+#include "py/mphal.h"
 #include "se_services.h"
 #include "mbedtls_config_port.h"
-
-#if defined(MBEDTLS_HAVE_TIME)
-#include "shared/timeutils/timeutils.h"
-#include "mbedtls/platform_time.h"
-#endif
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
     uint32_t val = 0;
@@ -52,14 +47,7 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 #if defined(MBEDTLS_HAVE_TIME)
 
 time_t alif_mbedtls_time(time_t *timer) {
-    // TODO implement proper RTC time
-    unsigned int year = 2025;
-    unsigned int month = 1;
-    unsigned int date = 1;
-    unsigned int hours = 12;
-    unsigned int minutes = 0;
-    unsigned int seconds = 0;
-    return timeutils_seconds_since_epoch(year, month, date, hours, minutes, seconds);
+    return mp_hal_time_get(NULL);
 }
 
 #endif

--- a/ports/alif/modtime.c
+++ b/ports/alif/modtime.c
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+#include "shared/timeutils/timeutils.h"
+
+// Get the localtime.
+static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
+    mp_timestamp_t s = mp_hal_time_get(NULL);
+    timeutils_seconds_since_epoch_to_struct_time(s, tm);
+}
+
+// Return the number of seconds since the Epoch.
+static mp_obj_t mp_time_time_get(void) {
+    return mp_obj_new_int_from_uint(mp_hal_time_get(NULL));
+}

--- a/ports/alif/mpconfigport.h
+++ b/ports/alif/mpconfigport.h
@@ -119,7 +119,9 @@
 #define MICROPY_PY_OS_UNAME                     (1)
 #define MICROPY_PY_OS_URANDOM                   (1)
 #define MICROPY_PY_RANDOM_SEED_INIT_FUNC        (se_services_rand64())
-#define MICROPY_PY_TIME                         (1)
+#define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME (1)
+#define MICROPY_PY_TIME_TIME_TIME_NS            (1)
+#define MICROPY_PY_TIME_INCLUDEFILE             "ports/alif/modtime.c"
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE          "ports/alif/modmachine.c"
 #define MICROPY_PY_MACHINE_RESET                (1)

--- a/ports/alif/mphalport.c
+++ b/ports/alif/mphalport.c
@@ -167,7 +167,9 @@ void mp_hal_delay_ms(mp_uint_t ms) {
 }
 
 uint64_t mp_hal_time_ns(void) {
-    return 0;
+    uint32_t microseconds;
+    uint32_t s = mp_hal_time_get(&microseconds);
+    return (uint64_t)s * 1000000000ULL + (uint64_t)microseconds * 1000ULL;
 }
 
 void mp_hal_pin_config(const machine_pin_obj_t *pin, uint32_t mode,

--- a/ports/alif/mphalport.h
+++ b/ports/alif/mphalport.h
@@ -373,3 +373,5 @@ enum {
 void mp_hal_generate_laa_mac(int idx, uint8_t buf[6]);
 void mp_hal_get_mac(int idx, uint8_t buf[6]);
 void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest);
+
+uint32_t mp_hal_time_get(uint32_t *microseconds);


### PR DESCRIPTION
### Summary

This PR finishes the time implementation on the alif port:
- adds `machine.RTC.datetime` to get/set the RTC
- adds `time.time()`, `time.time_ns()`, `time.localtime()`, `time.mktime()`, `time.gmtime()`
- implements time for littlefs and FAT
- implements time for certificates for mbedTLS

The Epoch is 1970 and the time range is the year 1970 to 2106.  Resolution is 30 microseconds (achievable via `time.time_ns()`).

### Testing

Tested on OPENMV_AE3, running the entire test suite:
- all extmod time tests now pass
- all SSL certificate based network tests now pass

### Trade-offs and Alternatives

The LPRTC peripheral is a 32-bit counter with a 16-bit prescaler.  I configured the counter to count at 1Hz (to get maximum date range) and then used the prescaler value to get 30 microsecond resolution.  That's essentially a 32+15=47-bit counter.  That's the best scheme I could come up with.
