### PR TITLE
tests/ports/rp2: Decrease test lower bound for thread lightsleep time.

### DIFF
--- a/tests/ports/rp2/rp2_lightsleep_thread.py
+++ b/tests/ports/rp2/rp2_lightsleep_thread.py
@@ -9,6 +9,7 @@ N_SLEEPS = 5
 SLEEP_MS = 250
 
 IDEAL_RUNTIME = N_SLEEPS * SLEEP_MS
+MIN_RUNTIME = 2 * SLEEP_MS
 MAX_RUNTIME = (N_SLEEPS + 1) * SLEEP_MS
 MAX_DELTA = 20
 
@@ -52,14 +53,17 @@ class LightSleepInThread(unittest.TestCase):
         # is unspecified.
         #
         # Currently, the other thread will return immediately if one is already
-        # in lightsleep. Therefore, runtime can be between IDEAL_RUNTIME and
-        # IDEAL_RUNTIME * 2 depending on how many times the calls to lightsleep() race
-        # each other.
+        # in lightsleep doing set up, or waking up.  When a thread is actually in the
+        # sleep section of lightsleep, the CPU clock is stopped and that also stops
+        # the other thread.  It's possible for the total sleep time of this test to
+        # be less than IDEAL_RUNTIME due to the order in which each thread gets to go
+        # to sleep first and whether the other thread is paused before or after it
+        # tries to enter lightsleep itself.
         #
         # Note this test case is really only here to ensure that the rp2 hasn't
         # hung or failed to sleep at all - not to verify any correct behaviour
         # when there's a race to call lightsleep().
-        self.assertGreaterEqual(self.elapsed_ms(), IDEAL_RUNTIME - MAX_DELTA)
+        self.assertGreaterEqual(self.elapsed_ms(), MIN_RUNTIME - MAX_DELTA)
         self.assertLessEqual(self.elapsed_ms(), IDEAL_RUNTIME * 2 + MAX_DELTA)
 
 


### PR DESCRIPTION
### Summary

This PR makes the rp2-specific lightsleep test more lenient, so it passes.

This test was added in #16454, and even back then it did not pass reliably on RP2040.  The issue is that threads can race each other to enter lightsleep mode, and when one of them actually stops the CPU clock the other thread is stopped as well.  Depending on whether the other thread was just entering or just exiting lightsleep itself, the total duration of all sleeps can vary and can be as small as 2*T.

So, adjust the minimum to allow 2*T.

Work done in collaboration with @projectgus .

### Testing

Tested on RPI_PICO, RPI_PICO_W and RPI_PICO2 in RISCV mode.  It passes on all of them reliably.

### Trade-offs and Alternatives

This makes the test more lenient, ie less strict.  But this part of the test is really only there to make sure the rp2 doesn't lock up, rather than make sure the lightsleep is accurate.

`machine.lightsleep()` is anyway (1) specified only to wait at most the given time; and (2) not well specified when multiple threads call it at the same time.  So it seems OK to make the test more lenient.