### PR TITLE
tests: Improve test hardware configuration by putting board-specific settings in `target_wiring` module

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -30,6 +30,7 @@ project(micropython)
 set(MICROPY_PORT_DIR    ${CMAKE_CURRENT_SOURCE_DIR})
 set(MICROPY_DIR         ${MICROPY_PORT_DIR}/../..)
 set(MICROPY_TARGET      micropython)
+string(TOUPPER          ZEPHYR_${BOARD} MICROPY_BOARD)
 
 include(${MICROPY_DIR}/py/py.cmake)
 include(${MICROPY_DIR}/extmod/extmod.cmake)

--- a/tests/extmod/machine_uart_irq_txidle.py
+++ b/tests/extmod/machine_uart_irq_txidle.py
@@ -10,32 +10,7 @@ except (ImportError, AttributeError):
     raise SystemExit
 
 import time, sys
-
-# Configure pins based on the target.
-if "alif" in sys.platform:
-    uart_id = 1
-    tx_pin = None
-elif "rp2" in sys.platform:
-    uart_id = 0
-    tx_pin = "GPIO0"
-    rx_pin = "GPIO1"
-elif "samd" in sys.platform and "ItsyBitsy M0" in sys.implementation._machine:
-    uart_id = 0
-    tx_pin = "D1"
-    rx_pin = "D0"
-elif "samd" in sys.platform and "ItsyBitsy M4" in sys.implementation._machine:
-    uart_id = 3
-    tx_pin = "D1"
-    rx_pin = "D0"
-elif "mimxrt" in sys.platform:
-    uart_id = 1
-    tx_pin = None
-elif "nrf" in sys.platform:
-    uart_id = 0
-    tx_pin = None
-else:
-    print("Please add support for this test on this platform.")
-    raise SystemExit
+from target_wiring import uart_loopback_args, uart_loopback_kwargs
 
 
 def irq(u):
@@ -46,11 +21,7 @@ text = "Hello World" * 20
 
 # Test that the IRQ is called after the write has completed.
 for bits_per_s in (2400, 9600, 115200):
-    if tx_pin is None:
-        uart = UART(uart_id, bits_per_s)
-    else:
-        uart = UART(uart_id, bits_per_s, tx=tx_pin, rx=rx_pin)
-
+    uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
     uart.irq(irq, uart.IRQ_TXIDLE)
 
     # The IRQ_TXIDLE shall trigger after the message has been sent. Thus

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -8,50 +8,35 @@ except ImportError:
     raise SystemExit
 
 import time, sys
+from target_wiring import uart_loopback_args, uart_loopback_kwargs
 
 initial_delay_ms = 0
 bit_margin = 0
 timing_margin_us = 100
 
-# Configure pins based on the target.
+# Tune test parameters based on the target.
 if "alif" in sys.platform:
-    uart_id = 1
-    pins = {}
     bit_margin = 1
 elif "esp32" in sys.platform:
-    uart_id = 1
-    pins = {}
     timing_margin_us = 400
 elif "mimxrt" in sys.platform:
-    uart_id = 1
-    pins = {}
     initial_delay_ms = 20  # UART sends idle frame after init, so wait for that
     bit_margin = 1
+elif "nrf" in sys.platform:
+    timing_margin_us = 130
 elif "pyboard" in sys.platform:
-    if "STM32WB" in sys.implementation._machine:
-        uart_id = "LP1"
-    else:
-        uart_id = 4
-    pins = {}
     initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
     bit_margin = 1  # first start-bit must wait to sync with the UART clock
 elif "rp2" in sys.platform:
-    uart_id = 0
-    pins = {"tx": "GPIO0", "rx": "GPIO1"}
     timing_margin_us = 180
 elif "samd" in sys.platform:
-    uart_id = 2
-    pins = {"tx": "D1", "rx": "D0"}
     timing_margin_us = 300
     bit_margin = 1
-else:
-    print("SKIP")
-    raise SystemExit
 
 # Test that write+flush takes the expected amount of time to execute.
 for bits_per_s in (2400, 9600, 115200):
     text = "Hello World"
-    uart = UART(uart_id, bits_per_s, bits=8, parity=None, stop=1, **pins)
+    uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
     time.sleep_ms(initial_delay_ms)
 
     start_us = time.ticks_us()

