### PR TITLE
esp32: Bump esp_tinyusb component, add component version lock files to source control.

### DIFF
--- a/ports/esp32/.gitignore
+++ b/ports/esp32/.gitignore
@@ -1,2 +1,1 @@
-dependencies.lock
 managed_components/

--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -61,5 +61,21 @@ set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 # Include main IDF cmake file.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+# Generate individual dependencies.lock files based on chip target
+idf_build_set_property(DEPENDENCIES_LOCK lockfiles/dependencies.lock.${IDF_TARGET})
+
 # Define the project.
 project(micropython)
+
+# Check for lockfile changes and either warn or error depending on build type
+message("Checking lockfile contents...")
+execute_process(COMMAND git diff --exit-code lockfiles/ WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    RESULT_VARIABLE RES)
+if (RES)
+    # Maintainer builds (CI or autobuild runs) should fail if this has happened
+    if($ENV{MICROPY_MAINTAINER_BUILD})
+        message(FATAL_ERROR "Failing build as lockfiles are dirty (see above). Check that ESP-IDF versions match.")
+    else()
+        message(WARNING "Component lockfile contents have changed (see above). This may be due to building with a different ESP-IDF version. Please mention this output if reporting an issue with MicroPython.")
+    endif()
+endif()

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -30,8 +30,9 @@ framework, aka SDK).  The ESP-IDF includes the libraries and RTOS needed to
 manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
-The ESP-IDF changes quickly and MicroPython only supports certain versions.
-Currently MicroPython supports v5.2, v5.2.2, v5.3, v5.4, v5.4.1 and v5.4.2.
+The ESP-IDF changes quickly and MicroPython only supports certain versions. The
+current recommended version of ESP-IDF for MicroPython is v5.4.2. MicroPython
+also supports v5.2, v5.2.2, v5.3, v5.4 and v5.4.1.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).

