### PR TITLE
runtime: Fix printing failed allocation amounts.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1684,14 +1684,21 @@ mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_i
 #endif // MICROPY_ENABLE_COMPILER
 
 MP_NORETURN void m_malloc_fail(size_t num_bytes) {
-    DEBUG_printf("memory allocation failed, allocating %u bytes\n", (uint)num_bytes);
+    DEBUG_printf("memory allocation failed, allocating " UINT_FMT " bytes\n", (mp_uint_t)num_bytes);
     #if MICROPY_ENABLE_GC
     if (gc_is_locked()) {
         mp_raise_msg(&mp_type_MemoryError, MP_ERROR_TEXT("memory allocation failed, heap is locked"));
     }
     #endif
+    #if defined(__LP64__) || defined(_WIN64)
+    MP_STATIC_ASSERT(sizeof(size_t) == sizeof(mp_uint_t));
     mp_raise_msg_varg(&mp_type_MemoryError,
-        MP_ERROR_TEXT("memory allocation failed, allocating %u bytes"), (uint)num_bytes);
+        MP_ERROR_TEXT("memory allocation failed, allocating " UINT_FMT " bytes"), (mp_uint_t)num_bytes);
+    #else
+    MP_STATIC_ASSERT(sizeof(size_t) == sizeof(unsigned));
+    mp_raise_msg_varg(&mp_type_MemoryError,
+        MP_ERROR_TEXT("memory allocation failed, allocating %u bytes"), (unsigned)num_bytes);
+    #endif
 }
 
 #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NONE


### PR DESCRIPTION
### Summary

On LP64 and LLP64 systems, size_t is bigger than unsigned. Printing the failed allocation as mp_uint_t allows the correct failed allocation size to be shown. I noticed this in #17925.

However, there are occasions where mp_uint_t is bigger than size_t (nanbox).  In that case, preserve the existing code path to avoid growth in executable size.

Example where this affects the failed allocation message (on x86_64 coverage build):
```
>>> "a" * (1 << 54)
```

Before, this would print the size as 1.  Now it prints it as 18014398509481985 (2**54 + 1).

### Testing

I built locally and verified that large failed allocations showed the correct value.

### Trade-offs and Alternatives

The code ends up more complicated than it was previously, with the hope of avoiding code growth.

I can remove the added size assertions if preferred. I did want to see if the assertions were correct across all builds done by CI.