### PR TITLE
tests/run-internalbench: Add option for running against CPython.

### DIFF
--- a/tests/run-internalbench.py
+++ b/tests/run-internalbench.py
@@ -21,8 +21,14 @@ if os.name == "nt":
     MICROPYTHON = os.getenv(
         "MICROPY_MICROPYTHON", "../ports/windows/build-standard/micropython.exe"
     )
+    CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
 else:
     MICROPYTHON = os.getenv("MICROPY_MICROPYTHON", "../ports/unix/build-standard/micropython")
+    CPYTHON3 = os.getenv("MICROPY_CPYTHON3", "python3")
+
+MICROPYTHON_CMD = [MICROPYTHON, "-X", "emit=bytecode"]
+CPYTHON3_CMD = [CPYTHON3, "-BS"]
+
 
 injected_bench_code = b"""
 import time
@@ -43,14 +49,14 @@ sys.modules['bench'] = bench_class
 """
 
 
-def execbench(pyb, filename, iters):
+def execbench(test_instance, filename, iters):
     with open(filename, "rb") as f:
         pyfile = f.read()
     code = (injected_bench_code + pyfile).replace(b"20000000", str(iters).encode("utf-8"))
-    return pyb.exec(code).replace(b"\r\n", b"\n")
+    return test_instance.exec(code).replace(b"\r\n", b"\n")
 
 
-def run_tests(pyb, test_dict, iters):
+def run_tests(test_instance, test_dict, iters):
     test_count = 0
     testcase_count = 0
 
@@ -59,19 +65,17 @@ def run_tests(pyb, test_dict, iters):
         baseline = None
         for test_file in tests:
             # run MicroPython
-            if pyb is None:
+            if isinstance(test_instance, list):
                 # run on PC
                 try:
-                    output_mupy = subprocess.check_output(
-                        [MICROPYTHON, "-X", "emit=bytecode", test_file[0]]
-                    )
+                    output_mupy = subprocess.check_output(test_instance + [test_file[0]])
                 except subprocess.CalledProcessError:
                     output_mupy = b"CRASH"
             else:
                 # run on pyboard
-                pyb.enter_raw_repl()
+                test_instance.enter_raw_repl()
                 try:
-                    output_mupy = execbench(pyb, test_file[0], iters)
+                    output_mupy = execbench(test_instance, test_file[0], iters)
                 except pyboard.PyboardError:
                     output_mupy = b"CRASH"
 
