### PR TITLE
alif/alif.mk: Add MPY_CROSS_FLAGS setting.

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -22,6 +22,8 @@ include $(TOP)/extmod/extmod.mk
 ################################################################################
 # Project specific settings and compiler/linker flags
 
+MPY_CROSS_FLAGS += -march=armv7emdp
+
 CROSS_COMPILE ?= arm-none-eabi-
 ALIF_DFP_REL_TOP ?= lib/alif_ensemble-cmsis-dfp
 ALIF_DFP_REL_HERE ?= $(TOP)/lib/alif_ensemble-cmsis-dfp


### PR DESCRIPTION
### Summary

The HP and HE CPUs have double-precision hardware floating point, so can use the armv7emdp architecture.

This allows frozen code to use native/viper/asm_thumb decorators.

Fixes issue #17896.

### Testing

Tested on OPENMV_AE3, putting native/viper/asm_thumb code in a frozen module.  It works.