### PR TITLE
py/gc: Clean up finaliser allocation methods.

### DIFF
--- a/extmod/vfs_lfsx_file.c
+++ b/extmod/vfs_lfsx_file.c
@@ -90,9 +90,9 @@ mp_obj_t MP_VFS_LFSx(file_open)(mp_obj_t self_in, mp_obj_t path_in, mp_obj_t mod
     }
 
     #if LFS_BUILD_VERSION == 1
-    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, uint8_t, self->lfs.cfg->prog_size, type);
+    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->prog_size, type);
     #else
-    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, uint8_t, self->lfs.cfg->cache_size, type);
+    MP_OBJ_VFS_LFSx_FILE *o = mp_obj_malloc_var_with_finaliser(MP_OBJ_VFS_LFSx_FILE, file_buffer, uint8_t, self->lfs.cfg->cache_size, type);
     #endif
     o->vfs = self;
     #if !MICROPY_GC_CONSERVATIVE_CLEAR

--- a/ports/esp8266/posix_helpers.c
+++ b/ports/esp8266/posix_helpers.c
@@ -33,7 +33,7 @@
 // Functions for external libs like axTLS, BerkeleyDB, etc.
 
 void *malloc(size_t size) {
-    void *p = gc_alloc(size, false);
+    void *p = gc_alloc(size, 0);
     if (p == NULL) {
         // POSIX requires ENOMEM to be set in case of error
         errno = ENOMEM;

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -270,7 +270,7 @@ static mp_obj_t extra_coverage(void) {
         gc_unlock();
 
         // using gc_realloc to resize to 0, which means free the memory
-        void *p = gc_alloc(4, false);
+        void *p = gc_alloc(4, 0);
         mp_printf(&mp_plat_print, "%p\n", gc_realloc(p, 0, false));
 
         // calling gc_nbytes with a non-heap pointer

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -56,8 +56,8 @@
 #undef malloc
 #undef free
 #undef realloc
-#define malloc(b) gc_alloc((b), false)
-#define malloc_with_finaliser(b) gc_alloc((b), true)
+#define malloc(b) gc_alloc((b), 0)
+#define malloc_with_finaliser(b) gc_alloc((b), GC_ALLOC_FLAG_HAS_FINALISER)
 #define free gc_free
 #define realloc(ptr, n) gc_realloc(ptr, n, true)
 #define realloc_ext(ptr, n, mv) gc_realloc(ptr, n, mv)

--- a/py/obj.h
+++ b/py/obj.h
@@ -947,11 +947,11 @@ void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *type);
 // Object allocation macros for allocating objects that have a finaliser.
 #if MICROPY_ENABLE_FINALISER
 #define mp_obj_malloc_with_finaliser(struct_type, obj_type) ((struct_type *)mp_obj_malloc_with_finaliser_helper(sizeof(struct_type), obj_type))
-#define mp_obj_malloc_var_with_finaliser(struct_type, var_type, var_num, obj_type) ((struct_type *)mp_obj_malloc_with_finaliser_helper(sizeof(struct_type) + sizeof(var_type) * (var_num), obj_type))
+#define mp_obj_malloc_var_with_finaliser(struct_type, var_field, var_type, var_num, obj_type) ((struct_type *)mp_obj_malloc_with_finaliser_helper(offsetof(struct_type, var_field) + sizeof(var_type) * (var_num), obj_type))
 void *mp_obj_malloc_with_finaliser_helper(size_t num_bytes, const mp_obj_type_t *type);
 #else
 #define mp_obj_malloc_with_finaliser(struct_type, obj_type) mp_obj_malloc(struct_type, obj_type)
-#define mp_obj_malloc_var_with_finaliser(struct_type, var_type, var_num, obj_type) mp_obj_malloc_var(struct_type, var_type, var_num, obj_type)
+#define mp_obj_malloc_var_with_finaliser(struct_type, var_field, var_type, var_num, obj_type) mp_obj_malloc_var(struct_type, var_field, var_type, var_num, obj_type)
 #endif
 
 // These macros are derived from more primitive ones and are used to


### PR DESCRIPTION
Cleans up 24234937747e6d7fd920d21358fb26b826398e1a to theoretically fix the situation where a build includes LFS but not MICROPY_ENABLE_FINALISER; and cleans up 5ed578e5b48730606536ded9a711223ae9a70262 to make existing calls to `gc_alloc` more readable by translating the old-API `bool` values into their modern flags replacements.