### PR TITLE
py: py.cmake: Add nlraarch64

### DIFF
--- a/py/py.cmake
+++ b/py/py.cmake
@@ -58,6 +58,7 @@ set(MICROPY_SOURCE_PY
     ${MICROPY_PY_DIR}/mpz.c
     ${MICROPY_PY_DIR}/nativeglue.c
     ${MICROPY_PY_DIR}/nlr.c
+    ${MICROPY_PY_DIR}/nlraarch64.c
     ${MICROPY_PY_DIR}/nlrmips.c
     ${MICROPY_PY_DIR}/nlrpowerpc.c
     ${MICROPY_PY_DIR}/nlrrv32.c


### PR DESCRIPTION
### Summary

Currently, at least the zephyr port cannot be built for aarch64 targets due to the missing `nlr*` definations.

### Testing

Tested with [PocketBeagle 2](https://docs.zephyrproject.org/latest/boards/beagle/pocketbeagle_2/doc/index.html) A53 cores.

