### PR TITLE
tests/internal_bench: Benchmark class instantiation and failed attribute lookups.

### DIFF
--- a/tests/internal_bench/class_instance-0-object.py
+++ b/tests/internal_bench/class_instance-0-object.py
@@ -1,0 +1,11 @@
+import bench
+
+X = object
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-0.1-object-gc.py
+++ b/tests/internal_bench/class_instance-0.1-object-gc.py
@@ -1,0 +1,13 @@
+import bench
+import gc
+
+X = object
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+    gc.collect()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-1-empty.py
+++ b/tests/internal_bench/class_instance-1-empty.py
@@ -1,0 +1,13 @@
+import bench
+
+
+class X:
+    pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-1.1-classattr.py
+++ b/tests/internal_bench/class_instance-1.1-classattr.py
@@ -1,0 +1,13 @@
+import bench
+
+
+class X:
+    x = 0
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-1.2-func.py
+++ b/tests/internal_bench/class_instance-1.2-func.py
@@ -1,0 +1,14 @@
+import bench
+
+
+class X:
+    def f(self):
+        pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-1.3-empty-gc.py
+++ b/tests/internal_bench/class_instance-1.3-empty-gc.py
@@ -1,0 +1,15 @@
+import bench
+import gc
+
+
+class X:
+    pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+    gc.collect()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-2-init.py
+++ b/tests/internal_bench/class_instance-2-init.py
@@ -1,0 +1,14 @@
+import bench
+
+
+class X:
+    def __init__(self):
+        pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-2.1-init_super.py
+++ b/tests/internal_bench/class_instance-2.1-init_super.py
@@ -1,0 +1,14 @@
+import bench
+
+
+class X:
+    def __init__(self):
+        return super().__init__()
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-2.2-new.py
+++ b/tests/internal_bench/class_instance-2.2-new.py
@@ -1,0 +1,14 @@
+import bench
+
+
+class X:
+    def __new__(cls):
+        return super().__new__(cls)
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-3-del.py
+++ b/tests/internal_bench/class_instance-3-del.py
@@ -1,0 +1,14 @@
+import bench
+
+
+class X:
+    def __del__(self):
+        pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-3.1-del-gc.py
+++ b/tests/internal_bench/class_instance-3.1-del-gc.py
@@ -1,0 +1,16 @@
+import bench
+import gc
+
+
+class X:
+    def __del__(self):
+        pass
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+    gc.collect()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-4-slots.py
+++ b/tests/internal_bench/class_instance-4-slots.py
@@ -1,0 +1,13 @@
+import bench
+
+
+class X:
+    __slots__ = ["x"]
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/class_instance-4.1-slots5.py
+++ b/tests/internal_bench/class_instance-4.1-slots5.py
@@ -1,0 +1,13 @@
+import bench
+
+
+class X:
+    __slots__ = ["a", "b", "c", "d", "x"]
+
+
+def test(num):
+    for i in range(num // 5):
+        x = X()
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9-getattr.py
+++ b/tests/internal_bench/var-9-getattr.py
@@ -1,0 +1,16 @@
+import bench
+
+
+class Foo:
+    pass
+
+
+def test(num):
+    o = Foo()
+    o.num = num
+    i = 0
+    while i < getattr(o, "num", num):
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9.1-getattr_default.py
+++ b/tests/internal_bench/var-9.1-getattr_default.py
@@ -1,0 +1,15 @@
+import bench
+
+
+class Foo:
+    pass
+
+
+def test(num):
+    o = Foo()
+    i = 0
+    while i < getattr(o, "num", num):
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9.2-getattr_default_special.py
+++ b/tests/internal_bench/var-9.2-getattr_default_special.py
@@ -2,9 +2,6 @@ import bench
 
 
 class Foo:
-    def __init__(self):
-        self.num = 20000000
-
     def __delattr__(self, name):  # just trigger the 'special lookups' flag on the class
         pass
 
@@ -12,7 +9,7 @@ class Foo:
 def test(num):
     o = Foo()
     i = 0
-    while i < o.num:
+    while i < getattr(o, "num", num):
         i += 1
 
 

--- a/tests/internal_bench/var-9.3-except_ok.py
+++ b/tests/internal_bench/var-9.3-except_ok.py
@@ -1,0 +1,23 @@
+import bench
+
+
+class Foo:
+    pass
+
+
+def test(num):
+    o = Foo()
+    o.num = num
+
+    def get():
+        try:
+            return o.num
+        except AttributeError:
+            return num
+
+    i = 0
+    while i < get():
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9.4-except_selfinduced.py
+++ b/tests/internal_bench/var-9.4-except_selfinduced.py
@@ -1,0 +1,22 @@
+import bench
+
+
+class Foo:
+    pass
+
+
+def test(num):
+    o = Foo()
+
+    def get():
+        try:
+            raise AttributeError
+        except AttributeError:
+            return num
+
+    i = 0
+    while i < get():
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9.5-except_error.py
+++ b/tests/internal_bench/var-9.5-except_error.py
@@ -1,0 +1,22 @@
+import bench
+
+
+class Foo:
+    pass
+
+
+def test(num):
+    o = Foo()
+
+    def get():
+        try:
+            return o.num
+        except AttributeError:
+            return num
+
+    i = 0
+    while i < get():
+        i += 1
+
+
+bench.run(test)

--- a/tests/internal_bench/var-9.6-except_error_special.py
+++ b/tests/internal_bench/var-9.6-except_error_special.py
@@ -2,17 +2,21 @@ import bench
 
 
 class Foo:
-    def __init__(self):
-        self.num = 20000000
-
     def __delattr__(self, name):  # just trigger the 'special lookups' flag on the class
         pass
 
 
 def test(num):
     o = Foo()
+
+    def get():
+        try:
+            return o.num
+        except AttributeError:
+            return num
+
     i = 0
-    while i < o.num:
+    while i < get():
         i += 1
 
 


### PR DESCRIPTION
### Summary
As part of my current efforts implementing `__del__` for user classes (#18005), I've found it necessary to benchmark the performance of class instantiation, as well as understand the broader impact of the potentially-extremely-expensive scenario of trying to look up and attribute and failing to find it (e.g. a penalty that might be paid if setting finaliser flags for user objects regardless of applicability.)

This PR also includes a fix to the `var-6.2-instance-speciallookup.py` originally added by 82db5c81e027f6ad305a43ec3c90a13ba319e3b4 / #16806, as the `__getattr__` method actually does _not_ trigger a class's special lookups flag as originally believed.

### Testing

Note that the tests testing the `AttributeError` paths are actually _extremely_ slow --- ~24 seconds, compared to just 2.8 seconds for the path that sets but never needs the exception handler, and 7.6 seconds for a version that just raises its own `AttributeError` immediately.

I've run the new benchmarks against my Ryzen 9 3900X, with the following (extremely noisy) results.

<details>

<summary>Results from Ryzen 9 3900X @ 3.80 GHz</summary>

```
internal_bench/arrayop:
    0.192s (+00.00%) internal_bench/arrayop-1-list_inplace.py
    0.376s (+95.85%) internal_bench/arrayop-2-list_map.py
    0.216s (+12.54%) internal_bench/arrayop-3-bytearray_inplace.py
    0.415s (+116.28%) internal_bench/arrayop-4-bytearray_map.py
internal_bench/bytealloc:
    0.852s (+00.00%) internal_bench/bytealloc-1-bytes_n.py
    1.594s (+87.06%) internal_bench/bytealloc-2-repeat.py
internal_bench/bytebuf:
    0.204s (+00.00%) internal_bench/bytebuf-1-inplace.py
    1.105s (+440.71%) internal_bench/bytebuf-2-join_map_bytes.py
    0.420s (+105.64%) internal_bench/bytebuf-3-bytarray_map.py
internal_bench/class_create:
    0.494s (+00.00%) internal_bench/class_create-0-empty.py
    0.665s (+34.64%) internal_bench/class_create-1-slots.py
    0.656s (+32.68%) internal_bench/class_create-1.1-slots5.py
    0.571s (+15.58%) internal_bench/class_create-2-classattr.py
    0.987s (+99.75%) internal_bench/class_create-2.1-classattr5.py
    1.293s (+161.63%) internal_bench/class_create-2.3-classattr5objs.py
    0.592s (+19.89%) internal_bench/class_create-3-instancemethod.py
    0.635s (+28.59%) internal_bench/class_create-4-classmethod.py
    0.590s (+19.41%) internal_bench/class_create-4.1-classmethod_implicit.py
    0.655s (+32.61%) internal_bench/class_create-5-staticmethod.py
    0.618s (+25.08%) internal_bench/class_create-6-getattribute.py
    0.615s (+24.38%) internal_bench/class_create-6.1-getattr.py
    0.561s (+13.51%) internal_bench/class_create-6.2-property.py
    0.543s (+09.87%) internal_bench/class_create-6.3-descriptor.py
    0.579s (+17.10%) internal_bench/class_create-7-inherit.py
    0.620s (+25.49%) internal_bench/class_create-7.1-inherit_initsubclass.py
    0.952s (+92.68%) internal_bench/class_create-8-metaclass_setname.py
    1.765s (+257.08%) internal_bench/class_create-8.1-metaclass_setname5.py
internal_bench/class_instance:
    0.430s (+00.00%) internal_bench/class_instance-0-object.py
    0.423s (-01.70%) internal_bench/class_instance-0.1-object-gc.py
    0.664s (+54.32%) internal_bench/class_instance-1-empty.py
    0.643s (+49.59%) internal_bench/class_instance-1.1-classattr.py
    0.981s (+128.18%) internal_bench/class_instance-1.2-func.py
    0.629s (+46.25%) internal_bench/class_instance-1.3-empty-gc.py
    0.825s (+91.77%) internal_bench/class_instance-2-init.py
    1.363s (+216.91%) internal_bench/class_instance-2.1-init_super.py
    1.348s (+213.43%) internal_bench/class_instance-2.2-new.py
    0.591s (+37.37%) internal_bench/class_instance-3-del.py
    0.600s (+39.57%) internal_bench/class_instance-3.1-del-gc.py
    0.588s (+36.68%) internal_bench/class_instance-4-slots.py
    0.584s (+35.78%) internal_bench/class_instance-4.1-slots5.py
internal_bench/from_iter:
    0.070s (+00.00%) internal_bench/from_iter-1-list_bound.py
    0.336s (+379.26%) internal_bench/from_iter-2-list_unbound.py
    0.104s (+48.93%) internal_bench/from_iter-3-tuple_bound.py
    0.338s (+382.77%) internal_bench/from_iter-4-tuple_unbound.py
    0.088s (+26.05%) internal_bench/from_iter-5-bytes_bound.py
    0.357s (+409.58%) internal_bench/from_iter-6-bytes_unbound.py
    0.081s (+15.60%) internal_bench/from_iter-7-bytearray_bound.py
    0.378s (+439.66%) internal_bench/from_iter-8-bytearray_unbound.py
internal_bench/func_args:
    2.106s (+00.00%) internal_bench/func_args-1.1-pos_1.py
    2.909s (+38.10%) internal_bench/func_args-1.2-pos_3.py
    2.466s (+17.11%) internal_bench/func_args-2-pos_default_2_of_3.py
    2.430s (+15.38%) internal_bench/func_args-3.1-kw_1.py
    2.895s (+37.47%) internal_bench/func_args-3.2-kw_3.py
internal_bench/func_builtin:
    0.251s (+00.00%) internal_bench/func_builtin-1-enum_pos.py
    0.250s (-00.69%) internal_bench/func_builtin-2-enum_kw.py
internal_bench/funcall:
    0.653s (+00.00%) internal_bench/funcall-1-inline.py
    2.321s (+255.33%) internal_bench/funcall-2-funcall.py
    2.115s (+223.74%) internal_bench/funcall-3-funcall-local.py
internal_bench/loop_count:
    0.567s (+00.00%) internal_bench/loop_count-1-range.py
    0.350s (-38.23%) internal_bench/loop_count-2-range_iter.py
    0.493s (-12.98%) internal_bench/loop_count-3-while_up.py
    0.453s (-20.07%) internal_bench/loop_count-4-while_down_gt.py
    0.521s (-08.10%) internal_bench/loop_count-5-while_down_ne.py
    0.531s (-06.26%) internal_bench/loop_count-5.1-while_down_ne_localvar.py
internal_bench/var:
    0.528s (+00.00%) internal_bench/var-1-constant.py
    0.709s (+34.27%) internal_bench/var-2-global.py
    0.483s (-08.58%) internal_bench/var-3-local.py
    0.522s (-01.14%) internal_bench/var-4-arg.py
    1.455s (+175.67%) internal_bench/var-5-class-attr.py
    0.626s (+18.53%) internal_bench/var-6-instance-attr.py
    0.618s (+17.02%) internal_bench/var-6.1-instance-attr-5.py
    0.620s (+17.42%) internal_bench/var-6.2-instance-speciallookup.py
    3.191s (+504.59%) internal_bench/var-6.3-instance-property.py
    3.706s (+602.17%) internal_bench/var-6.4-instance-descriptor.py
    4.471s (+747.06%) internal_bench/var-6.5-instance-getattr.py
    2.955s (+459.89%) internal_bench/var-7-instance-meth.py
    1.050s (+98.85%) internal_bench/var-8-namedtuple-1st.py
    1.080s (+104.62%) internal_bench/var-8.1-namedtuple-5th.py
    2.316s (+338.71%) internal_bench/var-9-getattr.py
    3.634s (+588.41%) internal_bench/var-9.1-getattr_default.py
    3.738s (+608.23%) internal_bench/var-9.2-getattr_default_special.py
    3.123s (+491.70%) internal_bench/var-9.3-except_ok.py
    7.915s (+1399.52%) internal_bench/var-9.4-except_selfinduced.py
    25.187s (+4671.55%) internal_bench/var-9.5-except_error.py
    24.623s (+4564.82%) internal_bench/var-9.6-except_error_special.py
11 tests performed (85 individual testcases)
```

</details>

<details>

<summary>Results from Pico2, Cortex M33 @ 300 MHz</summary>

```
internal_bench/arrayop:
    0.049s (+00.00%) internal_bench/arrayop-1-list_inplace.py
    0.169s (+242.67%) internal_bench/arrayop-2-list_map.py
    0.058s (+17.65%) internal_bench/arrayop-3-bytearray_inplace.py
    0.186s (+275.85%) internal_bench/arrayop-4-bytearray_map.py
internal_bench/bytealloc:
    0.142s (+00.00%) internal_bench/bytealloc-1-bytes_n.py
    0.353s (+148.73%) internal_bench/bytealloc-2-repeat.py
internal_bench/bytebuf:
    0.058s (+00.00%) internal_bench/bytebuf-1-inplace.py
    0.525s (+802.11%) internal_bench/bytebuf-2-join_map_bytes.py
    0.186s (+219.50%) internal_bench/bytebuf-3-bytarray_map.py
internal_bench/class_create:
    0.192s (+00.00%) internal_bench/class_create-0-empty.py
    0.249s (+29.89%) internal_bench/class_create-1-slots.py
    0.249s (+29.93%) internal_bench/class_create-1.1-slots5.py
    0.233s (+21.33%) internal_bench/class_create-2-classattr.py
    0.372s (+94.01%) internal_bench/class_create-2.1-classattr5.py
    0.484s (+152.13%) internal_bench/class_create-2.3-classattr5objs.py
    0.236s (+22.86%) internal_bench/class_create-3-instancemethod.py
    0.258s (+34.57%) internal_bench/class_create-4-classmethod.py
    0.236s (+23.02%) internal_bench/class_create-4.1-classmethod_implicit.py
    0.258s (+34.53%) internal_bench/class_create-5-staticmethod.py
    0.235s (+22.33%) internal_bench/class_create-6-getattribute.py
    0.235s (+22.42%) internal_bench/class_create-6.1-getattr.py
    0.250s (+30.45%) internal_bench/class_create-6.2-property.py
    0.239s (+24.86%) internal_bench/class_create-6.3-descriptor.py
    0.207s (+07.77%) internal_bench/class_create-7-inherit.py
    0.207s (+07.96%) internal_bench/class_create-7.1-inherit_initsubclass.py
    0.318s (+65.61%) internal_bench/class_create-8-metaclass_setname.py
    0.611s (+218.50%) internal_bench/class_create-8.1-metaclass_setname5.py
internal_bench/class_instance:
    0.107s (+00.00%) internal_bench/class_instance-0-object.py
    0.109s (+02.13%) internal_bench/class_instance-0.1-object-gc.py
    0.234s (+119.36%) internal_bench/class_instance-1-empty.py
    0.235s (+119.95%) internal_bench/class_instance-1.1-classattr.py
    0.235s (+119.97%) internal_bench/class_instance-1.2-func.py
    0.237s (+121.82%) internal_bench/class_instance-1.3-empty-gc.py
    0.683s (+539.63%) internal_bench/class_instance-2-init.py
    1.004s (+839.27%) internal_bench/class_instance-2.1-init_super.py
    0.961s (+799.20%) internal_bench/class_instance-2.2-new.py
    0.235s (+119.97%) internal_bench/class_instance-3-del.py
    0.237s (+122.05%) internal_bench/class_instance-3.1-del-gc.py
    0.230s (+115.67%) internal_bench/class_instance-4-slots.py
    0.230s (+115.63%) internal_bench/class_instance-4.1-slots5.py
internal_bench/from_iter:
    0.018s (+00.00%) internal_bench/from_iter-1-list_bound.py
    0.094s (+430.70%) internal_bench/from_iter-2-list_unbound.py
    0.019s (+09.24%) internal_bench/from_iter-3-tuple_bound.py
    0.094s (+429.65%) internal_bench/from_iter-4-tuple_unbound.py
    0.021s (+15.83%) internal_bench/from_iter-5-bytes_bound.py
    0.103s (+480.15%) internal_bench/from_iter-6-bytes_unbound.py
    0.020s (+11.54%) internal_bench/from_iter-7-bytearray_bound.py
    0.117s (+558.59%) internal_bench/from_iter-8-bytearray_unbound.py
internal_bench/func_args:
    0.904s (+00.00%) internal_bench/func_args-1.1-pos_1.py
    0.939s (+03.88%) internal_bench/func_args-1.2-pos_3.py
    0.962s (+06.46%) internal_bench/func_args-2-pos_default_2_of_3.py
    1.049s (+16.07%) internal_bench/func_args-3.1-kw_1.py
    1.314s (+45.32%) internal_bench/func_args-3.2-kw_3.py
internal_bench/func_builtin:
    0.090s (+00.00%) internal_bench/func_builtin-1-enum_pos.py
    0.096s (+06.30%) internal_bench/func_builtin-2-enum_kw.py
internal_bench/funcall:
    0.182s (+00.00%) internal_bench/funcall-1-inline.py
    1.599s (+778.52%) internal_bench/funcall-2-funcall.py
    1.499s (+723.61%) internal_bench/funcall-3-funcall-local.py
internal_bench/loop_count:
    0.177s (+00.00%) internal_bench/loop_count-1-range.py
    0.101s (-42.84%) internal_bench/loop_count-2-range_iter.py
    0.183s (+03.38%) internal_bench/loop_count-3-while_up.py
    0.183s (+03.01%) internal_bench/loop_count-4-while_down_gt.py
    0.199s (+12.03%) internal_bench/loop_count-5-while_down_ne.py
    0.200s (+12.78%) internal_bench/loop_count-5.1-while_down_ne_localvar.py
internal_bench/var:
    0.198s (+00.00%) internal_bench/var-1-constant.py
    0.241s (+21.55%) internal_bench/var-2-global.py
    0.183s (-07.41%) internal_bench/var-3-local.py
    0.183s (-07.40%) internal_bench/var-4-arg.py
    0.435s (+119.52%) internal_bench/var-5-class-attr.py
    0.245s (+23.58%) internal_bench/var-6-instance-attr.py
    0.245s (+23.59%) internal_bench/var-6.1-instance-attr-5.py
    0.245s (+23.58%) internal_bench/var-6.2-instance-speciallookup.py
    2.239s (+1030.76%) internal_bench/var-6.3-instance-property.py
    2.626s (+1225.98%) internal_bench/var-6.4-instance-descriptor.py
    2.746s (+1286.68%) internal_bench/var-6.5-instance-getattr.py
    2.450s (+1137.22%) internal_bench/var-7-instance-meth.py
    0.297s (+50.17%) internal_bench/var-8-namedtuple-1st.py
    0.319s (+60.94%) internal_bench/var-8.1-namedtuple-5th.py
    0.936s (+372.80%) internal_bench/var-9-getattr.py
    1.379s (+596.27%) internal_bench/var-9.1-getattr_default.py
    1.447s (+630.82%) internal_bench/var-9.2-getattr_default_special.py
    1.730s (+773.41%) internal_bench/var-9.3-except_ok.py
    4.205s (+2023.36%) internal_bench/var-9.4-except_selfinduced.py
    -1.000s (-604.99%) internal_bench/var-9.5-except_error.py
    -1.000s (-604.99%) internal_bench/var-9.6-except_error_special.py
```

</details>

### Trade-offs and Alternatives

At the moment, `__del__` is not implemented on user classes, so `class_instance-3-del.py` has no actual functionality at the moment. Is there some object in the existing MicroPython codebase that has a very simple finaliser that could be used to test gc finaliser performance?
