### PR TITLE
docs: Verify correctness of documented examples.

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,54 @@
+import __future__
+
+from pathlib import Path
+
+from docs_test.mp_evaluator import MicroPythonDocTestEvaluator, MicroPythonEvaluator
+from docs_test.mp_parser import (
+    MicroPythonClearNamespaceParser,
+    MicroPythonDocTestParser,
+    MicroPythonSkipParser,
+)
+from sybil import Sybil
+from sybil.integration.pytest import SybilItem as OriginalSybilItem
+from sybil.parsers.rest import CodeBlockParser, DocTestDirectiveParser, PythonCodeBlockParser
+
+
+# Monkeypatch SybilItem.reportinfo to return 0-based line numbers as pytest expects
+# In conftest.py near top
+def _patch_sybil_line_numbers():
+    from sybil.integration.pytest import SybilItem as _SybilItem
+
+    if getattr(_SybilItem.reportinfo, "_mp_patched", False):
+        return
+    original = _SybilItem.reportinfo
+
+    def patched(self):
+        path, _, info = original(self)
+        # original returns 1-based; convert to 0-based for pytest
+        return path, self.example.line - 1, info
+
+    patched._mp_patched = True  # type: ignore[attr-defined]
+    _SybilItem.reportinfo = patched
+
+
+_patch_sybil_line_numbers()
+
+# docs_path = Path(__file__).parent / "examples"
+# docs_path = Path(__file__).parent / "micropython/docs"
+docs_path = Path(__file__).parent
+
+mp_code = Sybil(
+    path=docs_path.as_posix(),
+    parsers=[
+        MicroPythonSkipParser(),  # MCU-aware skip parser
+        MicroPythonClearNamespaceParser(),  # Clear namespace between logical blocks
+        MicroPythonDocTestParser(),  # Custom doctest & directive parser
+        CodeBlockParser(
+            language="python", evaluator=MicroPythonEvaluator()
+        ),  # Standard code block evaluator
+    ],
+    pattern="*.rst",
+)
+
+
+pytest_collect_file = (mp_code).pytest()

--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -269,6 +269,7 @@ Module usage in MicroPython
 
 Once built into your copy of MicroPython, the module
 can now be accessed in Python just like any other builtin module, e.g.
+.. skip: start
 
 .. code-block:: python
 
@@ -285,3 +286,5 @@ can now be accessed in Python just like any other builtin module, e.g.
     sleep_ms(1000)
     print(watch.time())
     # should display approximately 1000
+
+.. skip: end

--- a/docs/develop/library.rst
+++ b/docs/develop/library.rst
@@ -28,12 +28,11 @@ Implementing a core module
 Like CPython, MicroPython has core builtin modules that can be accessed through import statements.
 An example is the ``gc`` module discussed in :ref:`memorymanagement`.
 
-.. code-block:: bash
+.. code-block:: python
 
-   >>> import gc
-   >>> gc.enable()
-   >>>
-
+   import gc
+   gc.enable()
+   
 MicroPython has several other builtin standard/core modules like ``io``, ``array`` etc.
 Adding a new core module involves several modifications.
 

--- a/docs/develop/memorymgt.rst
+++ b/docs/develop/memorymgt.rst
@@ -23,8 +23,9 @@ live objects while the sweep phase goes through the heap reclaiming all unmarked
 
 Garbage collection functionality in MicroPython is available through the ``gc`` built-in
 module:
+.. skip: next
 
-.. code-block:: bash
+.. code-block:: python
 
    >>> x = 5
    >>> x

--- a/docs/develop/optimizations.rst
+++ b/docs/develop/optimizations.rst
@@ -59,6 +59,7 @@ These variables use ``const()`` from the MicroPython library. Therefore:
 Compiles to:
 
 .. code-block:: python
+
     def foo(a, b):
         return a + b
 

--- a/docs/develop/optimizations.rst
+++ b/docs/develop/optimizations.rst
@@ -50,11 +50,17 @@ These variables use ``const()`` from the MicroPython library. Therefore:
 
     X = const(1)
     _Y = const(2)
+
+    def foo(a, b):
+        return a + b
+
     foo(X, _Y)
 
 Compiles to:
 
 .. code-block:: python
+    def foo(a, b):
+        return a + b
 
     X = 1
     foo(1, 2)

--- a/docs/docs_test/mp_evaluator.py
+++ b/docs/docs_test/mp_evaluator.py
@@ -11,6 +11,7 @@ from sybil.evaluators.python import pad
 
 from doctest import Example as DocTestExample
 
