### PR TITLE
unix/modsocket: Set file descriptor to -1 on close

### DIFF
--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -140,9 +140,12 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
             // The rationale MicroPython follows is that close() just releases
             // file descriptor. If you're interested to catch I/O errors before
             // closing fd, fsync() it.
-            MP_THREAD_GIL_EXIT();
-            close(self->fd);
-            MP_THREAD_GIL_ENTER();
+            if (self->fd >= 0) {
+                MP_THREAD_GIL_EXIT();
+                close(self->fd);
+                MP_THREAD_GIL_ENTER();
+            }
+            self->fd = -1;
             return 0;
 
         case MP_STREAM_GET_FILENO:

--- a/tests/extmod/socket_fileno.py
+++ b/tests/extmod/socket_fileno.py
@@ -1,0 +1,17 @@
+# Test socket.fileno() functionality
+
+try:
+    import socket
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+if not hasattr(socket.socket, "fileno"):
+    print("SKIP")
+    raise SystemExit
+
+s = socket.socket()
+print(s.fileno() >= 0)
+
+s.close()
+print(s.fileno())  #  should print -1


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

Fixes #18104.

After s.close(), s.fileno() now returns -1, matching CPython behavior. Some code relies on this compatibility, as it allows checking whether a socket is closed by testing its fileno() value. This change ensures better interoperability with existing Python code and libraries.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Tested on Linux:
```
>>> import socket
>>> s = socket.socket()
>>> s.fileno()
3
>>> s.close()
>>> s.fileno()
-1
```