--- a/ports/esp32/lockfiles/README.md
+++ b/ports/esp32/lockfiles/README.md
@@ -1,0 +1,12 @@
+# ESP-IDF Component Lockfiles
+
+This directory contains the exact versions of ESP-IDF components that have been
+used to build MicroPython. It is updated by the [component version
+solver](https://docs.espressif.com/projects/idf-component-manager/en/latest/guides/version_solver.html).
+
+Unless you change the `main/idf_component.yml` file for MicroPython ESP32, files
+in this directory should only change contents if you build using a different
+ESP-IDF version to the last time the file was updated.
+
+*Please do not commit changes to these files and submit PRs unless the PR needs
+to change versions of components or ESP-IDF.*

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -1,0 +1,35 @@
+dependencies:
+  espressif/lan867x:
+    component_hash: 0ff9dae3affeff53811e7c8283e67c6d36dc0c03e3bc5102c0fba629e08bf6c4
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.3'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32
+    - esp32p4
+    version: 1.0.3
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/lan867x
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32
+version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -1,0 +1,21 @@
+dependencies:
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32c2
+version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -1,0 +1,21 @@
+dependencies:
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32c3
+version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -1,0 +1,21 @@
+dependencies:
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32c6
+version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -1,0 +1,50 @@
+dependencies:
+  espressif/esp_tinyusb:
+    component_hash: 96d232ced7afe1976119b62f7fbf1944a2a78b36228ff6f7b9318394ac1153cc
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    - name: espressif/tinyusb
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=0.14.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.7.6~1
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  espressif/tinyusb:
+    component_hash: aa65639878f27a44d349044afd9c3fc134a92bd560874fdac1d836019b5c07ca
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32p4
+    version: 0.18.0~4
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/esp_tinyusb
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32s2
+version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -1,0 +1,50 @@
+dependencies:
+  espressif/esp_tinyusb:
+    component_hash: 96d232ced7afe1976119b62f7fbf1944a2a78b36228ff6f7b9318394ac1153cc
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    - name: espressif/tinyusb
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=0.14.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.7.6~1
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  espressif/tinyusb:
+    component_hash: aa65639878f27a44d349044afd9c3fc134a92bd560874fdac1d836019b5c07ca
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32p4
+    version: 0.18.0~4
+  idf:
+    source:
+      type: idf
+    version: 5.4.2
+direct_dependencies:
+- espressif/esp_tinyusb
+- espressif/mdns
+- idf
+manifest_hash: 3b18b5bbac91c9fe5098d3759a37c84ed0828546d8cbc92e26e4c1698e689c8a
+target: esp32s3
+version: 2.0.0

--- a/ports/esp32/main/idf_component.yml
+++ b/ports/esp32/main/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   espressif/esp_tinyusb:
     rules:
       - if: "target in [esp32s2, esp32s3]"
-    version: "~1.0.0"
+    version: "~1.7.6"
   espressif/lan867x:
     version: "~1.0.0"
     rules:

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -45,7 +45,18 @@
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
     #if MICROPY_HW_USB_CDC
-    tud_cdc_configure_fifo_t cfg = { .rx_persistent = 0, .tx_persistent = 1 };
+    tud_cdc_configure_fifo_t cfg = { .rx_persistent = 0,
+                                     .tx_persistent = 1,
+
+                                     // This config flag is unreleased in TinyUSB >v0.18.0
+                                     // but included in Espressif's TinyUSB component since v0.18.0~3
+                                     //
+                                     // Versioning issue reported as
+                                     // https://github.com/espressif/esp-usb/issues/236
+                                     #if TUSB_VERSION_NUMBER > 1800 || defined(ESP_PLATFORM)
+                                     .tx_overwritabe_if_not_connected = 1,
+                                     #endif
+    };
     tud_cdc_configure_fifo(&cfg);
     #endif
 }

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -98,32 +98,45 @@ mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len) {
     if (!tusb_inited()) {
         return 0;
     }
+    mp_uint_t last_write = mp_hal_ticks_ms();
     size_t i = 0;
     while (i < len) {
         uint32_t n = len - i;
-        if (n > CFG_TUD_CDC_EP_BUFSIZE) {
-            n = CFG_TUD_CDC_EP_BUFSIZE;
-        }
-        if (tud_cdc_connected()) {
-            // If CDC port is connected but the buffer is full, wait for up to USC_CDC_TIMEOUT ms.
-            mp_uint_t t0 = mp_hal_ticks_ms();
-            while (n > tud_cdc_write_available() && (mp_uint_t)(mp_hal_ticks_ms() - t0) < MICROPY_HW_USB_CDC_TX_TIMEOUT) {
-                mp_event_wait_ms(1);
 
-                // Explicitly run the USB stack as the scheduler may be locked (eg we
-                // are in an interrupt handler), while there is data pending.
-                mp_usbd_task();
-            }
+        if (tud_cdc_connected()) {
             // Limit write to available space in tx buffer when connected.
+            //
+            // (If not connected then we write everything to the fifo, expecting
+            // it to overwrite old data so it will have latest data buffered
+            // when host connects.)
             n = MIN(n, tud_cdc_write_available());
-            if (n == 0) {
-                break;
-            }
         }
-        // When not connected we always write to usb fifo, ensuring it has latest data.
+
         uint32_t n2 = tud_cdc_write(str + i, n);
         tud_cdc_write_flush();
         i += n2;
+
+        if (i < len) {
+            if (n2 > 0) {
+                // reset the timeout each time we successfully write to the FIFO
+                last_write = mp_hal_ticks_ms();
+            } else {
+                if ((mp_uint_t)(mp_hal_ticks_ms() - last_write) >= MICROPY_HW_USB_CDC_TX_TIMEOUT) {
+                    break; // Timeout
+                }
+
+                if (tud_cdc_connected()) {
+                    // If we know we're connected then we can wait for host to make
+                    // more space
+                    mp_event_wait_ms(1);
+                }
+            }
+
+            // Always explicitly run the USB stack as the scheduler may be
+            // locked (eg we are in an interrupt handler), while there is data
+            // or a state change pending.
+            mp_usbd_task();
+        }
     }
     return i;
 }

--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -48,6 +48,9 @@ git -C ${MICROPY_AUTOBUILD_MICROPYTHON_REPO}/lib/pico-sdk submodule update --ini
 ########################################
 # Build all firmware
 
+# Fail on some things which are warnings otherwise
+export MICROPY_MAINTAINER_BUILD=1
+
 pushd ${MICROPY_AUTOBUILD_MICROPYTHON_REPO}
 
 # build cross compiler

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -171,14 +171,17 @@ function ci_cc3200_build {
 ########################################################################################
 # ports/esp32
 
-# GitHub tag of ESP-IDF to use for CI (note: must be a tag or a branch)
-IDF_VER=v5.4.2
+# GitHub tag of ESP-IDF to use for CI, extracted from the esp32 dependency lockfile
+# This should end up as a tag name like vX.Y.Z
+# (note: This hacky parsing can be replaced with 'yq' once Ubuntu >=24.04 is in use)
+IDF_VER=v$(grep -A10 "idf:" ports/esp32/lockfiles/dependencies.lock.esp32 | grep "version:" | head -n1 | sed -E 's/ +version: //')
 PYTHON=$(command -v python3 2> /dev/null)
 PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
 
 export IDF_CCACHE_ENABLE=1
 
 function ci_esp32_idf_setup {
+    echo "Using ESP-IDF version $IDF_VER"
     git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git
     # doing a treeless clone isn't quite as good as --shallow-submodules, but it
     # is smaller than full clones and works when the submodule commit isn't a head.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -9,6 +9,9 @@ fi
 # Ensure known OPEN_MAX (NO_FILES) limit.
 ulimit -n 1024
 
+# Fail on some things which are warnings otherwise
+export MICROPY_MAINTAINER_BUILD=1
+
 ########################################################################################
 # general helper functions
 


### PR DESCRIPTION
### Summary

Three changes: two related to ESP-IDF dependencies, one to TinyUSB:

* Update the esp_tinyusb version to the latest to partly fix native USB serial corruption issues from macOS hosts:
  - Alternative to #17913.
  - Relates to https://github.com/orgs/micropython/discussions/17465.
  - Relates to https://github.com/micropython/micropython/issues/17865 but may not fix @gohai's issue.
  - Closes #17560 (probably).
* Rewrite the CDC write function to allow for the new `tx_overwritabe_if_not_connected` flag released by Espressif in their TinyUSB `v0.18.0~3` component (have reported this versioning inconsistency to them [here](https://github.com/espressif/esp-usb/issues/236)). Updating with this change otherwise silently changes the CDC FIFO behaviour to "block" and can cause hangs if the FIFO is full and TinyUSB thinks it is disconnected (due to DCD not set). Also rewrite this function to make sure TinyUSB task is always called, avoiding the possibility of a race between the USB host state and TinyUSB processing the state change.
* Adds the ESP-IDF Component Manager dependency lock files to the MicroPython repo. This is the only way to be sure that everyone builds with the same versions of components, and it's the approach recommended by Espressif. It's more complex for MicroPython because we need one lock file per chip. Provided the ESP-IDF version stays the same, building MicroPython shouldn't cause this file's contents to be updated - if you build MicroPython with a different ESP-IDF version then this file's contents will be regenerated (but this is actually an important signal that behaviour may be different...). This change would have prevented any automatic update to `v0.18.0~3`, which seems to be one of the reasons release v1.26 has issues with ESP32-S3 USB.
* Check for lock file changes during builds, and warn on normal developer builds or fail in CI or nightly builds. Added new environment variable `MICROPY_MAINTAINER_BUILD` to distinguish these.

Windows users may still have issues with lost bytes on ESP32-S3 native USB unless they either roll back to mpremote v1.25 or use https://github.com/micropython/micropython/pull/17999

### Testing

* At this stage I haven't done any testing myself. In particular, I don't have easy access to a macOS host to reproduce the data corruption issue.
* I pushed a temporary commit to this PR that contains a change to fail CI because the dependency lock files will mismatch. [Failed job](https://github.com/micropython/micropython/actions/runs/17090726957/job/48463760708#step:7:5443).
* Tested TinyUSB change by running vcprate.py on ESP32-S3, SAMD51 (Seeed Wio Terminal) and Pi Pico.
* Also re-ran unit tests on ESP32-S3 and Pi Pico.

### Trade-offs and Alternatives

* @agatti has submitted #17913 which seems like it is a better short-term fix for all currently known TinyUSB issues. However, using upstream TinyUSB is a risk in the future because it's possible Espressif will make fixes that don't immediately go upstream. For example, upstream TinyUSB released `0.18.0` in December but Espressif have tagged [0.18.1, 0.18.2, 0.18.3, 0.18.4](https://github.com/espressif/tinyusb/tags) since then... If we use upstream TinyUSB then it's likely we'll eventually run into issues that Espressif has already fixed in their fork, or that we should report to Espressif but can't report them because we're not using their supported TinyUSB.
* There may be alternatives to adding all these lock files to Git. One alternative would be to specify all of the component versions exactly in `idf_component.yml` using `==` to get specific versions. However, this still doesn't provide any tracking of when the ESP-IDF version has changed from whatever the current recommended version is...
* Paying more attention to exact component versions means from now that we'll need to also pay attention to updating components (and the lock file) when it's relevant to do so. However, as seen from this esp_tinyusb issue then that's probably something that we should do anyway.

*This work was funded through GitHub Sponsors.*