@@ -105,7 +109,7 @@ def main():
 {test_instance_description}
 {test_directory_description}
 """,
-        epilog=test_instance_epilog,
+        epilog=f"""{test_instance_epilog}- cpython - use CPython to run the benchmarks instead\n""",
     )
     cmd_parser.add_argument(
         "-t", "--test-instance", default="unix", help="the MicroPython instance to test"
@@ -128,8 +132,15 @@ def main():
     cmd_parser.add_argument("files", nargs="*", help="input test files")
     args = cmd_parser.parse_args()
 
-    # Note pyboard support is copied over from run-tests.py, not tests, and likely needs revamping
-    pyb = get_test_instance(args.test_instance, args.baudrate, args.user, args.password)
+    if args.test_instance == "cpython":
+        test_instance = CPYTHON3_CMD
+    else:
+        # Note pyboard support is copied over from run-tests.py, not tests, and likely needs revamping
+        test_instance = get_test_instance(
+            args.test_instance, args.baudrate, args.user, args.password
+        )
+        if test_instance is None:
+            test_instance = MICROPYTHON_CMD
 
     if len(args.files) == 0:
         if args.test_dirs:
@@ -153,7 +164,7 @@ def main():
             continue
         test_dict[m.group(1)].append([t, None])
 
-    if not run_tests(pyb, test_dict, args.iters):
+    if not run_tests(test_instance, test_dict, args.iters):
         sys.exit(1)
 
 


### PR DESCRIPTION
### Summary

Occasionally, it's useful to be able to compare MicroPython's performance figures to CPython's. This change adds the ability to run the internalbench test runner with `--test-instance=cpython` in order to execute the same test routines against CPython and produce a benchmark performance report in the same format as MicroPython.

### Testing

Here's a comparison of results on CPython 3.12.0 vs MicroPython built from master, on my Ryzen 9 3900X.
It should be no surprise that MicroPython is slower in almost all of the tests --- but it's actually significantly faster in the class creation benchmarks. (Probably because it doesn't offer nearly as much as to metaclassing, though...)

| Test                                     | | CPython | vs MPy | | MicroPython | vs CPy |
| ---------------------------------------- |-| ----- | ----------:|-| ----- | --------:|
| arrayop-1-list_inplace.py                | | 0.059 | +189.83%   | | 0.171 | -65.50%  |
| arrayop-2-list_map.py                    | | 0.082 | +303.66%   | | 0.331 | -75.23%  |
| arrayop-3-bytearray_inplace.py           | | 0.099 | +90.91%    | | 0.189 | -47.62%  |
| arrayop-4-bytearray_map.py               | | 0.080 | +366.25%   | | 0.373 | -78.55%  |
| bytealloc-1-bytes_n.py                   | | 0.004 | +5900.00%  | | 0.240 | -98.33%  |
| bytealloc-2-repeat.py                    | | 0.003 | +46100.00% | | 1.386 | -99.78%  |
| bytebuf-1-inplace.py                     | | 0.091 | +102.20%   | | 0.184 | -50.54%  |
| bytebuf-2-join_map_bytes.py              | | 0.293 | +796.25%   | | 2.626 | -88.84%  |
| bytebuf-3-bytarray_map.py                | | 0.084 | +334.52%   | | 0.365 | -76.99%  |
| class_create-0-empty.py                  | | 2.499 | -82.31%    | | 0.442 | +465.38% |
| class_create-1-slots.py                  | | 2.497 | -76.57%    | | 0.585 | +326.84% |
| class_create-1.1-slots5.py               | | 2.858 | -79.08%    | | 0.598 | +377.93% |
| class_create-2-classattr.py              | | 2.523 | -78.72%    | | 0.537 | +369.83% |
| class_create-2.1-classattr5.py           | | 2.640 | -65.15%    | | 0.920 | +186.96% |
| class_create-2.3-classattr5objs.py       | | 2.676 | -55.75%    | | 1.184 | +126.01% |
| class_create-3-instancemethod.py         | | 2.573 | -78.20%    | | 0.561 | +358.65% |
| class_create-4-classmethod.py            | | 4.361 | -86.24%    | | 0.600 | +626.83% |
| class_create-4.1-classmethod_implicit.py | | 2.645 | -77.92%    | | 0.584 | +352.91% |
| class_create-5-staticmethod.py           | | 2.842 | -79.56%    | | 0.581 | +389.16% |
| class_create-6-getattribute.py           | | 2.481 | -79.00%    | | 0.521 | +376.20% |
| class_create-6.1-getattr.py              | | 2.565 | -79.34%    | | 0.530 | +383.96% |
| class_create-6.2-property.py             | | 2.694 | -82.55%    | | 0.470 | +473.19% |
| class_create-6.3-descriptor.py           | | 2.523 | -82.56%    | | 0.440 | +473.41% |
| class_create-7-inherit.py                | | 2.641 | -84.36%    | | 0.413 | +539.47% |
| class_create-7.1-inherit_initsubclass.py | | 2.583 | -83.74%    | | 0.420 | +515.00% |
| class_create-8-metaclass_setname.py      | | 2.585 | -74.97%    | | 0.647 | +299.54% |
| class_create-8.1-metaclass_setname5.py   | | 2.934 | -54.57%    | | 1.333 | +120.11% |
| from_iter-1-list_bound.py                | | 0.005 | +900.00%   | | 0.050 | -90.00%  |
| from_iter-2-list_unbound.py              | | 0.070 | +312.86%   | | 0.289 | -75.78%  |
| from_iter-3-tuple_bound.py               | | 0.004 | +2125.00%  | | 0.089 | -95.51%  |
| from_iter-4-tuple_unbound.py             | | 0.068 | +319.12%   | | 0.285 | -76.14%  |
| from_iter-5-bytes_bound.py               | | 0.009 | +711.11%   | | 0.073 | -87.67%  |
| from_iter-6-bytes_unbound.py             | | 0.073 | +327.40%   | | 0.312 | -76.60%  |
| from_iter-7-bytearray_bound.py           | | 0.005 | +1360.00%  | | 0.073 | -93.15%  |
| from_iter-8-bytearray_unbound.py         | | 0.067 | +404.48%   | | 0.338 | -80.18%  |
| func_args-1.1-pos_1.py                   | | 0.676 | +164.64%   | | 1.789 | -62.21%  |
| func_args-1.2-pos_3.py                   | | 0.730 | +176.99%   | | 2.022 | -63.90%  |
| func_args-2-pos_default_2_of_3.py        | | 0.730 | +184.25%   | | 2.075 | -64.82%  |
| func_args-3.1-kw_1.py                    | | 2.534 | -19.38%    | | 2.043 | +24.03%  |
| func_args-3.2-kw_3.py                    | | 1.456 | +80.98%    | | 2.635 | -44.74%  |
| func_builtin-1-enum_pos.py               | | 0.128 | +77.34%    | | 0.227 | -43.61%  |
| func_builtin-2-enum_kw.py                | | 0.156 | +48.72%    | | 0.232 | -32.76%  |
| funcall-1-inline.py                      | | 0.619 | -5.17%     | | 0.587 | +5.45%   |
| funcall-2-funcall.py                     | | 1.061 | +93.50%    | | 2.053 | -48.32%  |
| funcall-3-funcall-local.py               | | 0.995 | +94.77%    | | 1.938 | -48.66%  |
| loop_count-1-range.py                    | | 0.259 | +100.00%   | | 0.518 | -50.00%  |
| loop_count-2-range_iter.py               | | 0.260 | +30.77%    | | 0.340 | -23.53%  |
| loop_count-3-while_up.py                 | | 0.434 | +14.06%    | | 0.495 | -12.32%  |
| loop_count-4-while_down_gt.py            | | 0.441 | +4.54%     | | 0.461 | -4.34%   |
| loop_count-5-while_down_ne.py            | | 0.455 | -0.88%     | | 0.451 | +0.89%   |
| loop_count-5.1-while_down_ne_localvar.py | | 0.433 | +13.39%    | | 0.491 | -11.81%  |
| var-1-constant.py                        | | 0.447 | +371.14%   | | 2.106 | -78.77%  |
| var-2-global.py                          | | 0.466 | +43.56%    | | 0.669 | -30.34%  |
| var-3-local.py                           | | 0.423 | +16.31%    | | 0.492 | -14.02%  |
| var-4-arg.py                             | | 0.427 | +13.82%    | | 0.486 | -12.14%  |
| var-5-class-attr.py                      | | 0.540 | +138.70%   | | 1.289 | -58.11%  |
| var-6-instance-attr.py                   | | 0.535 | +12.52%    | | 0.602 | -11.13%  |
| var-6.1-instance-attr-5.py               | | 0.519 | +12.14%    | | 0.582 | -10.82%  |
| var-6.2-instance-speciallookup.py        | | 0.499 | +21.64%    | | 0.607 | -17.79%  |
| var-6.3-instance-property.py             | | 0.772 | +264.64%   | | 2.815 | -72.58%  |
| var-6.4-instance-descriptor.py           | | 1.385 | +148.16%   | | 3.437 | -59.70%  |
| var-6.5-instance-getattr.py              | | 1.822 | +84.30%    | | 3.358 | -45.74%  |
| var-7-instance-meth.py                   | | 0.893 | +177.94%   | | 2.482 | -64.02%  |
| var-8-namedtuple-1st.py                  | | 0.701 | +27.10%    | | 0.891 | -21.32%  |
| var-8.1-namedtuple-5th.py                | | 0.685 | +36.79%    | | 0.937 | -26.89%  |

<details>

<summary>Raw benchmark results</summary>

Benchmarks from CPython::
```
anson@wsl:~/mpy/micropython/tests$ python3 --version
Python 3.12.0
anson@wsl:~/mpy/micropython/tests$ ./run-internalbench.py --test-instance=cpython
internal_bench/arrayop:
    0.059s (+00.00%) internal_bench/arrayop-1-list_inplace.py
    0.082s (+38.19%) internal_bench/arrayop-2-list_map.py
    0.099s (+68.21%) internal_bench/arrayop-3-bytearray_inplace.py
    0.080s (+35.62%) internal_bench/arrayop-4-bytearray_map.py
internal_bench/bytealloc:
    0.004s (+00.00%) internal_bench/bytealloc-1-bytes_n.py
    0.003s (-07.98%) internal_bench/bytealloc-2-repeat.py
internal_bench/bytebuf:
    0.091s (+00.00%) internal_bench/bytebuf-1-inplace.py
    0.293s (+223.72%) internal_bench/bytebuf-2-join_map_bytes.py
    0.084s (-07.49%) internal_bench/bytebuf-3-bytarray_map.py
internal_bench/class_create:
    2.499s (+00.00%) internal_bench/class_create-0-empty.py
    2.497s (-00.07%) internal_bench/class_create-1-slots.py
    2.858s (+14.37%) internal_bench/class_create-1.1-slots5.py
    2.523s (+00.99%) internal_bench/class_create-2-classattr.py
    2.640s (+05.65%) internal_bench/class_create-2.1-classattr5.py
    2.676s (+07.08%) internal_bench/class_create-2.3-classattr5objs.py
    2.573s (+02.98%) internal_bench/class_create-3-instancemethod.py
    4.361s (+74.52%) internal_bench/class_create-4-classmethod.py
    2.645s (+05.83%) internal_bench/class_create-4.1-classmethod_implicit.py
    2.842s (+13.71%) internal_bench/class_create-5-staticmethod.py
    2.481s (-00.70%) internal_bench/class_create-6-getattribute.py
    2.565s (+02.64%) internal_bench/class_create-6.1-getattr.py
    2.694s (+07.82%) internal_bench/class_create-6.2-property.py
    2.523s (+00.96%) internal_bench/class_create-6.3-descriptor.py
    2.641s (+05.68%) internal_bench/class_create-7-inherit.py
    2.583s (+03.38%) internal_bench/class_create-7.1-inherit_initsubclass.py
    2.585s (+03.46%) internal_bench/class_create-8-metaclass_setname.py
    2.934s (+17.41%) internal_bench/class_create-8.1-metaclass_setname5.py
internal_bench/from_iter:
    0.005s (+00.00%) internal_bench/from_iter-1-list_bound.py
    0.070s (+1351.00%) internal_bench/from_iter-2-list_unbound.py
    0.004s (-09.68%) internal_bench/from_iter-3-tuple_bound.py
    0.068s (+1316.44%) internal_bench/from_iter-4-tuple_unbound.py
    0.009s (+92.32%) internal_bench/from_iter-5-bytes_bound.py
    0.073s (+1411.34%) internal_bench/from_iter-6-bytes_unbound.py
    0.005s (-02.45%) internal_bench/from_iter-7-bytearray_bound.py
    0.067s (+1291.96%) internal_bench/from_iter-8-bytearray_unbound.py
internal_bench/func_args:
    0.676s (+00.00%) internal_bench/func_args-1.1-pos_1.py
    0.730s (+07.97%) internal_bench/func_args-1.2-pos_3.py
    0.730s (+08.00%) internal_bench/func_args-2-pos_default_2_of_3.py
    2.534s (+274.90%) internal_bench/func_args-3.1-kw_1.py
    1.456s (+115.49%) internal_bench/func_args-3.2-kw_3.py
internal_bench/func_builtin:
    0.128s (+00.00%) internal_bench/func_builtin-1-enum_pos.py
    0.156s (+22.43%) internal_bench/func_builtin-2-enum_kw.py
internal_bench/funcall:
    0.619s (+00.00%) internal_bench/funcall-1-inline.py
    1.061s (+71.37%) internal_bench/funcall-2-funcall.py
    0.995s (+60.74%) internal_bench/funcall-3-funcall-local.py
internal_bench/loop_count:
    0.259s (+00.00%) internal_bench/loop_count-1-range.py
    0.260s (+00.17%) internal_bench/loop_count-2-range_iter.py
    0.434s (+67.15%) internal_bench/loop_count-3-while_up.py
    0.441s (+70.04%) internal_bench/loop_count-4-while_down_gt.py
    0.455s (+75.39%) internal_bench/loop_count-5-while_down_ne.py
    0.433s (+67.04%) internal_bench/loop_count-5.1-while_down_ne_localvar.py
internal_bench/var:
    0.447s (+00.00%) internal_bench/var-1-constant.py
    0.466s (+04.13%) internal_bench/var-2-global.py
    0.423s (-05.41%) internal_bench/var-3-local.py
    0.427s (-04.59%) internal_bench/var-4-arg.py
    0.540s (+20.69%) internal_bench/var-5-class-attr.py
    0.535s (+19.61%) internal_bench/var-6-instance-attr.py
    0.519s (+16.10%) internal_bench/var-6.1-instance-attr-5.py
    0.499s (+11.58%) internal_bench/var-6.2-instance-speciallookup.py
    0.772s (+72.63%) internal_bench/var-6.3-instance-property.py
    1.385s (+209.42%) internal_bench/var-6.4-instance-descriptor.py
    1.822s (+307.08%) internal_bench/var-6.5-instance-getattr.py
    0.893s (+99.60%) internal_bench/var-7-instance-meth.py
    0.701s (+56.76%) internal_bench/var-8-namedtuple-1st.py
    0.685s (+53.04%) internal_bench/var-8.1-namedtuple-5th.py
10 tests performed (65 individual testcases)
```

Benchmarks from MicroPython:
```
anson@wsl:~/mpy/micropython/tests$ ../ports/unix/build-standard/micropython --version
MicroPython v1.27.0-preview.118.g7da0641c76 on 2025-09-11; linux [GCC 12.3.0] version
anson@wsl:~/mpy/micropython/tests$ ./run-internalbench.py --test-instance=unix
internal_bench/arrayop:
    0.171s (+00.00%) internal_bench/arrayop-1-list_inplace.py
    0.331s (+94.03%) internal_bench/arrayop-2-list_map.py
    0.189s (+10.98%) internal_bench/arrayop-3-bytearray_inplace.py
    0.373s (+118.92%) internal_bench/arrayop-4-bytearray_map.py
internal_bench/bytealloc:
    0.240s (+00.00%) internal_bench/bytealloc-1-bytes_n.py
    1.386s (+478.29%) internal_bench/bytealloc-2-repeat.py
internal_bench/bytebuf:
    0.184s (+00.00%) internal_bench/bytebuf-1-inplace.py
    2.626s (+1328.57%) internal_bench/bytebuf-2-join_map_bytes.py
    0.365s (+98.80%) internal_bench/bytebuf-3-bytarray_map.py
internal_bench/class_create:
    0.442s (+00.00%) internal_bench/class_create-0-empty.py
    0.585s (+32.41%) internal_bench/class_create-1-slots.py
    0.598s (+35.28%) internal_bench/class_create-1.1-slots5.py
    0.537s (+21.41%) internal_bench/class_create-2-classattr.py
    0.920s (+108.16%) internal_bench/class_create-2.1-classattr5.py
    1.184s (+167.84%) internal_bench/class_create-2.3-classattr5objs.py
    0.561s (+26.87%) internal_bench/class_create-3-instancemethod.py
    0.600s (+35.66%) internal_bench/class_create-4-classmethod.py
    0.584s (+32.12%) internal_bench/class_create-4.1-classmethod_implicit.py
    0.581s (+31.52%) internal_bench/class_create-5-staticmethod.py
    0.521s (+17.89%) internal_bench/class_create-6-getattribute.py
    0.530s (+19.88%) internal_bench/class_create-6.1-getattr.py
    0.470s (+06.29%) internal_bench/class_create-6.2-property.py
    0.440s (-00.49%) internal_bench/class_create-6.3-descriptor.py
    0.413s (-06.47%) internal_bench/class_create-7-inherit.py
    0.420s (-05.04%) internal_bench/class_create-7.1-inherit_initsubclass.py
    0.647s (+46.50%) internal_bench/class_create-8-metaclass_setname.py
    1.333s (+201.54%) internal_bench/class_create-8.1-metaclass_setname5.py
internal_bench/from_iter:
    0.050s (+00.00%) internal_bench/from_iter-1-list_bound.py
    0.289s (+479.40%) internal_bench/from_iter-2-list_unbound.py
    0.089s (+79.02%) internal_bench/from_iter-3-tuple_bound.py
    0.285s (+471.85%) internal_bench/from_iter-4-tuple_unbound.py
    0.073s (+45.53%) internal_bench/from_iter-5-bytes_bound.py
    0.312s (+525.91%) internal_bench/from_iter-6-bytes_unbound.py
    0.073s (+45.92%) internal_bench/from_iter-7-bytearray_bound.py
    0.338s (+577.61%) internal_bench/from_iter-8-bytearray_unbound.py
internal_bench/func_args:
    1.789s (+00.00%) internal_bench/func_args-1.1-pos_1.py
    2.022s (+13.03%) internal_bench/func_args-1.2-pos_3.py
    2.075s (+16.00%) internal_bench/func_args-2-pos_default_2_of_3.py
    2.043s (+14.18%) internal_bench/func_args-3.1-kw_1.py
    2.635s (+47.28%) internal_bench/func_args-3.2-kw_3.py
internal_bench/func_builtin:
    0.227s (+00.00%) internal_bench/func_builtin-1-enum_pos.py
    0.232s (+01.99%) internal_bench/func_builtin-2-enum_kw.py
internal_bench/funcall:
    0.587s (+00.00%) internal_bench/funcall-1-inline.py
    2.053s (+249.59%) internal_bench/funcall-2-funcall.py
    1.938s (+230.00%) internal_bench/funcall-3-funcall-local.py
internal_bench/loop_count:
    0.518s (+00.00%) internal_bench/loop_count-1-range.py
    0.340s (-34.30%) internal_bench/loop_count-2-range_iter.py
    0.495s (-04.39%) internal_bench/loop_count-3-while_up.py
    0.461s (-10.90%) internal_bench/loop_count-4-while_down_gt.py
    0.451s (-12.98%) internal_bench/loop_count-5-while_down_ne.py
    0.491s (-05.21%) internal_bench/loop_count-5.1-while_down_ne_localvar.py
internal_bench/var:
    2.106s (+00.00%) internal_bench/var-1-constant.py
    0.669s (-68.26%) internal_bench/var-2-global.py
    0.492s (-76.62%) internal_bench/var-3-local.py
    0.486s (-76.93%) internal_bench/var-4-arg.py
    1.289s (-38.81%) internal_bench/var-5-class-attr.py
    0.602s (-71.44%) internal_bench/var-6-instance-attr.py
    0.582s (-72.36%) internal_bench/var-6.1-instance-attr-5.py
    0.607s (-71.17%) internal_bench/var-6.2-instance-speciallookup.py
    2.815s (+33.65%) internal_bench/var-6.3-instance-property.py
    3.437s (+63.21%) internal_bench/var-6.4-instance-descriptor.py
    3.358s (+59.45%) internal_bench/var-6.5-instance-getattr.py
    2.482s (+17.83%) internal_bench/var-7-instance-meth.py
    0.891s (-57.70%) internal_bench/var-8-namedtuple-1st.py
    0.937s (-55.52%) internal_bench/var-8.1-namedtuple-5th.py
10 tests performed (65 individual testcases)
```

</details>