+
 class MicroPythonEvaluator:
     """
     The :any:`Evaluator` to use for :class:`Regions <sybil.Region>` containing
@@ -112,7 +113,7 @@ class MicroPythonDocTestEvaluator(DocTestEvaluator):
                                     "name 'x' is" in expected_error
                                     and "name 'x' is" in actual_error
                                 ):
-                                    return  ''.join(output) # Consider this a match
+                                    return "".join(output)  # Consider this a match
 
                     raise AssertionError(f"Expected: {expected_output!r}, Got: {actual_output!r}")
 

--- a/docs/docs_test/mp_evaluator.py
+++ b/docs/docs_test/mp_evaluator.py
@@ -1,0 +1,181 @@
+import __future__
+from typing import List
+
+
+import pytest
+from .mp_runner import reset_micropython_mcu, run_micropython_code
+from sybil import Example, Region, Sybil
+from sybil.evaluators.doctest import DocTestEvaluator
+from sybil.evaluators.python import pad
+
+
+from doctest import Example as DocTestExample
+
+class MicroPythonEvaluator:
+    """
+    The :any:`Evaluator` to use for :class:`Regions <sybil.Region>` containing
+    MicroPython source code.
+    """
+
+    def __init__(self) -> None:
+        self.flags = 0
+
+    def __call__(self, example: Example) -> None:
+        # There must be a nicer way to get line numbers to be correct...
+        source = pad(example.parsed, example.line + example.parsed.line_offset)
+        # TODO : run in the correct micropython port
+        run_micropython_code(source)
+
+
+class MicroPythonDocTestEvaluator(DocTestEvaluator):
+    """
+    Evaluator for doctests that runs them on connected MCU using mpremote
+    """
+
+    def __call__(self, sybil_example: Example) -> str:
+        """Run doctest examples on the MCU"""
+        # Get the doctest examples - could be a single example or a list
+        examples = sybil_example.parsed
+        output: List[str] = []
+        # TODO : run each example and collect output
+        # TODO - I do not think this should be called with a list of things if parsed properly
+
+        # Handle both single example and list of examples
+        if isinstance(examples, DocTestExample):
+            examples_list = [examples]
+        elif isinstance(examples, list):
+            examples_list = examples
+        else:
+            # Fallback - try to iterate
+            try:
+                examples_list = list(examples)
+            except TypeError:
+                examples_list = [examples]
+
+        for doctest_example in examples_list:
+            if isinstance(doctest_example, DocTestExample):
+                # Extract clean Python source code from the doctest example
+                clean_source = self._clean_doctest_source(doctest_example.source)
+                expected_output = doctest_example.want.strip()
+
+                # Check if we need to wrap the last line in print() for expressions
+                if expected_output and self._should_print_result(
+                    clean_source.split("\n")[-1], expected_output
+                ):
+                    lines = clean_source.split("\n")
+                    last_line = lines[-1].strip()
+                    if last_line and not any(keyword in last_line for keyword in ["print(", "="]):
+                        # Use repr() to match doctest behavior which shows the representation
+                        lines[-1] = f"print(repr({last_line}))"
+                        clean_source = "\n".join(lines)
+
+                # Run the clean source code on the MCU and capture output
+                try:
+                    actual_output = run_micropython_code(clean_source).strip()
+                except Exception as e:
+                    # Check if this is an expected error (traceback in expected output)
+                    if expected_output and (
+                        "Traceback" in expected_output or "Error:" in expected_output
+                    ):
+                        # Extract error output from the exception
+                        if hasattr(e, "args") and e.args:
+                            error_msg = str(e.args[0])
+                            if "stdout:" in error_msg:
+                                # Extract the stdout part which contains the traceback
+                                stdout_part = error_msg.split("stdout: ")[1]
+                                actual_output = stdout_part.strip()
+                            else:
+                                actual_output = str(e).strip()
+                        else:
+                            actual_output = str(e).strip()
+                    else:
+                        # Re-raise if this wasn't an expected error
+                        raise
+
+                # Simple comparison - you might want to make this more sophisticated
+                if expected_output and actual_output != expected_output:
+                    # For traceback comparisons, be more flexible
+                    if "Traceback" in expected_output and "Traceback" in actual_output:
+                        # Check if the key error information matches
+                        expected_lines = expected_output.strip().split("\n")
+                        actual_lines = actual_output.strip().split("\n")
+
+                        # Check the last line (the actual error)
+                        if expected_lines and actual_lines:
+                            expected_error = expected_lines[-1].strip()
+                            actual_error = actual_lines[-1].strip()
+
+                            # Handle minor differences in error messages
+                            if "NameError" in expected_error and "NameError" in actual_error:
+                                # Compare the core error message, allowing for slight variations
+                                if (
+                                    "name 'x' is" in expected_error
+                                    and "name 'x' is" in actual_error
+                                ):
+                                    return  ''.join(output) # Consider this a match
+
+                    raise AssertionError(f"Expected: {expected_output!r}, Got: {actual_output!r}")
+
+    def _clean_doctest_source(self, doctest_source: str) -> str:
+        """
+        Clean doctest source by removing >>> and ... prefixes to get actual Python code
+        """
+        lines = doctest_source.split("\n")
+        cleaned_lines = []
+
+        for line in lines:
+            if line.startswith(">>> "):
+                # Remove the >>> prefix
+                code_line = line[4:]
+                cleaned_lines.append(code_line)
+            elif line.startswith("... "):
+                # Remove the ... prefix (continuation line) but preserve remaining indentation
+                cleaned_lines.append(line[4:])
+            elif line.strip() == "...":
+                # Handle standalone ... continuation (empty line)
+                cleaned_lines.append("")
+            elif line.strip():
+                # Keep non-empty lines that don't start with >>> or ...
+                cleaned_lines.append(line)
+
+        # Remove any trailing empty lines
+        while cleaned_lines and not cleaned_lines[-1].strip():
+            cleaned_lines.pop()
+
+        return "\n".join(cleaned_lines)
+
+    def _should_print_result(self, code_line: str, expected_output: str) -> bool:
+        """
+        Determine if a line of code should have its result printed
+        based on whether there's expected output and the code is an expression
+        """
+        if not expected_output.strip():
+            return False
+
+        # Simple heuristic: if the line doesn't contain assignment, import, def, class, etc.
+        # and there's expected output, it's probably an expression that should be printed
+        keywords_that_dont_print = [
+            "=",
+            "import ",
+            "def ",
+            "class ",
+            "if ",
+            "for ",
+            "while ",
+            "try:",
+            "with ",
+            "print(",
+        ]
+        code_stripped = code_line.strip()
+
+        # Skip if it already has print
+        if "print(" in code_stripped:
+            return False
+
+        # Skip if it contains statement keywords
+        for keyword in keywords_that_dont_print:
+            if keyword in code_stripped:
+                return False
+
+        # If it looks like a simple expression and we expect output, wrap it in print
+        return True

--- a/docs/docs_test/mp_parser.py
+++ b/docs/docs_test/mp_parser.py
@@ -1,0 +1,435 @@
+import __future__
+
+import re
+from doctest import DocTestParser as StdDocTestParser
+
+from .mp_evaluator import MicroPythonDocTestEvaluator, MicroPythonEvaluator
+from .mp_runner import reset_micropython_mcu, run_micropython_code
+from sybil import Example, Region
+from sybil.parsers.abstract.doctest import DocTestStringParser
+from sybil.parsers.rest import DocTestParser
+
+
+class MicroPythonDocTestStringParser(DocTestStringParser):
+    """
+    Custom doctest string parser that avoids conflicts with code blocks
+    and runs doctests on MicroPython MCU
+    """
+
+    def __call__(self, string: str, name: str):
+        """Override the callable interface to use our custom parse method"""
+        return self.parse(string, name)
+
+    def parse(self, text: str, path: str):
+        """Parse text and yield regions, handling both inline doctests and doctest directives"""
+
+        lines = text.split("\n")
+
+        # Find all code block regions AND skip regions to avoid conflicts
+        exclusion_regions = []
+        in_code_block = False
+        code_block_start = None
+        in_skip_region = False
+        skip_region_start = None
+
+        for line_idx, line in enumerate(lines):
+            stripped = line.strip()
+
+            # Handle code blocks
+            if stripped.startswith(".. code-block::"):
+                in_code_block = True
+                code_block_start = line_idx
+            elif in_code_block and line and not line.startswith(" ") and not line.startswith("\t"):
+                # End of code block (when we hit non-indented content)
+                if code_block_start is not None:
+                    exclusion_regions.append((code_block_start, line_idx))
+                in_code_block = False
+                code_block_start = None
+
+            # Handle skip regions (start/end pairs)
+            elif stripped.startswith(".. skip:") and "start" in stripped:
+                # Begin skip region
+                in_skip_region = True
+                skip_region_start = line_idx
+            elif stripped.startswith(".. skip:") and "end" in stripped:
+                # End skip region
+                if in_skip_region and skip_region_start is not None:
+                    exclusion_regions.append(
+                        (skip_region_start, line_idx + 1)
+                    )  # Include the end line
+                in_skip_region = False
+                skip_region_start = None
+
+            # Handle other skip directives (like .. skip: next) that are single-directive exclusions
+            elif stripped.startswith(".. skip:") and not in_skip_region:
+                # Single skip directive - exclude until next non-indented content
+                single_skip_start = line_idx
+                # Look ahead to find the end of this single skip directive
+                j = line_idx + 1
+                while j < len(lines):
+                    next_line = lines[j]
+                    if (
+                        next_line
+                        and not next_line.startswith(" ")
+                        and not next_line.startswith("\t")
+                    ):
+                        exclusion_regions.append((single_skip_start, j))
+                        break
+                    j += 1
+                else:
+                    # Skip goes to end of file
+                    exclusion_regions.append((single_skip_start, len(lines)))
+
+        # Handle case where code block goes to end of file
+        if in_code_block and code_block_start is not None:
+            exclusion_regions.append((code_block_start, len(lines)))
+
+        # Handle case where skip region goes to end of file without proper end
+        if in_skip_region and skip_region_start is not None:
+            exclusion_regions.append((skip_region_start, len(lines)))
+
+        # Now parse for doctest content, avoiding exclusion regions
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+
+            # Check if we're inside an exclusion region
+            inside_exclusion = any(start <= i < end for start, end in exclusion_regions)
+            if inside_exclusion:
+                i += 1
+                continue
+
+            # Handle doctest directives
+            if stripped == ".. doctest::":
+                start_line = i
+                i += 1  # Skip the directive line
+
+                # Skip any options/arguments lines
+                while i < len(lines) and (
+                    not lines[i].strip() or lines[i].startswith(" :") or lines[i].startswith("\t:")
+                ):
+                    i += 1
+
+                # Collect indented doctest content
+                doctest_lines = []
+                while i < len(lines):
+                    current_line = lines[i]
+
+                    # Check if we're entering an exclusion region
+                    inside_exclusion = any(start <= i < end for start, end in exclusion_regions)
+                    if inside_exclusion:
+                        break
+
+                    # If line is indented (part of the directive content)
+                    if (
+                        current_line.startswith(" ")
+                        or current_line.startswith("\t")
+                        or not current_line.strip()
+                    ):
+                        if (
+                            current_line.strip().startswith(">>> ")
+                            or current_line.strip().startswith("... ")
+                            or not current_line.strip()
+                        ):
+                            doctest_lines.append(current_line)
+                        elif doctest_lines:  # Expected output after doctest commands
+                            doctest_lines.append(current_line)
+                        i += 1
+                    else:
+                        # End of indented block
+                        break
+
+                # Process the doctest directive content
+                if doctest_lines:
+                    # Remove common indentation
+                    import textwrap
+
+                    doctest_text = textwrap.dedent("\n".join(doctest_lines)).strip()
+
+                    if doctest_text:
+                        # Use standard doctest parser to extract examples
+                        std_parser = StdDocTestParser()
+                        examples = std_parser.get_examples(doctest_text, path)
+
+                        if examples:
+                            # Calculate character positions for the entire directive region
+                            start_pos = sum(
+                                len(lines[j]) + 1 for j in range(start_line)
+                            )  # +1 for newline
+                            end_line = start_line + len([lines[start_line]]) + len(doctest_lines)
+                            end_pos = sum(
+                                len(lines[j]) + 1 for j in range(min(end_line, len(lines)))
+                            )
+
+                            # Create one region for all examples in this directive
+                            yield Region(
+                                start=start_pos,
+                                end=end_pos,
+                                parsed=examples,
+                                evaluator=self.evaluator,
+                            )
+
+            # Handle inline doctests (outside of directives)
+            elif stripped.startswith(">>> "):
+                # FIRST check if we're inside an exclusion region before processing
+                inside_exclusion = any(start <= i < end for start, end in exclusion_regions)
+                if inside_exclusion:
+                    i += 1
+                    continue
+
+                start_line = i
+                doctest_lines = []
+
+                # Collect the doctest block
+                while i < len(lines):
+                    current_line = lines[i]
+                    stripped = current_line.strip()
+
+                    # Check if we're entering an exclusion region
+                    inside_exclusion = any(start <= i < end for start, end in exclusion_regions)
+                    if inside_exclusion:
+                        break
+
+                    if stripped.startswith(">>> ") or stripped.startswith("... "):
+                        doctest_lines.append(current_line)
+                        i += 1
+                    elif not stripped:  # Empty line
+                        # Check if next non-empty line is expected output or another construct
+                        peek_idx = i + 1
+                        while peek_idx < len(lines) and not lines[peek_idx].strip():
+                            peek_idx += 1
+
+                        if peek_idx < len(lines):
+                            peek_line = lines[peek_idx].strip()
+                            # If it's another doctest or RST directive, stop here
+                            if peek_line.startswith(">>> ") or peek_line.startswith(".. "):
+                                break
+                            # Otherwise, include expected output
+                            else:
+                                # Include the empty line and continue to expected output
+                                doctest_lines.append(current_line)
+                                i += 1
+                        else:
+                            break
+                    elif not (stripped.startswith(">>>") or stripped.startswith(".. ")):
+                        # This is expected output, include it
+                        doctest_lines.append(current_line)
+                        i += 1
+                    else:
+                        # Hit another construct, stop
+                        break
+
+                # Process the collected inline doctest block
+                if doctest_lines:
+                    doctest_text = "\n".join(doctest_lines)
+                    # Use standard doctest parser to extract examples
+                    std_parser = StdDocTestParser()
+                    examples = std_parser.get_examples(doctest_text, path)
+
+                    if examples:
+                        # Calculate character positions
+                        start_pos = sum(
+                            len(lines[j]) + 1 for j in range(start_line)
+                        )  # +1 for newline
+                        end_pos = start_pos + len(doctest_text)
+
+                        # Create one region for all examples in this doctest block
+                        yield Region(
+                            start=start_pos, end=end_pos, parsed=examples, evaluator=self.evaluator
+                        )
+            else:
+                i += 1
+
+
+class MicroPythonDocTestParser(DocTestParser):
+    """
+    MicroPython-aware doctest parser that subclasses Sybil's DocTestParser
+    """
+
+    def __init__(self, optionflags: int = 0):
+        # Don't call super().__init__ because we want to use our custom string parser
+        self.string_parser = MicroPythonDocTestStringParser(
+            evaluator=MicroPythonDocTestEvaluator()
+        )
+
+
+class MicroPythonSkipper:
+    """
+    MCU-aware version of Sybil's Skipper that evaluates conditions on MicroPython MCU
+    """
+
+    def __init__(self, directive: str) -> None:
+        self.document_state = {}
+        self.directive = directive
+
+    def state_for(self, example):
+        document = example.document
+        if document not in self.document_state:
+            from sybil.evaluators.skip import SkipState
+
+            self.document_state[document] = SkipState()
+        return self.document_state[example.document]
+
+    def install(self, example, state, reason):
+        document = example.document
+        document.push_evaluator(self)
+        if reason:
+            reason = reason.lstrip()
+            if reason.startswith("if"):
+                condition = reason[2:].strip()
+                # Evaluate condition on MCU instead of host
+                should_skip = self._evaluate_condition_on_mcu(condition)
+                if should_skip:
+                    from unittest import SkipTest
+
+                    state.exception = SkipTest("MCU condition evaluated to True")
+                else:
+                    state.active = False
+            else:
+                # Handle quoted reasons (non-conditional) - just skip with the quoted reason
+                from unittest import SkipTest
+
+                state.exception = SkipTest(reason.strip('"'))
+        else:
+            # Simple skip directive without reason - always skip
+            from unittest import SkipTest
+
+            state.exception = SkipTest("Skipped by directive")
+
+    def remove(self, example):
+        document = example.document
+        document.pop_evaluator(self)
+        del self.document_state[document]
+
+    def evaluate_skip_example(self, example):
+        state = self.state_for(example)
+        directive = self.directive
+        action, reason = example.parsed
+
+        if action not in ("start", "next", "end"):
+            raise ValueError("Bad skip action: " + action)
+        if state.last_action is None and action not in ("start", "next"):
+            raise ValueError(f"'{directive}: {action}' must follow '{directive}: start'")
+        elif state.last_action and action != "end":
+            raise ValueError(
+                f"'{directive}: {action}' cannot follow '{directive}: {state.last_action}'"
+            )
+
+        state.last_action = action
+
+        if action == "start":
+            self.install(example, state, reason)
+        elif action == "next":
+            self.install(example, state, reason)
+            state.remove = True
+        elif action == "end":
+            self.remove(example)
+            if reason:
+                raise ValueError("Cannot have condition on 'skip: end'")
+
+    def evaluate_other_example(self, example):
+        state = self.state_for(example)
+        if state.remove:
+            self.remove(example)
+        if not state.active:
+            from sybil.example import NotEvaluated
+
+            raise NotEvaluated()
+        if state.exception is not None:
+            raise state.exception
+
+    def __call__(self, example):
+        if example.region.evaluator is self:
+            self.evaluate_skip_example(example)
+        else:
+            self.evaluate_other_example(example)
+
+    def _evaluate_condition_on_mcu(self, condition: str) -> bool:
+        """Evaluate a condition on the MicroPython MCU and return True if should skip"""
+        try:
+            # Create Python code that evaluates the condition and returns the result
+            test_code = f"""
+try:
+    result = {condition}
+    print("SKIP_CONDITION_RESULT:", result)
+except Exception as e:
+    print("SKIP_CONDITION_ERROR:", str(e))
+"""
+            output = run_micropython_code(test_code)
+            print(f"MCU Skip evaluation output: {output.strip()}")
+
+            # Parse the output
+            for line in output.split("\n"):
+                if line.startswith("SKIP_CONDITION_RESULT:"):
+                    result_str = line.split("SKIP_CONDITION_RESULT:", 1)[1].strip()
+                    # Convert string representation back to boolean
+                    result = result_str.lower() == "true"
+                    print(f"Skip condition '{condition}' evaluated to: {result}")
+                    return result
+                elif line.startswith("SKIP_CONDITION_ERROR:"):
+                    # If there's an error, don't skip (default behavior)
+                    print(f"Skip condition error: {line}")
+                    return False
+
+            return False  # Default: don't skip if we can't determine the result
+
+        except Exception as e:
+            print(f"Error evaluating skip condition on MCU: {e}")
+            return False  # Default: don't skip on error
+
+
+class MicroPythonSkipParser:
+    """
+    MCU-aware skip parser that subclasses the original SkipParser behavior
+    but evaluates conditions on the MicroPython MCU
+    """
+
+    def __init__(self):
+        from sybil.parsers.rest import SkipParser
+
+        # Create a standard SkipParser and copy its behavior
+        self._standard_parser = SkipParser()
+        # But use our MCU-aware skipper
+        self.skipper = MicroPythonSkipper("skip")
+        # Copy the lexers from the standard parser
+        self.lexers = self._standard_parser.lexers
+        self.directive = "skip"
+
+    def __call__(self, document):
+        """Parse document using standard SkipParser logic but with MCU evaluation"""
+        for lexed in self.lexers(document):
+            arguments = lexed.lexemes["arguments"]
+            if arguments is None:
+                raise ValueError(f"missing arguments to {self.directive}")
+
+            from sybil.parsers.abstract.skip import SKIP_ARGUMENTS_PATTERN
+
+            match = SKIP_ARGUMENTS_PATTERN.match(arguments)
+            if match is None:
+                raise ValueError(f"malformed arguments to {self.directive}: {arguments!r}")
+
+            yield Region(lexed.start, lexed.end, match.groups(), self.skipper)
+
+
+class MicroPythonClearNamespaceParser:
+    """
+    Parser for clear-namespace directives that resets the MicroPython MCU
+    """
+
+    def __call__(self, document):
+        """Parse document and yield regions for clear-namespace directives"""
+        # Look for clear-namespace directive (with or without ::)
+        pattern = r"^(?P<indent> *)\.\.[ \t]+clear-namespace[ \t]*(?:::)?[ \t]*$"
+
+        for match in re.finditer(pattern, document.text, re.MULTILINE):
+            yield Region(
+                start=match.start(),
+                end=match.end(),
+                parsed=None,  # No parsing needed
+                evaluator=self._clear_namespace_evaluator,
+            )
+
+    def _clear_namespace_evaluator(self, example: Example) -> None:
+        """Reset the MicroPython MCU to clear the namespace"""
+        reset_micropython_mcu()

--- a/docs/docs_test/mp_parser.py
+++ b/docs/docs_test/mp_parser.py
@@ -346,10 +346,17 @@ class MicroPythonSkipper:
             self.evaluate_other_example(example)
 
     def _evaluate_condition_on_mcu(self, condition: str) -> bool:
-        """Evaluate a condition on the MicroPython MCU and return True if should skip"""
+        """Evaluate a condition on the MicroPython MCU and return True if should skip.
+        The os, sys, and platform modules are available for condition checks.
+        """
         try:
             # Create Python code that evaluates the condition and returns the result
             test_code = f"""
