### PR TITLE
stm32: Fix issues for STM32G0.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -212,6 +212,14 @@ static inline uint32_t adc_get_internal_channel(uint32_t channel) {
     if (channel == 16) {
         channel = ADC_CHANNEL_TEMPSENSOR;
     }
+    #elif defined(STM32G0)
+    if (channel == 12) {
+        channel = ADC_CHANNEL_TEMPSENSOR;
+    } else if (channel == 13) {
+        channel = ADC_CHANNEL_VREFINT;
+    } else if (channel == 14) {
+        channel = ADC_CHANNEL_VBAT;
+    }
     #elif defined(STM32G4)
     if (channel == 16) {
         channel = ADC_CHANNEL_TEMPSENSOR_ADC1;
@@ -344,6 +352,10 @@ static void adcx_init_periph(ADC_HandleTypeDef *adch, uint32_t resolution) {
     adch->Init.DataAlign = ADC_DATAALIGN_RIGHT;
     adch->Init.DMAContinuousRequests = DISABLE;
     #elif defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32WB)
+    #if defined(STM32G0)
+    adch->Init.SamplingTimeCommon1 = ADC_SAMPLETIME_12CYCLES_5;
+    adch->Init.SamplingTimeCommon2 = ADC_SAMPLETIME_160CYCLES_5;
+    #endif
     #if defined(STM32G4) || defined(STM32H5)
     adch->Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV16;
     #else
@@ -432,9 +444,9 @@ static void adc_config_channel(ADC_HandleTypeDef *adc_handle, uint32_t channel) 
     }
     #elif defined(STM32G0)
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel)) {
-        sConfig.SamplingTime = ADC_SAMPLETIME_160CYCLES_5;
+        sConfig.SamplingTime = ADC_SAMPLINGTIME_COMMON_2;
     } else {
-        sConfig.SamplingTime = ADC_SAMPLETIME_12CYCLES_5;
+        sConfig.SamplingTime = ADC_SAMPLINGTIME_COMMON_1;
     }
     #elif defined(STM32G4) || defined(STM32H5) || defined(STM32L4) || defined(STM32WB)
     if (__HAL_ADC_IS_CHANNEL_INTERNAL(channel)) {
@@ -939,9 +951,9 @@ float adc_read_core_temp_float(ADC_HandleTypeDef *adcHandle) {
     return 0.0f; // TODO
     #else
 
-    #if defined(STM32G4) || defined(STM32L1) || defined(STM32L4)
+    #if defined(STM32G0) || defined(STM32G4) || defined(STM32L1) || defined(STM32L4)
     // Update the reference correction factor before reading tempsensor
-    // because TS_CAL1 and TS_CAL2 of STM32G4,L1/L4 are at VDDA=3.0V
+    // because TS_CAL1 and TS_CAL2 of STM32G0,G4,L1,L4 are at VDDA=3.0V
     adc_read_core_vref(adcHandle);
     #endif
 
@@ -966,9 +978,9 @@ float adc_read_core_temp_float(ADC_HandleTypeDef *adcHandle) {
 }
 
 float adc_read_core_vbat(ADC_HandleTypeDef *adcHandle) {
-    #if defined(STM32G4) || defined(STM32L4)
+    #if defined(STM32G0) || defined(STM32G4) || defined(STM32L4)
     // Update the reference correction factor before reading tempsensor
-    // because VREFINT of STM32G4,L4 is at VDDA=3.0V
+    // because VREFINT of STM32G0,G4,L4 is at VDDA=3.0V
     adc_read_core_vref(adcHandle);
     #endif
 

--- a/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G0B1RE/mpconfigboard.h
@@ -18,13 +18,17 @@
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_2
 
 #if MICROPY_HW_CLK_USE_HSI
-#define MICROPY_HW_CLK_PLLM (16)
+#define MICROPY_HW_CLK_PLLM (1)
+#define MICROPY_HW_CLK_PLLN (8)
 #else
-#define MICROPY_HW_CLK_PLLM (8)
+// HSE comes from ST-LINK 8MHz, not crystal.
+#define MICROPY_HW_CLK_USE_BYPASS (1)
+#define MICROPY_HW_CLK_PLLM (1)
+#define MICROPY_HW_CLK_PLLN (16)
 #endif
-#define MICROPY_HW_CLK_PLLN (336)
-#define MICROPY_HW_CLK_PLLP (RCC_PLLP_DIV4)
-#define MICROPY_HW_CLK_PLLQ (7)
+#define MICROPY_HW_CLK_PLLP (2)
+#define MICROPY_HW_CLK_PLLQ (2)
+#define MICROPY_HW_CLK_PLLR (2)
 
 // USART1 config
 #define MICROPY_HW_UART1_TX         (pin_A9)

--- a/ports/stm32/machine_adc.c
+++ b/ports/stm32/machine_adc.c
@@ -244,12 +244,12 @@ void adc_config(ADC_TypeDef *adc, uint32_t bits) {
     }
     #endif
 
-    #if defined(STM32G4) || defined(STM32H5) || defined(STM32H7) || defined(STM32L0) || defined(STM32L4) || defined(STM32WB) || defined(STM32WL)
+    #if defined(STM32G0) || defined(STM32G4) || defined(STM32H5) || defined(STM32H7) || defined(STM32L0) || defined(STM32L4) || defined(STM32WB) || defined(STM32WL)
     if (!(adc->CR & ADC_CR_ADVREGEN)) {
         adc->CR = ADC_CR_ADVREGEN; // enable VREG
         #if defined(STM32H7)
         mp_hal_delay_us(10); // T_ADCVREG_STUP
-        #elif defined(STM32G4) || defined(STM32L4) || defined(STM32WB)
+        #elif defined(STM32G0) || defined(STM32G4) || defined(STM32L4) || defined(STM32WB)
         mp_hal_delay_us(20); // T_ADCVREG_STUP
         #endif
     }
@@ -378,6 +378,12 @@ static void adc_config_channel(ADC_TypeDef *adc, uint32_t channel, uint32_t samp
     adc->SMPR = sample_time << ADC_SMPR_SMP1_Pos; // select sample time from SMP1 (default)
     #else
     adc->SMPR = sample_time << ADC_SMPR_SMP_Pos; // select sample time
+    #endif
+
+    #if defined(STM32G0)
+    if (__LL_ADC_IS_CHANNEL_INTERNAL(channel)) {
+        channel = __LL_ADC_CHANNEL_TO_DECIMAL_NB(channel);
+    }
     #endif
     adc->CHSELR = 1 << channel; // select channel for conversion
 

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -145,17 +145,12 @@ void SystemClock_Config(void) {
     }
 
     // Use the PLL to get a 64MHz SYSCLK
-    #define PLLM (HSI_VALUE / 16000000) // input is 8MHz
-    #define PLLN (8) // 8*16MHz = 128MHz
-    #define PLLP (2) // f_P = 64MHz
-    #define PLLQ (2) // f_Q = 64MHz
-    #define PLLR (2) // f_R = 64MHz
     RCC->PLLCFGR =
-        (PLLP - 1) << RCC_PLLCFGR_PLLP_Pos | RCC_PLLCFGR_PLLPEN
-            | (PLLQ - 1) << RCC_PLLCFGR_PLLQ_Pos | RCC_PLLCFGR_PLLQEN
-            | (PLLR - 1) << RCC_PLLCFGR_PLLR_Pos | RCC_PLLCFGR_PLLREN
-            | PLLN << RCC_PLLCFGR_PLLN_Pos
-            | (PLLM - 1) << RCC_PLLCFGR_PLLM_Pos
+        (MICROPY_HW_CLK_PLLP - 1) << RCC_PLLCFGR_PLLP_Pos | RCC_PLLCFGR_PLLPEN
+            | (MICROPY_HW_CLK_PLLQ - 1) << RCC_PLLCFGR_PLLQ_Pos | RCC_PLLCFGR_PLLQEN
+            | (MICROPY_HW_CLK_PLLR - 1) << RCC_PLLCFGR_PLLR_Pos | RCC_PLLCFGR_PLLREN
+            | MICROPY_HW_CLK_PLLN << RCC_PLLCFGR_PLLN_Pos
+            | (MICROPY_HW_CLK_PLLM - 1) << RCC_PLLCFGR_PLLM_Pos
             | RCC_PLLCFGR_PLLSRC_HSI;
 
     #else

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -108,7 +108,7 @@ void rtc_init_start(bool force_init) {
     // Enable the RTC APB bus clock, to communicate with the RTC.
     #if defined(STM32H5)
     __HAL_RCC_RTC_CLK_ENABLE();
-    #elif defined(STM32WL)
+    #elif defined(STM32G0) || defined(STM32WL)
     __HAL_RCC_RTCAPB_CLK_ENABLE();
     #endif
 

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -541,7 +541,7 @@ void RTC_IRQHandler(void) {
 #if defined(STM32G0)
 void RTC_TAMP_IRQHandler(void) {
     IRQ_ENTER(RTC_TAMP_IRQn);
-    RTC->MISR &= ~RTC_MISR_WUTMF; // clear wakeup interrupt flag
+    RTC->SCR |= RTC_SCR_CWUTF; // clear wakeup interrupt flag
     Handle_EXTI_Irq(EXTI_RTC_WAKEUP);    // clear EXTI flag and execute optional callback
     Handle_EXTI_Irq(EXTI_RTC_TIMESTAMP); // clear EXTI flag and execute optional callback
     IRQ_EXIT(RTC_TAMP_IRQn);

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -865,7 +865,7 @@ static const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
 
     #if defined(TIM4)
     #if defined(STM32G0B1xx) || defined(STM32G0C1xx)
-    TIM_ENTRY(3, TIM3_TIM4_IRQn),
+    TIM_ENTRY(4, TIM3_TIM4_IRQn),
     #else
     TIM_ENTRY(4, TIM4_IRQn),
     #endif


### PR DESCRIPTION
### Summary

This PR is patch set for STM32G0.

* Refactor clock settings for STM32G0.
Clock definition should be in mpconfigboard.h and use them at clock initialization.

* Fix pyb.ADC issue when reading internal sensors.
  ```python
  import pyb
  a=pyb.ADCAll(12,0x70033)
  a.read_core_temp()
  ```
  -> Got invalid value: `-93.78223`

* Fix machine.ADC issue when machine.ADC is called.
  ```python
  import machine
  a=machine.ADC(1)
  ```
  -> `machine.ADC` does not return and board needs hardware reset.

* Fix `Timer(4)` returns error.
  ```python
  import pyb
  t=pyb.Timer(4)
  ```
  -> Got following exception even STM32G0 has TIM4.
  ```shell
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
  ValueError: Timer(4) doesn't exist
  ```

* Fix pyb.RTC and machine.RTC does not work.
  * RTC did not initialized.
    ```python
    import pyb
    rtc=pyb.RTC()
    rtc.datetime()
    ```
    -> Got invalid datetime (2000, 0, 0, 0, 0, 0, 0, 0).
    
  * The board need hardware reset when RTC.wakeup is woke up.
    ```python
    import pyb
    rtc=pyb.RTC()
    rtc.wakeup(0)
    ```

### Testing

Tested:
* NUCLEO_G0B1RE


### Trade-offs and Alternatives

This PR contains #18111.

