### PR TITLE
 py/scheduler: Refactor mp_handle_pending to use flags.

### DIFF
--- a/ports/stm32/usbd_hid_interface.c
+++ b/ports/stm32/usbd_hid_interface.c
@@ -26,7 +26,7 @@
 
 #include "usbd_hid_interface.h"
 
-#include "py/mpstate.h"
+#include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "usb.h"

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -52,6 +52,12 @@ typedef enum {
     MP_ARG_KW_ONLY   = 0x200,
 } mp_arg_flag_t;
 
+typedef enum {
+    MP_HANDLE_PENDING_CALLBACKS_ONLY,
+    MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS,
+    MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS,
+} mp_handle_pending_behaviour_t;
+
 typedef union _mp_arg_val_t {
     bool u_bool;
     mp_int_t u_int;
@@ -100,7 +106,14 @@ void mp_sched_keyboard_interrupt(void);
 #if MICROPY_ENABLE_VM_ABORT
 void mp_sched_vm_abort(void);
 #endif
-void mp_handle_pending(bool raise_exc);
+
+void mp_handle_pending_internal(mp_handle_pending_behaviour_t behavior);
+
+static inline void mp_handle_pending(bool raise_exc) {
+    mp_handle_pending_internal(raise_exc ?
+        MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS :
+        MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
+}
 
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);


### PR DESCRIPTION
### Summary

Calling `mp_handle_pending(false)` clears pending exceptions/vm_abort even though they were not handled. This causes pending exceptions/vm_abort to be lost which can be a problem if a tool triggers a vm_abort and waits for soft-reboot...
This patch keeps the pending exceptions and/or VM abort if they were not handled, to allow a following `mp_event_handle_nowait` for example, to deal with them. This seems to me like the correct behavior Vs. clearing pending exceptions, but I could be missing something very very obvious that explains why the current behavior the way it is. If this is the case, what should do then if some code needs to handle pending events but it can't afford raising exceptions, and also can't drop VM aborts?

### Testing

I only did some very limited testing just to confirm that this was indeed what's causing VM aborts to be lost.

### Trade-offs and Alternatives

I guess we could just add our own helper function that restores pending exceptions? For example:
```C
void mp_handle_pending_restore(void) {
    bool vm_abort = MP_STATE_VM(vm_abort);
    mp_obj_t exc_obj = MP_STATE_THREAD(mp_pending_exception);

    mp_handle_pending(false);

    MP_STATE_VM(vm_abort) = vm_abort;
    MP_STATE_THREAD(mp_pending_exception) = exc_obj;
}
```
But I kind of want to avoid leaking VM internals outside of `scheduler.c` and to understand if this break anything.