+try:
+    import os, sys
+    import platform
+except ImportError:
+    pass
 try:
     result = {condition}
     print("SKIP_CONDITION_RESULT:", result)

--- a/docs/docs_test/mp_runner.py
+++ b/docs/docs_test/mp_runner.py
@@ -1,0 +1,44 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run_micropython_code(source: str) -> str:
+    """Run source code on MCU and return the output"""
+    # TODO: add option to run against unix port ( webassembly / windows )
+    # TODO: add option to run against specific port / board (e.g. pyboard, esp32, etc)
+    # TODO: Skip if no mpremote / no board detected
+    # TODO: add option to run against simulator (WOKWI)
+    tf = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tf:
+            tf.write(source)
+            tf.close()
+            cmd = ["mpremote", "resume", "run", tf.name]
+            print("Running:", " ".join(cmd))
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return result.stdout
+    except subprocess.CalledProcessError as e:
+        print(f"source: {'-' * 40}\n{source}\n{'-' * 40}")
+        raise Exception(
+            f"mpremote exited with code {e.returncode}, stderr: {e.stderr}, stdout: {e.stdout}"
+        )
+    finally:
+        if tf:
+            Path(tf.name).unlink()
+
+
+def reset_micropython_mcu() -> None:
+    """Reset the MicroPython MCU to clear namespace/state"""
+    try:
+        cmd = ["mpremote", "reset"]
+        print("Running:", " ".join(cmd))
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+        # Give the MCU a moment to restart
+        import time
+
+        time.sleep(0.5)
+    except subprocess.CalledProcessError as e:
+        raise Exception(
+            f"mpremote reset failed with code {e.returncode}, stderr: {e.stderr}, stdout: {e.stdout}"
+        )

--- a/docs/docs_test/mp_runner.py
+++ b/docs/docs_test/mp_runner.py
@@ -9,6 +9,7 @@ def run_micropython_code(source: str) -> str:
     # TODO: add option to run against specific port / board (e.g. pyboard, esp32, etc)
     # TODO: Skip if no mpremote / no board detected
     # TODO: add option to run against simulator (WOKWI)
+    __tracebackhide__ = True  # hide helper details
     tf = None
     try:
         with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tf:
@@ -30,6 +31,7 @@ def run_micropython_code(source: str) -> str:
 
 def reset_micropython_mcu() -> None:
     """Reset the MicroPython MCU to clear namespace/state"""
+    __tracebackhide__ = True  # hide helper details
     try:
         cmd = ["mpremote", "reset"]
         print("Running:", " ".join(cmd))

--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -35,14 +35,18 @@ Tab-completion is useful to find out what methods an object has.
 Paste mode (ctrl-E) is useful to paste a large slab of Python code into
 the REPL.
 
-The :mod:`machine` module::
+The :mod:`machine` module:
+
+.. code-block:: python
 
     import machine
 
     machine.freq()          # get the current frequency of the CPU
     machine.freq(240000000) # set the CPU frequency to 240 MHz
 
-The :mod:`esp` module::
+The :mod:`esp` module:
+
+.. code-block:: python
 
     import esp
 
@@ -56,7 +60,9 @@ The :mod:`esp` module::
     esp.flash_write(byte_offset, buffer)
     esp.flash_read(byte_offset, buffer)
 
-The :mod:`esp32` module::
+The :mod:`esp32` module:
+
+.. code-block:: python
 
     import esp32
 
@@ -69,7 +75,9 @@ by reading the temperature sensor immediately after waking up from sleep.
 
 ESP32C3, ESP32C6, ESP32S2, and ESP32S3 also have an internal temperature sensor available.
 It is implemented a bit differently to the ESP32 and returns the temperature in
-Celsius::
+Celsius:
+
+.. code-block:: python
 
     esp32.mcu_temperature() # read the internal temperature of the MCU, in Celsius
 
@@ -79,7 +87,9 @@ Networking
 WLAN
 ^^^^
 
-The :class:`network.WLAN` class in the :mod:`network` module::
+The :class:`network.WLAN` class in the :mod:`network` module:
+    
+.. code-block:: python
 
     import network
 
@@ -96,7 +106,9 @@ The :class:`network.WLAN` class in the :mod:`network` module::
     ap.config(max_clients=10)             # set how many clients can connect to the network
     ap.active(True)                       # activate the interface
 
-A useful function for connecting to your local WiFi network is::
+A useful function for connecting to your local WiFi network is:
+
+.. code-block:: python
 
     def do_connect():
         import machine, network
