### PR TITLE
ci.sh: Fix missing `set -e`.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1011,6 +1011,7 @@ function _ci_main {
             _ci_help
         ;;
         (*)
+            set -e
             cd $(dirname "$0")/..
             while [ $# -ne 0 ]; do
                 ci_$1


### PR DESCRIPTION
### Summary

This is needed to correctly stop after an error in a ci step when running ci.sh as a script.

### Testing

While testing #18092 I noticed that the ci.sh script incorrectly proceeded after a failed step. After this change, it correctly stopped.
