### PR TITLE
stm32: Fix LPUART init failure with low baudrate.

### DIFF
--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -673,7 +673,7 @@ bool uart_init(machine_uart_obj_t *uart_obj,
     huart.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_DISABLE;
     #endif
 
-    #if defined(STM32H7) || defined(STM32N6) || defined(STM32WB)
+    #if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32H7) || defined(STM32N6) || defined(STM32WB)
     // Compute the smallest prescaler that will allow the given baudrate.
     uint32_t presc = UART_PRESCALER_DIV1;
     if (uart_obj->uart_id == PYB_LPUART_1) {


### PR DESCRIPTION
### Summary

UART prescaler value should set up collectly to initialize LPUART with low baudrate for STM32G0/G4/H5.
This can be implemented similarly to STM32H7/N6/WB.

The following code does not work:
```python
from machine import UART
uart = UART('LP1', baudrate=9600, bits=8, parity=None, stop=1)
```
An error occured with following message:
```
ValueError: set baudrate 0 is not within 5% of desired value
```

LPUART should be initialized without errors.

### Testing

Tested with:
* NUCLEO-G01RB
* NUCLEO-G474RE
* NUCLEO-H563ZI

### Remarks
STM32WL may have same issue but I couldn't check because I don't have it.