### PR TITLE
Fix NULL pointer dereference in mp_obj_get_type #17944

### DIFF
--- a/tests/basics/list_sort_sideeffect.py
+++ b/tests/basics/list_sort_sideeffect.py
@@ -1,0 +1,29 @@
+try:
+    import gc
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class Evil:
+    n_calls = 0
+
+    def __init__(self, arr, val):
+        self.arr = arr
+        self.val = val
+
+    def __lt__(self, other):
+        Evil.n_calls += 1
+        if Evil.n_calls == 16:
+            self.arr.clear()
+            gc.collect()
+        return self.val < other.val
+
+
+a = []
+a.extend(Evil(a, i) for i in range(32))
+
+try:
+    a.sort()
+except ValueError:
+    print("ValueError")

--- a/tests/basics/list_sort_sideeffect.py.exp
+++ b/tests/basics/list_sort_sideeffect.py.exp
@@ -1,0 +1,1 @@
+ValueError


### PR DESCRIPTION
### Summary

py/obj:Against null during list.sort,add testcase.
If a list's comparison function calls array.clear() and gc.collect() during sort, an element slot can
become MP_OBJ_NULL. Guard mp_obj_get_type() to avoid a NULL dereference.

Closes: #17941

### Testing

Testing on unix port. 


