### PR TITLE
unix/make: Allow out-of-tree test.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -26,6 +26,9 @@ FROZEN_MANIFEST ?= variants/manifest.py
 # This should be configured by the mpconfigvariant.mk
 PROG ?= micropython
 
+# For use in test rules below
+ABS_PROG = $(abspath $(BUILD)/$(PROG))
+
 # qstr definitions (must come before including py.mk)
 QSTR_DEFS += qstrdefsport.h
 QSTR_GLOBAL_DEPENDENCIES += $(VARIANT_DIR)/mpconfigvariant.h
@@ -257,16 +260,13 @@ include $(TOP)/py/mkrules.mk
 .PHONY: test test_full_no_native test_full test//% test/% test-failures print-failures clean-failures
 
 test: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py
 
 test//%: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -i "$*"
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py -i "$*"
 
 test-failures: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --run-failures
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py --run-failures
 
 print-failures:
 	cd $(TOP)/tests && ./run-tests.py --print-failures
@@ -275,18 +275,15 @@ clean-failures:
 	cd $(TOP)/tests && ./run-tests.py --clean-failures
 
 test/%: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py -d "$*"
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py -d "$*"
 
 test_full_no_native: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py test
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS)
-	cat $(TOP)/tests/basics/0prelim.py | ./$(BUILD)/$(PROG) | grep -q 'abc'
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS)
+	cat $(TOP)/tests/basics/0prelim.py | $(ABS_PROG) | grep -q 'abc'
 
 test_full: $(BUILD)/$(PROG) $(TOP)/tests/run-tests.py test_full_no_native
-	$(eval DIRNAME=ports/$(notdir $(CURDIR)))
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --emit native
-	cd $(TOP)/tests && MICROPY_MICROPYTHON=../$(DIRNAME)/$(BUILD)/$(PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py --emit native
+	cd $(TOP)/tests && MICROPY_MICROPYTHON=$(ABS_PROG) ./run-tests.py --via-mpy $(RUN_TESTS_MPY_CROSS_FLAGS) --emit native
 
 test_gcov: test_full
 	gcov -o $(BUILD)/py $(TOP)/py/*.c


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This allows running test with out-of-tree build like:

```sh
$ make -C ports/unix/ BUILD=/tmp/aaa MICROPY_MPYCROSS=~/bin/mpy-cross test
```

Having output folder out of source tree not only allows us to build and test variants in parallel, but also to ease integratoin with systems using cmake (e.g. NuttX).

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Local test on Ubuntu 22.04 with following variants:

- Coverage: 1042 tests passed 20 tests skipped
- Standard:  1006 tests passed 56 tests skipped
- Longlong: 934 tests passed 128 tests skipped
- Nanbox: 953 tests passed 109 tests skipped
- Minimal: 465 tests performed 351 tests passed 482 tests skipped
