### PR TITLE
py: allow importing a method from a class instance, and add associated webassembly test

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1562,14 +1562,11 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     mp_obj_t dest[2];
 
     mp_load_method_maybe(module, name, dest);
-
     if (dest[1] != MP_OBJ_NULL) {
-        // Hopefully we can't import bound method from an object
-    import_error:
-        mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("can't import name %q"), name);
-    }
-
-    if (dest[0] != MP_OBJ_NULL) {
+        // Importing a bound method from a class instance.
+        return mp_obj_new_bound_meth(dest[0], dest[1]);
+    } else if (dest[0] != MP_OBJ_NULL) {
+        // Importing a function or attribute.
         return dest[0];
     }
 
@@ -1602,6 +1599,9 @@ mp_obj_t mp_import_from(mp_obj_t module, qstr name) {
     goto import_error;
 
     #endif
+
+import_error:
+    mp_raise_msg_varg(&mp_type_ImportError, MP_ERROR_TEXT("can't import name %q"), name);
 }
 
 void mp_import_all(mp_obj_t module) {

--- a/tests/basics/import_instance_method.py
+++ b/tests/basics/import_instance_method.py
@@ -1,0 +1,38 @@
+# Test importing a method from a class instance.
+# This is not a common thing to do, but ensures MicroPython has the same semantics as CPython.
+
+import sys
+
+if not hasattr(sys, "modules"):
+    print("SKIP")
+    raise SystemExit
+
+
+class A:
+    def __init__(self, value):
+        self.value = value
+
+    def meth(self):
+        return self.value
+
+    def meth_with_arg(self, a):
+        return [self.value, a]
+
+
+# Register a class instance as the module "mod".
+sys.modules["mod"] = A(1)
+
+# Try importing it as a module.
+import mod
+
+print(mod.meth())
+print(mod.meth_with_arg(2))
+
+# Change the module.
+sys.modules["mod"] = A(3)
+
+# Try importing it using "from ... import".
+from mod import meth, meth_with_arg
+
+print(meth())
+print(meth_with_arg(4))

--- a/tests/ports/webassembly/register_js_module.js
+++ b/tests/ports/webassembly/register_js_module.js
@@ -1,6 +1,45 @@
+// Test the registerJsModule() public API method.
+
 import(process.argv[2]).then((mp) => {
     mp.loadMicroPython().then((py) => {
+        // Simple module.
         py.registerJsModule("js_module", { y: 2 });
         py.runPython("import js_module; print(js_module); print(js_module.y)");
+
+        // Module with functions.
+        // In particular test how "this" behaves.
+        py.registerJsModule("js_module2", {
+            yes: true,
+            add1(x) {
+                return x + 1;
+            },
+            getThis() {
+                return this;
+            },
+        });
+
+        console.log("====");
+
+        // Test using simple import.
+        py.runPython(`
+import js_module2
+
+print(js_module2.yes)
+print(js_module2.add1(1))
+print(js_module2.getThis())
+print(js_module2.getThis().yes)
+`);
+
+        console.log("====");
+
+        // Test using "from ... import".
+        py.runPython(`
+from js_module2 import yes, add1, getThis
+
+print(yes)
+print(add1(2))
+print(getThis())
+print(getThis().yes)
+`);
     });
 });

--- a/tests/ports/webassembly/register_js_module.js.exp
+++ b/tests/ports/webassembly/register_js_module.js.exp
@@ -1,2 +1,12 @@
 <JsProxy 2>
 2
+====
+True
+2
+<JsProxy 3>
+True
+====
+True
+3
+<JsProxy 3>
+True


### PR DESCRIPTION
### Summary

This change follows CPython behaviour, allowing to use `from instance import method` to import a bound method from a class instance.

Admittedly this is probably a very rarely used pattern in Python, but it resolves a long standing comment about whether or not this is actually possible (it turns out it is possible!).  A test is added to show how it works.

The main reason for this change is to fix a big problem with imports in the webassembly port.  Prior to this fix, it was not possible to do `from js_module import function`, where `js_module` is a JavaScript object registered to be visible to Python through the webassembly API function `registerJsModule(js_module)`.

### Testing

Tests are added that will be run under CI.

### Trade-offs and Alternatives

This adds a bit of code size to all ports, to support a very rare feature.  But I can't think of any other way around that, it's part of the (C)Python semantics and we need it for the webassembly port.  I guess the feature could be made optional, but I feel like that's too fine grained a config option.