### PR TITLE
Additional make & ci.sh improvements

### DIFF
--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -285,6 +285,21 @@ See also :ref:`writingtests`.
 Additional make targets for developers
 --------------------------------------
 
+In all ``make``-based ports, there is a target to print the size of a specific object file.
+When a change is confined to a single file, this is useful when testing variations to find smaller alternatives.
+
+For instance, to print the size of ``objstr.o`` in the ``py/`` directory when making a unix standard build:
+
+.. code-block:: bash
+
+   $ make build-standard/py/objstr.sz
+
+Similarly, there is a target to save the preprocessed version of a file:
+
+.. code-block:: bash
+
+   $ make build-standard/py/objstr.pp
+
 In ``ports/unix`` there are additional targets related to running tests:
 
 .. code-block:: bash

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -282,6 +282,19 @@ To run a selection of tests on a board/device connected over USB use:
 
 See also :ref:`writingtests`.
 
+Additional make targets for developers
+--------------------------------------
+
+In ``ports/unix`` there are additional targets related to running tests:
+
+.. code-block:: bash
+
+   $ make test//int       # Run all tests matching the pattern "int"
+   $ make test/ports/unix # Run all tests in ports/unix
+   $ make test-failures   # Re-run only the failed tests
+   $ make print-failures  # print the differences for failed tests
+   $ make clean-failures  # delete the .exp and .out files from failed tests
+
 Using ci.sh locally
 -------------------
 

--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -306,6 +306,22 @@ As an example, you can build and test the unix minimal port with:
 
    $ tools/ci.sh unix_minimal_build unix_minimal_run_tests
 
+If you use the bash shell, you can add a ``ci`` command with tab completion:
+
+.. code-block:: bash
+
+   $ eval `tools/ci.sh --bash-completion`
+   $ ci unix_cov<tab>
+
+This will complete the ci step name to ``unix_coverage_``.
+Pressing tab a second time will show the list of matching steps:
+
+.. code-block:: bash
+
+   $ ci unix_coverage_<tab>
+   unix_coverage_32bit_build
+   unix_coverage_32bit_run_native_mpy_tests…
+
 Folder structure
 ----------------
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -108,6 +108,10 @@ $(BUILD)/%.pp: %.c FORCE
 	$(ECHO) "PreProcess $<"
 	$(Q)$(CPP) $(CFLAGS) -Wp,-C,-dD,-dI -o $@ $<
 
+.PHONY: $(BUILD)/%.sz
+$(BUILD)/%.sz: $(BUILD)/%.o
+	$(Q)$(SIZE) $<
+
 # Special case for compiling auto-generated source files.
 $(BUILD)/%.o: $(BUILD)/%.c
 	$(call compile_c)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1005,10 +1005,21 @@ function _ci_help {
     exit
 }
 
+function _ci_bash_completion {
+    echo "alias ci=\"$(readlink -f "$0")\"; complete -W '$(grep '^function ci_' $0 | awk '{print $2}' | sed 's/^ci_//')' ci"
+}
+
 function _ci_main {
     case "$1" in
         (-h|-?|--help)
             _ci_help
+        ;;
+        (--bash-completion)
+            _ci_bash_completion
+        ;;
+        (-*)
+            echo "Unknown option: $1" 1>&2
+            exit 1
         ;;
         (*)
             cd $(dirname "$0")/..


### PR DESCRIPTION
### Summary

This PR includes several items related only by the fact that they relate to the local developer experience:

 * bash tab completion for ci.sh
 * new %.sz makefile rule for quickly checking individual object file size
 * put documentation for these plus %.pp rule into developer docs

### Testing

I used each feature locally. I built and read the html documentation.

### Trade-offs and Alternatives

As I understand it, other modern interactive shells such as zsh and fish need different completion code. I only use bash.