### PR TITLE
py/mkrules.cmake: Clean genhdr and frozen_mpy dirs.

### DIFF
--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -100,6 +100,12 @@ if(MICROPY_ROM_TEXT_COMPRESSION)
     )
 endif()
 
+# Ensure genhdr directory is removed on clean
+
+set_property(TARGET ${MICROPY_TARGET} APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+    "${MICROPY_GENHDR_DIR}"
+)
+
 # Command to force the build of another command
 
 # Generate mpversion.h
@@ -243,6 +249,10 @@ add_custom_command(
 
 if(MICROPY_FROZEN_MANIFEST)
     set(MICROPY_FROZEN_CONTENT "${CMAKE_BINARY_DIR}/frozen_content.c")
+
+    set_property(TARGET ${MICROPY_TARGET} APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+        "${CMAKE_BINARY_DIR}/frozen_mpy"
+    )
 
     target_sources(${MICROPY_TARGET} PRIVATE
         ${MICROPY_FROZEN_CONTENT}


### PR DESCRIPTION
CMake builds relied upon the parent Makefile removing the entire build directory to successfully clean build artifacts.

py/mkrules.cmake: Add ADDITIONAL_CLEAN_FILES properties to ensure a
		  "make clean" from within the build directory removes
                  the genhdr and frozen_mpy directories.

### Summary

I've been hacking on the UNIX port for an experimental project. This included migrating it to CMake, causing me to run into numerous normally hidden issues- I'm trying to document them by means of Issue or PR rather than forget them entirely.

This issue, in particular, is a long-standing bugbear of mine, relating to how I work with MicroPython builds locally. So it gets a PR.

### Testing

Built the RP2 port with `make BOARD=RPI_PICO`, then `cd build-RPI_PICO` and `make clean` to verify `genhdr` and `frozen_mpy` are removed.

### Trade-offs and Alternatives

This is a bit of a workaround, since MicroPython's CMake tooling is infamously shy at updating genhdr contents when they change- usually causing any additional qstrings to require a full clean (manually remove the build directory) and rebuild. Normally the "Makefile" wrapping CMake handles this by blowing away the entire build directory (💀), but relying on a makefile to fixup CMake tooling is a little absurd.

These directories *should* be removed when executing a `make clean`, but this might not be the best approach. I think CMake has the right levers to pull to make this happen implicitly. Identifying where in the qstr chain CMake is hiccuping is rather more involved though.
