### PR TITLE
esp32: Reduce binary size of RISC-V boards including ESP32-C6

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C2/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_C2/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c2)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.ble
     boards/sdkconfig.c2
     # C2 has unusably low free RAM without these optimisations

--- a/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_C3/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c3)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.ble
     boards/ESP32_GENERIC_C3/sdkconfig.c3usb
 )

--- a/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_C6/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c6)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.c6
     boards/sdkconfig.ble
 )

--- a/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.cmake
+++ b/ports/esp32/boards/GARATRONIC_PYBSTICK26_ESP32C3/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c3)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.ble
     boards/GARATRONIC_PYBSTICK26_ESP32C3/sdkconfig.board
 )

--- a/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.cmake
+++ b/ports/esp32/boards/LOLIN_C3_MINI/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c3)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.ble
     boards/LOLIN_C3_MINI/sdkconfig.board
 )

--- a/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.cmake
+++ b/ports/esp32/boards/M5STACK_NANOC6/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c6)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.c6
     boards/sdkconfig.ble
 )

--- a/ports/esp32/boards/UM_TINYC6/mpconfigboard.cmake
+++ b/ports/esp32/boards/UM_TINYC6/mpconfigboard.cmake
@@ -2,6 +2,7 @@ set(IDF_TARGET esp32c6)
 
 set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
+    boards/sdkconfig.riscv
     boards/sdkconfig.c6
     boards/sdkconfig.ble
     boards/UM_TINYC6/sdkconfig.board

--- a/ports/esp32/boards/sdkconfig.c6
+++ b/ports/esp32/boards/sdkconfig.c6
@@ -1,2 +1,10 @@
 # Workaround for https://github.com/espressif/esp-idf/issues/14456
 CONFIG_ESP_SYSTEM_HW_STACK_GUARD=n
+
+# 802.15.4 not currently supported in MicroPython, disabling saves
+# a little compile time (no difference in binary)
+CONFIG_IEEE802154_ENABLED=n
+
+# Using the SPI flash implementation in ROM saves about 10KB of binary size
+# (and some static RAM)
+CONFIG_SPI_FLASH_ROM_IMPL=y

--- a/ports/esp32/boards/sdkconfig.riscv
+++ b/ports/esp32/boards/sdkconfig.riscv
@@ -1,0 +1,3 @@
+# ESP RISC-V binary sizes are generally larger than Xtensa ones,
+# so switch to size optimization by default
+CONFIG_COMPILER_OPTIMIZATION_SIZE=y


### PR DESCRIPTION
### Summary

* ESP32-C6 binary size has been getting close to the 2MB partition limit.
* In general ESP32 RISC-V binaries are larger than Xtensa binaries, due to architecture differences (also true for ARM Thumb-2 vs RISC-V Compact).

This PR switches all esp32 RISC-V boards to optimise for size (-0s) instead of performance (-O2). This also reduces the static D/IRAM usage, which translates to more free RAM at runtime.

| Size       | Before     | After      | Delta      |
| ---------- | ---------- | ---------- | ----------------------- |
| C2 Total Binary  | 1680384    | 1494224    | -186160    |
| C2 D/IRAM Usage  |   83710    |   79080    |   -4630    |
| C3 Total Binary  | 1833328    | 1636624    | -196704    |
| C3 D/IRAM Usage |  139608    |  131896    |   -7712    |
| C6 Total Binary | 2024432 | 1813216 | -211216 |
| C6 D/IRAM Usage | 167187 | 148584 | -18603 |

On ESP32-C6 this PR also switches to using the SPI flash driver from ROM, which saves about an extra 10KB of flash. There is some risk of a regression due to this change, but we already use this option on ESP32-C2 so it should be safe enough.

### Testing

* Ran the basic unit tests on all three boards, noted no new failures.

### Trade-offs and Alternatives

* Could make the app partition larger for C6, but this requires a full re-flash of C6 boards and may not run any faster (due to cache overhead from larger binary size).