### PR TITLE
STM32: Enable I2CTarget for STM32L4.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -279,10 +279,6 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len) {
 #elif defined(STM32L4)
 #define APB1ENR            APB1ENR1
 #define RCC_APB1ENR_I2C1EN RCC_APB1ENR1_I2C1EN
-#if defined(STM32L432xx)
-// Not a real peripheral, only needed for i2c_id calculation in i2c_init.
-#define I2C2_BASE          (APB1PERIPH_BASE + 0x5800UL)
-#endif
 #endif
 
 static uint16_t i2c_timeout_ms[MICROPY_HW_MAX_I2C];

--- a/ports/stm32/i2cslave.c
+++ b/ports/stm32/i2cslave.c
@@ -76,7 +76,7 @@ void i2c_slave_irq_handler(i2c_slave_t *i2c) {
     }
 }
 
-#elif defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
+#elif defined(STM32F7) || defined(STM32H7) || defined(STM32L4) || defined(STM32WB)
 
 void i2c_slave_init_helper(i2c_slave_t *i2c, int addr) {
     i2c->CR1 = I2C_CR1_STOPIE | I2C_CR1_ADDRIE | I2C_CR1_RXIE | I2C_CR1_TXIE;

--- a/ports/stm32/i2cslave.h
+++ b/ports/stm32/i2cslave.h
@@ -28,7 +28,7 @@
 
 #include STM32_HAL_H
 
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32L4) || defined(STM32WB)
 
 #if !defined(I2C2_BASE)
 // This MCU doesn't have I2C2_BASE, define it so that the i2c_idx calculation works.
@@ -63,7 +63,7 @@ static inline void i2c_slave_init(i2c_slave_t *i2c, int irqn, int irq_pri, int a
         volatile uint32_t tmp = RCC->APB1ENR1; // Delay after enabling clock
         (void)tmp;
     }
-    #elif defined(STM32WB)
+    #elif defined(STM32L4) || defined(STM32WB)
     RCC->APB1ENR1 |= 1 << (RCC_APB1ENR1_I2C1EN_Pos + i2c_idx);
     volatile uint32_t tmp = RCC->APB1ENR1; // Delay after enabling clock
     (void)tmp;

--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -640,7 +640,7 @@
     || defined(MICROPY_HW_I2C3_SCL) || defined(MICROPY_HW_I2C4_SCL)
 #define MICROPY_HW_ENABLE_HW_I2C (1)
 #ifndef MICROPY_HW_ENABLE_HW_I2C_TARGET
-#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32WB)
+#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32L4) || defined(STM32WB)
 #define MICROPY_HW_ENABLE_HW_I2C_TARGET (1)
 #else
 #define MICROPY_HW_ENABLE_HW_I2C_TARGET (0)


### PR DESCRIPTION
STM32L4 uses the same I2C controller as STM32WB.
Change `defined(STM32WB)` to `defined(STM32WB) || defined(STM32L4) `in:
stm32/i2cslave.c
stm32/i2cslave.h
stm32/mpconfigboard_common.h

### Testing

Tested with custom STM32L496 board. Created I2C and I2CTarget with
wire link betweenports and read data from I2CTarget buffer.