### PR TITLE
github: Retry Windows VS2017 & 2019 install steps.

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -29,8 +29,10 @@ jobs:
         include:
         - visualstudio: '2017'
           vs_version: '[15, 16)'
+          custom_vs_install: true
         - visualstudio: '2019'
           vs_version: '[16, 17)'
+          custom_vs_install: true
         - visualstudio: '2022'
           vs_version: '[17, 18)'
         # trim down the number of jobs in the matrix
@@ -43,18 +45,17 @@ jobs:
     env:
       CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
     steps:
-    - name: Install Visual Studio 2017
-      if: matrix.visualstudio == '2017'
+    - name: Install Visual Studio ${{ matrix.visualstudio }}
+      if: matrix.custom_vs_install
+      shell: bash
+      # Shell functions in this block are to retry intermittent corrupt
+      # downloads (with a clean download dir) before failing the job outright
       run: |
-        choco install visualstudio2017buildtools
-        choco install visualstudio2017-workload-vctools
-        choco install windows-sdk-8.1
-    - name: Install Visual Studio 2019
-      if: matrix.visualstudio == '2019'
-      run: |
-        choco install visualstudio2019buildtools
-        choco install visualstudio2019-workload-vctools
-        choco install windows-sdk-8.1
+        try () { ($@) || ($@) || ($@) || ($@) }
+        clean_install () ( rm -rf $TEMP/chocolatey; choco install $1 )
+        try clean_install visualstudio${{ matrix.visualstudio }}buildtools
+        try clean_install visualstudio${{ matrix.visualstudio }}-workload-vctools
+        try clean_install windows-sdk-8.1
     - uses: microsoft/setup-msbuild@v2
       with:
         vs-version: ${{ matrix.vs_version }}


### PR DESCRIPTION
### Summary

These seem to fail intermittently pretty often, here's a sample failing job:
https://github.com/micropython/micropython/actions/runs/17537964844/job/49804339088#step:2:544

I *think* what happens is that the downloaded `sdksetup.exe` is intermittently corrupted (or possibly it then runs and downloads something which is corrupted). This PR changes the step to retry each `choco install` up to three times, deleting the temporary download directory each time, before failing outright.

This work was funded through GitHub Sponsors.

### Testing

* Will try and run this PR's CI checks enough times that at least one VS install would have failed. [Automated using this script](https://gist.github.com/projectgus/b270618857b75261908464b43632cdc6)

### Trade-offs and Alternatives

* There are apparently ways to [cache the Windows install setup instead](https://chadgolden.com/blog/github-actions-windows-runners-vhdx-caching-to-the-rescue), which might be faster as well, but we're already running very close to the GitHub Actions 10GB cache limit with our existing caches.