### PR TITLE
stm32: Change flash latency for NUCLEO-G474RE.

### DIFF
--- a/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
@@ -29,7 +29,7 @@
 #define MICROPY_HW_CLK_USE_HSI48    (1) // for RNG
 
 // 4 wait states
-#define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_8
+#define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_4
 
 // UART config
 #define MICROPY_HW_LPUART1_TX       (pin_A2)  // A2 (to STLINK), B11, C1

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -494,7 +494,7 @@ MP_WEAK void SystemClock_Config(void) {
     #endif
 
     #if defined(STM32G4)
-    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_8) != HAL_OK) {
+    if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, MICROPY_HW_FLASH_LATENCY) != HAL_OK) {
         MICROPY_BOARD_FATAL_ERROR("HAL_RCC_ClockConfig");
     }
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_LPUART1


### PR DESCRIPTION
### Summary

For NUCLEO-G474RE, `FLASH_LATENCY_4` can be specified instead of `FLASH_LATENCY_8` because it runs at 170MHz.
This PR improves performance of script execution.

### Testing

Tested with `run-perfbench.py`.
There is no failures and most of benchmark tests are faster than before.
```
diff of microsecond times (lower is better)
N=170 M=128                before-g4.txt -> after-g4.txt         diff      diff% (error%)
bm_chaos.py                 234623.12 ->  157713.62 :  -76909.50 = -32.780% (+/-0.00%)
bm_fannkuch.py              132340.88 ->   92167.25 :  -40173.63 = -30.356% (+/-0.00%)
bm_fft.py                   499842.25 ->  357396.50 : -142445.75 = -28.498% (+/-0.00%)
bm_float.py                  76701.62 ->   50193.88 :  -26507.74 = -34.560% (+/-0.00%)
bm_hexiom.py                355765.00 ->  240444.75 : -115320.25 = -32.415% (+/-0.00%)
bm_nqueens.py               404124.25 ->  272933.75 : -131190.50 = -32.463% (+/-0.00%)
bm_pidigits.py              132201.38 ->  102616.38 :  -29585.00 = -22.379% (+/-0.04%)
bm_wordcount.py             263868.38 ->  189437.38 :  -74431.00 = -28.208% (+/-0.00%)
core_import_mpy_multi.py    121774.38 ->   87436.62 :  -34337.76 = -28.198% (+/-0.00%)
core_import_mpy_single.py    14488.62 ->   10606.12 :   -3882.50 = -26.797% (+/-0.00%)
core_locals.py              306749.50 ->  218089.62 :  -88659.88 = -28.903% (+/-0.00%)
core_qstr.py                 26706.88 ->   21018.62 :   -5688.26 = -21.299% (+/-0.00%)
core_str.py                 303604.12 ->  234149.88 :  -69454.24 = -22.877% (+/-0.00%)
core_yield_from.py           71278.00 ->   58654.38 :  -12623.62 = -17.710% (+/-0.00%)
misc_aes.py                 131571.75 ->   90583.50 :  -40988.25 = -31.153% (+/-0.00%)
misc_mandel.py              229207.38 ->  151315.62 :  -77891.76 = -33.983% (+/-0.00%)
misc_pystone.py             207243.00 ->  146953.12 :  -60289.88 = -29.091% (+/-0.00%)
misc_raytrace.py            234849.25 ->  156920.00 :  -77929.25 = -33.183% (+/-0.00%)
viper_call0.py               52665.12 ->   52649.12 :     -16.00 =  -0.030% (+/-0.00%)
viper_call1a.py              55137.88 ->   55121.12 :     -16.76 =  -0.030% (+/-0.00%)
viper_call1b.py              81092.00 ->   69423.38 :  -11668.62 = -14.389% (+/-0.00%)
viper_call1c.py              80209.38 ->   68363.88 :  -11845.50 = -14.768% (+/-0.00%)
viper_call2a.py              56549.38 ->   56533.12 :     -16.26 =  -0.029% (+/-0.00%)
viper_call2b.py              91332.38 ->   79840.75 :  -11491.63 = -12.582% (+/-0.00%)
```
