### PR TITLE
docs: Always use sphinx_rtd_theme.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinxcontrib.jquery",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -128,20 +129,9 @@ rst_epilog = """
 
 # -- Options for HTML output ----------------------------------------------
 
-# on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get("READTHEDOCS", None) == "True"
+import sphinx_rtd_theme
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    try:
-        import sphinx_rtd_theme
-
-        html_theme = "sphinx_rtd_theme"
-        html_theme_path = [sphinx_rtd_theme.get_html_theme_path(), "."]
-    except:
-        html_theme = "default"
-        html_theme_path = ["."]
-else:
-    html_theme_path = ["."]
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx~=7.2.6
 sphinxcontrib.jquery==4.1
+sphinx-rtd-theme==3.0.2


### PR DESCRIPTION

### Summary

Without this, the wy-alert block pushed all the content to the right, making the locally built pages nearly illegible.

### Testing

I built the docs locally and looked at them.

### Trade-offs and Alternatives

It might be possible to add css to the default theme so that a wy-alert is set correctly; but sphinx-rtd-theme is easy to install and gets very close to the exact rtd look so I'm not sure why you'd go to the trouble.