### PR TITLE
cc3200/mpconfigport: Use MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES.

### DIFF
--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -32,31 +32,27 @@
 #include "semphr.h"
 #endif
 
+// Set the rom feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES)
+
 // options to control how MicroPython is built
 
 #define MICROPY_GC_STACK_ENTRY_TYPE                 uint16_t
 #define MICROPY_ALLOC_PATH_MAX                      (128)
 #define MICROPY_PERSISTENT_CODE_LOAD                (1)
-#define MICROPY_EMIT_THUMB                          (0)
-#define MICROPY_EMIT_INLINE_THUMB                   (0)
 #define MICROPY_COMP_CONST_LITERAL                  (0)
 #define MICROPY_COMP_MODULE_CONST                   (1)
 #define MICROPY_ENABLE_GC                           (1)
 #define MICROPY_ENABLE_FINALISER                    (1)
-#define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN            (0)
-#define MICROPY_STACK_CHECK                         (0)
+#define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF      (1)
+#define MICROPY_KBD_EXCEPTION                       (1)
 #define MICROPY_HELPER_REPL                         (1)
 #define MICROPY_ENABLE_SOURCE_LINE                  (1)
-#define MICROPY_ENABLE_DOC_STRING                   (0)
 #define MICROPY_REPL_AUTO_INDENT                    (1)
 #define MICROPY_ERROR_REPORTING                     (MICROPY_ERROR_REPORTING_TERSE)
 #define MICROPY_LONGINT_IMPL                        (MICROPY_LONGINT_IMPL_MPZ)
-#define MICROPY_FLOAT_IMPL                          (MICROPY_FLOAT_IMPL_NONE)
-#define MICROPY_OPT_COMPUTED_GOTO                   (0)
 #define MICROPY_READER_VFS                          (1)
-#ifndef DEBUG // we need ram on the launchxl while debugging
-#define MICROPY_CPYTHON_COMPAT                      (1)
-#else
+#ifdef DEBUG // we need ram on the launchxl while debugging
 #define MICROPY_CPYTHON_COMPAT                      (0)
 #endif
 
@@ -74,7 +70,7 @@
 #define MICROPY_USE_INTERNAL_ERRNO                  (1)
 #define MICROPY_VFS                                 (1)
 #define MICROPY_VFS_FAT                             (1)
-#define MICROPY_PY_ASYNC_AWAIT (0)
+#define MICROPY_PY_ASYNC_AWAIT                      (0)
 #define MICROPY_PY_ALL_SPECIAL_METHODS              (1)
 #define MICROPY_PY_BUILTINS_BYTES_HEX               (1)
 #define MICROPY_PY_BUILTINS_INPUT                   (1)
@@ -88,32 +84,16 @@
 #define MICROPY_PY_BUILTINS_EXECFILE                (1)
 #define MICROPY_PY_ARRAY_SLICE_ASSIGN               (1)
 #define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (1)
-#else
-#define MICROPY_PY_BUILTINS_STR_UNICODE             (0)
-#define MICROPY_PY_BUILTINS_STR_SPLITLINES          (0)
-#define MICROPY_PY_BUILTINS_MEMORYVIEW              (0)
-#define MICROPY_PY_BUILTINS_FROZENSET               (0)
-#define MICROPY_PY_BUILTINS_EXECFILE                (0)
-#define MICROPY_PY_ARRAY_SLICE_ASSIGN               (0)
-#define MICROPY_PY_COLLECTIONS_ORDEREDDICT          (0)
 #endif
-#define MICROPY_PY_MICROPYTHON_MEM_INFO             (0)
 #define MICROPY_PY_SYS_MAXSIZE                      (1)
-#define MICROPY_PY_SYS_EXIT                         (1)
 #define MICROPY_PY_SYS_STDFILES                     (1)
-#define MICROPY_PY_CMATH                            (0)
-#define MICROPY_PY_IO                               (1)
 #define MICROPY_PY_ERRNO                            (1)
 #define MICROPY_PY_ERRNO_ERRORCODE                  (0)
 #define MICROPY_PY_THREAD                           (1)
 #define MICROPY_PY_THREAD_GIL                       (1)
 #define MICROPY_PY_BINASCII                         (1)
-#define MICROPY_PY_UCTYPES                          (0)
-#define MICROPY_PY_DEFLATE                          (0)
 #define MICROPY_PY_JSON                             (1)
 #define MICROPY_PY_RE                               (1)
-#define MICROPY_PY_HEAPQ                            (0)
-#define MICROPY_PY_HASHLIB                          (0)
 #define MICROPY_PY_OS                               (1)
 #define MICROPY_PY_OS_INCLUDEFILE                   "ports/cc3200/mods/modos.c"
 #define MICROPY_PY_OS_DUPTERM                       (1)
@@ -124,7 +104,6 @@
 #define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME     (1)
 #define MICROPY_PY_TIME_TIME_TIME_NS                (1)
 #define MICROPY_PY_TIME_INCLUDEFILE                 "ports/cc3200/mods/modtime.c"
-#define MICROPY_PY_VFS                              (1)
 #define MICROPY_PY_MACHINE                          (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE              "ports/cc3200/mods/modmachine.c"
 #define MICROPY_PY_MACHINE_RESET                    (1)
@@ -132,10 +111,6 @@
 #define MICROPY_PY_MACHINE_DISABLE_IRQ_ENABLE_IRQ   (1)
 #define MICROPY_PY_MACHINE_WDT                      (1)
 #define MICROPY_PY_MACHINE_WDT_INCLUDEFILE          "ports/cc3200/mods/machine_wdt.c"
-
-#define MICROPY_ENABLE_EMERGENCY_EXCEPTION_BUF      (1)
-#define MICROPY_EMERGENCY_EXCEPTION_BUF_SIZE        (0)
-#define MICROPY_KBD_EXCEPTION                       (1)
 
 // We define our own list of errno constants to include in errno module
 #define MICROPY_PY_ERRNO_LIST \


### PR DESCRIPTION
### Summary

This commit makes it explicit that the port uses the MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES feature level, and removes config options that are the default at this level.

This change is a no-op for the firmware.

### Testing

Built WIPY the firmware before and after this commit, and verified in the .bin that the only changes were to the git hash and firmware CRC.

### Trade-offs and Alternatives

Eventually we can use these smaller ports (cc3200, esp8266, zephyr minimal) to define the MICROPY_CONFIG_ROM_LEVEL_BASIC_FEATURES feature level, by looking at the features these small ports enable.  But for now this change is a clean up and preparation step.
