### PR TITLE
tests/machine_encoder.py: Fix esp32 Encoder: only 3 pulses to count first rotation.

### DIFF
--- a/tests/extmod_hardware/machine_encoder.py
+++ b/tests/extmod_hardware/machine_encoder.py
@@ -11,22 +11,16 @@ except ImportError:
     raise SystemExit
 
 import sys
+import unittest
 from machine import Pin
+from target_wiring import encoder_loopback_id, encoder_loopback_out_pins, encoder_loopback_in_pins
 
 PRINT = False
 PIN_INIT_VALUE = 1
 
-if "esp32" in sys.platform:
-    id = 0
-    out0_pin = 4
-    in0_pin = 5
-    out1_pin = 12
-    in1_pin = 13
-else:
-    print("Please add support for this test on this platform.")
-    raise SystemExit
-
-import unittest
+id = encoder_loopback_id
+out0_pin, out1_pin = encoder_loopback_out_pins
+in0_pin, in1_pin = encoder_loopback_in_pins
 
 out0_pin = Pin(out0_pin, mode=Pin.OUT)
 in0_pin = Pin(in0_pin, mode=Pin.IN)

--- a/tests/extmod_hardware/machine_encoder.py
+++ b/tests/extmod_hardware/machine_encoder.py
@@ -13,6 +13,9 @@ except ImportError:
 import sys
 from machine import Pin
 
+PRINT = False
+PIN_INIT_VALUE = 1
+
 if "esp32" in sys.platform:
     id = 0
     out0_pin = 4
@@ -33,25 +36,70 @@ in1_pin = Pin(in1_pin, mode=Pin.IN)
 
 class TestEncoder(unittest.TestCase):
     def setUp(self):
-        out0_pin(0)
-        out1_pin(0)
-        self.enc = Encoder(id, in0_pin, in1_pin)
+        out0_pin(PIN_INIT_VALUE)
+        out1_pin(PIN_INIT_VALUE)
+        self.enc = Encoder(id, in0_pin, in1_pin, phases=1)
+        self.enc2 = Encoder(id + 1, in0_pin, in1_pin, phases=2)
+        self.enc4 = Encoder(id + 2, in0_pin, in1_pin, phases=4)
         self.pulses = 0  # track the expected encoder position in software
+        if PRINT:
+            print(
+                "\nout0_pin() out1_pin() enc.value() enc2.value() enc4.value() |",
+                out0_pin(),
+                out1_pin(),
+                "|",
+                self.enc.value(),
+                self.enc2.value(),
+                self.enc4.value(),
+            )
 
     def tearDown(self):
         self.enc.deinit()
+        try:
+            self.enc2.deinit()
+        except:
+            pass
+        try:
+            self.enc4.deinit()
+        except:
+            pass
 
     def rotate(self, pulses):
         for _ in range(abs(pulses)):
             self.pulses += 1 if (pulses > 0) else -1
-            q = self.pulses % 4
-            # Only one pin should change state each "step" so output won't glitch
-            out0_pin(q in (1, 2))
-            out1_pin(q in (2, 3))
+            if pulses > 0:
+                if self.pulses % 2:
+                    out0_pin(not out0_pin())
+                else:
+                    out1_pin(not out1_pin())
+            else:
+                if self.pulses % 2:
+                    out1_pin(not out1_pin())
+                else:
+                    out0_pin(not out0_pin())
+        if PRINT:
+            print(
+                "out0_pin() out1_pin() enc.value() enc2.value() enc4.value() pulses self.pulses |",
+                out0_pin(),
+                out1_pin(),
+                "|",
+                self.enc.value(),
+                self.enc2.value(),
+                self.enc4.value(),
+                "|",
+                pulses,
+                self.pulses,
+            )
 
-    def assertPosition(self, value):
+    def assertPosition(self, value, value2=None, value4=None):
         self.assertEqual(self.enc.value(), value)
+        if not value2 is None:
+            self.assertEqual(self.enc2.value(), value2)
+        if not value4 is None:
+            self.assertEqual(self.enc4.value(), value4)
+        pass
 
+    @unittest.skipIf(sys.platform == "mimxrt", "cannot read back the pin")
     def test_connections(self):
         # Test the hardware connections are correct. If this test fails, all tests will fail.
         for ch, outp, inp in ((0, out0_pin, in0_pin), (1, out1_pin, in1_pin)):
