### PR TITLE
stm32: Fix passing invalid argument to RTC callback.

### DIFF
--- a/ports/stm32/extint.c
+++ b/ports/stm32/extint.c
@@ -127,7 +127,7 @@ static uint8_t pyb_extint_mode[EXTI_NUM_VECTORS];
 static bool pyb_extint_hard_irq[EXTI_NUM_VECTORS];
 
 // The callback arg is a small-int or a ROM Pin object, so no need to scan by GC
-static mp_obj_t pyb_extint_callback_arg[EXTI_NUM_VECTORS];
+mp_obj_t pyb_extint_callback_arg[EXTI_NUM_VECTORS];
 
 #if !defined(ETH)
 #define ETH_WKUP_IRQn   62  // Some MCUs don't have ETH, but we want a value to put in our table

--- a/ports/stm32/extint.h
+++ b/ports/stm32/extint.h
@@ -64,6 +64,7 @@
 #endif
 
 #define EXTI_NUM_VECTORS        (PYB_EXTI_NUM_VECTORS)
+extern mp_obj_t pyb_extint_callback_arg[];
 
 void extint_init0(void);
 

--- a/ports/stm32/rtc.c
+++ b/ports/stm32/rtc.c
@@ -771,6 +771,7 @@ mp_obj_t pyb_rtc_wakeup(size_t n_args, const mp_obj_t *args) {
 
     // set the callback
     MP_STATE_PORT(pyb_extint_callback)[EXTI_RTC_WAKEUP] = callback;
+    pyb_extint_callback_arg[EXTI_RTC_WAKEUP] = MP_OBJ_NEW_SMALL_INT(EXTI_RTC_WAKEUP);
 
     // disable register write protection
     RTC->WPR = 0xca;


### PR DESCRIPTION

### Summary

The folling code does not work with NUCLEO_F401RE.

```python
from pyb import RTC

def cb(v):
    print(v)

rtc=RTC()
rtc.wakeup(1000, cb)
```

NameError exception occurred with following message.
The argument of callback should be accessed without exception.

```shell
Traceback (most recent call last):
  File "<stdin>", line 2, in cb
NameError: local variable referenced before assignment
```

To fix this issue, this PR passes `EXTI_RTC_WAKEUP` to callback argument.
This is equivalent behavior with ExtInt callback when ExtInt is mapped to RTC interrupt by passing an integer value.

### Testing

Tested with NUCLEO_F401RE.
The argument of callback can be read (22 with NUCLEO_F401RE).


