### PR TITLE
tests/thread/thread_gc1: Skip unreliable test in Github CI.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -810,7 +810,8 @@ function ci_unix_macos_run_tests {
     # - float_parse and float_parse_doubleprec parse/print floats out by a few mantissa bits
     # - ffi_callback crashes for an unknown reason
     # - thread/stress_heap.py is flaky
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython ./run-tests.py --exclude '(float_parse|float_parse_doubleprec|ffi_callback|thread/stress_heap).py')
+    # - thread/thread_gc1.py is flaky
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython ./run-tests.py --exclude '(float_parse|float_parse_doubleprec|ffi_callback|thread/stress_heap|thread/thread_gc1).py')
 }
 
 function ci_unix_qemu_mips_setup {
@@ -831,8 +832,9 @@ function ci_unix_qemu_mips_run_tests {
     # Issues with MIPS tests:
     # - thread/stress_aes.py takes around 50 seconds
     # - thread/stress_recurse.py is flaky
+    # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'thread/stress_recurse.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py')
 }
 
 function ci_unix_qemu_arm_setup {
@@ -854,8 +856,9 @@ function ci_unix_qemu_arm_run_tests {
     # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
     # - thread/stress_aes.py takes around 70 seconds
     # - thread/stress_recurse.py is flaky
+    # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py|thread/stress_recurse.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py|thread/stress_recurse.py|thread/thread_gc1.py')
 }
 
 function ci_unix_qemu_riscv64_setup {
@@ -876,8 +879,9 @@ function ci_unix_qemu_riscv64_run_tests {
     # Issues with RISCV-64 tests:
     # - thread/stress_aes.py takes around 140 seconds
     # - thread/stress_recurse.py is flaky
+    # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py --exclude 'thread/stress_recurse.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py')
 }
 
 ########################################################################################


### PR DESCRIPTION
### Summary

`thread/thread_gc1.py` is a constant source of spurious failures in Github CI.

This PR adds it to the list of tests skipped when running on Github CI using either macos, qemu_riscv64, qemu_mips, or qemu_arm, to help reduce the overall false positive rate and improve the predictive value of the test fail indication.

### Testing

I examined a sample of the [last 25 unix port Github Actions runs](https://github.com/micropython/micropython/actions/workflows/ports_unix.yml), tabulated their outcomes and the causes attributable to any failures, and examined relevant statistics over the results to 

| Action Run                                                                      | Outcome | Failed Job(s) | Cause |
| ---------------------------------------------------------------------------------- | ---- | ------------- | ----- |
| [17256297609](https://github.com/micropython/micropython/actions/runs/17256297609) | FAIL | macos | thread/thread_gc1.py |
| [17248166934](https://github.com/micropython/micropython/actions/runs/17248166934) | PASS | | |
| [17239364181](https://github.com/micropython/micropython/actions/runs/17239364181) | FAIL | macos | thread/thread_gc1.py |
| [17239346523](https://github.com/micropython/micropython/actions/runs/17239346523) | PASS | | |
| [17232449204](https://github.com/micropython/micropython/actions/runs/17232449204) | FAIL | macos | thread/thread_gc1.py (possibly valid) |
| [17230929159](https://github.com/micropython/micropython/actions/runs/17230929159) | FAIL | qemu_arm | cmdline/repl_sys_ps1_ps2.py |
| [17230082929](https://github.com/micropython/micropython/actions/runs/17230082929) | PASS | | |
| [17226283109](https://github.com/micropython/micropython/actions/runs/17226283109) | FAIL | settrace_stackless<br>macos<br>qemu_mips | thread/thread_gc1.py<br>thread/thread_gc1.py<br>thread/thread_gc1.py|
| [17226266333](https://github.com/micropython/micropython/actions/runs/17226266333) | PASS | | |
| [17225202917](https://github.com/micropython/micropython/actions/runs/17225202917) | FAIL | macos<br>qemu_riscv64 | thread/thread_gc1.py<br>thread/thread_gc1.py |
| [17224743621](https://github.com/micropython/micropython/actions/runs/17224743621) | FAIL | settrace_stackless<br>macos | thread/thread_gc1.py<br>thread/thread_gc1.py |
| [17224739270](https://github.com/micropython/micropython/actions/runs/17224739270) | FAIL | macos | thread/thread_gc1.py |
| [17220251949](https://github.com/micropython/micropython/actions/runs/17220251949) | FAIL | macos | thread/thread_gc1.py |
| [17218037418](https://github.com/micropython/micropython/actions/runs/17218037418) | PASS | | |
| [17218024199](https://github.com/micropython/micropython/actions/runs/17218024199) | PASS | | |
| [17212060390](https://github.com/micropython/micropython/actions/runs/17212060390) | FAIL | macos | thread/thread_gc1.py |
| [17211892105](https://github.com/micropython/micropython/actions/runs/17211892105) |CANCEL| | |
| [17209911695](https://github.com/micropython/micropython/actions/runs/17209911695) | FAIL | macos | thread/thread_gc1.py |
| [17209904205](https://github.com/micropython/micropython/actions/runs/17209904205) | FAIL | macos | thread/thread_gc1.py |
| [17196446007](https://github.com/micropython/micropython/actions/runs/17196446007) | PASS | | |
| [17196132542](https://github.com/micropython/micropython/actions/runs/17196132542) | FAIL | macos | thread/thread_gc1.py |
| [17180766768](https://github.com/micropython/micropython/actions/runs/17180766768) | PASS | | |
| [17175320257](https://github.com/micropython/micropython/actions/runs/17175320257) | PASS | | |
| [17175019154](https://github.com/micropython/micropython/actions/runs/17175019154) | FAIL | macos<br>qemu_mips | thread/thread_gc1.py<br>thread/thread_gc1.py |
| [17175013008](https://github.com/micropython/micropython/actions/runs/17175013008) |CANCEL| | |

Of the 14 test failures observed in this sample, all but one were attributable to `thread/thread_gc1.py`, with all but one of these failures happening on macos or qemu. (Note that one of these changes did touch thread code, so for the sake of robustness I've assumed it's actually a true positive in my analysis.)

This test has a false positive rate of 59% over this sample, an F1 score of 0.13, and a positive predictive value of 7.14% (i.e. when the test suite reports failure for a PR, the chance that the failure is due to the PR's change is only 7%, due to this test.)

This test should therefore be disabled in these scenarios where it's unreliable.

