### PR TITLE
stm32/i2c: Add hardware I2C implementation for STM32G4.

### DIFF
--- a/ports/stm32/i2c.c
+++ b/ports/stm32/i2c.c
@@ -271,12 +271,12 @@ int i2c_write(i2c_t *i2c, const uint8_t *src, size_t len, size_t next_len) {
     return num_acks;
 }
 
-#elif defined(STM32F0) || defined(STM32F7) || defined(STM32H7) || defined(STM32L4)
+#elif defined(STM32F0) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7) || defined(STM32L4)
 
 #if defined(STM32H7)
 #define APB1ENR            APB1LENR
 #define RCC_APB1ENR_I2C1EN RCC_APB1LENR_I2C1EN
-#elif defined(STM32L4)
+#elif defined(STM32G4) || defined(STM32L4)
 #define APB1ENR            APB1ENR1
 #define RCC_APB1ENR_I2C1EN RCC_APB1ENR1_I2C1EN
 #endif

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -34,7 +34,7 @@
 
 #define I2C_POLL_DEFAULT_TIMEOUT_US (50000) // 50ms
 
-#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32H7) || defined(STM32L1) || defined(STM32L4)
+#if defined(STM32F0) || defined(STM32F4) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7) || defined(STM32L1) || defined(STM32L4)
 
 typedef struct _machine_hard_i2c_obj_t {
     mp_obj_base_t base;


### PR DESCRIPTION
### Summary
For STM32G4, hardware I2C can implement same as STM32L4 for machine.I2C. 
This PR makes to be able to use of hardware I2C in machine.I2C.

### Testing
Tested on NUCLEO-G474RE.