### PR TITLE
stm32/adc: Get ADC working on STM32N6 MCUs.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -314,6 +314,11 @@ static void adcx_clock_enable(ADC_HandleTypeDef *adch) {
 static void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     adcx_clock_enable(adch);
 
+    // Set ADC clock prescaler, if it's not done by HAL_ADC_Init() below.
+    #if defined(STM32N6)
+    LL_RCC_SetADCPrescaler(4 - 1); // 200MHz / 4 = 50MHz
+    #endif
+
     adch->Init.Resolution = resolution;
     adch->Init.ContinuousConvMode = DISABLE;
     adch->Init.DiscontinuousConvMode = DISABLE;
@@ -387,7 +392,7 @@ static void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     #endif
     #if defined(STM32G0)
     HAL_ADCEx_Calibration_Start(adch);
-    #elif defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32WB)
+    #elif defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32N6) || defined(STM32WB)
     HAL_ADCEx_Calibration_Start(adch, ADC_SINGLE_ENDED);
     #endif
 }
@@ -461,7 +466,7 @@ static void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) 
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel)) {
         sConfig.SamplingTime = ADC_SAMPLETIME_246CYCLES_5;
     } else {
-        sConfig.SamplingTime = ADC_SAMPLETIME_11CYCLES_5;
+        sConfig.SamplingTime = ADC_SAMPLETIME_46CYCLES_5;
     }
     sConfig.SingleDiff = ADC_SINGLE_ENDED;
     sConfig.OffsetNumber = ADC_OFFSET_NONE;

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -86,7 +86,7 @@
 #define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_12CYCLES_5
 #define ADC_SAMPLETIME_DEFAULT_INT  ADC_SAMPLETIME_247CYCLES_5
 #elif defined(STM32N6)
-#define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_11CYCLES_5
+#define ADC_SAMPLETIME_DEFAULT      ADC_SAMPLETIME_46CYCLES_5
 #define ADC_SAMPLETIME_DEFAULT_INT  ADC_SAMPLETIME_246CYCLES_5
 #endif
 
@@ -232,6 +232,8 @@ void adc_config(ADC_TypeDef *adc, uint32_t bits) {
     ADC1_COMMON->CCR = 0; // ADCPR=PCLK/2
     #elif defined(STM32L1)
     ADC1_COMMON->CCR = 1 << ADC_CCR_ADCPRE_Pos; // ADCPRE=2
+    #elif defined(STM32N6)
+    LL_RCC_SetADCPrescaler(4 - 1); // 200MHz / 4 = 50MHz
     #elif defined(STM32WB)
     ADC1_COMMON->CCR = 0 << ADC_CCR_PRESC_Pos | 0 << ADC_CCR_CKMODE_Pos; // PRESC=1, MODE=ASYNC
     #elif defined(STM32WL)
@@ -324,7 +326,7 @@ void adc_config(ADC_TypeDef *adc, uint32_t bits) {
 
     #elif defined(STM32N6)
 
-    uint32_t cfgr1_clr = ADC_CFGR1_CONT | ADC_CFGR1_EXTEN;
+    uint32_t cfgr1_clr = ADC_CFGR1_CONT | ADC_CFGR1_EXTEN | ADC_CFGR1_RES;
     uint32_t cfgr1 = res << ADC_CFGR1_RES_Pos;
     adc->CFGR1 = (adc->CFGR1 & ~cfgr1_clr) | cfgr1;
 
@@ -439,13 +441,6 @@ static void adc_config_channel(ADC_TypeDef *adc, uint32_t channel, uint32_t samp
     #if defined(STM32G4) || defined(STM32H5) || defined(STM32H7A3xx) || defined(STM32H7A3xxQ) || defined(STM32H7B3xx) || defined(STM32H7B3xxQ) || defined(STM32N6)
     ADC_Common_TypeDef *adc_common = ADC12_COMMON;
     #elif defined(STM32H7)
-    #if defined(ADC_VER_V5_V90)
-    if (adc != ADC3) {
-        adc->PCSEL_RES0 |= 1 << channel;
-    }
-    #else
-    adc->PCSEL |= 1 << channel;
-    #endif
     ADC_Common_TypeDef *adc_common = adc == ADC3 ? ADC3_COMMON : ADC12_COMMON;
     #elif defined(STM32L4)
     ADC_Common_TypeDef *adc_common = ADCx_COMMON;
@@ -475,6 +470,7 @@ static void adc_config_channel(ADC_TypeDef *adc, uint32_t channel, uint32_t samp
         adc->OR |= ADC_OR_OP0; // Enable Vddcore channel on ADC2
     #endif
     }
+
     #if defined(STM32G4) || defined(STM32H5) || defined(STM32N6) || defined(STM32WB)
     // MCU uses encoded literals for internal channels -> extract ADC channel for following code
     if (__LL_ADC_IS_CHANNEL_INTERNAL(channel)) {
@@ -482,6 +478,17 @@ static void adc_config_channel(ADC_TypeDef *adc, uint32_t channel, uint32_t samp
     }
     adc->DIFSEL &= ~(1 << channel); // Set channel to Single-ended.
     #endif
+
+    #if defined(STM32H7) || defined(STM32N6)
+    #if defined(ADC_VER_V5_V90)
+    if (adc != ADC3) {
+        adc->PCSEL_RES0 |= 1 << channel;
+    }
+    #else
+    adc->PCSEL |= 1 << channel;
+    #endif
+    #endif
+
     adc->SQR1 = (channel & 0x1f) << ADC_SQR1_SQ1_Pos | (1 - 1) << ADC_SQR1_L_Pos;
     __IO uint32_t *smpr;
     if (channel <= 9) {

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -316,6 +316,7 @@ static void risaf_init(void) {
     rimc_master.MasterCID = RIF_CID_1;
     rimc_master.SecPriv = RIF_ATTRIBUTE_SEC | RIF_ATTRIBUTE_PRIV;
 
+    HAL_RIF_RISC_SetSlaveSecureAttributes(RIF_RISC_PERIPH_INDEX_ADC12, RIF_ATTRIBUTE_SEC | RIF_ATTRIBUTE_PRIV);
     HAL_RIF_RIMC_ConfigMasterAttributes(RIF_MASTER_INDEX_SDMMC1, &rimc_master);
     HAL_RIF_RISC_SetSlaveSecureAttributes(RIF_RISC_PERIPH_INDEX_SDMMC1, RIF_ATTRIBUTE_SEC | RIF_ATTRIBUTE_PRIV);
     HAL_RIF_RIMC_ConfigMasterAttributes(RIF_MASTER_INDEX_SDMMC2, &rimc_master);


### PR DESCRIPTION
### Summary

Changes made here for N6 to get ADC working:
- set RIF security attributes for ADC12
- clock ADC12 at 50MHz (maximum) so it runs at spec (max 5Msamp/sec)
- calibrate the ADC in `adc.c`
- increase sampling time for standard channels to 46.5 cycles
- set preselection register in `machine_adc.c`

Thanks to @anchung-chen for some hints on what needed to be done.

### Testing

Tested on OPENMV_N6 board, reading an ADC on PA11 that was connected to VDD and GND.

Also retested NUCLEO_H723ZG to make sure that still works (it does), because H7 code also changed a bit here.

### Trade-offs and Alternatives

I clocked the ADC down to 50MHz (assuming a 200MHz HCLK) to make sure it doesn't run too fast (was originally at 100MHZ).  That's simple logic but could be improved, eg calculate the prescaler based on the actual HCLK value.  (Eventually that could be specified by the user in `ADCBlock`.)