@@ -64,7 +112,7 @@ class TestEncoder(unittest.TestCase):
     def test_basics(self):
         self.assertPosition(0)
         self.rotate(100)
-        self.assertPosition(100 // 4)
+        self.assertPosition(100 // 4, 100 // 2, 100)
         self.rotate(-100)
         self.assertPosition(0)
 
@@ -72,27 +120,39 @@ class TestEncoder(unittest.TestCase):
         # With phase=1 (default), need 4x pulses to count a rotation
         self.assertPosition(0)
         self.rotate(1)
-        self.assertPosition(0)
+        self.assertPosition(1, 1, 1)
         self.rotate(1)
-        self.assertPosition(0)
+        self.assertPosition(1, 1, 2)
         self.rotate(1)
-        self.assertPosition(1)  # only 3 pulses to count first rotation?
+        self.assertPosition(1, 2, 3)
         self.rotate(1)
-        self.assertPosition(1)
+        self.assertPosition(1, 2, 4)  # +4
         self.rotate(1)
-        self.assertPosition(1)
+        self.assertPosition(2, 3, 5)
         self.rotate(1)
-        self.assertPosition(1)
+        self.assertPosition(2, 3, 6)
         self.rotate(1)
-        self.assertPosition(2)  # 4 for next rotation
+        self.assertPosition(2, 4, 7)
+        self.rotate(1)
+        self.assertPosition(2, 4, 8)  # +4
         self.rotate(-1)
-        self.assertPosition(1)
-        self.rotate(-4)
-        self.assertPosition(0)
-        self.rotate(-4)
-        self.assertPosition(-1)
+        self.assertPosition(2, 4, 7)
         self.rotate(-3)
-        self.assertPosition(-1)
+        self.assertPosition(1, 2, 4)  # -4
+        self.rotate(-4)
+        self.assertPosition(0, 0, 0)  # -4
+        self.rotate(-1)
+        self.assertPosition(0, 0, -1)
+        self.rotate(-1)
+        self.assertPosition(0, -1, -2)
+        self.rotate(-1)
+        self.assertPosition(0, -1, -3)
+        self.rotate(-1)
+        self.assertPosition(-1, -2, -4)  # -4
+        self.rotate(-1)
+        self.assertPosition(-1, -2, -5)
+        self.rotate(-3)
+        self.assertPosition(-2, -4, -8)  # -4
 
 
 if __name__ == "__main__":

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -309,6 +309,7 @@ tests_requiring_slice = (
 tests_requiring_target_wiring = (
     "extmod/machine_uart_irq_txidle.py",
     "extmod/machine_uart_tx.py",
+    "extmod_hardware/machine_encoder.py",
     "extmod_hardware/machine_uart_irq_break.py",
     "extmod_hardware/machine_uart_irq_rx.py",
     "extmod_hardware/machine_uart_irq_rxidle.py",

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -2,6 +2,11 @@
 #
 # Connect:
 # - GPIO4 to GPIO5
+# - GPIO12 to GPIO13
 
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {"tx": 4, "rx": 5}
+
+encoder_loopback_id = 0
+encoder_loopback_out_pins = (4, 12)
+encoder_loopback_in_pins = (5, 13)


### PR DESCRIPTION
Add pin initial level.
Add test Encoder phases x2 and x4.

Explanation to the https://github.com/micropython/micropython/pull/12346#discussion_r2241771478

Output waveform of industrial quadrature encoders:
<img width="768" height="278" alt="image" src="https://github.com/user-attachments/assets/a038fc02-52de-4fb4-acdc-0f73e005863e" />

Output waveform of rotary encoders is slightly different:
<img width="765" height="623" alt="image" src="https://github.com/user-attachments/assets/e8dea7dc-71df-42f0-8662-ba4828d28a30" />
They have several fixed positions per revolution with channel A and channel B output levels equal to 1.
I suspect that @jonathanhogg, @jimmo used exactly this kind of encoder.

He has high levels of input channels and  increment the Encoder on the falling edge of channel A.
https://github.com/micropython/micropython/blob/744270ac1b9ed3929cd41d1a6e1f6ea0e785745d/ports/esp32/modules/machine.py#L161

So, the esp32 test requires initial high levels of channels before starting the count.

Also added mimxrt configuration from the #12347
@robert-hh You can cherry-pick from here too.