### PR TITLE
unix/main: Ensure atexit function is called on sys.exit() with -m <module>.

### DIFF
--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -669,12 +669,18 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 subpkg_tried = false;
 
             reimport:
+                mp_hal_set_interrupt_char(CHAR_CTRL_C);
                 if (nlr_push(&nlr) == 0) {
                     mod = mp_builtin___import__(MP_ARRAY_SIZE(import_args), import_args);
+                    mp_hal_set_interrupt_char(-1);
+                    mp_handle_pending(true);
                     nlr_pop();
                 } else {
                     // uncaught exception
-                    return handle_uncaught_exception(nlr.ret_val) & 0xff;
+                    mp_hal_set_interrupt_char(-1);
+                    mp_handle_pending(false);
+                    ret = handle_uncaught_exception(nlr.ret_val) & 0xff;
+                    break;
                 }
 
                 // If this module is a package, see if it has a `__main__.py`.

--- a/tests/cmdline/cmd_module_atexit.py
+++ b/tests/cmdline/cmd_module_atexit.py
@@ -1,0 +1,16 @@
+# cmdline: -m cmdline.cmd_module_atexit
+#
+# Test running as a module and using sys.atexit.
+
+import sys
+
+if not hasattr(sys, "atexit"):
+    print("SKIP")
+    raise SystemExit
+
+# Verify we ran as a module.
+print(sys.argv)
+
+sys.atexit(lambda: print("done"))
+
+print("start")

--- a/tests/cmdline/cmd_module_atexit.py.exp
+++ b/tests/cmdline/cmd_module_atexit.py.exp
@@ -1,0 +1,3 @@
+['cmdline.cmd_module_atexit', 'cmdline/cmd_module_atexit.py']
+start
+done

--- a/tests/cmdline/cmd_module_atexit_exc.py
+++ b/tests/cmdline/cmd_module_atexit_exc.py
@@ -1,0 +1,19 @@
+# cmdline: -m cmdline.cmd_module_atexit_exc
+#
+# Test running as a module and using sys.atexit, with script completion via sys.exit.
+
+import sys
+
+if not hasattr(sys, "atexit"):
+    print("SKIP")
+    raise SystemExit
+
+# Verify we ran as a module.
+print(sys.argv)
+
+sys.atexit(lambda: print("done"))
+
+print("start")
+
+# This will raise SystemExit to finish the script, and atexit should still be run.
+sys.exit(0)

--- a/tests/cmdline/cmd_module_atexit_exc.py.exp
+++ b/tests/cmdline/cmd_module_atexit_exc.py.exp
@@ -1,0 +1,3 @@
+['cmdline.cmd_module_atexit_exc', 'cmdline/cmd_module_atexit_exc.py']
+start
+done


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

Fixes #18103.

Previously, when running `micropython -m <module>` and the module called sys.exit(), the registered atexit function was not executed. This was due to sys.exit() raising a SystemExit exception, which bypassed the atexit handler. This change fixes the issue so that the atexit function is properly invoked when exiting via sys.exit().

Additionally, following the pattern in execute_from_lexer, mp_hal_set_interrupt_char() and mp_handle_pending() handling were added to ensure that the atexit function is also executed when the user exits via Ctrl-C.


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Tested on Linux.

a.py:
```
import sys, time

def onexit():
    print('Exiting...')

sys.atexit(onexit)
sys.exit(0)  # or time.sleep(1000) and press Ctrl-C
```

```
micropython -m a
```

