### PR TITLE
Show mpy-cross version

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -119,6 +119,7 @@ static int compile_and_save(const char *file, const char *output_file, const cha
 
 static int usage(char **argv) {
     printf(
+        MICROPY_BANNER_NAME_AND_VERSION "\n\n"
         "usage: %s [<opts>] [-X <implopt>] [--] <input filename>\n"
         "Options:\n"
         "--version : show version information\n"
@@ -358,6 +359,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
         exit(1);
     }
     #endif
+
+    if (mp_verbose_flag) {
+        mp_printf(&mp_stderr_print, MICROPY_BANNER_NAME_AND_VERSION "\n");
+    }
 
     if (input_file == NULL) {
         mp_printf(&mp_stderr_print, "no input file\n");

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -171,3 +171,9 @@ typedef mp_off_t off_t;
 #endif
 
 extern const struct _mp_print_t mp_stdout_print;
+
+#if MICROPY_PREVIEW_VERSION_2
+#define MICROPY_BANNER_NAME_AND_VERSION "mpy-cross (with v2.0 preview) " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+#else
+#define MICROPY_BANNER_NAME_AND_VERSION "mpy-cross " MICROPY_GIT_TAG " on " MICROPY_BUILD_DATE
+#endif


### PR DESCRIPTION


### Summary
Formerly, there was no obvious way to get the micropython version information from the mpy-cross binary.

Now the version number is shown in the usage message and also in the verbose output produced by `mpy-cross -v`. (This also means you can sort of use `mpy-cross -v` as a version check command, as long as you don't mind the failing exit code)

Typical output:
```
$ mpy-cross -h
mpy-cross v1.27.0-preview.88.g704c70c5bb.dirty on 2025-08-30

usage: ./build/mpy-cross …
```

```
$ mpy-cross -v
$ ./mpy-cross/build/mpy-cross -v
mpy-cross v1.27.0-preview.88.g704c70c5bb.dirty on 2025-08-30
no input file
```
### Testing

I built & ran mpy-cross locally.

### Trade-offs and Alternatives

Is adding a `--version` argument worth it?

Would showing other information (e.g., MPY_VERSION & MPY_SUB_VERSION) be useful?