### PR TITLE
rp2: Add execctrl option for the PIO decorator.

### DIFF
--- a/docs/library/rp2.PIO.rst
+++ b/docs/library/rp2.PIO.rst
@@ -103,3 +103,12 @@ Constants
 
     These constants are used for the *trigger* argument to `PIO.irq`.
 
+.. data:: PIO.STATUS_TXLEVEL
+          PIO.STATUS_RXLEVEL
+          PIO.STATUS_IRQ
+
+    These constants are used for the *execctrl* argument of `asm_pio`, to
+    configure the behaviour of ``mov(_, status)`` instructions. For example,
+    set ``execctrl=PIO.STATUS_TXLEVEL + n`` to detect when the TX FIFO has
+    fewer than *n* words left. Note that `PIO.STATUS_IRQ` is not available
+    on RP2040.

--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -23,7 +23,7 @@ The ``rp2`` module includes functions for assembling PIO programs.
 
 For running PIO programs, see :class:`rp2.StateMachine`.
 
-.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, side_pindir=False, in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE)
+.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, side_pindir=False, in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE, execctrl=0)
 
     Assemble a PIO program.
 
@@ -37,8 +37,12 @@ For running PIO programs, see :class:`rp2.StateMachine`.
       be at most 5.
     - *sideset_init* configures the pins used for ``.side()`` modifiers. There
       can be at most 5.
-    - *side_pindir* when set to ``True`` configures ``.side()`` modifiers to be
-      used for pin directions, instead of pin values (the default, when ``False``).
+    - *side_pindir* determines whether ``.side()`` modifiers are used for
+      pin directions or pin values. When set to ``True``, ``.side()``
+      modifiers control pin directions; when set to ``False``, ``.side()``
+      modifiers control pin values. If left at the default ``None``, the
+      behaviour depends on bit 29 of the *execctrl* argument below: with the
+      default *execctrl* of 0, ``.side()`` modifiers control pin values.
 
     The following parameters are used by default, but can be overridden in
     `StateMachine.init()`:
@@ -59,6 +63,11 @@ For running PIO programs, see :class:`rp2.StateMachine`.
     - *fifo_join* configures whether the 4-word TX and RX FIFOs should be
       combined into a single 8-word FIFO for one direction only. The options
       are `PIO.JOIN_NONE`, `PIO.JOIN_RX` and `PIO.JOIN_TX`.
+    - *execctrl* configures the value of the EXECCTRL register, which
+      controls the behaviour of the state machine. See the constants
+      `PIO.STATUS_TXLEVEL`, `PIO.STATUS_RXLEVEL` and `PIO.STATUS_IRQ` which
+      can be used with this register to configure the effect of
+      ``mov(_ , status)`` instructions.
 
 .. function:: asm_pio_encode(instr, sideset_count, sideset_opt=False)
 

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -27,7 +27,7 @@ class PIOASMEmit:
         out_init=None,
         set_init=None,
         sideset_init=None,
-        side_pindir=False,
+        side_pindir=None,
         in_shiftdir=PIO.SHIFT_LEFT,
         out_shiftdir=PIO.SHIFT_LEFT,
         autopush=False,
@@ -35,13 +35,17 @@ class PIOASMEmit:
         push_thresh=32,
         pull_thresh=32,
         fifo_join=PIO.JOIN_NONE,
+        execctrl=0,
     ):
         # array is a built-in module so importing it here won't require
         # scanning the filesystem.
         from array import array
 
         self.labels = {}
-        execctrl = side_pindir << 29
+        if side_pindir:
+            execctrl |= 1 << 29
+        elif side_pindir is not None:
+            execctrl &= ~(1 << 29)
         shiftctrl = (
             fifo_join << 30
             | (pull_thresh & 0x1F) << 25

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -512,6 +512,15 @@ static const mp_rom_map_elem_t rp2_pio_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM1), MP_ROM_INT(0x200) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM2), MP_ROM_INT(0x400) },
     { MP_ROM_QSTR(MP_QSTR_IRQ_SM3), MP_ROM_INT(0x800) },
+
+    #if PICO_RP2040
+    { MP_ROM_QSTR(MP_QSTR_STATUS_TXLEVEL), MP_ROM_INT(0x00) },
+    { MP_ROM_QSTR(MP_QSTR_STATUS_RXLEVEL), MP_ROM_INT(0x10) },
+    #else
+    { MP_ROM_QSTR(MP_QSTR_STATUS_TXLEVEL), MP_ROM_INT(0x00) },
+    { MP_ROM_QSTR(MP_QSTR_STATUS_RXLEVEL), MP_ROM_INT(0x20) },
+    { MP_ROM_QSTR(MP_QSTR_STATUS_IRQ), MP_ROM_INT(0x40) },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(rp2_pio_locals_dict, rp2_pio_locals_dict_table);
 


### PR DESCRIPTION
### Summary

The rp2 PIO assembler includes support for instructions like
```
mov(y, status)
```
which can be used to detect when the TX and RX FIFOs pass a configurable threshold, for example to trigger an interrupt handler to fill/empty them.

However, to actually use these instructions, the relevant threshold needs to be configured in the `execctrl` register, and at present, only the `side_pindir` bit can be set.

Expose an `execctrl=` keyword argument in the PIO decorator to do this, together with constants in rp2.PIO which can be used like
```python
@rp2.asm_pio(execctrl = rp2.PIO.STATUS_TXLEVEL + n)
def program():
    [...]
    mov(y, status)
    jmp(not_y, "skip")
    irq(rel(0))
    label("skip")
    [...]
```
to generate an interrupt if the TX FIFO has fewer than n words left.

This also fixes a bug with the existing `side_pindir` option, which is meant to be boolean. Previously, if it was passed an integer other than 0 or 1, unintended high bits in the `execctrl` value would be set, not just the intended bit 29.

### Testing

I've tested (and used) this functionality on a real rp2350 board.

Unfortunately there are no in-tree tests at all for the rp2 PIO assembler yet, so there isn't a natural place to add a simple test for this new option. I propose to write a full set of tests to cover as much as I can of that decorator, but will submit in a separate PR.

### Trade-offs and Alternatives

It is possible to work around the lack of assembler execctrl support by patching the word of the program array that corresponds to the execctrl register, for example
```python
program[4] = program[4] & ~127 | 1 # set status if txlevel < 1
```
but this assumes undocumented internal details of the rp2 pio module.