### PR TITLE
mkrules: Always rebuild preprocessor targets.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -104,7 +104,7 @@ vpath %.cpp . $(TOP) $(USER_C_MODULES)
 $(BUILD)/%.o: %.cpp
 	$(call compile_cxx)
 
-$(BUILD)/%.pp: %.c
+$(BUILD)/%.pp: %.c FORCE
 	$(ECHO) "PreProcess $<"
 	$(Q)$(CPP) $(CFLAGS) -Wp,-C,-dD,-dI -o $@ $<
 


### PR DESCRIPTION
### Summary
These files are only built on demand for developers, and it is a quick process.

Without this, a sequence like this would leave the developer with an outdated `main.pp` to inspect:

```
make build-standard/main.o  # Create dependency information
make build-standard/main.pp
touch input.h
make build-standard/main.pp # Rebuilds now, wouldn't have before
```

### Testing

I locally used the `.pp` targets and they behaved as I stated above.

### Trade-offs and Alternatives

Initially I wanted to use dependency analysis but this seems the better way based on discussion.