### PR TITLE
ports: zephyr: Add PocketBeagle 2 rev A1 A53 support

### DIFF
--- a/ports/zephyr/boards/pocketbeagle_2_am6254_a53.conf
+++ b/ports/zephyr/boards/pocketbeagle_2_am6254_a53.conf
@@ -1,0 +1,3 @@
+# Hardware features
+CONFIG_I2C=y
+CONFIG_GPIO=y


### PR DESCRIPTION
### Summary

Adds support for PocketBeagle 2 A53 for rev A1. The firmware is normally loaded by u-boot.

### Testing

Tested on PocketBeagle 2 rev A1.

