### PR TITLE
zephyr: Supports adding external user modules.

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -57,6 +57,7 @@ set(MICROPY_SOURCE_PORT
     mpthreadport.c
 )
 list(TRANSFORM MICROPY_SOURCE_PORT PREPEND ${MICROPY_PORT_DIR}/)
+include(${MICROPY_DIR}/py/usermod.cmake)
 
 set(MICROPY_SOURCE_SHARED
     libc/printf.c
@@ -97,6 +98,7 @@ set(MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_DRIVERS}
     ${MICROPY_SOURCE_LIB}
     ${MICROPY_SOURCE_PORT}
+    ${MICROPY_SOURCE_USERMOD}
 )
 
 zephyr_get_include_directories_for_lang(C includes)
@@ -112,6 +114,7 @@ zephyr_library_include_directories(
     ${MICROPY_INC_CORE}
     ${MICROPY_PORT_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${MICROPY_INC_USERMOD}
 )
 
 zephyr_library_compile_options(


### PR DESCRIPTION
zephyr: Supports adding external user modules.

In order to allow users to add external user modules to Zephyr, the relevant macro definition modules are included in port/zephyr.

Signed-off-by: Xinglei Li <xinglei.li@seeed.cc>