--- a/tests/extmod_hardware/machine_uart_irq_break.py
+++ b/tests/extmod_hardware/machine_uart_irq_break.py
@@ -12,23 +12,7 @@ except (ImportError, AttributeError):
     raise SystemExit
 
 import time, sys
-
-# Configure pins based on the target.
-if "esp32" in sys.platform:
-    _machine = sys.implementation._machine
-    if "ESP32S2" in _machine or "ESP32C3" in _machine or "ESP32C6" in _machine:
-        print("SKIP")
-        raise SystemExit
-    uart_id = 1
-    tx_pin = 4
-    rx_pin = 5
-elif "rp2" in sys.platform:
-    uart_id = 0
-    tx_pin = "GPIO0"
-    rx_pin = "GPIO1"
-else:
-    print("Please add support for this test on this platform.")
-    raise SystemExit
+from target_wiring import uart_loopback_args, uart_loopback_kwargs
 
 
 def irq(u):
@@ -37,7 +21,7 @@ def irq(u):
 
 # Test that the IRQ is called for each break received.
 for bits_per_s in (2400, 9600, 57600):
-    uart = UART(uart_id, bits_per_s, tx=tx_pin, rx=rx_pin)
+    uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
     uart.irq(irq, uart.IRQ_BREAK)
 
     print("write", bits_per_s)

--- a/tests/extmod_hardware/machine_uart_irq_rxidle.py
+++ b/tests/extmod_hardware/machine_uart_irq_rxidle.py
@@ -12,52 +12,10 @@ except (ImportError, AttributeError):
     raise SystemExit
 
 import time, sys
+from target_wiring import uart_loopback_args, uart_loopback_kwargs
 
 # Target tuning options.
-tune_wait_initial_rxidle = False
-
-# Configure pins based on the target.
-if "alif" in sys.platform:
-    uart_id = 1
-    tx_pin = None
-    rx_pin = None
-elif "esp32" in sys.platform:
-    uart_id = 1
-    tx_pin = 4
-    rx_pin = 5
-elif "mimxrt" in sys.platform:
-    uart_id = 1
-    tx_pin = None
-elif "pyboard" in sys.platform:
-    tune_wait_initial_rxidle = True
-    if "STM32WB" in sys.implementation._machine:
-        # LPUART(1) is on PA2/PA3
-        uart_id = "LP1"
-    else:
-        # UART(4) is on PA0/PA1
-        uart_id = 4
-    tx_pin = None
-    rx_pin = None
-elif "renesas-ra" in sys.platform:
-    uart_id = 9
-    tx_pin = None  # P602 @ RA6M2
-    rx_pin = None  # P601 @ RA6M2
-elif "rp2" in sys.platform:
-    uart_id = 0
-    tx_pin = "GPIO0"
-    rx_pin = "GPIO1"
-elif "samd" in sys.platform and "ItsyBitsy M0" in sys.implementation._machine:
-    uart_id = 0
-    tx_pin = "D1"
-    rx_pin = "D0"
-    byte_by_byte = True
-elif "samd" in sys.platform and "ItsyBitsy M4" in sys.implementation._machine:
-    uart_id = 3
-    tx_pin = "D1"
-    rx_pin = "D0"
-else:
-    print("Please add support for this test on this platform.")
-    raise SystemExit
+tune_wait_initial_rxidle = sys.platform == "pyboard"
 
 
 def irq(u):
@@ -71,10 +29,7 @@ for bits_per_s in (2400, 9600, 115200):
     print("========")
     print("bits_per_s:", bits_per_s)
 
-    if tx_pin is None:
-        uart = UART(uart_id, bits_per_s)
-    else:
-        uart = UART(uart_id, bits_per_s, tx=tx_pin, rx=rx_pin)
+    uart = UART(*uart_loopback_args, baudrate=bits_per_s, **uart_loopback_kwargs)
 
     # Ignore a possible initial RXIDLE condition after creating UART.
     if tune_wait_initial_rxidle:

--- a/tests/feature_check/target_info.py
+++ b/tests/feature_check/target_info.py
@@ -20,6 +20,7 @@ arch = [
     "xtensawin",
     "rv32imc",
 ][sys_mpy >> 10]
