### PR TITLE
py/stream: Reuse write implementation for readinto.

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -97,6 +97,7 @@ static const mp_rom_map_elem_t rawfile_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&mp_stream_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_write1), MP_ROM_PTR(&mp_stream_write1_obj) },
     { MP_ROM_QSTR(MP_QSTR_readinto), MP_ROM_PTR(&mp_stream_readinto_obj) },
+    { MP_ROM_QSTR(MP_QSTR_readinto1), MP_ROM_PTR(&mp_stream_readinto1_obj) },
     { MP_ROM_QSTR(MP_QSTR_readline), MP_ROM_PTR(&mp_stream_unbuffered_readline_obj) },
     { MP_ROM_QSTR(MP_QSTR_ioctl), MP_ROM_PTR(&mp_stream_ioctl_obj) },
 };

--- a/py/stream.c
+++ b/py/stream.c
@@ -261,9 +261,14 @@ void mp_stream_write_adaptor(void *self, const char *buf, size_t len) {
     mp_stream_write(MP_OBJ_FROM_PTR(self), buf, len, MP_STREAM_RW_WRITE);
 }
 
-static mp_obj_t stream_write_generic(size_t n_args, const mp_obj_t *args, byte flags) {
+static mp_obj_t stream_readinto_write_generic(size_t n_args, const mp_obj_t *args, byte flags) {
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+    mp_get_buffer_raise(args[1], &bufinfo, (flags & MP_STREAM_RW_WRITE) ? MP_BUFFER_READ : MP_BUFFER_WRITE);
+
+    // CPython extension, allow optional maximum length and offset:
+    // - stream.operation(buf, max_len)
+    // - stream.operation(buf, off, max_len)
+    // Similar to https://docs.python.org/3/library/socket.html#socket.socket.recv_into
     size_t max_len = (size_t)-1;
     size_t off = 0;
     if (n_args == 3) {
@@ -276,53 +281,28 @@ static mp_obj_t stream_write_generic(size_t n_args, const mp_obj_t *args, byte f
         }
     }
     bufinfo.len -= off;
+
+    // Perform the readinto or write operation.
     return mp_stream_write(args[0], (byte *)bufinfo.buf + off, MIN(bufinfo.len, max_len), flags);
 }
 
 static mp_obj_t stream_write_method(size_t n_args, const mp_obj_t *args) {
-    return stream_write_generic(n_args, args, MP_STREAM_RW_WRITE);
+    return stream_readinto_write_generic(n_args, args, MP_STREAM_RW_WRITE);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_write_obj, 2, 4, stream_write_method);
 
 static mp_obj_t stream_write1_method(size_t n_args, const mp_obj_t *args) {
-    return stream_write_generic(n_args, args, MP_STREAM_RW_WRITE | MP_STREAM_RW_ONCE);
+    return stream_readinto_write_generic(n_args, args, MP_STREAM_RW_WRITE | MP_STREAM_RW_ONCE);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_write1_obj, 2, 4, stream_write1_method);
 
-static mp_obj_t stream_readinto_generic(size_t n_args, const mp_obj_t *args, byte flags) {
-    mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
-
-    // CPython extension: if 2nd arg is provided, that's max len to read,
-    // instead of full buffer. Similar to
-    // https://docs.python.org/3/library/socket.html#socket.socket.recv_into
-    mp_uint_t len = bufinfo.len;
-    if (n_args > 2) {
-        len = mp_obj_get_int(args[2]);
-        if (len > bufinfo.len) {
-            len = bufinfo.len;
-        }
-    }
-
-    int error;
-    mp_uint_t out_sz = mp_stream_rw(args[0], bufinfo.buf, len, &error, flags);
-    if (error != 0) {
-        if (mp_is_nonblocking_error(error)) {
-            return mp_const_none;
-        }
-        mp_raise_OSError(error);
-    } else {
-        return MP_OBJ_NEW_SMALL_INT(out_sz);
-    }
-}
-
 static mp_obj_t stream_readinto(size_t n_args, const mp_obj_t *args) {
-    return stream_readinto_generic(n_args, args, MP_STREAM_RW_READ);
+    return stream_readinto_write_generic(n_args, args, MP_STREAM_RW_READ);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_readinto_obj, 2, 3, stream_readinto);
 
 static mp_obj_t stream_readinto1(size_t n_args, const mp_obj_t *args) {
-    return stream_readinto_generic(n_args, args, MP_STREAM_RW_READ | MP_STREAM_RW_ONCE);
+    return stream_readinto_write_generic(n_args, args, MP_STREAM_RW_READ | MP_STREAM_RW_ONCE);
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_readinto1_obj, 2, 3, stream_readinto1);
 

--- a/tests/ports/unix/extra_coverage.py
+++ b/tests/ports/unix/extra_coverage.py
@@ -33,6 +33,7 @@ print(stream.read())  # read all encounters non-blocking error
 print(stream.read(1))  # read 1 byte encounters non-blocking error
 print(stream.readline())  # readline encounters non-blocking error
 print(stream.readinto(bytearray(10)))  # readinto encounters non-blocking error
+print(stream.readinto1(bytearray(10)))  # readinto1 encounters non-blocking error
 print(stream.write(b"1"))  # write encounters non-blocking error
 print(stream.write1(b"1"))  # write1 encounters non-blocking error
 stream.set_buf(b"123")
@@ -47,6 +48,28 @@ except OSError:
     print("OSError")
 stream.set_error(0)
 print(stream.ioctl(0, bytearray(10)))  # successful ioctl call
+
+print("# stream.readinto")
+
+# stream.readinto will read 3 bytes then try to read more to fill the buffer,
+# but on the second attempt will encounter EIO and should raise that error.
+stream.set_error(errno.EIO)
+stream.set_buf(b"123")
+buf = bytearray(4)
+try:
+    stream.readinto(buf)
+except OSError as er:
+    print("OSError", er.errno == errno.EIO)
+print(buf)
+
+# stream.readinto1 will read 3 bytes then should return them immediately, and
+# not encounter the EIO.
+stream.set_error(errno.EIO)
+stream.set_buf(b"123")
+buf = bytearray(4)
+print(stream.readinto1(buf), buf)
+
+print("# stream textio")
 
 stream2 = data[3]  # is textio
 print(stream2.read(1))  # read 1 byte encounters non-blocking error with textio stream

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -214,11 +214,17 @@ None
 None
 None
 None
+None
 b'123'
 b'123'
 b'123'
 OSError
 0
+# stream.readinto
+OSError True
+bytearray(b'123\x00')
+3 bytearray(b'123\x00')
+# stream textio
 None
 None
 cpp None


### PR DESCRIPTION
### Summary

This commit refactors some common code in the core stream implementation, to reduce code size while retaining the same functionality.

### Testing

To be tested by CI.

### Trade-offs and Alternatives

readinto/readinto1 could now support an additional 4th argument (like write) but I don't want to introduce even more CPython incompatibility, so I left them as having a maximum of 3 args (in the `MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN` macro).