### PR TITLE
makemoduledefs: Avoid empty module lists.

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -79,7 +79,9 @@ static void mp_help_print_modules(void) {
     mp_obj_t list = mp_obj_new_list(0, NULL);
 
     mp_help_add_from_map(list, &mp_builtin_module_map);
+    #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
     mp_help_add_from_map(list, &mp_builtin_extensible_module_map);
+    #endif
 
     #if MICROPY_MODULE_FROZEN
     extern const char mp_frozen_names[];

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -403,6 +403,7 @@ static mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
         // all the locations in sys.path.
         stat = stat_top_level(level_mod_name, &path);
 
+        #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
         // If filesystem failed, now try and see if it matches an extensible
         // built-in module.
         if (stat == MP_IMPORT_STAT_NO_EXIST) {
@@ -411,6 +412,7 @@ static mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
                 return module_obj;
             }
         }
+        #endif
     } else {
         DEBUG_printf("Searching for sub-module\n");
 
@@ -646,11 +648,13 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }
+    #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
     // Now try as an extensible built-in (e.g. `time`).
     module_obj = mp_module_get_builtin(module_name_qstr, true);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }
+    #endif
 
     // Couldn't find the module, so fail
     #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE

--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -394,7 +394,7 @@ static mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
         // An import of a non-extensible built-in will always bypass the
         // filesystem. e.g. `import micropython` or `import pyb`. So try and
         // match a non-extensible built-ins first.
-        module_obj = mp_module_get_builtin(level_mod_name, false);
+        module_obj = mp_module_get_builtin(level_mod_name);
         if (module_obj != MP_OBJ_NULL) {
             return module_obj;
         }
@@ -407,7 +407,7 @@ static mp_obj_t process_import_at_level(qstr full_mod_name, qstr level_mod_name,
         // If filesystem failed, now try and see if it matches an extensible
         // built-in module.
         if (stat == MP_IMPORT_STAT_NO_EXIST) {
-            module_obj = mp_module_get_builtin(level_mod_name, true);
+            module_obj = mp_module_get_builtin_extensible(level_mod_name);
             if (module_obj != MP_OBJ_NULL) {
                 return module_obj;
             }
@@ -644,13 +644,13 @@ mp_obj_t mp_builtin___import___default(size_t n_args, const mp_obj_t *args) {
 
     // Try the name directly as a non-extensible built-in (e.g. `micropython`).
     qstr module_name_qstr = mp_obj_str_get_qstr(args[0]);
-    mp_obj_t module_obj = mp_module_get_builtin(module_name_qstr, false);
+    mp_obj_t module_obj = mp_module_get_builtin(module_name_qstr);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }
     #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
     // Now try as an extensible built-in (e.g. `time`).
-    module_obj = mp_module_get_builtin(module_name_qstr, true);
+    module_obj = mp_module_get_builtin_extensible(module_name_qstr);
     if (module_obj != MP_OBJ_NULL) {
         return module_obj;
     }

--- a/py/makemoduledefs.py
+++ b/py/makemoduledefs.py
@@ -85,19 +85,25 @@ def generate_module_table_header(modules):
             )
         )
 
+    # There should always be at least one module (__main__ in runtime.c)
+    assert mod_defs
+
     print("\n#define MICROPY_REGISTERED_MODULES \\")
 
     for mod_def in sorted(mod_defs):
         print("    {mod_def} \\".format(mod_def=mod_def))
-
     print("// MICROPY_REGISTERED_MODULES")
 
-    print("\n#define MICROPY_REGISTERED_EXTENSIBLE_MODULES \\")
+    # There are not necessarily any extensible modules (e.g., bare-arm or minimal x86)
+    print("\n#define MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES ", len(extensible_mod_defs))
 
-    for mod_def in sorted(extensible_mod_defs):
-        print("    {mod_def} \\".format(mod_def=mod_def))
+    if extensible_mod_defs:
+        print("\n#define MICROPY_REGISTERED_EXTENSIBLE_MODULES \\")
 
-    print("// MICROPY_REGISTERED_EXTENSIBLE_MODULES")
+        for mod_def in sorted(extensible_mod_defs):
+            print("    {mod_def} \\".format(mod_def=mod_def))
+
+        print("// MICROPY_REGISTERED_EXTENSIBLE_MODULES")
 
 
 def generate_module_delegations(delegations):

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -174,7 +174,12 @@ static const mp_module_delegation_entry_t mp_builtin_module_delegation_table[] =
 
 // Attempts to find (and initialise) a built-in, otherwise returns
 // MP_OBJ_NULL.
-mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible) {
+mp_obj_t mp_module_get_builtin_impl(qstr module_name
+    #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
+    , bool extensible
+    #endif
+    ) {
+
     #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
     const mp_map_t *map = extensible ? &mp_builtin_extensible_module_map : &mp_builtin_module_map;
     #else

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -152,11 +152,13 @@ static const mp_rom_map_elem_t mp_builtin_module_table[] = {
 };
 MP_DEFINE_CONST_MAP(mp_builtin_module_map, mp_builtin_module_table);
 
+#if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
 static const mp_rom_map_elem_t mp_builtin_extensible_module_table[] = {
     // built-in modules declared with MP_REGISTER_EXTENSIBLE_MODULE()
     MICROPY_REGISTERED_EXTENSIBLE_MODULES
 };
 MP_DEFINE_CONST_MAP(mp_builtin_extensible_module_map, mp_builtin_extensible_module_table);
+#endif
 
 #if MICROPY_MODULE_ATTR_DELEGATION && defined(MICROPY_MODULE_DELEGATIONS)
 typedef struct _mp_module_delegation_entry_t {
@@ -173,7 +175,13 @@ static const mp_module_delegation_entry_t mp_builtin_module_delegation_table[] =
 // Attempts to find (and initialise) a built-in, otherwise returns
 // MP_OBJ_NULL.
 mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible) {
-    mp_map_elem_t *elem = mp_map_lookup((mp_map_t *)(extensible ? &mp_builtin_extensible_module_map : &mp_builtin_module_map), MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
+    #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
+    const mp_map_t *map = extensible ? &mp_builtin_extensible_module_map : &mp_builtin_module_map;
+    #else
+    const mp_map_t *map = &mp_builtin_module_map;
+    #endif
+    mp_map_elem_t *elem = mp_map_lookup((mp_map_t *)map, MP_OBJ_NEW_QSTR(module_name), MP_MAP_LOOKUP);
+
     if (!elem) {
         #if MICROPY_PY_SYS
         // Special case for sys, which isn't extensible but can always be
@@ -183,6 +191,7 @@ mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible) {
         }
         #endif
 
+        #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
         if (extensible) {
             // At this point we've already tried non-extensible built-ins, the
             // filesystem, and now extensible built-ins. No match, so fail
@@ -204,6 +213,8 @@ mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible) {
             return MP_OBJ_NULL;
         }
         elem = mp_map_lookup((mp_map_t *)&mp_builtin_extensible_module_map, MP_OBJ_NEW_QSTR(qstr_from_strn(module_name_str + 1, module_name_len - 1)), MP_MAP_LOOKUP);
+        #endif
+
         if (!elem) {
             return MP_OBJ_NULL;
         }

--- a/py/objmodule.c
+++ b/py/objmodule.c
@@ -217,7 +217,7 @@ mp_obj_t mp_module_get_builtin_impl(qstr module_name
         if (module_name_str[0] != 'u') {
             return MP_OBJ_NULL;
         }
-        elem = mp_map_lookup((mp_map_t *)&mp_builtin_extensible_module_map, MP_OBJ_NEW_QSTR(qstr_from_strn(module_name_str + 1, module_name_len - 1)), MP_MAP_LOOKUP);
+        elem = mp_map_lookup((mp_map_t *)&mp_builtin_extensible_module_map, MP_OBJ_NEW_QSTR(qstr_find_strn(module_name_str + 1, module_name_len - 1)), MP_MAP_LOOKUP);
         #endif
 
         if (!elem) {

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -35,7 +35,10 @@
 #endif
 
 extern const mp_map_t mp_builtin_module_map;
+
+#if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
 extern const mp_map_t mp_builtin_extensible_module_map;
+#endif
 
 mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible);
 

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -40,12 +40,11 @@ extern const mp_map_t mp_builtin_module_map;
 extern const mp_map_t mp_builtin_extensible_module_map;
 
 mp_obj_t mp_module_get_builtin_impl(qstr module_name, bool extensible);
-#define mp_module_get_builtin(module_name, extensible) mp_module_get_builtin_impl((module_name), (extensible))
+#define mp_module_get_builtin(module_name) mp_module_get_builtin_impl((module_name), false)
+#define mp_module_get_builtin_extensible(module_name) mp_module_get_builtin_impl((module_name), true)
 #else
 mp_obj_t mp_module_get_builtin_impl(qstr module_name);
-#define mp_module_get_builtin(module_name, extensible) ( \
-    MP_STATIC_ASSERT(!extensible), mp_module_get_builtin_impl((module_name)) \
-    )
+#define mp_module_get_builtin(module_name) mp_module_get_builtin_impl((module_name))
 #endif
 void mp_module_generic_attr(qstr attr, mp_obj_t *dest, const uint16_t *keys, mp_obj_t *values);
 

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -38,10 +38,15 @@ extern const mp_map_t mp_builtin_module_map;
 
 #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
 extern const mp_map_t mp_builtin_extensible_module_map;
+
+mp_obj_t mp_module_get_builtin_impl(qstr module_name, bool extensible);
+#define mp_module_get_builtin(module_name, extensible) mp_module_get_builtin_impl((module_name), (extensible))
+#else
+mp_obj_t mp_module_get_builtin_impl(qstr module_name);
+#define mp_module_get_builtin(module_name, extensible) ( \
+    MP_STATIC_ASSERT(!extensible), mp_module_get_builtin_impl((module_name)) \
+    )
 #endif
-
-mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible);
-
 void mp_module_generic_attr(qstr attr, mp_obj_t *dest, const uint16_t *keys, mp_obj_t *values);
 
 #endif // MICROPY_INCLUDED_PY_OBJMODULE_H

--- a/py/py.mk
+++ b/py/py.mk
@@ -252,7 +252,7 @@ $(HEADER_BUILD)/compressed.data.h: $(HEADER_BUILD)/compressed.collected
 	$(Q)$(PYTHON) $(PY_SRC)/makecompresseddata.py $< > $@
 
 # build a list of registered modules for py/objmodule.c.
-$(HEADER_BUILD)/moduledefs.h: $(HEADER_BUILD)/moduledefs.collected
+$(HEADER_BUILD)/moduledefs.h: $(HEADER_BUILD)/moduledefs.collected $(PY_SRC)/makemoduledefs.py
 	@$(ECHO) "GEN $@"
 	$(Q)$(PYTHON) $(PY_SRC)/makemoduledefs.py $< > $@
 

--- a/py/repl.c
+++ b/py/repl.c
@@ -162,8 +162,11 @@ static bool test_qstr(mp_obj_t obj, qstr name) {
         return dest[0] != MP_OBJ_NULL;
     } else {
         // try builtin module
-        return mp_map_lookup((mp_map_t *)&mp_builtin_module_map, MP_OBJ_NEW_QSTR(name), MP_MAP_LOOKUP) ||
-               mp_map_lookup((mp_map_t *)&mp_builtin_extensible_module_map, MP_OBJ_NEW_QSTR(name), MP_MAP_LOOKUP);
+        return mp_map_lookup((mp_map_t *)&mp_builtin_module_map, MP_OBJ_NEW_QSTR(name), MP_MAP_LOOKUP)
+               #if MICROPY_HAVE_REGISTERED_EXTENSIBLE_MODULES
+               || mp_map_lookup((mp_map_t *)&mp_builtin_extensible_module_map, MP_OBJ_NEW_QSTR(name), MP_MAP_LOOKUP)
+               #endif
+        ;
     }
 }
 


### PR DESCRIPTION
### Summary

An empty array is a C extension supported by clang & gcc but not msvc. If the extensible module list is empty, eliminate the global variable and all code related to it. This is expected to not only resolve the problem building micropython but also saves code in the minimal build, which has no extensible modules.

Closes: #18141

### Testing

I ran a unix "make test" locally. I also built the "minimal" port, which at least exercises the case of empty *extensible* module list. (saves 256 bytes of text locally)

### Trade-offs and Alternatives

In #18141, @Robert-m-lucas suggested always adding a NULL entry at the end of the table, but this is probably undesirable since it would require extra text everywhere.

Initially this PR also handled the case of an empty non-extensible module list but it appears at least one such module will always exist (`__main__` in runtime.c)

Closes: #18141
Signed-off-by: Jeff Epler <jepler@unpythonic.net>