### PR TITLE
unix: avoid crashing after heap lock in REPL

### DIFF
--- a/ports/unix/input.c
+++ b/ports/unix/input.c
@@ -104,6 +104,9 @@ void prompt_write_history(void) {
     #if MICROPY_USE_READLINE == 1
     char *home = getenv("HOME");
     if (home != NULL) {
+        if (MP_STATE_THREAD(gc_lock_depth) != 0) {
+            return;
+        }
         vstr_t vstr;
         vstr_init(&vstr, 50);
         vstr_printf(&vstr, "%s/.micropython.history", home);

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -209,6 +209,9 @@ static int do_repl(void) {
         mp_hal_stdio_mode_raw();
 
     input_restart:
+        // If the GC is locked at this point there is no way out except a reset,
+        // so force the GC to be unlocked to help the user debug what went wrong.
+        MP_STATE_THREAD(gc_lock_depth) = 0;
         vstr_reset(&line);
         int ret = readline(&line, mp_repl_get_ps1());
         mp_parse_input_kind_t parse_input_kind = MP_PARSE_SINGLE_INPUT;

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -598,9 +598,7 @@ friendly_repl_reset:
 
         // If the GC is locked at this point there is no way out except a reset,
         // so force the GC to be unlocked to help the user debug what went wrong.
-        if (MP_STATE_THREAD(gc_lock_depth) != 0) {
-            MP_STATE_THREAD(gc_lock_depth) = 0;
-        }
+        MP_STATE_THREAD(gc_lock_depth) = 0;
 
         vstr_reset(&line);
         int ret = readline(&line, mp_repl_get_ps1());

--- a/tests/cmdline/repl_lock.py
+++ b/tests/cmdline/repl_lock.py
@@ -1,0 +1,7 @@
+import micropython
+micropython.heap_lock()
+1+1
+micropython.heap_lock()
+None # Cause the repl's line storage to be enlarged ----------------
+micropython.heap_lock()
+raise SystemExit

--- a/tests/cmdline/repl_lock.py.exp
+++ b/tests/cmdline/repl_lock.py.exp
@@ -1,0 +1,10 @@
+MicroPython \.\+ version
+Use \.\+
+>>> import micropython
+>>> micropython.heap_lock()
+>>> 1+1
+2
+>>> micropython.heap_lock()
+>>> None # Cause the repl's line storage to be enlarged ----------------
+>>> micropython.heap_lock()
+>>> raise SystemExit


### PR DESCRIPTION
### Summary

Closes: #17934 

There were 3 distinct scenarios I ran into:
 * The one reported in #17934, locking heap & exiting REPL. This led to a crash in `prompt_write_history`.
 * The one reported in #4205, where it wasn't possible to enter a new line of code with the heap locked
 * A similar variant where simply typing a long line in the repl would cause a crash (same cause as #4205 though)

Lock the heap, then type a long line:
```
>>> micropython.heap_lock()
>>> ffffffffffffffffffffffffffffffffffffffffFATAL: uncaught NLR 0x5555557593d0
```

### Testing

I manually tested each variation I had discovered. I also added a CI-time test though I'm not 100% sure it's correct.