### PR TITLE
unix: run all test directories when using `--via-mpy` for tests

### DIFF
--- a/extmod/vfs_blockdev.c
+++ b/extmod/vfs_blockdev.c
@@ -69,7 +69,7 @@ static int mp_vfs_blockdev_call_rw(mp_obj_t *args, size_t block_num, size_t bloc
         // and negative integer on errors. Check for positive integer
         // results as some callers (i.e. littlefs) will produce corrupt
         // results from these.
-        int i = MP_OBJ_SMALL_INT_VALUE(ret);
+        int i = mp_obj_get_int(ret);
         return i > 0 ? (-MP_EINVAL) : i;
     }
 }

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -278,16 +278,15 @@ test/%: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -d "$*"
 
-test_full_no_native: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
+test_full_no_native: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py test
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) -d basics float micropython
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS)
 	cat $(TOP)/tests/basics/0prelim.py | ./$(BUILD)/$(PROG) | grep -q 'abc'
 
 test_full: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py test_full_no_native
 	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
 	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --emit native
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native -d basics float micropython
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native
 
 test_gcov: test_full
 	gcov -o $(BUILD)/py $(TOP)/py/*.c

--- a/tests/extmod/vfs_blockdev_invalid.py
+++ b/tests/extmod/vfs_blockdev_invalid.py
@@ -70,8 +70,8 @@ def test(vfs_class):
         try:
             with fs.open("test", "r") as f:
                 print("opened")
-        except OSError as e:
-            print("OSError", e)
+        except Exception as e:
+            print(type(e), e)
 
         # This variant should succeed on open, may fail on read
         # unless the filesystem cached the contents already
@@ -81,8 +81,8 @@ def test(vfs_class):
                 bdev.read_res = res
                 print("read 1", f.read(1))
                 print("read rest", f.read())
-        except OSError as e:
-            print("OSError", e)
+        except Exception as e:
+            print(type(e), e)
 
 
 test(vfs.VfsLfs2)

--- a/tests/extmod/vfs_blockdev_invalid.py.exp
+++ b/tests/extmod/vfs_blockdev_invalid.py.exp
@@ -2,27 +2,27 @@
 opened
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-OSError [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-OSError [Errno 22] EINVAL
+<class 'OSError'> [Errno 22] EINVAL
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-OSError [Errno 22] EINVAL
+<class 'OSError'> [Errno 22] EINVAL
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-OSError [Errno 22] EINVAL
+<class 'TypeError'> can't convert str to int
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 <class 'VfsFat'>
 opened
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
-OSError [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> [Errno 5] EIO
+<class 'TypeError'> can't convert str to int
+<class 'TypeError'> can't convert str to int

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -107,6 +107,19 @@ PC_PLATFORMS = ("darwin", "linux", "win32")
 platform_to_port_map = {"pyboard": "stm32", "WiPy": "cc3200"}
 platform_to_port_map.update({p: "unix" for p in PC_PLATFORMS})
 
+# Tests to skip for values of the `--via-mpy` argument.
+via_mpy_tests_to_skip = {
+    # Skip the following when mpy is enabled.
+    True: (
+        # These print out the filename and that's expected to match the .py name.
+        "import/import_file.py",
+        "io/argv.py",
+        "misc/sys_settrace_features.py",
+        "misc/sys_settrace_generator.py",
+        "misc/sys_settrace_loop.py",
+    ),
+}
+
 # Tests to skip for specific emitters.
 emitter_tests_to_skip = {
     # Some tests are known to fail with native emitter.
@@ -924,6 +937,9 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_tests.add("unicode/file1.py")  # requires local file access
         skip_tests.add("unicode/file2.py")  # requires local file access
         skip_tests.add("unicode/file_invalid.py")  # requires local file access
+
+    # Skip certain tests when going via a .mpy file.
+    skip_tests.update(via_mpy_tests_to_skip.get(args.via_mpy, ()))
 
     # Skip emitter-specific tests.
     skip_tests.update(emitter_tests_to_skip.get(args.emit, ()))


### PR DESCRIPTION
### Summary

Currently testing on the unix port with `--via-mpy` only runs tests in the `basics`, `float` and  `micropython` test directories.

This PR removes that restriction and now runs `--via-mpy` tests using all possible test directories.  This improves test coverage.

### Testing

Will be tested by CI.  Only the unix port is affected here.

### Trade-offs and Alternatives

This will make unix CI a little slower, by around 20 seconds.  But it gets more coverage.