### PR TITLE
ci: Sanitize and get coverage from mpy-cross too.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -90,6 +90,7 @@ jobs:
       run: source tools/ci.sh && ci_unix_coverage_run_native_mpy_tests
     - name: Run gcov coverage analysis
       run: |
+        (cd mpy-cross && gcov -o build/py ../py/*.c || true)
         (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
         (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
     - name: Upload coverage to Codecov

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -530,14 +530,14 @@ CI_UNIX_OPTS_QEMU_RISCV64=(
 
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
     # Macro MP_ASAN allows detecting ASan on gcc<=13
-    CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -DMP_ASAN=1"
-    LDFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0"
+    CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -fno-sanitize-recover -DMP_ASAN=1"
+    LDFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -fno-sanitize-recover"
 )
 
 CI_UNIX_OPTS_SANITIZE_UNDEFINED=(
     # Macro MP_UBSAN allows detecting UBSan on gcc<=13
-    CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute -DMP_UBSAN=1"
-    LDFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute"
+    CFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover -DMP_UBSAN=1"
+    LDFLAGS_EXTRA="-fsanitize=undefined -fno-sanitize=nonnull-attribute -fno-sanitize-recover"
 )
 
 function ci_unix_build_helper {
@@ -774,7 +774,7 @@ function ci_unix_settrace_stackless_run_tests {
 }
 
 function ci_unix_sanitize_undefined_build {
-    make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C mpy-cross "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
     make ${MAKEOPTS} -C ports/unix submodules
     make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
     ci_unix_build_ffi_lib_helper gcc
@@ -785,7 +785,7 @@ function ci_unix_sanitize_undefined_run_tests {
 }
 
 function ci_unix_sanitize_address_build {
-    make ${MAKEOPTS} -C mpy-cross
+    make ${MAKEOPTS} -C mpy-cross "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
     make ${MAKEOPTS} -C ports/unix submodules
     make ${MAKEOPTS} -C ports/unix VARIANT=coverage "${CI_UNIX_OPTS_SANITIZE_ADDRESS[@]}"
     ci_unix_build_ffi_lib_helper gcc

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -637,6 +637,10 @@ function ci_unix_coverage_setup {
 }
 
 function ci_unix_coverage_build {
+    make ${MAKEOPTS} -C mpy-cross COPT="-Os -fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs -ftest-coverage -lm" DEBUG=1
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage submodules
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage deplibs
+    make ${MAKEOPTS} -C ports/unix VARIANT=coverage
     ci_unix_build_helper VARIANT=coverage
     ci_unix_build_ffi_lib_helper gcc
 }


### PR DESCRIPTION
### Summary

There are no new findings, but this ensures the code paths unique to mpy-cross are checked with the sanitizers.

I think that new coverage may turn up as well (e.g., MICROPY_DYNAMIC_COMPILER) if I've got the CI rules right.

### Testing

I ran the coverage, ubsan, and asan commands in ci.sh locally.

### Trade-offs and Alternatives

Not a trade-off per se, but specifically adding mpy-cross tests that would exercise all emitters when built with coverage & sanitizers would potentially have benefits.