### PR TITLE
tests/net_inet/tls_num_errors.py: Make alloc of emg-exc-buf optional.

### DIFF
--- a/tests/net_inet/tls_num_errors.py
+++ b/tests/net_inet/tls_num_errors.py
@@ -3,15 +3,21 @@
 import socket, ssl, sys
 
 try:
-    from micropython import alloc_emergency_exception_buf, heap_lock, heap_unlock
+    from micropython import heap_lock, heap_unlock
 except:
     print("SKIP")
     raise SystemExit
 
+try:
+    from micropython import alloc_emergency_exception_buf
+
+    alloc_emergency_exception_buf(256)
+except:
+    pass
+
 
 # test with heap locked to see it switch to number-only error message
 def test(addr):
-    alloc_emergency_exception_buf(256)
     s = socket.socket()
     s.connect(addr)
     try:


### PR DESCRIPTION
### Summary

The unix port doesn't have `micropython.alloc_emergency_exception_buf()` but it's still possible to run and pass this test.  So make that call optional.

### Testing

Tested on the unix port, and PYBD_SF6.  Passes on both.