### PR TITLE
esp32: Revert "esp32/mpconfigport: Disable I2CTarget on ESP32-C6 to ..".

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -137,8 +137,7 @@
 #define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 #ifndef MICROPY_PY_MACHINE_I2C_TARGET
 // I2C target hardware is limited on ESP32 (eg read event comes after the read) so we only support newer SoCs.
-// ESP32C6 does not have enough flash space so also disable it on that SoC.
-#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32 && !CONFIG_IDF_TARGET_ESP32C6)
+#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32)
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/esp32/machine_i2c_target.c"
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX   (2)
 #endif


### PR DESCRIPTION
### Summary

This reverts commit 3c9546ea0911b50d4b85ad4046864c90f84b3fd3.

I2CTarget now fits on ESP32-C6 because it's compiled with -Os, see commit 5b98126c21f8eaa996e258761a291a7a88624082.

### Testing

I originally tested I2CTarget when developing it, but it needed to be disabled due to size constraints.  Now it fits, and CI will test the build (for ESP32_GENERIC_C6 at least).