@@ -134,9 +146,12 @@ external Ethernet PHY to be wired to the chip's EMAC pins. Most of the EMAC pin
 assignments are fixed, consult the ESP32 datasheet for details.
 
 If the PHY is connected, the internal Ethernet MAC can be configured via
-the :class:`network.LAN` constructor::
+the :class:`network.LAN` constructor:
+
+.. code-block:: python
 
     import network
+    import time
 
     lan = network.LAN(mdc=PIN_MDC, ...)   # Set the pin and mode configuration
     lan.active(True)                      # activate the interface
@@ -170,7 +185,9 @@ Optional keyword arguments:
   ``machine.Pin.OUT``. If not specified, the board default is used
   (typically input, but may be different if a particular board has Ethernet.)
 
-These are working configurations for LAN interfaces of some popular ESP32 boards::
+These are working configurations for LAN interfaces of some popular ESP32 boards:
+
+.. code-block:: python
 
     # Olimex ESP32-GATEWAY: power controlled by Pin(5)
     # Olimex ESP32 PoE and ESP32-PoE ISO: power controlled by Pin(12)
@@ -208,7 +225,9 @@ interfaces that connect via a SPI bus, rather than an Ethernet RMII interface.
      to save code size.
 
 SPI Ethernet uses the same :class:`network.LAN` constructor, with a different
-set of keyword arguments::
+set of keyword arguments:
+
+.. code-block:: python
 
     import machine, network
 
@@ -242,7 +261,9 @@ Optional keyword arguments for the constructor:
   switches the power of the SPI Ethernet interface.
 
 Here is a sample configuration for a WIZNet W5500 chip connected to pins on
-an ESP32-S3 development board::
+an ESP32-S3 development board:
+
+.. code-block:: python
 
     import machine, network
     from machine import Pin, SPI
@@ -258,7 +279,9 @@ an ESP32-S3 development board::
 Delay and timing
 ----------------
 
-Use the :mod:`time <time>` module::
+Use the :mod:`time <time>` module:
+
+.. code-block:: python
 
     import time
 
@@ -274,7 +297,9 @@ Timers
 The ESP32 port has one, two or four hardware timers, depending on the ESP32 device type.
 There is 1 timer for ESP32C2, 2 timers for ESP32C4, ESP32C6 and ESP32H4, and
 4 timers otherwise. Use the :ref:`machine.Timer <machine.Timer>` class
-with a timer ID of 0, 0 and 1, or from 0 to 3 (inclusive)::
+with a timer ID of 0, 0 and 1, or from 0 to 3 (inclusive):
+
+.. code-block:: python
 
     from machine import Timer
 
@@ -298,7 +323,9 @@ Virtual timers are not currently supported on this port.
 Pins and GPIO
 -------------
 
-Use the :ref:`machine.Pin <machine.Pin>` class::
+Use the :ref:`machine.Pin <machine.Pin>` class:
+
+.. code-block:: python
 
     from machine import Pin
 
@@ -355,7 +382,9 @@ using ``on()`` or ``value(1)``.
 UART (serial bus)
 -----------------
 
-See :ref:`machine.UART <machine.UART>`. ::
+See :ref:`machine.UART <machine.UART>`. :
+
+.. code-block:: python
 
     from machine import UART
 
@@ -389,7 +418,9 @@ range from 1Hz to 40MHz but there is a tradeoff; as the base frequency
 `LED Control <https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/peripherals/ledc.html>`_
 for more details.
 
-Use the :ref:`machine.PWM <machine.PWM>` class::
+Use the :ref:`machine.PWM <machine.PWM>` class:
+
+.. code-block:: python
 
     from machine import Pin, PWM, lightsleep
 
@@ -453,7 +484,9 @@ DAC (digital to analog conversion)
 On the ESP32, DAC functionality is available on pins 25, 26.
 On the ESP32S2, DAC functionality is available on pins 17, 18.
 
-Use the DAC::
+Use the DAC:
+
+.. code-block:: python
 
     from machine import DAC, Pin
 
@@ -466,7 +499,9 @@ ADC (analog to digital conversion)
 On the ESP32, ADC functionality is available on pins 32-39 (ADC block 1) and
 pins 0, 2, 4, 12-15 and 25-27 (ADC block 2).
 
-Use the :ref:`machine.ADC <machine.ADC>` class::
+Use the :ref:`machine.ADC <machine.ADC>` class:
+
+.. code-block:: python
 
     from machine import ADC
 
@@ -577,7 +612,9 @@ The ESP32 provides up to 8 pulse counter peripherals depending on the hardware,
 with id 0..7. These can be configured to count rising and/or falling edges on
 any input pin.
 
-Use the :ref:`esp32.PCNT <esp32.PCNT>` class::
+Use the :ref:`esp32.PCNT <esp32.PCNT>` class:
+
+.. code-block:: python
 
     from machine import Pin
     from esp32 import PCNT
@@ -593,7 +630,9 @@ implement quadrature decoding or up/down signal counters.
 
 See the :ref:`machine.Counter <machine.Counter>` and
 :ref:`machine.Encoder <machine.Encoder>` classes for simpler abstractions of
-common pulse counting applications::
+common pulse counting applications:
+
+.. code-block:: python
 
     from machine import Pin, Counter
 
@@ -610,7 +649,9 @@ Software SPI bus
 ----------------
 
 Software SPI (using bit-banging) works on all pins, and is accessed via the
-:ref:`machine.SoftSPI <machine.SoftSPI>` class::
+:ref:`machine.SoftSPI <machine.SoftSPI>` class:
+
+.. code-block:: python
 
     from machine import Pin, SoftSPI
 
@@ -658,7 +699,9 @@ miso   12           19
 =====  ===========  ============
 
 Hardware SPI is accessed via the :ref:`machine.SPI <machine.SPI>` class and
-has the same methods as software SPI above::
+has the same methods as software SPI above:
+
+.. code-block:: python
 
     from machine import Pin, SPI
 
@@ -670,7 +713,9 @@ Software I2C bus
 ----------------
 
 Software I2C (using bit-banging) works on all output-capable pins, and is
-accessed via the :ref:`machine.SoftI2C <machine.SoftI2C>` class::
+accessed via the :ref:`machine.SoftI2C <machine.SoftI2C>` class:
+
+.. code-block:: python
 
     from machine import Pin, SoftI2C
 
@@ -699,7 +744,9 @@ sda    19           26
 =====  ===========  ============
 
 The driver is accessed via the :ref:`machine.I2C <machine.I2C>` class and
-has the same methods as software I2C above::
+has the same methods as software I2C above:
+
+.. code-block:: python
 
     from machine import Pin, I2C
 
@@ -709,7 +756,9 @@ has the same methods as software I2C above::
 I2S bus
 -------
 
-See :ref:`machine.I2S <machine.I2S>`. ::
+See :ref:`machine.I2S <machine.I2S>`. :
+
+.. code-block:: python
 
     from machine import I2S, Pin
 
@@ -727,7 +776,9 @@ ESP32 has two I2S buses with id=0 and id=1
 Real time clock (RTC)
 ---------------------
 
-See :ref:`machine.RTC <machine.RTC>` ::
+See :ref:`machine.RTC <machine.RTC>` :
+
+.. code-block:: python
 
     from machine import RTC
 
@@ -740,7 +791,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
 WDT (Watchdog timer)
 --------------------
 
-See :ref:`machine.WDT <machine.WDT>`. ::
+See :ref:`machine.WDT <machine.WDT>`. :
+
+.. code-block:: python
 
     from machine import WDT
 
@@ -753,7 +806,9 @@ See :ref:`machine.WDT <machine.WDT>`. ::
 Deep-sleep mode
 ---------------
 
-The following code can be used to sleep, wake and check the reset cause::
+The following code can be used to sleep, wake and check the reset cause:
+
+.. code-block:: python
 
     import machine
 
@@ -779,7 +834,9 @@ deep-sleep.
 If the pull resistors are not actively required during deep-sleep and are likely
 to cause current leakage (for example a pull-up resistor is connected to ground
 through a switch), then they should be disabled to save power before entering
-deep-sleep mode::
+deep-sleep mode:
+
+.. code-block:: python
 
     from machine import Pin, deepsleep
 
@@ -796,7 +853,9 @@ deep-sleep if pad hold is enabled with the ``hold=True`` argument to
 
 Non-RTC GPIO pins will be disconnected by default on entering deep-sleep.
 Configuration of non-RTC pins - including output level - can be retained by
-enabling pad hold on the pin and enabling GPIO pad hold during deep-sleep::
+enabling pad hold on the pin and enabling GPIO pad hold during deep-sleep:
+
+.. code-block:: python
 
     from machine import Pin, deepsleep
     import esp32
@@ -816,7 +875,9 @@ sleep. See :ref:`Pins_and_GPIO` above for a further discussion of pad holding.
 SD card
 -------
 
-See :ref:`machine.SDCard <machine.SDCard>`. ::
+See :ref:`machine.SDCard <machine.SDCard>`. :
+
+.. code-block:: python
 
     import machine, os, vfs
 
@@ -832,7 +893,9 @@ RMT
 ---
 
 The RMT is ESP32-specific and allows generation of accurate digital pulses with
-12.5ns resolution.  See :ref:`esp32.RMT <esp32.RMT>` for details.  Usage is::
+12.5ns resolution.  See :ref:`esp32.RMT <esp32.RMT>` for details.  Usage is:
+
+.. code-block:: python
 
     import esp32
     from machine import Pin
@@ -848,7 +911,9 @@ unavailable on those SoCs.
 OneWire driver
 --------------
 
-The OneWire driver is implemented in software and works on all pins::
+The OneWire driver is implemented in software and works on all pins:
+
+.. code-block:: python
 
     from machine import Pin
     import onewire
@@ -861,7 +926,9 @@ The OneWire driver is implemented in software and works on all pins::
     ow.write('123')         # write bytes on the bus
     ow.select_rom(b'12345678') # select a specific device by its ROM code
 
-There is a specific driver for DS18S20 and DS18B20 devices::
+There is a specific driver for DS18S20 and DS18B20 devices:
+
+.. code-block:: python
 
     import time, ds18x20
     ds = ds18x20.DS18X20(ow)
@@ -878,7 +945,9 @@ sample the temperature.
 NeoPixel and APA106 driver
 --------------------------
 
