### PR TITLE
stm32/uart: Enable UART FIFO for STM32N6.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -445,7 +445,7 @@ HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	)
 endif
 
-ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),h7))
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),h7 n6))
 HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
     hal_uart_ex.c \
     )

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -665,7 +665,7 @@ bool uart_init(machine_uart_obj_t *uart_obj,
     huart.Init.HwFlowCtl = flow;
     huart.Init.OverSampling = UART_OVERSAMPLING_16;
 
-    #if defined(STM32G4) || defined(STM32H7) // WB also has a fifo..
+    #if defined(STM32G4) || defined(STM32H7) || defined(STM32N6) // WB also has a fifo..
     huart.FifoMode = UART_FIFOMODE_ENABLE;
     #endif
 
@@ -717,7 +717,7 @@ bool uart_init(machine_uart_obj_t *uart_obj,
         uart_obj->char_width = CHAR_WIDTH_8BIT;
     }
 
-    #if defined(STM32H7)
+    #if defined(STM32H7) || defined(STM32N6)
     HAL_UARTEx_SetTxFifoThreshold(&huart, UART_TXFIFO_THRESHOLD_1_8);
     HAL_UARTEx_SetRxFifoThreshold(&huart, UART_RXFIFO_THRESHOLD_1_8);
     HAL_UARTEx_EnableFifoMode(&huart);
@@ -1186,8 +1186,8 @@ size_t uart_tx_data(machine_uart_obj_t *self, const void *src_in, size_t num_cha
     // timeout_char by FIFO size + 1.
     // STM32G4 has 8 words FIFO.
     timeout = (8 + 1) * self->timeout_char;
-    #elif defined(STM32H7)
-    // STM32H7 has 16 words FIFO.
+    #elif defined(STM32H7) || defined(STM32N6)
+    // STM32H7 and STM32N6 have 16 words FIFO.
     timeout = (16 + 1) * self->timeout_char;
     #else
     // The timeout specified here is for waiting for the TX data register to


### PR DESCRIPTION
Enable UART FIFO for STM32N6.
### Summary

Enable UART FIFO for N6.

### Testing

Tested with baudrate 921600.