### PR TITLE
tests: change all CLI test runners to use the new `--test-instance` argument scheme

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -225,7 +225,7 @@ test_natmod: $(BUILD)/firmware.elf
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && \
 		for natmod in btree deflate framebuf heapq random_basic re; do \
-		./run-natmodtests.py -p -d execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_EXTRA) extmod/$$natmod*.py; \
+		./run-natmodtests.py -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_EXTRA) extmod/$$natmod*.py; \
 		done
 
 $(BUILD)/firmware.elf: $(LDSCRIPT) $(OBJ)

--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -12,9 +12,6 @@ from glob import glob
 
 run_tests_module = __import__("run-tests")
 
-sys.path.append("../tools")
-import pyboard
-
 prepare_script_for_target = run_tests_module.prepare_script_for_target
 
 # Paths for host executables
@@ -47,12 +44,12 @@ def run_script_on_target(target, script):
     output = b""
     err = None
 
-    if isinstance(target, pyboard.Pyboard):
+    if hasattr(target, "enter_raw_repl"):
         # Run via pyboard interface
         try:
             target.enter_raw_repl()
             output = target.exec_(script)
-        except pyboard.PyboardError as er:
+        except run_tests_module.pyboard.PyboardError as er:
             err = er
     else:
         # Run local executable
@@ -125,7 +122,7 @@ def run_benchmarks(args, target, param_n, param_m, n_average, test_list):
                 f.write(test_script)
 
         # Process script through mpy-cross if needed
-        if isinstance(target, pyboard.Pyboard) or args.via_mpy:
+        if hasattr(target, "enter_raw_repl") or args.via_mpy:
             crash, test_script_target = prepare_script_for_target(args, script_text=test_script)
             if crash:
                 test_results.append((test_file, "fail", "preparation"))
@@ -253,17 +250,17 @@ def compute_diff(file1, file2, diff_score):
 def main():
     cmd_parser = argparse.ArgumentParser(description="Run benchmarks for MicroPython")
     cmd_parser.add_argument(
-        "-t", "--diff-time", action="store_true", help="diff time outputs from a previous run"
+        "-m", "--diff-time", action="store_true", help="diff time outputs from a previous run"
     )
     cmd_parser.add_argument(
         "-s", "--diff-score", action="store_true", help="diff score outputs from a previous run"
     )
     cmd_parser.add_argument(
-        "-p", "--pyboard", action="store_true", help="run tests via pyboard.py"
+        "-t", "--test-instance", default="unix", help="the MicroPython instance to test"
     )
-    cmd_parser.add_argument(
-        "-d", "--device", default="/dev/ttyACM0", help="the device for pyboard.py"
-    )
+    cmd_parser.add_argument("--baudrate", default=115200, help="baud rate of the serial device")
+    cmd_parser.add_argument("--user", default="micro", help="telnet login username")
+    cmd_parser.add_argument("--password", default="python", help="telnet login password")
     cmd_parser.add_argument("-a", "--average", default="8", help="averaging number")
     cmd_parser.add_argument(
         "--emit", default="bytecode", help="MicroPython emitter to use (bytecode or native)"
@@ -295,15 +292,18 @@ def main():
     M = int(args.M[0])
     n_average = int(args.average)
 
-    if args.pyboard:
-        if not args.mpy_cross_flags:
-            args.mpy_cross_flags = "-march=armv7m"
-        target = pyboard.Pyboard(args.device)
-        target.enter_raw_repl()
-    else:
+    target = run_tests_module.get_test_instance(
+        args.test_instance, args.baudrate, args.user, args.password
+    )
+    if target is None:
+        # Use the unix port of MicroPython.
         target = [MICROPYTHON, "-X", "emit=" + args.emit]
         if args.heapsize is not None:
             target.extend(["-X", "heapsize=" + args.heapsize])
+    else:
+        # Use a remote target.
+        if not args.mpy_cross_flags:
+            args.mpy_cross_flags = "-march=armv7m"
 
     if len(args.files) == 0:
         tests_skip = ("benchrun.py",)
@@ -324,7 +324,7 @@ def main():
     test_results = run_benchmarks(args, target, N, M, n_average, tests)
     res = run_tests_module.create_test_report(args, test_results)
 
-    if isinstance(target, pyboard.Pyboard):
+    if hasattr(target, "exit_raw_repl"):
         target.exit_raw_repl()
         target.close()
 

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -246,6 +246,17 @@ def platform_to_port(platform):
     return platform_to_port_map.get(platform, platform)
 
 
+def convert_device_shortcut_to_real_device(device):
+    if device.startswith("a") and device[1:].isdigit():
+        return "/dev/ttyACM" + device[1:]
+    elif device.startswith("u") and device[1:].isdigit():
+        return "/dev/ttyUSB" + device[1:]
+    elif device.startswith("c") and device[1:].isdigit():
+        return "COM" + device[1:]
+    else:
+        return device
+
+
 def get_test_instance(test_instance, baudrate, user, password):
     if test_instance.startswith("port:"):
         _, port = test_instance.split(":", 1)
@@ -253,15 +264,9 @@ def get_test_instance(test_instance, baudrate, user, password):
         return None
     elif test_instance == "webassembly":
         return PyboardNodeRunner()
-    elif test_instance.startswith("a") and test_instance[1:].isdigit():
-        port = "/dev/ttyACM" + test_instance[1:]
-    elif test_instance.startswith("u") and test_instance[1:].isdigit():
-        port = "/dev/ttyUSB" + test_instance[1:]
-    elif test_instance.startswith("c") and test_instance[1:].isdigit():
-        port = "COM" + test_instance[1:]
     else:
         # Assume it's a device path.
-        port = test_instance
+        port = convert_device_shortcut_to_real_device(test_instance)
 
     global pyboard
     sys.path.append(base_path("../tools"))


### PR DESCRIPTION
### Summary

Back in PR #16111 (see commit 8978102f3595ae321484a6be44c1dcf25c8909a9) the `run-tests.py` script was changed to use an improved way of selecting the test instance, eg:
```py
$ ./run-tests.py -t a0
```
that would run on `/dev/ttyACM0`.  This has been a very nice improvement, makes it easier to specify the target.

This PR updates all other test runners to use the same scheme:
- `run-multitests.py` -- previously used `-i`, eg `-i pyb:a0`
- `run-natmodtests.py` -- previously used `-d` and `-p`, eg `-p -d /dev/ttyACM0'
- `run-perfbench.py` -- previously used `-d` and `-p`

The `run-internalbench.py` runner was already updated in 88cb6bc818546e7fe8b862c784e1e4a6b8a12b8a

Now, everything uses the same scheme.

### Testing

Tested locally running on the unix port and some boards attached to serial ports.

CI will also test this.

Octoprobe will need updating.

### Trade-offs and Alternatives

Users will need to learn the new CLI options.  And some existing ones had to be renamed because they clashed with `-t`.

We could leave things as they are, but it's pretty awkward how the test runners all use different CLI options to select the test target.

There's still quite a bit of refactoring that could be done, to consolidate more code between the test runners.  But in the interest of making small, manageable steps, I've only done the first step of converting the command line options.
