### PR TITLE
stm32/main: Use defined constants to enable N6 clocks during low power.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -400,19 +400,21 @@ void stm32_main(uint32_t reset_mode) {
 
     #if defined(STM32N6)
     // SRAM, XSPI needs to remain awake during sleep, eg so DMA from flash works.
-    LL_MEM_EnableClockLowPower(0xffffffff);
+    LL_MEM_EnableClockLowPower(LL_MEM_AXISRAM1 | LL_MEM_AXISRAM2 | LL_MEM_AXISRAM3
+        | LL_MEM_AXISRAM4 | LL_MEM_AXISRAM5 | LL_MEM_AXISRAM6 | LL_MEM_AHBSRAM1 | LL_MEM_AHBSRAM2
+        | LL_MEM_BKPSRAM | LL_MEM_FLEXRAM | LL_MEM_CACHEAXIRAM | LL_MEM_VENCRAM | LL_MEM_BOOTROM);
     LL_AHB5_GRP1_EnableClockLowPower(LL_AHB5_GRP1_PERIPH_XSPI2 | LL_AHB5_GRP1_PERIPH_XSPIM);
     LL_APB4_GRP1_EnableClock(LL_APB4_GRP1_PERIPH_RTC | LL_APB4_GRP1_PERIPH_RTCAPB);
     LL_APB4_GRP1_EnableClockLowPower(LL_APB4_GRP1_PERIPH_RTC | LL_APB4_GRP1_PERIPH_RTCAPB);
 
     // Enable some AHB peripherals during sleep.
-    LL_AHB1_GRP1_EnableClockLowPower(0xffffffff); // GPDMA1, ADC12
-    LL_AHB4_GRP1_EnableClockLowPower(0xffffffff); // GPIOA-Q, PWR, CRC
+    LL_AHB1_GRP1_EnableClockLowPower(LL_AHB1_GRP1_PERIPH_ALL); // GPDMA1, ADC12
+    LL_AHB4_GRP1_EnableClockLowPower(LL_AHB4_GRP1_PERIPH_ALL); // GPIOA-Q, PWR, CRC
 
     // Enable some APB peripherals during sleep.
-    LL_APB1_GRP1_EnableClockLowPower(0xffffffff); // I2C, I3C, LPTIM, SPI, TIM, UART, WWDG
-    LL_APB2_GRP1_EnableClockLowPower(0xffffffff); // SAI, SPI, TIM, UART
-    LL_APB4_GRP1_EnableClockLowPower(0xffffffff); // I2C, LPTIM, LPUART, RTC, SPI
+    LL_APB1_GRP1_EnableClockLowPower(LL_APB1_GRP1_PERIPH_ALL); // I2C, I3C, LPTIM, SPI, TIM, UART, WWDG
+    LL_APB2_GRP1_EnableClockLowPower(LL_APB2_GRP1_PERIPH_ALL); // SAI, SPI, TIM, UART
+    LL_APB4_GRP1_EnableClockLowPower(LL_APB4_GRP1_PERIPH_ALL); // I2C, LPTIM, LPUART, RTC, SPI
     #endif
 
     mpu_init();


### PR DESCRIPTION
### Summary

Use constants from the HAL instead of literal numbers to select which peripheral clocks are enabled during low power mode.

Note that although LL_AHB4_GRP1_PERIPH_ALL exists, it does not define all of the peripherals, so they are explicitly named instead.

### Testing

Verified that OPENMV_N6 firmware builds without error.
