### PR TITLE
github/workflows: Add check for misspelling of "MicroPython".

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -10,4 +10,9 @@ jobs:
     # codespell version should be kept in sync with .pre-commit-config.yml
     - run: pip install --user codespell==2.4.1 tomli
     - run: codespell
-
+    # additionally check for misspelling of "MicroPython"
+    - run: |
+        if git grep -n Micropython -- ":(exclude).github/workflows/codespell.yml"; then
+            echo "Please correct capitalisation of MicroPython on the above lines"
+            exit 1
+        fi

--- a/ports/mimxrt/machine_pwm.c
+++ b/ports/mimxrt/machine_pwm.c
@@ -375,7 +375,7 @@ static void configure_pwm(machine_pwm_obj_t *self) {
     }
 }
 
-// Micropython API functions
+// MicroPython API functions
 //
 static void mp_machine_pwm_init_helper(machine_pwm_obj_t *self,
     size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/ports/zephyr/README.md
+++ b/ports/zephyr/README.md
@@ -211,8 +211,8 @@ run the following after you built an image with the previous command:
 File Systems
 ------------
 
-The Zephyr Micropython port provides 2 options for handling filesystems on the device:
-The first is the Micropython filesystem management, which uses Micropython's filesystem code and
+The Zephyr MicroPython port provides 2 options for handling filesystems on the device:
+The first is the MicroPython filesystem management, which uses MicroPython's filesystem code and
 relies on zephyr's FlashArea API, this is enabled by default when 
 `CONFIG_FLASH` and `CONFIG_FLASH_MAP` are turned on.
 The second option is using Zephyr's Filesystem management:
@@ -241,13 +241,13 @@ Then, a fstab must be added to the dts overlay, for example:
 		};
 	};
 	
-It is then possible to use the FS like a normal Micropython filesystem:
+It is then possible to use the FS like a normal MicroPython filesystem:
 
     import vfs, zephyr
     zfs = zephyr.FileSystem(zephyr.FileSystem.fstab()[0])
     vfs.mount(zfs, "/zephyr")
 
-You may disable Micropython's File system code to save space:
+You may disable MicroPython's File system code to save space:
     
     CONFIG_MICROPY_VFS_FAT=n
     CONFIG_MICROPY_VFS_LFS1=n

--- a/ports/zephyr/src/usbd.c
+++ b/ports/zephyr/src/usbd.c
@@ -56,7 +56,7 @@ USBD_DEVICE_DEFINE(mp_usbd,
 
 USBD_DESC_LANG_DEFINE(mp_lang);
 USBD_DESC_MANUFACTURER_DEFINE(mp_mfr, "Zephyr Project");
-USBD_DESC_PRODUCT_DEFINE(mp_product, "Micropython on Zephyr RTOS");
+USBD_DESC_PRODUCT_DEFINE(mp_product, "MicroPython on Zephyr RTOS");
 USBD_DESC_SERIAL_NUMBER_DEFINE(mp_sn);
 
 USBD_DESC_CONFIG_DEFINE(fs_cfg_desc, "FS Configuration");

--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -1,4 +1,4 @@
-# Micropython package installer
+# MicroPython package installer
 # Ported from micropython-lib/micropython/mip/mip.py.
 # MIT license; Copyright (c) 2022 Jim Mussared
 


### PR DESCRIPTION
### Summary

"MicroPython" is sometimes misspelled as "Micropython".

Add a check for that as part of CI.

### Testing

To be tested by CI.  There are 3 cases that will need fixing.

### Trade-offs and Alternatives

This is a little hacky, but at least it's simple.  I tried to get codespell to do it but could not (it doesn't consider case when spelling).