### PR TITLE
Fix NULL pointer dereference in mp_obj_get_type

### DIFF
--- a/py/obj.c
+++ b/py/obj.c
@@ -57,6 +57,9 @@ const mp_obj_type_t *MICROPY_WRAP_MP_OBJ_GET_TYPE(mp_obj_get_type)(mp_const_obj_
     #if MICROPY_OBJ_IMMEDIATE_OBJS && MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_A
 
     if (mp_obj_is_obj(o_in)) {
+        if (o_in == MP_OBJ_NULL) {
+            mp_raise_TypeError(MP_ERROR_TEXT("object reference invalidated during operation"));
+        }
         const mp_obj_base_t *o = MP_OBJ_TO_PTR(o_in);
         return o->type;
     } else {

--- a/tests/basics/list_sort_sideeffect_clear_gc.py
+++ b/tests/basics/list_sort_sideeffect_clear_gc.py
@@ -1,0 +1,19 @@
+import gc
+class check:
+    def __init__(self, arr1, arr2):
+        self.arr1 = arr1
+        self.arr2 = arr2
+    
+    def __lt__(self, other):
+        self.arr1.clear()
+        self.arr2.extend([777] * 5)
+        gc.collect()
+        self.arr2.clear()
+        return True
+
+d1 = []
+d2 = []
+contaminators = [check(d1, d2) for _ in range(3)]
+d1.extend(contaminators)
+d2.extend(contaminators)
+d1.sort()


### PR DESCRIPTION
### Summary

If a list's comparison function calls array.clear() and gc.collect()
during sort, an element slot can become MP_OBJ_NULL. Guard
mp_obj_get_type() to avoid a NULL dereference and raise a proper
exception instead of crashing.

Closes: #17941

### Testing

Tested on Unix port. 