### PR TITLE
network_ppp: Stop polling if stream or PPP PCB are removed.

### DIFF
--- a/extmod/network_ppp_lwip.c
+++ b/extmod/network_ppp_lwip.c
@@ -146,7 +146,7 @@ static mp_obj_t network_ppp_poll(size_t n_args, const mp_obj_t *args) {
 
     mp_int_t total_len = 0;
     mp_obj_t stream;
-    while ((stream = self->stream) != mp_const_none) {
+    while (self->state >= STATE_ACTIVE && (stream = self->stream) != mp_const_none) {
         uint8_t buf[256];
         int err;
         mp_uint_t len = mp_stream_rw(stream, buf, sizeof(buf), &err, 0);

--- a/extmod/network_ppp_lwip.c
+++ b/extmod/network_ppp_lwip.c
@@ -145,8 +145,8 @@ static mp_obj_t network_ppp_poll(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_int_t total_len = 0;
-    mp_obj_t stream = self->stream;
-    while (stream != mp_const_none) {
+    mp_obj_t stream;
+    while ((stream = self->stream) != mp_const_none) {
         uint8_t buf[256];
         int err;
         mp_uint_t len = mp_stream_rw(stream, buf, sizeof(buf), &err, 0);

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -154,7 +154,7 @@ static mp_obj_t network_ppp_poll(size_t n_args, const mp_obj_t *args) {
 
     mp_int_t total_len = 0;
     mp_obj_t stream;
-    while ((stream = self->stream) != mp_const_none) {
+    while (self->state >= STATE_ACTIVE && (stream = self->stream) != mp_const_none) {
         uint8_t buf[256];
         int err;
         mp_uint_t len = mp_stream_rw(stream, buf, sizeof(buf), &err, 0);

--- a/ports/esp32/network_ppp.c
+++ b/ports/esp32/network_ppp.c
@@ -153,8 +153,8 @@ static mp_obj_t network_ppp_poll(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_int_t total_len = 0;
-    mp_obj_t stream = self->stream;
-    while (stream != mp_const_none) {
+    mp_obj_t stream;
+    while ((stream = self->stream) != mp_const_none) {
         uint8_t buf[256];
         int err;
         mp_uint_t len = mp_stream_rw(stream, buf, sizeof(buf), &err, 0);


### PR DESCRIPTION
### Summary

Two small fixes that improve when the `poll()` method stops looping trying to read more data from the stream:

- When the stream is set to `None`.
  - This was already intended and the case in the ESP32 version when I initially implemented support for the setting `stream` to None, but I didn't correctly port it over to the extmod version. And then later I brought the bug from the extmod version back to the ESP32 version. 😞 
- When PPP is disconnected.
  - When disconnecting from PPP the modem sends a confirmation. This message is received, like all messages, through the `poll()` method. lwIP may then immediately call our status callback with code `PPPERR_USER` to indicate the connection was closed. Our callback then immediately proceeds to free the PCB. Thus, during each new iteration of the loop in `poll()` we must check if we haven't disconnected in the meantime to prevent calling the `pppos_input_tcpip` with a PCB that is now NULL.

### Testing

Tested on the ESP32 by disconnecting and observing we no longer crash due to `self->pcb` being `NULL`.

Updated the extmod version to keep the two versions in sync. Haven't tested it on a port using the extmod version, but it looks like a correct condition to check there as well.
