### PR TITLE
tests/multi_net: clean up skip code, require SSL cert files

### DIFF
--- a/tests/multi_net/asyncio_tcp_readinto.py
+++ b/tests/multi_net/asyncio_tcp_readinto.py
@@ -1,13 +1,8 @@
 # Test asyncio stream readinto() method using TCP server/client
 
 try:
-    import asyncio
-except ImportError:
-    print("SKIP")
-    raise SystemExit
-
-try:
     import array
+    import asyncio
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tests/multi_net/sslcontext_server_client.py
+++ b/tests/multi_net/sslcontext_server_client.py
@@ -14,14 +14,10 @@ PORT = 8000
 certfile = "ec_cert.der"
 keyfile = "ec_key.der"
 
-try:
-    with open(certfile, "rb") as cf:
-        cert = cadata = cf.read()
-    with open(keyfile, "rb") as kf:
-        key = kf.read()
-except OSError:
-    print("SKIP")
-    raise SystemExit
+with open(certfile, "rb") as cf:
+    cert = cadata = cf.read()
+with open(keyfile, "rb") as kf:
+    key = kf.read()
 
 
 # Server

--- a/tests/multi_net/sslcontext_server_client_ciphers.py
+++ b/tests/multi_net/sslcontext_server_client_ciphers.py
@@ -14,14 +14,10 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    with open(cafile, "rb") as f:
-        cadata = f.read()
-    with open(key, "rb") as f:
-        keydata = f.read()
-except OSError:
-    print("SKIP")
-    raise SystemExit
+with open(cafile, "rb") as f:
+    cadata = f.read()
+with open(key, "rb") as f:
+    keydata = f.read()
 
 
 # Server

--- a/tests/multi_net/sslcontext_verify_callback.py
+++ b/tests/multi_net/sslcontext_verify_callback.py
@@ -15,14 +15,10 @@ PORT = 8000
 cert = cafile = "ec_cert.der"
 key = "ec_key.der"
 
-try:
-    with open(cafile, "rb") as f:
-        cadata = f.read()
-    with open(key, "rb") as f:
-        key = f.read()
-except OSError:
-    print("SKIP")
-    raise SystemExit
+with open(cafile, "rb") as f:
+    cadata = f.read()
+with open(key, "rb") as f:
+    key = f.read()
 
 
 def verify_callback(cert, depth):

--- a/tests/multi_net/tls_dtls_server_client.py
+++ b/tests/multi_net/tls_dtls_server_client.py
@@ -13,14 +13,10 @@ PORT = 8000
 certfile = "ec_cert.der"
 keyfile = "ec_key.der"
 
-try:
-    with open(certfile, "rb") as cf:
-        cert = cadata = cf.read()
-    with open(keyfile, "rb") as kf:
-        key = kf.read()
-except OSError:
-    print("SKIP")
-    raise SystemExit
+with open(certfile, "rb") as cf:
+    cert = cadata = cf.read()
+with open(keyfile, "rb") as kf:
+    key = kf.read()
 
 
 # DTLS server.


### PR DESCRIPTION
### Summary

In #17897 the tests were changed so they require SSL certificate files to be present.  I missed a few in that clean up, because they didn't use the `os.stat` pattern.  Fix that here.

Also, simplify SKIP logic in a test for the `array` module.

### Testing

Tested locally on the unix port.

