### PR TITLE
tests: Fix run-perfbench.py issues when -s or -m is used.

### DIFF
--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -194,7 +194,13 @@ def parse_output(filename):
         m = int(m.split("=")[1])
         data = []
         for l in f:
-            if ": " in l and ": SKIP" not in l and "CRASH: " not in l:
+            if (
+                ": " in l
+                and ": SKIP" not in l
+                and "CRASH: " not in l
+                and "skipped: " not in l
+                and "failed: " not in l
+            ):
                 name, values = l.strip().split(": ")
                 values = tuple(float(v) for v in values.split())
                 data.append((name,) + values)


### PR DESCRIPTION
### Summary

The option `-s` (--diff-score) or `-m` (--diff-time) fails when the specified result contains tests that was skipped or failed.
This patch ignores line that is not benchmark result, such as "skipped: " or "failed: " message.

The following benchmark result:
```
N=84 M=80 n_average=8
perf_bench/bm_chaos.py: 267108.12 0.0039 187.19 0.0039
  :
perf_bench/bm_hexiom.py: SKIP: no matching params
  :
perf_bench/misc_aes.py: 64688.75 0.0013 247.34 0.0013
perf_bench/misc_mandel.py: SKIP: no matching params
perf_bench/misc_pystone.py: 240047.12 0.0004 1249.75 0.0004
perf_bench/misc_raytrace.py: SKIP: no matching params
  :
perf_bench/viper_call2b.py: 160237.62 0.0256 187.22 0.0256
21 tests performed
21 tests passed
3 tests skipped: perf_bench/bm_hexiom.py perf_bench/misc_mandel.py perf_bench/misc_raytrace.py
```
occures the following error:
```
ValueError: could not convert string to float: 'perf_bench/bm_hexiom.py'
```

The last line
```
3 tests skipped: perf_bench/bm_hexiom.py perf_bench/misc_mandel.py perf_bench/misc_raytrace.py
```
is not benchmark result, so this line can ignore.

### Testing

By applying this patch, run-perfbench.py compare result even benchmark result contains skipped result.
