### PR TITLE
MP_STATIC_ASSERT: Use _Static_assert or c++ static_assert

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -218,7 +218,7 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6

--- a/py/misc.h
+++ b/py/misc.h
@@ -79,6 +79,9 @@ typedef unsigned int uint;
 #if defined(_MSC_VER) || defined(__cplusplus)
 #define MP_STATIC_ASSERT_NONCONSTEXPR(cond) ((void)1)
 #else
+#if __clang__
+#pragma GCC diagnostic ignored "-Wgnu-folding-constant"
+#endif
 #define MP_STATIC_ASSERT_NONCONSTEXPR(cond) ((void)sizeof(char[1 - 2 * !(cond)]))
 #endif
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -63,7 +63,14 @@ typedef unsigned int uint;
 #define MP_STRINGIFY(x) MP_STRINGIFY_HELPER(x)
 
 // Static assertion macro
+#if __cplusplus
+#define MP_STATIC_ASSERT(cond) static_assert((cond), #cond)
+#elif __GNUC__ >= 5 || __STDC_VERSION__ >= 201112L
+#define MP_STATIC_ASSERT(cond) _Static_assert((cond), #cond)
+#else
 #define MP_STATIC_ASSERT(cond) ((void)sizeof(char[1 - 2 * !(cond)]))
+#endif
+
 // In C++ things like comparing extern const pointers are not constant-expressions so cannot be used
 // in MP_STATIC_ASSERT. Note that not all possible compiler versions will reject this. Some gcc versions
 // do, others only with -Werror=vla, msvc always does.
@@ -72,7 +79,7 @@ typedef unsigned int uint;
 #if defined(_MSC_VER) || defined(__cplusplus)
 #define MP_STATIC_ASSERT_NONCONSTEXPR(cond) ((void)1)
 #else
-#define MP_STATIC_ASSERT_NONCONSTEXPR(cond) MP_STATIC_ASSERT(cond)
+#define MP_STATIC_ASSERT_NONCONSTEXPR(cond) ((void)sizeof(char[1 - 2 * !(cond)]))
 #endif
 
 // Round-up integer division


### PR DESCRIPTION
### Summary

When _Static_assert can be used, the diagnostic quality is improved:
```
../py/objint.c: In function ‘mp_obj_int_make_new’:
../py/misc.h:67:32: error: static assertion failed: "37 == 42"
../py/objint.c:45:5: note: in expansion of macro ‘MP_STATIC_ASSERT’
```

As compared to a diagnostic about
```
../py/misc.h:71:50: error: size of unnamed array is negative
```

Related: #18116

### Testing

I built the unix coverage build locally. Since this is a compile-time only test, CI will be a good test.

### Trade-offs and Alternatives

Testing on godbolt indicated that this actually works back to gcc 4.5, but it's easier to use GNUC >= 5 as the test; Hypothetical users of 4.5, 4.6, or 4.7 will just get slightly worse diagnostics.

For "nonconstant" static asserts, the array trick still needs to be used; _Static_assert rejects these expressions just like C++ static_assert does.