### PR TITLE
alif/tinyusb_port: Fix setting of USB device addr for fast hosts.

### DIFF
--- a/ports/alif/tinyusb_port/tusb_alif_dcd.c
+++ b/ports/alif/tinyusb_port/tusb_alif_dcd.c
@@ -249,7 +249,11 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
 {
     LOG("%010u >%s", DWT->CYCCNT, __func__);
 
-    udev->dcfg_b.devaddr = dev_addr;
+    // Device address is set from the ISR when SETUP packet is received
+    // By point TinyUSB calls this function, the address has already been
+    // set and STATUS sent back to the host. Xfer call below is purely for
+    // internal TinyUSB state to conclude transaction and issue next SETUP req.
+
     dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
 }
 
@@ -571,6 +575,9 @@ static void _dcd_handle_depevt(uint8_t ep, uint8_t evt, uint8_t sts, uint16_t pa
 
             // XferNotReady NotActive for status stage
             if ((1 == ep) && (0b0010 == (sts & 0b1011))) {
+                if (0x00 == _ctrl_buf[0] && TUSB_REQ_SET_ADDRESS == _ctrl_buf[1]) {
+                    udev->dcfg_b.devaddr = _ctrl_buf[2];
+                }
                 _dcd_start_xfer(1, NULL, 0, TRBCTL_CTL_STAT2);
                 break;
             }


### PR DESCRIPTION
### Summary

A fast host (eg Mac M4) may request the status for the SET_ADDRESS before TinyUSB gets to process it.  This is because TinyUSB does not handle events inside the USB ISR, rather it waits for the top-level thread to process them.  Fix that by setting the USB device address as soon as TUSB_REQ_SET_ADDRESS comes in.

This patch follows the corresponding upstream fix: https://github.com/alifsemi/tinyusb/commit/fc40ea7fc6e6bd49baad6b504c88bb6a37c7a191

### Testing

Tested on ALIF_ENSEMBLE and OPENMV_AE3 boards, on an Arch Linux laptop.  Inspecting `dmsg` logs, everything looks as it did prior to this change, and USB CDC still works correctly.

### Trade-offs and Alternatives

We could instead update the Alif TinyUSB DCD driver to the latest official/upstream one found in https://github.com/alifsemi/tinyusb/.  But that's a lot more effort than just applying this patch.