+build = getattr(sys.implementation, "_build", "unknown")
 thread = getattr(sys.implementation, "_thread", None)
 
 # Detect how many bits of precision the floating point implementation has.
@@ -33,4 +34,4 @@ try:
 except NameError:
     float_prec = 0
 
-print(platform, arch, thread, float_prec, len("α") == 1)
+print(platform, arch, build, thread, float_prec, len("α") == 1)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -216,6 +216,9 @@ platform_tests_to_skip = {
     ),
 }
 
+# Tests that require `import target_wiring` to work.
+tests_requiring_target_wiring = ()
+
 
 def rm_f(fname):
     if os.path.exists(fname):
@@ -310,6 +313,7 @@ def detect_test_platform(pyb, args):
     args.float_prec = float_prec
     args.unicode = unicode
 
+    # Print the detected information about the target.
     print("platform={}".format(platform), end="")
     if arch:
         print(" arch={}".format(arch), end="")
@@ -321,7 +325,43 @@ def detect_test_platform(pyb, args):
         print(" float={}-bit".format(float_prec), end="")
     if unicode:
         print(" unicode", end="")
-    print()
+
+
+def detect_target_wiring_script(pyb, args):
+    tw_data = b""
+    tw_source = None
+    if args.target_wiring:
+        # A target_wiring path is explicitly provided, so use that.
+        tw_source = args.target_wiring
+        with open(tw_source, "rb") as f:
+            tw_data = f.read()
+    elif hasattr(pyb, "exec_raw") and pyb.exec_raw("import target_wiring") == (b"", b""):
+        # The board already has a target_wiring module available, so use that.
+        tw_source = "on-device"
+    else:
+        port = platform_to_port(args.platform)
+        build = args.build
+        tw_board_exact = None
+        tw_board_partial = None
+        tw_port = None
+        for file in os.listdir("target_wiring"):
+            file_base = file.removesuffix(".py")
+            if file_base == build:
+                # A file matching the target's board/build name.
+                tw_board_exact = file
+            elif file_base.endswith("x") and build.startswith(file_base.removesuffix("x")):
+                # A file with a partial match to the target's board/build name.
+                tw_board_partial = file
+            elif file_base == port:
+                # A file matching the target's port.
+                tw_port = file
+        tw_source = tw_board_exact or tw_board_partial or tw_port
+        if tw_source:
+            with open("target_wiring/" + tw_source, "rb") as f:
+                tw_data = f.read()
+    if tw_source:
+        print(" target_wiring={}".format(tw_source), end="")
+    pyb.target_wiring_script = tw_data
 
 
 def prepare_script_for_target(args, *, script_text=None, force_plain=False):
@@ -382,6 +422,12 @@ def run_script_on_remote_target(pyb, args, test_file, is_special):
     try:
         had_crash = False
         pyb.enter_raw_repl()
+        if test_file.endswith(tests_requiring_target_wiring) and pyb.target_wiring_script:
+            pyb.exec_(
+                "import sys;sys.modules['target_wiring']=__build_class__(lambda:exec("
+                + repr(pyb.target_wiring_script)
+                + "),'target_wiring')"
+            )
         output_mupy = pyb.exec_(script, timeout=TEST_TIMEOUT)
     except pyboard.PyboardError as e:
         had_crash = True
@@ -1285,6 +1331,11 @@ the last matching regex is used:
         default=None,
         help="prologue python file to execute before module import",
     )
+    cmd_parser.add_argument(
+        "--target-wiring",
+        default=None,
+        help="force the given script to be used as target_wiring.py",
+    )
     args = cmd_parser.parse_args()
 
     prologue = ""
@@ -1380,6 +1431,13 @@ the last matching regex is used:
     else:
         # tests explicitly given
         tests = args.files
+
+    # If any tests need it, prepare the target_wiring script for the target.
+    if pyb and any(test.endswith(tests_requiring_target_wiring) for test in tests):
+        detect_target_wiring_script(pyb, args)
+
+    # End the target information line.
+    print()
 
     if not args.keep_path:
         # Clear search path to make sure tests use only builtin modules, those in

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -291,7 +291,7 @@ def detect_test_platform(pyb, args):
     output = run_feature_check(pyb, args, "target_info.py")
     if output.endswith(b"CRASH"):
         raise ValueError("cannot detect platform: {}".format(output))
