### PR TITLE
py/gc: Expand finaliser check to include AT_MARK block type.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -580,7 +580,8 @@ static void gc_sweep_run_finalisers(void) {
             while (ftb) {
                 MICROPY_GC_HOOK_LOOP(block);
                 if (ftb & 1) { // FTB_GET(area, block) shortcut
-                    if (ATB_GET_KIND(area, block) == AT_HEAD) {
+                    byte atb_kind = ATB_GET_KIND(area, block);
+                    if (atb_kind == AT_HEAD || atb_kind == AT_MARK) {
                         mp_obj_base_t *obj = (mp_obj_base_t *)PTR_FROM_BLOCK(area, block);
                         if (obj->type != NULL) {
                             // if the object has a type then see if it has a __del__ method


### PR DESCRIPTION
This check is a remnant of the original finaliser implementation from 4f7e9f5c445b5c0b262d9dfb8fceda4830f4844b, all the way from pre-1.0. This was a valid optimisation back then, but after its ordering with other finaliser code changed in 8a2ff2ca7366f605dd55c93f6b393552b365cd10 the invariant it exploits is no longer valid, and it breaks down completely in the case of variable-length allocations made with `mp_obj_malloc_var_with_finaliser`.

This resulted in a latent bug in the VFS system, where depending on the precise memory layout, VFS finaliser routines could sometimes be inadvertently missed. This bug was discovered when encountering an identical issue with an attempt to implement `__del__` for user classes in #18005.

This perhaps should be removed completely for the reasons discussed in #18014, but removing it appears to induce some other issue with the tls module; this version is an attempt to see if expanding the check instead might help with that?

