### PR TITLE
unix: Add additional testing targets.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -254,11 +254,29 @@ endif
 
 include $(TOP)/py/mkrules.mk
 
-.PHONY: test test_full_no_native test_full
+.PHONY: test test_full_no_native test_full test//% test/% test-failures print-failures clean-failures
 
 test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
+
+test//%: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
+	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -i "$*"
+
+test-failures: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
+	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --run-failures
+
+print-failures:
+	cd $(TOP)/tests && ./run-tests.py --print-failures
+
+clean-failures:
+	cd $(TOP)/tests && ./run-tests.py --clean-failures
+
+test/%: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
+	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -d "$*"
 
 test_full_no_native: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -72,6 +72,14 @@ To run the complete testsuite, use:
 
     $ make test
 
+There are other make targets to interact with the testsuite:
+
+    $ make test//int       # Run all tests matching the pattern "int"
+    $ make test/ports/unix # Run all tests in ports/unix
+    $ make test-failures   # Re-run only the failed tests
+    $ make print-failures  # print the differences for failed tests
+    $ make clean-failures  # delete the .exp and .out files from failed tests
+
 The Unix port comes with a built-in package manager called `mip`, e.g.:
 
     $ ./build-standard/micropython -m mip install hmac


### PR DESCRIPTION
### Summary

These are convenience targets for running specific tests as a developer. They are more useful that invoking run-tests directly as they take account of the VARIANT= specified on the make command-line.

For instance, you can run all tests matching the regular expression "int" with `make VARIANT=... test//int`. (the new targets are all documented in README.md)

### Testing

I used each of the added targets locally and verified that they seemed to work as intended.

### Trade-offs and Alternatives

This doesn't do anything that isn't possible to day by properly setting `MICROPY_MICROPYTHON` and invoking run-tests.py directly but I find it's a good QOL enhancement. CircuitPython carries something similar but not quite the same. (note to @dhalbert in the future: if this is accepted, you should take this version and drop the one in circuitpython)