-    platform, arch, thread, float_prec, unicode = str(output, "ascii").strip().split()
+    platform, arch, build, thread, float_prec, unicode = str(output, "ascii").strip().split()
     if arch == "None":
         arch = None
     inlineasm_arch = detect_inline_asm_arch(pyb, args)
@@ -305,6 +305,7 @@ def detect_test_platform(pyb, args):
     if arch and not args.mpy_cross_flags:
         args.mpy_cross_flags = "-march=" + arch
     args.inlineasm_arch = inlineasm_arch
+    args.build = build
     args.thread = thread
     args.float_prec = float_prec
     args.unicode = unicode

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -217,7 +217,13 @@ platform_tests_to_skip = {
 }
 
 # Tests that require `import target_wiring` to work.
-tests_requiring_target_wiring = ()
+tests_requiring_target_wiring = (
+    "extmod/machine_uart_irq_txidle.py",
+    "extmod/machine_uart_tx.py",
+    "extmod_hardware/machine_uart_irq_break.py",
+    "extmod_hardware/machine_uart_irq_rx.py",
+    "extmod_hardware/machine_uart_irq_rxidle.py",
+)
 
 
 def rm_f(fname):

--- a/tests/target_wiring/EK_RA6M2.py
+++ b/tests/target_wiring/EK_RA6M2.py
@@ -1,0 +1,8 @@
+# Target wiring for EK_RA6M2.
+#
+# Connect:
+# - P601 to P602
+
+# UART(9) is on P602/P601.
+uart_loopback_args = (9,)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/NUCLEO_WB55.py
+++ b/tests/target_wiring/NUCLEO_WB55.py
@@ -1,0 +1,8 @@
+# Target wiring for NUCLEO_WB55.
+#
+# Connect:
+# - PA2 to PA3
+
+# LPUART(1) is on PA2/PA3.
+uart_loopback_args = ("LP1",)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/PYBx.py
+++ b/tests/target_wiring/PYBx.py
@@ -1,0 +1,8 @@
+# Target wiring for PYBV10, PYBV11, PYBLITEV10, PYBD_SF2, PYBD_SF3, PYBD_SF6.
+#
+# Connect:
+# - X1 to X2
+
+# UART("XA") is on X1/X2  (usually UART(4) on PA0/PA1).
+uart_loopback_args = ("XA",)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
+++ b/tests/target_wiring/ZEPHYR_NUCLEO_WB55RG.py
@@ -1,0 +1,7 @@
+# Target wiring for zephyr nucleo_wb55rg.
+#
+# Connect:
+# - TX=PC0 to RX=PC1
+
+uart_loopback_args = ("lpuart1",)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/alif.py
+++ b/tests/target_wiring/alif.py
@@ -1,0 +1,7 @@
+# Target wiring for general alif board.
+#
+# Connect:
+# - UART1 TX and RX, usually P0_5 and P0_4
+
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -1,0 +1,7 @@
+# Target wiring for general esp32 board.
+#
+# Connect:
+# - GPIO4 to GPIO5
+
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {"tx": 4, "rx": 5}

--- a/tests/target_wiring/mimxrt.py
+++ b/tests/target_wiring/mimxrt.py
@@ -1,0 +1,7 @@
+# Target wiring for general mimxrt board.
+#
+# Connect:
+# - UART1 TX and RX, usually D0 and D1
+
+uart_loopback_args = (1,)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/nrf.py
+++ b/tests/target_wiring/nrf.py
@@ -1,0 +1,7 @@
+# Target wiring for general nrf board.
+#
+# Connect:
+# - UART0 TX and RX
+
+uart_loopback_args = (0,)
+uart_loopback_kwargs = {}

--- a/tests/target_wiring/rp2.py
+++ b/tests/target_wiring/rp2.py
@@ -1,0 +1,7 @@
+# Target wiring for general rp2 board.
+#
+# Connect:
+# - GPIO0 to GPIO1
+
+uart_loopback_args = (0,)
+uart_loopback_kwargs = {"tx": "GPIO0", "rx": "GPIO1"}