-Use the ``neopixel`` and ``apa106`` modules::
+Use the ``neopixel`` and ``apa106`` modules:
+
+.. code-block:: python
 
     from machine import Pin
     from neopixel import NeoPixel
@@ -890,7 +959,9 @@ Use the ``neopixel`` and ``apa106`` modules::
     r, g, b = np[0]         # get first pixel colour
 
 
-The APA106 driver extends NeoPixel, but internally uses a different colour order::
+The APA106 driver extends NeoPixel, but internally uses a different colour order:
+
+.. code-block:: python
 
     from apa106 import APA106
     ap = APA106(pin, 8)
@@ -912,7 +983,9 @@ Capacitive touch
 ----------------
 
 ESP32, ESP32-S2 and ESP32-S3 support capacitive touch via the ``TouchPad`` class
-in the ``machine`` module::
+in the ``machine`` module:
+
+.. code-block:: python
 
     from machine import TouchPad, Pin
 
@@ -939,7 +1012,9 @@ ESP32-S3  1 to 14 inclusive
 
 Trying to assign to any other pins will result in a ``ValueError``.
 
-Note that TouchPads can be used to wake an ESP32 from sleep::
+Note that TouchPads can be used to wake an ESP32 from sleep:
+
+.. code-block:: python
 
     import machine
     from machine import TouchPad, Pin
