### PR TITLE
stm32: Set RCC_HSE_BYPASS for NUCLEO boards.

### DIFF
--- a/ports/stm32/boards/NUCLEO_F401RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F401RE/mpconfigboard.h
@@ -9,12 +9,14 @@
 // HSE is 8MHz, HSI is 16MHz CPU freq set to 84MHz
 // Default source for the clock is HSI.
 // For revisions of the board greater than C-01, HSE can be used as a
-// clock source by removing the #define MICROPY_HW_CLK_USE_HSE line
+// clock source by removing the #define MICROPY_HW_CLK_USE_HSI line
 #define MICROPY_HW_CLK_USE_HSI (1)
 
 #if MICROPY_HW_CLK_USE_HSI
 #define MICROPY_HW_CLK_PLLM (16)
 #else
+// HSE comes from ST-LINK 8MHz, not crystal.
+#define MICROPY_HW_CLK_USE_BYPASS (1)
 #define MICROPY_HW_CLK_PLLM (8)
 #endif
 #define MICROPY_HW_CLK_PLLN (336)

--- a/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F446RE/mpconfigboard.h
@@ -14,6 +14,8 @@
 #define MICROPY_HW_CLK_PLLN (336)
 #define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV2)
 #define MICROPY_HW_CLK_PLLQ (7)
+// HSE comes from ST-LINK 8MHz, not crystal.
+#define MICROPY_HW_CLK_USE_BYPASS (1)
 
 // UART config
 #define MICROPY_HW_UART1_TX     (pin_B6)    // Arduino D10, pin 17 on CN10

--- a/ports/stm32/boards/NUCLEO_F767ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_F767ZI/mpconfigboard.h
@@ -21,6 +21,8 @@ void NUCLEO_F767ZI_board_early_init(void);
 #define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV2)
 #define MICROPY_HW_CLK_PLLQ (9)
 #define MICROPY_HW_FLASH_LATENCY (FLASH_LATENCY_7) // 210-216 MHz needs 7 wait states
+// HSE comes from ST-LINK 8MHz, not crystal.
+#define MICROPY_HW_CLK_USE_BYPASS (1)
 
 // UART config
 #define MICROPY_HW_UART2_TX         (pin_D5)

--- a/ports/stm32/boards/NUCLEO_L152RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_L152RE/mpconfigboard.h
@@ -12,7 +12,7 @@
 // HSE is 8MHz, HSI is 16MHz CPU freq set to 32MHz
 // Default source for the clock is HSI.
 // For revisions of the board greater than C-01, HSE can be used as a
-// clock source by removing the #define MICROPY_HW_CLK_USE_HSE line
+// clock source by removing the #define MICROPY_HW_CLK_USE_HSI line
 #define MICROPY_HW_CLK_USE_HSI (1)
 
 #if MICROPY_HW_CLK_USE_HSI
@@ -21,6 +21,8 @@
 #else
 #define MICROPY_HW_CLK_PLLMUL (RCC_CFGR_PLLMUL12)
 #define MICROPY_HW_CLK_PLLDIV (RCC_CFGR_PLLDIV3)
+// HSE comes from ST-LINK 8MHz, not crystal.
+#define MICROPY_HW_CLK_USE_BYPASS (1)
 #endif
 
 // UART config

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -385,7 +385,9 @@ void SystemClock_Config(void) {
     RCC->CFGR = RCC_CFGR_PLLSRC_HSI;
     #else
     // Enable the 8MHz external oscillator
+    #if MICROPY_HW_CLK_USE_BYPASS
     RCC->CR |= RCC_CR_HSEBYP;
+    #endif
     RCC->CR |= RCC_CR_HSEON;
     while (!(RCC->CR & RCC_CR_HSERDY)) {
     }


### PR DESCRIPTION
For NUCLEO boards that does not have HSE crystal,
HSEState should set `RCC_HSE_BYPASS` to use HSE clock from ST-LINK 8MHz.

### Testing
Tested with:
* NUCLEO-F401RE
* NUCLEO-F446RE
* NUCLEO-F767ZI
* NUCLEO-L152RE

basic test with run-tests.py succeeded
(For NUCLEO-F401RE and NUCLEO-L152RE, `basics/class_setname_hazard_rand.py` failed but it is not due to this PR).

### Remarks
This PR changed only for the boards I have, but other NUCLEO board may need this definition.