--- a/tests/target_wiring/samd.py
+++ b/tests/target_wiring/samd.py
@@ -1,0 +1,7 @@
+# Target wiring for general samd board.
+#
+# Connect:
+# - D0 to D1
+
+uart_loopback_args = ()
+uart_loopback_kwargs = {"tx": "D1", "rx": "D0"}


### PR DESCRIPTION
### Summary

There are currently a few "hardware" tests that need external board connections to be made for them to work, eg bridging a pair of pins.  Eg all tests in `tests/extmod_hardware` need some kind of connection.

Along with the physical connections -- which are different for each board -- there needs to be corresponding Python settings, eg which UART instance to use and which pins for TX/RX.

These settings are currently hard-coded in each test file.  That has a few problems:
- settings are repeated, eg all the UART tests have pretty much the same settings code duplicated across them
- changing the settings means changing many files
- adding a new board means adding a lot of code
- the tests get bigger and bigger with each new board that they support, meaning they may not fit on targets with a small amount of RAM (that's already the case with `tests/extmod_hardware/machine_pwm.py`)
- if you have a custom board you have to manually edit the test to add your own settings

This PR aims to solve all the above problems by splitting the board-specific settings out into separate files, one for each board (or port).  They are placed in the `tests/target_wiring/` directory.  The `run-tests.py` test runner then loads the appropriate configuration for the target that is being tested, sends it to the board so it's available as `import target_wiring` (without needing a filesystem), and then executes the test (only tests that need `target_wiring` have it loaded).

This PR adds support for this `target_wiring` module, and converts all the existing `machine.UART` tests to use it.

### Testing

Tested locally on PYBV10 and ESP32-S2.  Still needs further testing once we decide this is the way forward.

### Trade-offs and Alternatives

Although the idea is straightforward, there were many decisions to make in the implementation:
1.  Selection of the correct `target_wiring` module follows a hierarchy: if an exact match for the board name is found (via `sys.implementation._build`) then that's used, otherwise there's a possible wildcard match on the board name (eg for PYB* boards, they can all use the same config), otherwise there's a match on the port name (eg rp2 boards can all use the same config).  This allows a lot of flexibility (maybe too much?).
2. I used a trick to send the `target_wiring` module to the board without using the filesystem or VFS hook.  It just evaluates a new class called `target_wiring` with the body of the class the script with the settings.  This should be pretty minimal and work on targets without a filesystem/VFS.
3. The same configuration is reused for `extmod/machine_uart*.py` tests ... they are not strictly hardware tests (they don't require external connections) but they do need to know which UART instance to use, and they can reuse the same instance used by `extmod_hardware/machine_uart*.py` tests.  Hopefully this won't be an issue, but it does confuse somewhat which tests require `target_wiring` configuration and which don't (ie it's no longer as simple as saying that only `extmod_hardware/` tests need `target_wiring`).
4. Eventually there may be other UART tests that need to be connected to a separate board.  As such I named the config options `uart_loopback_args` and `uart_loopback_kwargs`.  This shows the general problem that the approach may not scale well if lots of tests need subtly different configurations, eg `I2CTarget` will need a loopback configuration (4 pins) and a non-loopback configuration (another 2 pins).  To make it work, the config for these either need to be named differently, or selected very carefully so the pins can overlap.
5. Tests like `extmod_hardware/machine_pwm.py` can reuse the UART loopback pins, but probably they should be named differently, in case they can't be reused.
6. Need to think about how to handle zephyr boards, how to detect which configuration to use (need to either add special handling in `run-tests.py` for zephyr, or expose `sys.implementation._build` on that port). --> DONE, zephyr now has `sys.implementation._build`
7. To manually run a test using this new `target_wiring` module (without using `run-tests.py`) requires the user to explicitly copy across the correct `target_wiring.py` file to their device.
8. If there's a `target_wiring.py` on the device then it is overridden by the one injected by `run-tests.py`.  I think this is desired behaviour, so you don't have a stale/old file on there that messes up the test. --> CHANGED, any files on the board take precedence.
9. Need to add a way in `run-tests.py` for the user to select/override which `target_wiring.py` module to use, eg for custom boards, eg for Octoprobe. --> DONE, `--target-wiring` option added