@@ -957,7 +1032,9 @@ For more details on touchpads refer to `Espressif Touch Sensor
 DHT driver
 ----------
 
-The DHT driver is implemented in software and works on all pins::
+The DHT driver is implemented in software and works on all pins:
+
+.. code-block:: python
 
     import dht
     import machine
@@ -978,13 +1055,18 @@ WebREPL (web browser interactive prompt)
 WebREPL (REPL over WebSockets, accessible via a web browser) is an
 experimental feature available in ESP32 port. Download web client
 from https://github.com/micropython/webrepl (hosted version available
-at http://micropython.org/webrepl), and configure it by executing::
+at http://micropython.org/webrepl), and configure it by executing:
+
+.. code-block:: python
+
 
     import webrepl_setup
 
 and following on-screen instructions. After reboot, it will be available
 for connection. If you disabled automatic start-up on boot, you may
-run configured daemon on demand using::
+run configured daemon on demand using:
+
+.. code-block:: python
 
     import webrepl
     webrepl.start()

--- a/docs/esp32/tutorial/pwm.rst
+++ b/docs/esp32/tutorial/pwm.rst
@@ -11,7 +11,9 @@ compared with the length of a single period (low plus high time).  Maximum
 duty cycle is when the pin is high all of the time, and minimum is when it is
 low all of the time.
 
-* More comprehensive example with all **16 PWM channels and 8 timers**::
+* More comprehensive example with all **16 PWM channels and 8 timers**:
+
+.. code-block:: python
 
     from time import sleep
     from machine import Pin, PWM
@@ -33,7 +35,7 @@ low all of the time.
             except:
                 pass
 
-  Output is::
+Output is::
 
     PWM(Pin(2), freq=10000, duty_u16=4096)
     PWM(Pin(4), freq=10000, duty_u16=8192)
@@ -53,7 +55,9 @@ low all of the time.
     PWM(Pin(33), freq=80000, duty_u16=65535)
 
 
-* Example of a **smooth frequency change**::
+* Example of a **smooth frequency change**:
+
+.. code-block:: python
 
     from time import sleep
     from machine import Pin, PWM
@@ -81,9 +85,9 @@ low all of the time.
             elif f < F_MIN:
                 f = F_MIN
 
-  See PWM wave on Pin(27) with an oscilloscope.
+See PWM wave on Pin(27) with an oscilloscope.
 
-  Output is::
+Output is::
 
     PWM(Pin(27), freq=998, duty_u16=32768)
     PWM(Pin(27), freq=1202, duty_u16=32768)
@@ -107,6 +111,9 @@ low all of the time.
 
 
 * Example of a **smooth duty change**::
+.. skip: next
+
+.. code-block:: python
 
     from time import sleep
     from machine import Pin, PWM
@@ -138,9 +145,9 @@ low all of the time.
             duty_u16 = 0
             delta_d = -delta_d
 
-  PWM wave on Pin(27) with an oscilloscope.
+PWM wave on Pin(27) with an oscilloscope.
 
-  Output is::
+Output is::
 
     PWM(Pin(27), freq=998, duty_u16=0)
     PWM(Pin(27), freq=998, duty_u16=256)
@@ -166,7 +173,11 @@ low all of the time.
     PWM(Pin(27), freq=998, duty_u16=0)
 
 
-* Example of a **smooth duty change and PWM output inversion**::
+* Example of a **smooth duty change and PWM output inversion**:
+
+.. skip: next
+
+.. code-block:: python
 
     from utime import sleep
     from machine import Pin, PWM
@@ -206,7 +217,7 @@ low all of the time.
         except:
             pass
 
-  Output is::
+Output is::
 
     PWM(Pin(27), freq=5000, duty_u16=0)
     PWM(Pin(32), freq=5000, duty_u16=32768, invert=1)
@@ -224,6 +235,9 @@ low all of the time.
   See PWM waves on Pin(27) and Pin(32) with an oscilloscope.
 
 Note: New PWM parameters take effect in the next PWM cycle.
+.. skip: start
+
+.. code-block:: python
 
     pwm = PWM(2, duty=512)
     print(pwm)
@@ -240,12 +254,17 @@ Note: machine.freq(20_000_000) reduces the highest PWM frequency to 10 MHz.
 Note: the Pin.OUT mode does not need to be specified. The channel is initialized
 to PWM mode internally once for each Pin that is passed to the PWM constructor.
 
-The following code is wrong::
+The following code is wrong:
+
+.. code-block:: python
 
     pwm = PWM(Pin(5, Pin.OUT), freq=1000, duty=512)  # Pin(5) in PWM mode here
     pwm = PWM(Pin(5, Pin.OUT), freq=500, duty=256)  # Pin(5) in OUT mode here, PWM is off
 
-Use this code instead::
+.. skip: end
+Use this code instead:
+
+.. code-block:: python
 
     pwm = PWM(Pin(5), freq=1000, duty=512)
     pwm.init(freq=500, duty=256)

--- a/docs/esp32/tutorial/pwm.rst
+++ b/docs/esp32/tutorial/pwm.rst
@@ -110,7 +110,8 @@ Output is::
     PWM(Pin(27), freq=998, duty_u16=32768)
 
 
-* Example of a **smooth duty change**::
+* Example of a **smooth duty change**:
+
 .. skip: next
 
 .. code-block:: python
@@ -262,6 +263,7 @@ The following code is wrong:
     pwm = PWM(Pin(5, Pin.OUT), freq=500, duty=256)  # Pin(5) in OUT mode here, PWM is off
 
 .. skip: end
+
 Use this code instead:
 
 .. code-block:: python

--- a/docs/esp8266/quickref.rst
+++ b/docs/esp8266/quickref.rst
@@ -191,7 +191,9 @@ PWM can be enabled on all pins except Pin(16).  There is a single frequency
 for all channels, with range between 1 and 1000 (measured in Hz).  The duty
 cycle is between 0 and 1023 inclusive.
 
-Use the ``machine.PWM`` class::
+Use the ``machine.PWM`` class:
+
+.. code-block:: python
 
     from machine import Pin, PWM
 
@@ -222,7 +224,9 @@ Software SPI bus
 
 There are two SPI drivers. One is implemented in software (bit-banging)
 and works on all pins, and is accessed via the :ref:`machine.SoftSPI <machine.SoftSPI>`
-class::
+class:
+
+.. code-block:: python
 
     from machine import Pin, SoftSPI
 
@@ -266,7 +270,9 @@ I2C bus
 
 The I2C driver is implemented in software and works on all pins,
 and is accessed via the :ref:`machine.I2C <machine.I2C>` class (which is an
-alias of :ref:`machine.SoftI2C <machine.SoftI2C>`)::
+alias of :ref:`machine.SoftI2C <machine.SoftI2C>`):
+
+.. code-block:: python
 
     from machine import Pin, I2C
 
@@ -282,7 +288,9 @@ alias of :ref:`machine.SoftI2C <machine.SoftI2C>`)::
 Real time clock (RTC)
 ---------------------
 
-See :ref:`machine.RTC <machine.RTC>` ::
+See :ref:`machine.RTC <machine.RTC>` :
+
+.. code-block:: python
 
     from machine import RTC
 
@@ -305,7 +313,9 @@ See :ref:`machine.RTC <machine.RTC>` ::
 WDT (Watchdog timer)
 --------------------
 
-See :ref:`machine.WDT <machine.WDT>`. ::
+See :ref:`machine.WDT <machine.WDT>`. :
+
+.. code-block:: python
 
     from machine import WDT
 
@@ -317,7 +327,9 @@ Deep-sleep mode
 ---------------
 
 Connect GPIO16 to the reset pin (RST on HUZZAH).  Then the following code
-can be used to sleep, wake and check the reset cause::
+can be used to sleep, wake and check the reset cause:
+
+.. code-block:: python
 
     import machine
 
@@ -338,7 +350,9 @@ can be used to sleep, wake and check the reset cause::
 OneWire driver
 --------------
 
-The OneWire driver is implemented in software and works on all pins::
+The OneWire driver is implemented in software and works on all pins:
+
+.. code-block:: python
 
     from machine import Pin
     import onewire
@@ -351,7 +365,9 @@ The OneWire driver is implemented in software and works on all pins::
     ow.write('123')         # write bytes on the bus
     ow.select_rom(b'12345678') # select a specific device by its ROM code
 
-There is a specific driver for DS18S20 and DS18B20 devices::
+There is a specific driver for DS18S20 and DS18B20 devices:
+
+.. code-block:: python
 
     import time, ds18x20
     ds = ds18x20.DS18X20(ow)
@@ -368,7 +384,9 @@ sample the temperature.
 NeoPixel driver
 ---------------
 
-Use the ``neopixel`` module::
+Use the ``neopixel`` module:
+
+.. code-block:: python
 
     from machine import Pin
     from neopixel import NeoPixel
@@ -390,7 +408,9 @@ For low-level driving of a NeoPixel see `machine.bitstream`.
 APA102 driver
 -------------
 
-Use the ``apa102`` module::
+Use the ``apa102`` module:
+
+.. code-block:: python
 
     from machine import Pin
     from apa102 import APA102
@@ -402,7 +422,9 @@ Use the ``apa102`` module::
     apa.write()                  # write data to all pixels
     r, g, b, brightness = apa[0] # get first pixel colour
 
-For low-level driving of an APA102::
+For low-level driving of an APA102:
+
+.. code-block:: python
 
     import esp
     esp.apa102_write(clock_pin, data_pin, rgbi_buf)
@@ -410,7 +432,9 @@ For low-level driving of an APA102::
 DHT driver
 ----------
 
-The DHT driver is implemented in software and works on all pins::
+The DHT driver is implemented in software and works on all pins:
+
+.. code-block:: python
 
     import dht
     import machine
@@ -428,7 +452,9 @@ The DHT driver is implemented in software and works on all pins::
 SSD1306 driver
 --------------
 
-Driver for SSD1306 monochrome OLED displays. See tutorial :ref:`ssd1306`. ::
+Driver for SSD1306 monochrome OLED displays. See tutorial :ref:`ssd1306`. :
+
+.. code-block:: python
 
     from machine import Pin, I2C
     import ssd1306
@@ -445,13 +471,17 @@ WebREPL (web browser interactive prompt)
 WebREPL (REPL over WebSockets, accessible via a web browser) is an
 experimental feature available in ESP8266 port. Download web client
 from https://github.com/micropython/webrepl (hosted version available
-at http://micropython.org/webrepl), and configure it by executing::
+at http://micropython.org/webrepl), and configure it by executing:
+
+.. code-block:: python
 
     import webrepl_setup
 
 and following on-screen instructions. After reboot, it will be available
 for connection. If you disabled automatic start-up on boot, you may
-run configured daemon on demand using::
+run configured daemon on demand using:
+
+.. code-block:: python
 
     import webrepl
     webrepl.start()

--- a/docs/esp8266/tutorial/adc.rst
+++ b/docs/esp8266/tutorial/adc.rst
@@ -9,6 +9,7 @@ such an ADC pin object using::
     >>> adc = machine.ADC(0)
 
 Then read its value with::
+.. skip: next
 
     >>> adc.read()
     58

--- a/docs/esp8266/tutorial/apa102.rst
+++ b/docs/esp8266/tutorial/apa102.rst
@@ -8,6 +8,7 @@ They can operate at a much higher data and PWM frequencies than NeoPixels and
 are more suitable for persistence-of-vision effects.
 
 To create an APA102 object do the following::
+.. skip: start
 
     >>> import machine, apa102
     >>> strip = apa102.APA102(machine.Pin(5), machine.Pin(4), 60)
@@ -36,7 +37,9 @@ Use the ``write()`` method to output the colours to the LEDs::
 
     >>> strip.write()
 
-Demonstration::
+Demonstration:
+
+.. code-block:: python
 
     import time
     import machine, apa102
@@ -89,3 +92,5 @@ Demonstration::
     # End: Turn off all the LEDs
     strip.fill((0, 0, 0, 0))
     strip.write()
+
+.. skip: end

--- a/docs/esp8266/tutorial/dht.rst
+++ b/docs/esp8266/tutorial/dht.rst
@@ -26,6 +26,7 @@ To use the 1-wire interface, construct the objects referring to their data pin::
     >>> d = dht.DHT22(machine.Pin(4))
 
 Then measure and read their values with::
+.. skip: next
 
     >>> d.measure()
     >>> d.temperature()

--- a/docs/esp8266/tutorial/filesystem.rst
+++ b/docs/esp8266/tutorial/filesystem.rst
@@ -40,6 +40,7 @@ import the module::
     >>> import os
 
 Then try listing the contents of the filesystem::
+.. skip: next
 
     >>> os.listdir()
     ['boot.py', 'port_config.py', 'data.txt']

--- a/docs/esp8266/tutorial/neopixel.rst
+++ b/docs/esp8266/tutorial/neopixel.rst
@@ -40,6 +40,7 @@ Then use the ``write()`` method to output the colours to the LEDs::
 
 The following demo function makes a fancy show on the LEDs::
 
+.. code-block:: python
     import time
 
     def demo(np):
@@ -80,5 +81,5 @@ The following demo function makes a fancy show on the LEDs::
         np.write()
 
 Execute it using::
-
+    >>> np = neopixel.NeoPixel(machine.Pin(4), 8)
     >>> demo(np)

--- a/docs/esp8266/tutorial/neopixel.rst
+++ b/docs/esp8266/tutorial/neopixel.rst
@@ -38,9 +38,10 @@ Then use the ``write()`` method to output the colours to the LEDs::
 
     >>> np.write()
 
-The following demo function makes a fancy show on the LEDs::
+The following demo function makes a fancy show on the LEDs:
 
 .. code-block:: python
+
     import time
 
     def demo(np):

--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -21,6 +21,7 @@ The first thing to do is make sure we have the socket module available::
     >>> import socket
 
 .. skip: start
+
 Then get the IP address of the server::
 
     >>> addr_info = socket.getaddrinfo("towel.blinkenlights.nl", 23)

--- a/docs/esp8266/tutorial/network_tcp.rst
+++ b/docs/esp8266/tutorial/network_tcp.rst
@@ -20,6 +20,7 @@ The first thing to do is make sure we have the socket module available::
 
     >>> import socket
 
+.. skip: start
 Then get the IP address of the server::
 
     >>> addr_info = socket.getaddrinfo("towel.blinkenlights.nl", 23)
@@ -50,6 +51,7 @@ interrupt it).
 
 You should also be able to run this same code on your PC using normal Python if
 you want to try it out there.
+.. skip: end
 
 HTTP GET request
 ----------------
@@ -58,7 +60,9 @@ The next example shows how to download a webpage.  HTTP uses port 80 and you
 first need to send a "GET" request before you can download anything.  As part
 of the request you need to specify the page to retrieve.
 
-Let's define a function that can download and print a URL::
+Let's define a function that can download and print a URL:
+
+.. code-block:: python
 
     def http_get(url):
         import socket
@@ -76,6 +80,7 @@ Let's define a function that can download and print a URL::
         s.close()
 
 Then you can try::
+.. skip: start
 
     >>> http_get('http://micropython.org/ks/test.html')
 
@@ -85,7 +90,9 @@ Simple HTTP server
 ------------------
 
 The following code creates an simple HTTP server which serves a single webpage
-that contains a table with the state of all the GPIO pins::
+that contains a table with the state of all the GPIO pins:
+
+.. code-block:: python
 
     import machine
     pins = [machine.Pin(i, machine.Pin.IN) for i in (0, 2, 4, 5, 12, 13, 14, 15)]
@@ -121,3 +128,5 @@ that contains a table with the state of all the GPIO pins::
         cl.send('HTTP/1.0 200 OK\r\nContent-type: text/html\r\n\r\n')
         cl.send(response)
         cl.close()
+
+.. skip: end

--- a/docs/esp8266/tutorial/pins.rst
+++ b/docs/esp8266/tutorial/pins.rst
@@ -22,7 +22,7 @@ has no pull-up mode.
 You can read the value on the pin using::
 
     >>> pin.value()
-    0
+    1
 
 The pin on your board may return 0 or 1 here, depending on what it's connected
 to.  To make an output pin use::

--- a/docs/esp8266/tutorial/pwm.rst
+++ b/docs/esp8266/tutorial/pwm.rst
@@ -30,6 +30,7 @@ You can set the frequency and duty cycle using::
 Note that the duty cycle is between 0 (all off) and 1023 (all on), with 512
 being a 50% duty. Values beyond this min/max will be clipped. If you
 print the PWM object then it will tell you its current configuration::
+.. skip: next
 
     >>> pwm12
     PWM(12, freq=500, duty=512)

--- a/docs/esp8266/tutorial/repl.rst
+++ b/docs/esp8266/tutorial/repl.rst
@@ -159,6 +159,7 @@ ignored.)
 The function you just defined allows you to toggle a pin.  The pin object you
 created earlier should still exist (recreate it if it doesn't) and you can
 toggle the LED using::
+.. skip: start
 
     >>> toggle(pin)
 
@@ -173,6 +174,8 @@ print some text instead of calling toggle, to see the effect)::
     ...    
     ...    
     >>>
+
+.. skip: end
 
 This will toggle the LED at 1Hz (half a second on, half a second off).  To stop
 the toggling press ctrl-C, which will raise a KeyboardInterrupt exception and

--- a/docs/library/deflate.rst
+++ b/docs/library/deflate.rst
@@ -81,6 +81,7 @@ Examples
 A typical use case for :class:`deflate.DeflateIO` is to read or write a compressed
 file from storage:
 
+.. skip: begin
 .. code:: python
 
    import deflate
@@ -134,6 +135,7 @@ to turn it into a stream suitable for use with :class:`deflate.DeflateIO`:
        d.write(uncompressed_data)
    compressed_data = stream.getvalue()
 
+.. skip: end
 .. _deflate_wbits:
 
 Deflate window size

--- a/docs/library/errno.rst
+++ b/docs/library/errno.rst
@@ -17,7 +17,9 @@ Constants
     Error codes, based on ANSI C/POSIX standard. All error codes start with
     "E". As mentioned above, inventory of the codes depends on
     :term:`MicroPython port`. Errors are usually accessible as ``exc.errno``
-    where ``exc`` is an instance of `OSError`. Usage example::
+    where ``exc`` is an instance of `OSError`. Usage example:
+
+    .. code-block:: python
 
         try:
             os.mkdir("my_dir")
@@ -30,5 +32,6 @@ Constants
     Dictionary mapping numeric error codes to strings with symbolic error
     code (see above)::
 
+        >>> import errno
         >>> print(errno.errorcode[errno.EEXIST])
         EEXIST

--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -41,7 +41,9 @@ Methods
 
 .. method:: Timer.init(*, mode=Timer.PERIODIC, freq=-1, period=-1, callback=None, hard=True)
 
-   Initialise the timer. Example::
+   Initialise the timer. Example:
+
+    .. code-block:: python
 
        def mycallback(t):
            pass

--- a/docs/library/pyb.Timer.rst
+++ b/docs/library/pyb.Timer.rst
@@ -13,20 +13,26 @@ timer prescaler.  When the counter reaches the timer period it triggers an
 event, and the counter resets back to zero.  By using the callback method,
 the timer event can call a Python function.
 
-Example usage to toggle an LED at a fixed frequency::
+Example usage to toggle an LED at a fixed frequency:
+
+.. code-block:: python
 
     tim = pyb.Timer(4)              # create a timer object using timer 4
     tim.init(freq=2)                # trigger at 2Hz
     tim.callback(lambda t:pyb.LED(1).toggle())
 
-Example using named function for the callback::
+Example using named function for the callback:
+
+.. code-block:: python
 
     def tick(timer):                # we will receive the timer object when being called
         print(timer.counter())      # show current timer's counter value
     tim = pyb.Timer(4, freq=1)      # create a timer object using timer 4 - trigger at 1Hz
     tim.callback(tick)              # set the callback to our tick function
 
-Further examples::
+Further examples:
+
+.. code-block:: python
 
     tim = pyb.Timer(4, freq=100)    # freq in Hz
     tim = pyb.Timer(4, prescaler=0, period=99)
@@ -65,7 +71,9 @@ Methods
 .. method:: Timer.init(*, freq, prescaler, period, mode=Timer.UP, div=1, callback=None, deadtime=0, brk=Timer.BRK_OFF, hard=True)
 
    Initialise the timer.  Initialisation must be either by frequency (in Hz)
-   or by prescaler and period::
+   or by prescaler and period:
+
+    .. code-block:: python
 
        tim.init(freq=100)                  # set the timer to trigger at 100Hz
        tim.init(prescaler=83, period=999)  # set the prescaler and period directly

--- a/docs/pyboard/tutorial/accel.rst
+++ b/docs/pyboard/tutorial/accel.rst
@@ -3,6 +3,10 @@ The accelerometer
 
 Here you will learn how to read the accelerometer and signal using LEDs states like tilt left and tilt right.
 
+.. invisible-code-block: python
+
+    import pyb
+
 Using the accelerometer
 -----------------------
 
@@ -13,7 +17,6 @@ pyb.Accel() object and then call the x() method. ::
 
     >>> accel = pyb.Accel()
     >>> accel.x()
-    7
 
 This returns a signed integer with a value between around -30 and 30. Note that
 the measurement is very noisy, this means that even if you keep the board

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -17,6 +17,12 @@ The following video shows how to solder the headers, microphone and speaker onto
 
     <iframe style="margin-left:3em;" width="560" height="315" src="http://www.youtube.com/embed/fjB1DuZRveo?rel=0" frameborder="0" allowfullscreen></iframe>
 
+.. invisible-code-block:: python
+
+    import pyb
+    def volume(val):
+        pass
+
 For circuit schematics and datasheets for the components on the skin see :ref:`hardware_index`.
 
 Example code
@@ -26,11 +32,14 @@ The AMP skin has a speaker which is connected to ``DAC(1)`` via a small
 power amplifier.  The volume of the amplifier is controlled by a digital
 potentiometer, which is an I2C device with address 46 on the ``IC2(1)`` bus.
 
-To set the volume, define the following function::
+To set the volume, define the following function:
+.. skip: next
+.. code-block:: python
 
     import pyb
     def volume(val):
         pyb.I2C(1, pyb.I2C.CONTROLLER).mem_write(val, 46, 0)
+
 
 Then you can do::
 
@@ -38,7 +47,9 @@ Then you can do::
     >>> volume(127) # maximum volume
 
 To play a sound, use the ``write_timed`` method of the ``DAC`` object.
-For example::
+For example:
+
+.. code-block:: python
 
     import math
     from pyb import DAC
@@ -75,7 +86,9 @@ so it has to be small enough to fit in it.
 To play larger wave files you will have to use the micro-SD card to store it.
 Also the file must be read and sent to the DAC in small chunks that will fit
 the RAM limit of the microcontroller.  Here is an example function that can
-play 8-bit wave files with up to 16kHz sampling::
+play 8-bit wave files with up to 16kHz sampling:
+
+.. code-block:: python
 
     import wave
     from pyb import DAC

--- a/docs/pyboard/tutorial/amp_skin.rst
+++ b/docs/pyboard/tutorial/amp_skin.rst
@@ -17,11 +17,6 @@ The following video shows how to solder the headers, microphone and speaker onto
 
     <iframe style="margin-left:3em;" width="560" height="315" src="http://www.youtube.com/embed/fjB1DuZRveo?rel=0" frameborder="0" allowfullscreen></iframe>
 
-.. invisible-code-block:: python
-
-    import pyb
-    def volume(val):
-        pass
 
 For circuit schematics and datasheets for the components on the skin see :ref:`hardware_index`.
 
@@ -33,7 +28,17 @@ power amplifier.  The volume of the amplifier is controlled by a digital
 potentiometer, which is an I2C device with address 46 on the ``IC2(1)`` bus.
 
 To set the volume, define the following function:
+
+.. invisible-code-block: python
+
+    import pyb
+    def volume(val):
+        # mock implementation for docs test
+        pass
+
+
 .. skip: next
+
 .. code-block:: python
 
     import pyb

--- a/docs/pyboard/tutorial/lcd160cr_skin.rst
+++ b/docs/pyboard/tutorial/lcd160cr_skin.rst
@@ -45,6 +45,7 @@ LCD.  This test program is available on GitHub
 Copy it to the board over USB mass storage, or by using :ref:`mpremote`.
 
 To run the test from the MicroPython prompt do::
+.. skip: start
 
     >>> import lcd160cr_test
 
@@ -74,7 +75,9 @@ To erase the screen and draw a line, try::
 
 The next example draws random rectangles on the screen.  You can copy-and-paste it
 into the MicroPython prompt by first pressing "Ctrl-E" at the prompt, then "Ctrl-D"
-once you have pasted the text. ::
+once you have pasted the text. :
+
+.. code-block:: python
 
     from random import randint
     for i in range(1000):
@@ -132,3 +135,5 @@ is for the display to have power, ground and the power/enable pin driven high.
 Then any characters on the display's UART input will be printed to the screen.
 You can adjust the UART baudrate from the default of 115200 using the
 `set_uart_baudrate` method.
+
+.. skip: end

--- a/docs/pyboard/tutorial/lcd_skin.rst
+++ b/docs/pyboard/tutorial/lcd_skin.rst
@@ -31,7 +31,9 @@ Make sure the LCD skin is attached to the pyboard as pictured at the top of this
     >>> lcd.light(True)
     >>> lcd.write('Hello uPy!\n')
 
-You can make a simple animation using the code::
+You can make a simple animation using the code:
+
+.. code-block:: python
 
     import pyb
     lcd = pyb.LCD('X')
@@ -44,11 +46,11 @@ You can make a simple animation using the code::
 
 Using the touch sensor
 ----------------------
-
 To read the touch-sensor data you need to use the I2C bus.  The
 MPR121 capacitive touch sensor has address 90.
 
 To get started, try::
+.. skip: start
 
     >>> import pyb
     >>> i2c = pyb.I2C(1, pyb.I2C.CONTROLLER)
@@ -84,3 +86,5 @@ initialise the I2C bus using::
 
 There is also a demo which uses the LCD and the touch sensors together,
 and can be found `here <http://micropython.org/resources/examples/lcddemo.py>`__.
