### PR TITLE
core: Gracefully handle allocations that overflow size_t.

### DIFF
--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -66,8 +66,11 @@
 
 #define m_malloc_fail(num_bytes)        (m_malloc_fail_dyn((num_bytes)))
 #define m_malloc(n)                     (m_malloc_dyn((n)))
+#define m_malloc_overflow(base_size, element_size, count) (m_malloc_dyn((base_size) + (element_size) * (count)))
+#define m_malloc_overflow2(element_size, count) (m_malloc_dyn((element_size) * (count)))
 #define m_free(ptr)                     (m_free_dyn((ptr)))
 #define m_realloc(ptr, new_num_bytes)   (m_realloc_dyn((ptr), (new_num_bytes)))
+#define m_realloc_overflow(ptr, element_size, count)   (m_realloc_dyn((ptr), (element_size) * (count)))
 #define m_realloc_maybe(ptr, new_num_bytes, allow_move) (m_realloc_maybe_dyn((ptr), (new_num_bytes), (allow_move)))
 
 static MP_NORETURN inline void m_malloc_fail_dyn(size_t num_bytes) {

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -123,6 +123,7 @@ void *m_malloc_with_finaliser(size_t num_bytes) {
 }
 #endif
 
+#if !MICROPY_GC_CONSERVATIVE_CLEAR
 void *m_malloc0(size_t num_bytes) {
     void *ptr = m_malloc(num_bytes);
     // If this config is set then the GC clears all memory, so we don't need to.
@@ -131,6 +132,15 @@ void *m_malloc0(size_t num_bytes) {
     #endif
     return ptr;
 }
+
+void *m_malloc0_overflow(size_t base_size, size_t element_size, size_t element_count) {
+    return m_malloc0(mp_compute_size_overflow(base_size, element_size, element_count));
+}
+
+void *m_malloc0_overflow2(size_t element_size, size_t element_count) {
+    return m_malloc0_overflow(0, element_size, element_count);
+}
+#endif
 
 size_t mp_compute_size_overflow(size_t base_size, size_t element_size, size_t count) {
     size_t new_size;
@@ -157,16 +167,6 @@ void *m_malloc_maybe_overflow(size_t base_size, size_t element_size, size_t coun
 void *m_malloc_maybe_overflow2(size_t element_size, size_t element_count) {
     return m_malloc_maybe_overflow(0, element_size, element_count);
 }
-
-
-void *m_malloc0_overflow(size_t base_size, size_t element_size, size_t element_count) {
-    return m_malloc0(mp_compute_size_overflow(base_size, element_size, element_count));
-}
-
-void *m_malloc0_overflow2(size_t element_size, size_t element_count) {
-    return m_malloc0_overflow(0, element_size, element_count);
-}
-
 
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes)

--- a/py/misc.h
+++ b/py/misc.h
@@ -109,17 +109,25 @@ typedef unsigned int uint;
 // step and returning SIZE_MAX. All allocations of SIZE_MAX are assumed to
 // fail.
 size_t mp_compute_size_overflow(size_t base_size, size_t element_size, size_t count);
-void *m_malloc_overflow(size_t base_size, size_t element_size, size_t count);
-void *m_malloc_maybe_overflow(size_t base_size, size_t element_size, size_t count);
-void *m_malloc0_overflow(size_t base_size, size_t element_size, size_t count);
-void *m_malloc_overflow2(size_t element_size, size_t count);
 void *m_malloc_maybe_overflow2(size_t element_size, size_t count);
-void *m_malloc0_overflow2(size_t element_size, size_t count);
+void *m_malloc_maybe_overflow(size_t base_size, size_t element_size, size_t count);
+void *m_malloc_overflow2(size_t element_size, size_t count);
+void *m_malloc_overflow(size_t base_size, size_t element_size, size_t count);
 
 void *m_malloc(size_t num_bytes);
 void *m_malloc_maybe(size_t num_bytes);
 void *m_malloc_with_finaliser(size_t num_bytes);
+
+#if !MICROPY_GC_CONSERVATIVE_CLEAR
 void *m_malloc0(size_t num_bytes);
+void *m_malloc0_overflow2(size_t element_size, size_t count);
+void *m_malloc0_overflow(size_t base_size, size_t element_size, size_t count);
+#else
+#define m_malloc0 m_malloc
+#define m_malloc0_overflow2 m_malloc_overflow2
+#define m_malloc0_overflow m_malloc_overflow
+#endif
+
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
 void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
 void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2293,6 +2293,26 @@ typedef time_t mp_timestamp_t;
 #define MP_FALLTHROUGH
 #endif
 
+// If true, use __builtin_mul_overflow (a gcc intrinsic supported by clang) for
+// overflow checking when multiplying two small ints. Otherwise, use a portable
+// algorithm.
+//
+// Most MCUs have a with a 32x32->64 bit multiply instruction, in which case the
+// intrinsic is likely to be faster and generate smaller code. The main exception is
+// cortex-m0 with __ARM_ARCH_ISA_THUMB == 1.
+//
+// The intrinsic is in GCC from version 5. In principle it can be detected instead with
+// __has_builtin except this is only not GCC version 5.
+#ifndef MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC
+#if defined(__ARM_ARCH_ISA_THUMB) && (__GNUC__ >= 5)
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (__ARM_ARCH_ISA_THUMB >= 2)
+#elif (__GNUC__ >= 5)
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (1)
+#else
+#define MICROPY_USE_GCC_MUL_OVERFLOW_INTRINSIC (0)
+#endif
+#endif
+
 #ifndef MP_HTOBE16
 #if MP_ENDIANNESS_LITTLE
 #define MP_HTOBE16(x) ((uint16_t)((((x) & 0xff) << 8) | (((x) >> 8) & 0xff)))

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -132,7 +132,7 @@ static mp_obj_t list_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (n < 0) {
                 n = 0;
             }
-            mp_obj_list_t *s = list_new(o->len * n);
+            mp_obj_list_t *s = list_new(mp_compute_size_overflow(0, o->len, n));
             mp_seq_multiply(o->items, sizeof(*o->items), o->len, n, s->items);
             return MP_OBJ_FROM_PTR(s);
         }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -379,7 +379,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         if (!mp_obj_get_int_maybe(rhs_in, &n)) {
             return MP_OBJ_NULL; // op not supported
         }
-        if (n <= 0) {
+        if (n <= 0 || !lhs_len) {
             if (lhs_type == &mp_type_str) {
                 return MP_OBJ_NEW_QSTR(MP_QSTR_); // empty str
             } else {
@@ -387,7 +387,7 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
             }
         }
         vstr_t vstr;
-        vstr_init_len(&vstr, lhs_len * n);
+        vstr_init_len(&vstr, mp_compute_size_overflow(1, lhs_len, n) - 1);
         mp_seq_multiply(lhs_data, sizeof(*lhs_data), lhs_len, n, vstr.buf);
         return mp_obj_new_str_type_from_vstr(lhs_type, &vstr);
     }

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -162,7 +162,7 @@ mp_obj_t mp_obj_tuple_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (n <= 0) {
                 return mp_const_empty_tuple;
             }
-            mp_obj_tuple_t *s = MP_OBJ_TO_PTR(mp_obj_new_tuple(o->len * n, NULL));
+            mp_obj_tuple_t *s = MP_OBJ_TO_PTR(mp_obj_new_tuple(mp_compute_size_overflow(0, o->len, n), NULL));
             mp_seq_multiply(o->items, sizeof(*o->items), o->len, n, s->items);
             return MP_OBJ_FROM_PTR(s);
         }

--- a/tests/basics/overflow.py
+++ b/tests/basics/overflow.py
@@ -1,0 +1,15 @@
+# For 64 bit platforms, this hits the overflow case in mp_compute_size_overflow
+try:
+    "a" * 8 * (1 << 62)
+except (OverflowError, MemoryError):
+    print("MemoryError")
+    raise SystemExit
+
+# For 32-bit platforms, this hits the overflow case in mp_compute_size_overflow
+# We have to try this second, because if the *host* Python is 64 bits then this
+# will try to allocate multiple gigabytes of memory and run for a long time.
+try:
+    "a" * 8 * (1 << 29)
+except (OverflowError, MemoryError):
+    print("MemoryError")
+    raise SystemExit


### PR DESCRIPTION
### Summary
Frequently, allocations are sized based on a computation like `base_size + count * entry_size` or just `count * entry_size`.

If an integer overflow occurs in computation and is not checked for, this can lead to success with a smaller-than-intended allocation, followed by out-of-bounds access to the buffer. This is the underlying cause of #17925.

Add a utility function `mp_compute_size_overflow` to compute `base_size + count * entry_size` and use it in previously identified contexts:
 * the m_new and m_renew family of macros, which know the type and count of the objects they allocate
 * list, str, and tuple BINARY_OP_MULTIPLY, which create repetitions of a sequence.

In the latter case, note that overflow can occur in the a first step (when calculating the new *count of elements*) or in a second step (when calculating the *number of bytes*).

`mp_compute_size_overflow` doesn't directly raise an exception; instead, it returns SIZE_MAX, assuming no allocation of exactly SIZE_MAX can ever succeed. The existing code paths either return NULL or raise an exception, just as before.

The exception path will show an incorrect attempted allocation size e.g., 4294967295, in this case.

- [x] Look for alternatives that would reduce code growth
- [x] Fix natmod building
- [x] Implement a pathway for "non-gcc" compilers
- [x] Try to identify any other pathways that could have overflows of this type
- [x] Add tests that explicitly exercise the overflow paths

Closes: #17925

### Testing

I'm relying on CI testing to find any regressions introduced by this change.

### Trade-offs and Alternatives

The main alternative is to do nothing and accept that these constructs can cause crashes or wrong behavior. I have not identified any specific non-crashing behavior, but overflows of this type have been recognized as having security impacts as in e.g.,https://seclists.org/bugtraq/2002/Aug/91