### PR TITLE
tests/internal_bench/var: Benchmark ordered map accesses.

### DIFF
--- a/tests/internal_bench/var-6.6-instance-builtin_ordered.py
+++ b/tests/internal_bench/var-6.6-instance-builtin_ordered.py
@@ -1,0 +1,12 @@
+import bench
+
+
+def test(num):
+    i = 0
+    o = set()  # object with largest rom-frozen ordered locals_dict
+    n = "__contains__"  # last element in that dict for longest lookup
+    while i < num:
+        i += hasattr(o, n)  # True, converts to 1
+
+
+bench.run(test)


### PR DESCRIPTION
### Summary
This adds an internal_bench benchmark that benchmarks ordered map linear scan cache performance.

### Testing
I've run this benchmark against an experimental branch that disables the `MAP_CACHE_SET` operation from `py/map.c:208`.
Using my Pico2 Cortex M33 @ 300MHz, this benchmark runs in  0.920s on master, while deleting that line slows it to 1.847s, demonstrating a performance sensitivity I've not been able to find in any other benchmarks.

### Notes
Originally when I examined this, I was convinced that this line was actually in error --- it _looks_ like the map lookup cache is supposed to contain index-valued entries but the result of `elem - map->table` is a `ptrdiff_t` that should be out-of-scale from the table index by a factor of 8. Had my attempt to address this (https://github.com/AJMansfield/micropython/commit/171bdd1c9bdd97bad494ee268cb0495cf3d8b442) actually led to a performance improvement I'd be submitting a PR for that change instead, but after doing my due diligence to benchmark it it became clear this would actually be nearly as bad as removing that cache-setting line entirely, slowing this benchmark to 1.613s.