+
+.. skip: end

--- a/docs/pyboard/tutorial/servo.rst
+++ b/docs/pyboard/tutorial/servo.rst
@@ -32,6 +32,7 @@ Creating a Servo object
 Plug in a servo to position 1 (the one with pin X1) and create a servo object
 using::
 
+    >>> import pyb
     >>> servo1 = pyb.Servo(1)
 
 To change the angle of the servo use the ``angle`` method::
@@ -42,6 +43,7 @@ To change the angle of the servo use the ``angle`` method::
 The angle here is measured in degrees, and ranges from about -90 to +90,
 depending on the motor.  Calling ``angle`` without parameters will return
 the current angle::
+
 
     >>> servo1.angle()
     -60
@@ -61,6 +63,7 @@ to the desired angle, and stop when it gets there.  You can use this feature
 as a speed control, or to synchronise 2 or more servo motors.  If we have
 another servo motor (``servo2 = pyb.Servo(2)``) then we can do ::
 
+    >>> servo2 = pyb.Servo(2)
     >>> servo1.angle(-45, 2000); servo2.angle(60, 2000)
 
 This will move the servos together, making them both take 2 seconds to
@@ -100,6 +103,7 @@ called ``speed`` which sets the speed::
 
 ``speed`` has the same functionality as ``angle``: you can get the speed,
 set it, and set it with a time to reach the final speed. ::
+.. skip: start
 
     >>> servo1.speed()
     30
@@ -144,3 +148,5 @@ You can recalibrate the servo (change its default values) by using::
 
 Of course, you would change the above values to suit your particular
 servo motor.
+
+.. skip: end

--- a/docs/pyboard/tutorial/servo.rst
+++ b/docs/pyboard/tutorial/servo.rst
@@ -44,6 +44,7 @@ The angle here is measured in degrees, and ranges from about -90 to +90,
 depending on the motor.  Calling ``angle`` without parameters will return
 the current angle::
 
+.. skip: next
 
     >>> servo1.angle()
     -60

--- a/docs/pyboard/tutorial/timer.rst
+++ b/docs/pyboard/tutorial/timer.rst
@@ -10,6 +10,7 @@ Avoid using these timers if possible.
 
 Let's create a timer object::
 
+    >>> import pyb
     >>> tim = pyb.Timer(4)
 
 Now let's see what we just created::
@@ -24,6 +25,8 @@ it's not yet initialised.  So let's initialise it to trigger at 10 Hz
     >>> tim.init(freq=10)
 
 Now that it's initialised, we can see some information about the timer::
+
+.. skip: start
 
     >>> tim
     Timer(4, prescaler=624, period=13439, mode=UP, div=1)
@@ -45,6 +48,8 @@ current value of its counter::
     21504
 
 This counter will continuously change, and counts up.
+
+.. skip: end
 
 Timer callbacks
 ---------------

--- a/docs/pyboard/tutorial/usb_mouse.rst
+++ b/docs/pyboard/tutorial/usb_mouse.rst
@@ -6,7 +6,9 @@ of the default USB flash drive.
 
 To do this we must first edit the ``boot.py`` file to change the USB
 configuration.  If you have not yet touched your ``boot.py`` file then it
-will look something like this::
+will look something like this:
+
+.. code-block:: python
 
     # boot.py -- run on boot to configure USB and filesystem
     # Put app code in main.py
