### PR TITLE
tools/metrics.py: Compute mpy-cross size as part of size metrics.

### DIFF
--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -57,6 +57,8 @@ class PortData:
         self.needs_mpy_cross = dir not in ("bare-arm", "minimal")
 
 
+mpy_cross_output = "mpy-cross/build/mpy-cross"
+
 port_data = {
     "b": PortData("bare-arm", "bare-arm", "build/firmware.elf"),
     "m": PortData("minimal x86", "minimal", "build/firmware.elf"),
@@ -142,6 +144,8 @@ def do_diff(args):
     max_delta = None
     for key, value1 in data1.items():
         value2 = data2[key]
+        if key == mpy_cross_output:
+            name = "mpy-cross"
         for port in port_data.values():
             if key == "ports/{}/{}".format(port.dir, port.output):
                 name = port.name
@@ -207,6 +211,10 @@ def do_sizes(args):
     ports = parse_port_list(args)
 
     print("COMPUTING SIZES")
+
+    if any(port.needs_mpy_cross for port in ports):
+        syscmd("size", mpy_cross_output)
+
     for port in ports:
         syscmd("size", "ports/{}/{}".format(port.dir, port.output))
 


### PR DESCRIPTION
### Summary

Add support to `tools/metrics.py` to compute the size delta of `mpy-cross`, alongside the sizes of port firmware.  This is an easy and cheap addition because `mpy-cross` is usually built before the ports are.


Although the size of `mpy-cross` is not critical, it's still a nice indication of how the PR affects code size, and helps to eliminate any unwanted increases in `mpy-cross`.

### Testing

Tested locally, eg the output looks like (for no change):
```
$ ./tools/metrics.py diff size0 size0
  mpy-cross:    +0 +0.000% 
   unix x64:    +0 +0.000% standard
```

CI will also test this, it should include `mpy-cross` in the automatic report.

### Trade-offs and Alternatives

`mpy-cross` is already built as part of the code-size CI workflow, so we may as well report its size difference, along with port firmware size difference.  It doesn't increase the time for the CI.