### PR TITLE
stm32: Fix missing definition on stm module.

### DIFF
--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -41,7 +41,10 @@ class Lexer:
                 r"#define +(?P<id>[A-Z0-9_]+) +\(?(\(uint32_t\))?(?P<hex>0x[0-9A-F]+)U?L?\)?($| */\*)"
             ),
         ),
-        ("#define X", re.compile(r"#define +(?P<id>[A-Z0-9_]+) +(?P<id2>[A-Z0-9_]+)($| +/\*)")),
+        (
+            "#define X",
+            re.compile(r"#define +(?P<id>[A-Z0-9_]+) +\(?(?P<id2>[A-Z0-9_]+)\)?($| +/\*)"),
+        ),
         (
             "#define X+hex",
             re.compile(


### PR DESCRIPTION
### Summary

The following code does not work on NUCLEO_G0B1RE.
```python
prediv_a = stm.mem32[stm.RTC + stm.RTC_PRER] >> 16
```

An error occured with following message.
```shell
AttributeError: 'module' object has no attribute 'RTC'
```
Some other attributes that is connected to APB (such as TIM1, etc) are also not defined.

The lines like following were not handled by make-stmconst.py.
```c
#define APBPERIPH_BASE        (PERIPH_BASE)
```
For example, `stm.RTC` is not defined if `RTC_BASE` is defined as
```c
#define RTC_BASE              (APBPERIPH_BASE + 0x00002800UL)
```
because `APBPERIPH_BASE` is not handled as a valid id.
This is the reason that some attributes are not defined in stm module.
This patch adds RegExp that can handle above.

Remarks: In fact, there is no problem if the definition is
```c
#define APBPERIPH_BASE        PERIPH_BASE
```
The diffrence is whether there is a parentheses or not.
Most of platforms are defined as above in CMSIS.

### Testing

Tested:
* NUCLEO_G0B1RE
* NUCLEO_F401RE (checks that does not change definitions.)

### Trade-offs and Alternatives
This PR increases code size of NUCLEO_G0B1RE by 1920 Bytes.
Before:
```
   text	   data	    bss	    dec	    hex	filename
 300260	    108	   4020	 304388	  4a504	build-NUCLEO_G0B1RE/firmware.elf
```

After:
```
   text	   data	    bss	    dec	    hex	filename
 302180	    108	   4020	 306308	  4ac84	build-NUCLEO_G0B1RE/firmware.elf
```