@@ -17,12 +19,16 @@ will look something like this::
     #pyb.usb_mode('VCP+HID') # act as a serial device and a mouse
 
 To enable the mouse mode, uncomment the last line of the file, to
-make it look like::
+make it look like:
+
+.. code-block:: python
 
     pyb.usb_mode('VCP+HID') # act as a serial device and a mouse
 
 If you already changed your ``boot.py`` file, then the minimum code it
-needs to work is::
+needs to work is:
+
+.. code-block:: python
 
     import pyb
     pyb.usb_mode('VCP+HID')
@@ -41,6 +47,8 @@ To get the py-mouse to do anything we need to send mouse events to the PC.
 We will first do this manually using the REPL prompt.  Connect to your
 pyboard using your serial program and type the following (no need to type
 the ``#`` and text following it)::
+
+.. skip: start
 
     >>> hid = pyb.USB_HID()
     >>> hid.send((0, 100, 0, 0)) # (button status, x-direction, y-direction, scroll)
@@ -96,7 +104,9 @@ to the filesystem (the USB drive should appear), and you can edit ``main.py``.
 (Leave ``boot.py`` as-is, because we still want to go back to HID-mode after
 we finish editing ``main.py``.)
 
-In ``main.py`` put the following code::
+In ``main.py`` put the following code:
+
+.. code-block:: python
 
     import pyb
 
@@ -130,3 +140,4 @@ In the ``boot.py`` file, comment out (put a # in front of) the line with the
 
 Save your file, eject/unmount the drive, and reset the pyboard.  It is now
 back to normal operating mode.
+.. skip: end

--- a/docs/reference/mpyfiles.rst
+++ b/docs/reference/mpyfiles.rst
@@ -52,7 +52,9 @@ code) will raise ``ValueError('incompatible .mpy arch')``.
 If importing an .mpy file fails then try the following:
 
 * Determine the .mpy version and flags supported by your MicroPython system
-  by executing::
+  by executing:
+
+.. code-block:: python
 
     import sys
     sys_mpy = sys.implementation._mpy

--- a/docs/reference/repl.rst
+++ b/docs/reference/repl.rst
@@ -84,6 +84,7 @@ Interrupting a running program
 You can interrupt a running program by pressing Ctrl-C. This will raise a KeyboardInterrupt
 which will bring you back to the REPL, providing your program doesn't intercept the
 KeyboardInterrupt exception.
+.. skip: start
 
 For example:
 
@@ -142,6 +143,7 @@ the auto-indent feature, and changes the prompt from ``>>>`` to ``===``. For exa
 
 Paste Mode allows blank lines to be pasted. The pasted text is compiled as if
 it were a file. Pressing Ctrl-D exits paste mode and initiates the compilation.
+.. skip: end
 
 .. _repl_soft_reset:
 

--- a/docs/requirements-docs-test.txt
+++ b/docs/requirements-docs-test.txt
@@ -1,0 +1,7 @@
+# requirements for the documentation tests
+# TODO: Move to pyproject.toml ( uv pip install) 
+
+-r requirements.txt
+
+mpremote>=1.26.1
+sybil[pytest]

--- a/docs/wipy/general.rst
+++ b/docs/wipy/general.rst
@@ -96,6 +96,7 @@ inside ``/flash/sys/`` because it's actually saved bypassing the user file syste
 ends up inside the internal **hidden** file system, but rest assured that it was successfully
 transferred, and it has been signed with a MD5 checksum to verify its integrity. Now, reset
 the WiPy by pressing the switch on the board, or by typing::
+.. skip: next
 
     >>> import machine
     >>> machine.reset()
@@ -110,6 +111,7 @@ read the **release notes** before.
    needed for the Over The Air update.
 
 In order to check your software version, do::
+.. skip: next
 
    >>> import os
    >>> os.uname().release
@@ -250,11 +252,11 @@ default this is the peripheral that is used when constructing an I2C instance.
 The default pins are GP23 for SCL and GP13 for SDA, and one can create the
 default I2C peripheral simply by doing::
 
-    i2c = machine.I2C()
+    >>> i2c = machine.I2C()
 
 The pins and frequency can be specified as::
 
-    i2c = machine.I2C(freq=400000, scl='GP23', sda='GP13')
+    >>> i2c = machine.I2C(freq=400000, scl='GP23', sda='GP13')
 
 Only certain pins can be used as SCL/SDA.  Please refer to the pinout for further
 information.
@@ -266,7 +268,9 @@ Incompatible way to create SSL sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SSL sockets need to be created the following way before wrapping them with.
-``ssl.wrap_socket``::
+``ssl.wrap_socket``:
+
+.. code-block:: python
 
   import socket
   import ssl
@@ -288,7 +292,9 @@ FTP server, and they must be placed in specific paths with specific names.
 
 For instance to connect to the Blynk servers using certificates, take the file ``ca.pem`` located
 in the `blynk examples folder <https://github.com/wipy/wipy/tree/master/examples/blynk>`_.
-and put it in '/flash/cert/'. Then do::
+and put it in '/flash/cert/'. Then do:
+
+.. code-block:: python
 
   import socket
   import ssl
@@ -308,7 +314,9 @@ to be given, an initial chunk of ``data`` must be passed as well. **When using t
 care must be taken to make sure that the length of all intermediate chunks (including the
 initial one) is a multiple of 4 bytes.** The last chunk may be of any length.
 
-Example::
+Example:
+
+.. code-block:: python
 
    hash = hashlib.sha1('abcd1234', 1001)    # length of the initial piece is multiple of 4 bytes
    hash.update('1234')                       # also multiple of 4 bytes
@@ -333,7 +341,9 @@ The ``Server`` class controls the behaviour and the configuration of the FTP and
 services running on the WiPy. Any changes performed using this class' methods will
 affect both.
 
-Example::
+Example:
+
+.. code-block:: python
 
     import network
     server = network.Server()

--- a/docs/zephyr/tutorial/repl.rst
+++ b/docs/zephyr/tutorial/repl.rst
@@ -59,11 +59,11 @@ example::
 
 If your board has an LED, you can blink it using the following code::
 
-        >>>import time
-        >>>from machine import Pin
+        >>> import time
+        >>> from machine import Pin
 
-        >>>LED = Pin(("GPIO_1", 21), Pin.OUT)
-        >>>while True:
+        >>> LED = Pin(("GPIO_1", 21), Pin.OUT)
+        >>> while True:
         ...    LED.value(1)
         ...    time.sleep(0.5)
         ...    LED.value(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,15 @@ mccabe.max-complexity = 40
 #   repl_: not real python files
 #   viper_args: uses f(*)
 exclude = ["tests/basics/*.py", "tests/*/repl_*.py", "tests/micropython/viper_args.py"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+python_functions = ["test_", "*_test"]
+python_files = ["test_*.py", "*_test.py"]
+addopts = "-p no:doctest"
+testpaths = [
+    "docs",
+    ]
+
+junit_family = "xunit1"
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,10 @@ addopts = "-p no:doctest"
 testpaths = [
     "docs",
     ]
-
+norecursedirs = [
+    ".*",
+    "extmod",
+    "lib"
+]
 junit_family = "xunit1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,17 @@ minversion = "7.0"
 python_functions = ["test_", "*_test"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = "-p no:doctest"
+#  -q --tb=line
 testpaths = [
     "docs",
     ]
 norecursedirs = [
     ".*",
     "extmod",
-    "lib"
+    "lib",
+    "docs/docs_test",
+    "docs/conf.py",
+    "docs/conftest.py",
 ]
 junit_family = "xunit1"
 


### PR DESCRIPTION
### Overview
This DRAFT PR introduces a testing framework for validating scripts and code snippets embedded within our documentation RST files, ensuring that all code examples remain functional and accurate.

The framework leverages pytest, the Sybil library and mpremote to parse and execute code blocks, providing immediate feedback on any discrepancies or errors found in the examples. 

The [sybil](https://sybil.readthedocs.io/) framework offers : 
 - parsers for different documentation formats (like reStructuredText, and MarkDown)
 - can capture : 
    - doctest-style code blocks
    - standard python code blocks, 
    - and invisible code blocks
 - evaluators for different code types (like Python, Shell, etc.)
 - options to skip certain code blocks that are not meant to be executed, such as those requiring user interaction or external dependencies.

In order to validate MicroPython code snippets, we use `mpremote` to run the code on a connected MicroPython device.
For this, custom parsers and evaluators are implemented to handle the specific requirements of our documentation.

pytest is used as the test runner.


### High-Level Goals
- [x] Implement automated testing for scripts and code snippets in `.rst` documentation files
- [x] Ensure documentation examples are executable and produce expected results
- [x] allow local verification by running pytest to validate documentation examples by running them on an attached MicroPython device
- [ ] Integrate with CI/CD pipelines for continuous validation of documentation ( based on unix / webassembly / wokwi integration)
- [ ] Prevent broken or outdated code examples from being published in documentation

### Additions & Improvements Needed

- [ ] update docs to use the `.. code-block:: python` directive for code snippets
- [ ] clean up & simplify AI-spaghetti-code in the implementation
- [ ] avoid running never ending code blocks  `while True: pass`
- [ ] run port specific code blocks on the correct port ( currently all run on the same port)
- [ ] allow configuration of skip/fail if port not avaialble
- [ ] find a way for unix port to run multiple code blocks without resetting the state ( unix port will each code block runs in a new session)
- [ ] Set up CI/CD integration for automated documentation testing
- [ ] add reporting and logging for test results
- [ ] clean up the logging of errors ( currently too verbose)

#### Enhancements
- [ ] Create detailed error reporting for failed snippet tests
- [ ] Generate coverage reports for documentation examples
- [ ] move requirements to pyproject.toml ( requires uv ) 
- [ ] Fuzzy number matching using [DocTestParser(optionflags=NUMBER)])

    
#### Documentation
- [ ] Add documentaion on the setup 
- [ ] Document skip/ignore directives for code blocks
- [ ] Add examples of testable vs non-testable code snippets
- [ ] Create troubleshooting guide for common issues

#### Testing
- [ ] Write unit tests for parser and test runner components

### Trade-offs and Alternatives
- **Sybil vs Custom Parser**: Sybil was chosen for its simplicity and effectiveness in parsing documentation. A custom parser could offer more control but would require significant development effort.
- **pytest vs unittest**: pytest was selected for its ease of use and rich feature set. Unittest could be used for a more  traditional approach.
