### PR TITLE
py/compile: Throw SyntaxError instead of asserting.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -3277,7 +3277,9 @@ static void compile_scope_inline_asm(compiler_t *comp, scope_t *scope, pass_kind
         }
 
         // check structure of parse node
-        assert(MP_PARSE_NODE_IS_STRUCT(pns2->nodes[0]));
+        if (!MP_PARSE_NODE_IS_STRUCT(pns2->nodes[0])) {
+            goto not_an_instruction;
+        }
         if (!MP_PARSE_NODE_IS_NULL(pns2->nodes[1])) {
             goto not_an_instruction;
         }

--- a/tests/inlineasm/thumb/asmerrors.py
+++ b/tests/inlineasm/thumb/asmerrors.py
@@ -1,0 +1,4 @@
+try:
+    exec("@micropython.asm_thumb\ndef l():\n    a = di(a2, a2, -1)")
+except SyntaxError as e:
+    print(e)

--- a/tests/inlineasm/thumb/asmerrors.py.exp
+++ b/tests/inlineasm/thumb/asmerrors.py.exp
@@ -1,0 +1,1 @@
+expecting an assembler instruction


### PR DESCRIPTION
### Summary

This condition corresponds to invalid asm code like
```
@micropython.asm_rv32
def l():
    a=di(a2, a2, -1)
```
and possibly other forms where nodes[0] is not a STRUCT.


Closes: #18010

### Testing

I built mpy-cross locally and tested it on the reproducer, which now correctly produces a SyntaxError in this case.