### PR TITLE
stm32: Change flash latency for NUCLEO-F401RE.

### DIFF
--- a/ports/stm32/boards/NUCLEO_F401RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F401RE/mpconfigboard.h
@@ -21,6 +21,9 @@
 #define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV4)
 #define MICROPY_HW_CLK_PLLQ (7)
 
+// 84 MHz needs 2 wait states
+#define MICROPY_HW_FLASH_LATENCY (FLASH_LATENCY_2)
+
 // UART config
 #define MICROPY_HW_UART2_TX     (pin_A2)
 #define MICROPY_HW_UART2_RX     (pin_A3)


### PR DESCRIPTION
### Summary

When `MICROPY_HW_FLASH_LATENCY` is not defined, `FLASH_LATENCY_5` is used as flash latancy at
https://github.com/micropython/micropython/blob/d441788975a6dfb277ad9a3d54d651ae48817d16/ports/stm32/powerctrl.c#L297-L301

In fact, NUCLEO-F401RE runs at 84MHz. So `FLASH_LATENCY_2` can be specified for flash latency.
This patch adds `MICROPY_HW_FLASH_LATENCY` definition to NUCLEO-F401RE.

### Testing

Tested with `run-perfbench.py`.
There is no failures and most of benchmark tests are faster than before.
```
$ ./run-perfbench.py -m before.txt after.txt
diff of microsecond times (lower is better)
N=84 M=80                  before.txt ->  after.txt         diff      diff% (error%)
bm_chaos.py                 267108.12 ->  218521.00 :  -48587.12 = -18.190% (+/-0.00%)
bm_fannkuch.py              156421.00 ->  131239.62 :  -25181.38 = -16.098% (+/-0.00%)
bm_fft.py                   185441.38 ->  156468.38 :  -28973.00 = -15.624% (+/-0.00%)
bm_float.py                  47944.88 ->   37841.00 :  -10103.88 = -21.074% (+/-0.00%)
bm_nqueens.py               458208.62 ->  375490.00 :  -82718.62 = -18.053% (+/-0.00%)
bm_pidigits.py               66124.25 ->   58055.50 :   -8068.75 = -12.202% (+/-0.02%)
bm_wordcount.py             323345.38 ->  274736.62 :  -48608.76 = -15.033% (+/-0.00%)
core_import_mpy_multi.py    148190.88 ->  127123.25 :  -21067.63 = -14.217% (+/-0.00%)
core_import_mpy_single.py    17975.50 ->   15598.62 :   -2376.88 = -13.223% (+/-0.00%)
core_locals.py              386929.12 ->  332369.75 :  -54559.37 = -14.101% (+/-0.00%)
core_qstr.py                 38824.50 ->   35231.50 :   -3593.00 =  -9.254% (+/-0.00%)
core_str.py                 426293.12 ->  380882.25 :  -45410.87 = -10.652% (+/-0.00%)
core_yield_from.py          104591.62 ->   97049.38 :   -7542.24 =  -7.211% (+/-0.00%)
misc_aes.py                  64688.75 ->   54246.50 :  -10442.25 = -16.142% (+/-0.00%)
misc_pystone.py             240047.12 ->  206868.75 :  -33178.37 = -13.822% (+/-0.00%)
viper_call0.py              108001.00 ->  100128.12 :   -7872.88 =  -7.290% (+/-0.00%)
viper_call1a.py              98708.12 ->   98698.62 :      -9.50 =  -0.010% (+/-0.00%)
viper_call1b.py             141598.75 ->  131581.75 :  -10017.00 =  -7.074% (+/-0.00%)
viper_call1c.py             139887.75 ->  130151.75 :   -9736.00 =  -6.960% (+/-0.02%)
viper_call2a.py             100852.50 ->  100843.25 :      -9.25 =  -0.009% (+/-0.00%)
viper_call2b.py             160237.62 ->  150526.38 :   -9711.24 =  -6.061% (+/-0.03%)
```