### PR TITLE
py/obj: Document undocumented MP_TYPE_FLAG values.

### DIFF
--- a/py/obj.h
+++ b/py/obj.h
@@ -539,6 +539,10 @@ typedef mp_obj_t (*mp_fun_var_t)(size_t n, const mp_obj_t *);
 typedef mp_obj_t (*mp_fun_kw_t)(size_t n, const mp_obj_t *, mp_map_t *);
 
 // Flags for type behaviour (mp_obj_type_t.flags)
+// If MP_TYPE_FLAG_IS_SUBCLASSED is set, then subclasses of this class have been created.
+//   Mutations to this class that would require updating all subclasses must be rejected.
+// If MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS is set, then attribute lookups involving this
+//   class need to additionally check for special accessor methods, such as from descriptors.
 // If MP_TYPE_FLAG_EQ_NOT_REFLEXIVE is clear then __eq__ is reflexive (A==A returns True).
 // If MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE is clear then the type can't be equal to an
 //   instance of any different class that also clears this flag.  If this flag is set


### PR DESCRIPTION
### Summary
This adds comments documentign the meaning of the type flag bits `MP_TYPE_FLAG_IS_SUBCLASSED` and `MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS`, for consistency with the comments added later on documenting the other flags.

These flags were were originally made part of the public API in c3450effd4c3a402eeccf44a84a05ef4b36d69a0. This block of doc comments was only added later on when `MP_TYPE_FLAG_EQ_NOT_REFLEXIVE`, `MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE`, and `MP_TYPE_FLAG_EQ_HAS_NEQ_TEST` were added in 9ec1caf42e7733b5141b7aecf1b6e58834a94bf7.

### Testing
This is a documentation-only change, but I've certainly had my understanding of these flags tested while I was tracking down all of the weird garbage-collector behavior to implement #18005. 🙃