### PR TITLE
ci: Prepare to add esp32 to size report.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build
       run: source tools/ci.sh && ci_code_size_build
     - name: Compute code size difference
-      run: tools/metrics.py diff ~/size0 ~/size1 | tee diff
+      run: source tools/ci.sh && ci_code_size_report
     - name: Save PR number
       if: github.event_name == 'pull_request'
       env:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -122,6 +122,11 @@ function ci_code_size_build {
     return $STATUS
 }
 
+function ci_code_size_report {
+    # Allow errors from tools/metrics.py to propagate out of the pipe above.
+    (set -o pipefail; tools/metrics.py diff ~/size0 ~/size1 | tee diff)
+}
+
 ########################################################################################
 # .mpy file format
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -82,16 +82,20 @@ function ci_code_size_setup {
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=bmusxpdv
+    # Override the list by setting PORTS_TO_CHECK in the environment before invoking ci.
+    : ${PORTS_TO_CHECK:=bmusxpdv}
+    
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # Default GitHub pull request sets HEAD to a generated merge commit
     # between PR branch (HEAD^2) and base branch (i.e. master) (HEAD^1).
     #
     # We want to compare this generated commit with the base branch, to see what
-    # the code size impact would be if we merged this PR.
-    REFERENCE=$(git rev-parse --short HEAD^1)
-    COMPARISON=$(git rev-parse --short HEAD)
+    # the code size impact would be if we merged this PR. During CI we are at a merge commit,
+    # so this tests the merged PR against its merge base.
+    # Override the refs by setting REFERENCE and/or COMPARISON in the environment before invoking ci.
+    : ${REFERENCE:=$(git rev-parse --short HEAD^1)}
+    : ${COMPARISON:=$(git rev-parse --short HEAD)}
 
     echo "Comparing sizes of reference ${REFERENCE} to ${COMPARISON}..."
     git log --oneline $REFERENCE..$COMPARISON

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -105,12 +105,10 @@ function ci_code_size_build {
         git submodule update --init $SUBMODULES
         git show -s
         tools/metrics.py clean $PORTS_TO_CHECK
-        tools/metrics.py build $PORTS_TO_CHECK | tee $OUTFILE
+        # Allow errors from tools/metrics.py to propagate out of the pipe above.
+        (set -o pipefail; tools/metrics.py build $PORTS_TO_CHECK | tee $OUTFILE)
         return $?
     }
-
-    # Allow errors from tools/metrics.py to propagate out of the pipe above.
-    set -o pipefail
 
     # build reference, save to size0
     # ignore any errors with this build, in case master is failing
@@ -119,7 +117,6 @@ function ci_code_size_build {
     code_size_build_step $COMPARISON ~/size1
     STATUS=$?
 
-    set +o pipefail
     unset -f code_size_build_step
 
     return $STATUS

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -232,7 +232,7 @@ function ci_esp32_build_c2_c6 {
 function ci_esp8266_setup {
     sudo pip3 install pyserial esptool==3.3.1 pyelftools ar
     wget https://micropython.org/resources/xtensa-lx106-elf-standalone.tar.gz
-    zcat xtensa-lx106-elf-standalone.tar.gz | tar x
+    (set -o pipefile; zcat xtensa-lx106-elf-standalone.tar.gz | tar x)
     # Remove this esptool.py so pip version is used instead
     rm xtensa-lx106-elf/bin/esptool.py
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -110,6 +110,7 @@ function ci_code_size_build {
 
             COMMIT=$1
             OUTFILE=$2
+            IGNORE_ERRORS=$3
 
             echo "Building ${COMMIT}..."
             git checkout --detach $COMMIT
@@ -118,14 +119,15 @@ function ci_code_size_build {
             tools/metrics.py clean "$PORTS_TO_CHECK"
             # Allow errors from tools/metrics.py to propagate out of the pipe below.
             set -o pipefail
-            tools/metrics.py build "$PORTS_TO_CHECK" | tee $OUTFILE
+            tools/metrics.py build "$PORTS_TO_CHECK" | tee $OUTFILE || $IGNORE_ERRORS
+            return $?
         }
 
         # build reference, save to size0
         # ignore any errors with this build, in case master is failing
-        code_size_build_step $REFERENCE ~/size0
+        code_size_build_step $REFERENCE ~/size0 true
         # build PR/branch, save to size1
-        code_size_build_step $COMPARISON ~/size1
+        code_size_build_step $COMPARISON ~/size1 false
     )
 }
 

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -43,9 +43,9 @@ Other commands:
 
 """
 
-import collections, sys, re, subprocess
+import collections, sys, re, subprocess, multiprocessing
 
-MAKE_FLAGS = ["-j3", "CFLAGS_EXTRA=-DNDEBUG"]
+MAKE_FLAGS = ["-j{}".format(multiprocessing.cpu_count()), "CFLAGS_EXTRA=-DNDEBUG"]
 
 
 class PortData:

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -185,6 +185,10 @@ def do_clean(args):
     ports = parse_port_list(args)
 
     print("CLEANING")
+
+    if any(port.needs_mpy_cross for port in ports):
+        syscmd("make", "-C", "mpy-cross", "clean")
+
     for port in ports:
         syscmd("make", "-C", "ports/{}".format(port.dir), port.make_flags, "clean")
 


### PR DESCRIPTION
### Summary

I noticed that no xtensa builds were reported in the size report. I also made improvements to the surrounding scripts:
 * metrics.py now uses all available CPU parallelsim for calling "make"
 * metrics.py now cleans mpy-cross if it's used
 * for local testing, the set of PORTS_TO_CHECK, REFERENCE and COMPARISON can be overridden
 * for local testing, the original branch is restored after ci_code_size_build
 * pipefail manipulation is simplified by use of subshells
 * the command to generate the size change report is now a ci.sh step, ci_code_size_report
 * a possible unrelated error due to failure within the pipeline `zcat | tar` will now be caught
 * metrics.py can take a "pre_cmd" for a given port, used to inject the idf shell environment when building that port. A port's pre_cmd can be added or changed by setting an environment variable.

### Testing

I ran various ci.sh steps locally.

### Trade-offs and Alternatives

My past experience with having the idf environment loaded while trying to do other-port building made me believe that the approach I took is preferable to having the idf environment active through all of the size check build.

Due to the fact that the git version of `metrics.py` is used, _it breaks to actually add the build to the size check as part of this PR_, because at the base ref the build fails.

```diff
From fd5bf462c04c4135886d364a624333474fd9e170 Mon Sep 17 00:00:00 2001
From: Jeff Epler <jepler@gmail.com>
Date: Wed, 3 Sep 2025 13:49:55 -0500
Subject: [PATCH] ci: Add esp32 to code size build.

Signed-off-by: Jeff Epler <jepler@gmail.com>
---
 tools/ci.sh | 3 ++-
 1 file changed, 2 insertions(+), 1 deletion(-)

diff --git a/tools/ci.sh b/tools/ci.sh
index 5417ce8797..bfd1aaf357 100755
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -75,11 +75,12 @@ function ci_code_size_setup {
     ci_gcc_arm_setup
     ci_gcc_riscv_setup
     ci_picotool_setup
+    ci_esp32_idf_setup
 }
 
 function ci_code_size_build {
     # check the following ports for the change in their code size
-    PORTS_TO_CHECK=${1-bmusxpdv}
+    PORTS_TO_CHECK=${1-bmusxpdv3}
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 
     # Default GitHub pull request sets HEAD to a generated merge commit
-- 
2.47.2

```