### PR TITLE
alif/mpconfigport: Enable cryptolib and hashlib.md5/sha1.

### DIFF
--- a/ports/alif/mpconfigport.h
+++ b/ports/alif/mpconfigport.h
@@ -112,6 +112,9 @@
 
 // Extended modules
 #define MICROPY_EPOCH_IS_1970                   (1)
+#define MICROPY_PY_CRYPTOLIB                    (MICROPY_PY_SSL)
+#define MICROPY_PY_HASHLIB_MD5                  (MICROPY_PY_SSL)
+#define MICROPY_PY_HASHLIB_SHA1                 (MICROPY_PY_SSL)
 #define MICROPY_PY_OS_INCLUDEFILE               "ports/alif/modos.c"
 #define MICROPY_PY_OS_DUPTERM                   (1)
 #define MICROPY_PY_OS_SEP                       (1)


### PR DESCRIPTION
### Summary

They are enabled when SSL/mbedTLS is included in the firmware (following, eg, the stm32 port).  These new features cost around +1400 bytes of code size.

### Testing

Tested on OPENMV_AE3, running the `tests/extmod/` tests.  They pass.

### Trade-offs and Alternatives

Could leave these disabled, but this port has plenty of flash and this brings it up to par with other networking boards.
