### PR TITLE
py/gc: Remove finaliser check for AT_HEAD block type.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -580,26 +580,24 @@ static void gc_sweep_run_finalisers(void) {
             while (ftb) {
                 MICROPY_GC_HOOK_LOOP(block);
                 if (ftb & 1) { // FTB_GET(area, block) shortcut
-                    if (ATB_GET_KIND(area, block) == AT_HEAD) {
-                        mp_obj_base_t *obj = (mp_obj_base_t *)PTR_FROM_BLOCK(area, block);
-                        if (obj->type != NULL) {
-                            // if the object has a type then see if it has a __del__ method
-                            mp_obj_t dest[2];
-                            mp_load_method_maybe(MP_OBJ_FROM_PTR(obj), MP_QSTR___del__, dest);
-                            if (dest[0] != MP_OBJ_NULL) {
-                                // load_method returned a method, execute it in a protected environment
-                                #if MICROPY_ENABLE_SCHEDULER
-                                mp_sched_lock();
-                                #endif
-                                mp_call_function_1_protected(dest[0], dest[1]);
-                                #if MICROPY_ENABLE_SCHEDULER
-                                mp_sched_unlock();
-                                #endif
-                            }
+                    mp_obj_base_t *obj = (mp_obj_base_t *)PTR_FROM_BLOCK(area, block);
+                    if (obj->type != NULL) {
+                        // if the object has a type then see if it has a __del__ method
+                        mp_obj_t dest[2];
+                        mp_load_method_maybe(MP_OBJ_FROM_PTR(obj), MP_QSTR___del__, dest);
+                        if (dest[0] != MP_OBJ_NULL) {
+                            // load_method returned a method, execute it in a protected environment
+                            #if MICROPY_ENABLE_SCHEDULER
+                            mp_sched_lock();
+                            #endif
+                            mp_call_function_1_protected(dest[0], dest[1]);
+                            #if MICROPY_ENABLE_SCHEDULER
+                            mp_sched_unlock();
+                            #endif
                         }
-                        // clear finaliser flag
-                        FTB_CLEAR(area, block);
                     }
+                    // clear finaliser flag
+                    FTB_CLEAR(area, block);
                 }
                 ftb >>= 1;
                 block++;


### PR DESCRIPTION
This check is a remnant of the original finaliser implementation from 4f7e9f5c445b5c0b262d9dfb8fceda4830f4844b, all the way from pre-1.0. This was a valid optimisation back then, but after its ordering with other finaliser code changed in 8a2ff2ca7366f605dd55c93f6b393552b365cd10 the invariant it exploits is no longer valid, and it breaks down completely in the case of variable-length allocations made with `mp_obj_malloc_var_with_finaliser`.

This resulted in what I believe to be a latent bug in the VFS system, where depending on the precise memory layout, VFS finaliser routines could sometimes be inadvertently missed. This bug was discovered when encountering an identical issue with an attempt to implement `__del__` for user classes in #18005.

As can be seen from the test runs with the instrumentation in #18013, this branch is also not actually hit in most normal code --- it's not actually an optimisation now; removing this condition ought to be a strict improvement to garbage collector code size and performance.