### PR TITLE
py/mpprint: Use a padding buffer on the stack.

### DIFF
--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -40,20 +40,6 @@
 #include "py/formatfloat.h"
 #endif
 
-static const char pad_spaces[16] = {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
-#define pad_spaces_size  (sizeof(pad_spaces))
-static const char pad_common[23] = {'0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '_', '0', '0', '0', ',', '0', '0'};
-// The contents of pad_common is arranged to provide the following padding
-// strings with minimal flash size:
-//     0000000000000000 <- pad_zeroes
-//                 0000_000 <- pad_zeroes_underscore (offset: 12, size 5)
-//                      000,00 <- pad_zeroes_comma (offset: 17, size 4)
-#define pad_zeroes       (pad_common + 0)
-#define pad_zeroes_size  (16)
-#define pad_zeroes_underscore (pad_common + 12)
-#define pad_zeroes_underscore_size  (5)
-#define pad_zeroes_comma (pad_common + 17)
-#define pad_zeroes_comma_size  (4)
 
 static void plat_print_strn(void *env, const char *str, size_t len) {
     (void)env;
@@ -70,79 +56,59 @@ int mp_print_str(const mp_print_t *print, const char *str) {
     return len;
 }
 
+// Efficiently print `count` chars looping over `str[len]`.
+static void print_strn_cycle(const mp_print_t *print, const char *str, size_t len, size_t count) {
+    while (count >= len) {
+        print->print_strn(print->data, str, len);
+        count -= len;
+    }
+    if (count) {
+        print->print_strn(print->data, str, count);
+    }
+}
+
+// lcm(4,5) to match stride for both comma and underscore grouping
+#define PAD_BUF_SIZE 20
+
 int mp_print_strn(const mp_print_t *print, const char *str, size_t len, unsigned int flags, char fill, int width) {
     int left_pad = 0;
     int right_pad = 0;
     int pad = width - len;
-    int pad_size;
     int total_chars_printed = 0;
-    const char *pad_chars;
-    char grouping = flags >> PF_FLAG_SEP_POS;
 
-    if (!fill || fill == ' ') {
-        pad_chars = pad_spaces;
-        pad_size = pad_spaces_size;
-    } else if (fill == '0' && !grouping) {
-        pad_chars = pad_zeroes;
-        pad_size = pad_zeroes_size;
-    } else if (fill == '0') {
-        if (grouping == '_') {
-            pad_chars = pad_zeroes_underscore;
-            pad_size = pad_zeroes_underscore_size;
+    char pad_buf[PAD_BUF_SIZE];
+    MP_STATIC_ASSERT(sizeof(pad_buf) % 5 == 0); // stride for underscore grouping
+    MP_STATIC_ASSERT(sizeof(pad_buf) % 4 == 0); // stride for comma grouping
+
+    fill = fill ? fill : ' ';
+
+    if (pad > 0) {
+        if (flags & PF_FLAG_CENTER_ADJUST) {
+            left_pad = pad / 2;
+            right_pad = pad - left_pad;
+        } else if (flags & PF_FLAG_LEFT_ADJUST) {
+            left_pad = 0;
+            right_pad = pad;
         } else {
-            pad_chars = pad_zeroes_comma;
-            pad_size = pad_zeroes_comma_size;
+            left_pad = pad;
+            right_pad = 0;
         }
-        // The result will never start with a grouping character. An extra leading zero is added.
-        // width is dead after this so we can use it in calculation
-        if (width % pad_size == 0) {
-            pad++;
-            width++;
-        }
-        // position the grouping character correctly within the pad repetition
-        pad_chars += pad_size - 1 - width % pad_size;
-    } else {
-        // Other pad characters are fairly unusual, so we'll take the hit
-        // and output them 1 at a time.
-        pad_chars = &fill;
-        pad_size = 1;
-    }
 
-    if (flags & PF_FLAG_CENTER_ADJUST) {
-        left_pad = pad / 2;
-        right_pad = pad - left_pad;
-    } else if (flags & PF_FLAG_LEFT_ADJUST) {
-        right_pad = pad;
-    } else {
-        left_pad = pad;
-    }
+        memset(pad_buf, fill, sizeof(pad_buf));
 
-    if (left_pad > 0) {
+        // inside the (pad>0) condition just because we can be
+        print_strn_cycle(print, pad_buf, sizeof(pad_buf), left_pad);
         total_chars_printed += left_pad;
-        while (left_pad > 0) {
-            int p = left_pad;
-            if (p > pad_size) {
-                p = pad_size;
-            }
-            print->print_strn(print->data, pad_chars, p);
-            left_pad -= p;
-        }
     }
-    if (len) {
-        print->print_strn(print->data, str, len);
-        total_chars_printed += len;
-    }
-    if (right_pad > 0) {
-        total_chars_printed += right_pad;
-        while (right_pad > 0) {
-            int p = right_pad;
-            if (p > pad_size) {
-                p = pad_size;
-            }
-            print->print_strn(print->data, pad_chars, p);
-            right_pad -= p;
-        }
-    }
+
+    // indirect call is expensive, could condition this on `MP_LIKELY(len > 0)`
+    // but most `mp_print_strn` already check that and it's not actually a bug to invoke with 0 len
+    print->print_strn(print->data, str, len);
+    total_chars_printed += len;
+
+    print_strn_cycle(print, pad_buf, sizeof(pad_buf), right_pad);
+    total_chars_printed += right_pad;
+
     return total_chars_printed;
 }
 

--- a/tests/internal_bench/strformat-1-int.py
+++ b/tests/internal_bench/strformat-1-int.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.1.1-int-pad5-space.py
+++ b/tests/internal_bench/strformat-2.1.1-int-pad5-space.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{: >5d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.1.2-int-pad5-unusual.py
+++ b/tests/internal_bench/strformat-2.1.2-int-pad5-unusual.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!>5d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.1.3-int-pad5-center.py
+++ b/tests/internal_bench/strformat-2.1.3-int-pad5-center.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!^5d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.1.4-int-pad5-left.py
+++ b/tests/internal_bench/strformat-2.1.4-int-pad5-left.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!<5d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.2.1-int-pad20-space.py
+++ b/tests/internal_bench/strformat-2.2.1-int-pad20-space.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{: >20d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.2.2-int-pad20-unusual.py
+++ b/tests/internal_bench/strformat-2.2.2-int-pad20-unusual.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!>20d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.2.3-int-pad20-center.py
+++ b/tests/internal_bench/strformat-2.2.3-int-pad20-center.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!^20d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.2.4-int-pad20-left.py
+++ b/tests/internal_bench/strformat-2.2.4-int-pad20-left.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!<20d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.3.1-int-pad100-space.py
+++ b/tests/internal_bench/strformat-2.3.1-int-pad100-space.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{: >100d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.3.2-int-pad100-unusual.py
+++ b/tests/internal_bench/strformat-2.3.2-int-pad100-unusual.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!>100d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.3.3-int-pad100-center.py
+++ b/tests/internal_bench/strformat-2.3.3-int-pad100-center.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!^100d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.3.4-int-pad100-left.py
+++ b/tests/internal_bench/strformat-2.3.4-int-pad100-left.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!<100d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.4.1-int-pad500-space.py
+++ b/tests/internal_bench/strformat-2.4.1-int-pad500-space.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{: >500d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.4.2-int-pad500-unusual.py
+++ b/tests/internal_bench/strformat-2.4.2-int-pad500-unusual.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!>500d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.4.3-int-pad500-center.py
+++ b/tests/internal_bench/strformat-2.4.3-int-pad500-center.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!^500d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)

--- a/tests/internal_bench/strformat-2.4.4-int-pad500-left.py
+++ b/tests/internal_bench/strformat-2.4.4-int-pad500-left.py
@@ -1,0 +1,10 @@
+import bench
+
+
+def test(num):
+    f = "{:!<500d}"
+    for i in range(num // 10):
+        s = f.format(i)
+
+
+bench.run(test)


### PR DESCRIPTION
### Summary

This reworks `mp_print_strn` to use a stack-allocated padding buffer rather than special-cased hardcoded ROM strings in order to reduce code size and improve string formatting performance.

Note that this is actually just as performant, even for zeroes and spaces! On my RP2350 Cortex M33 hardware, spaces are about 1% faster for short-padding cases, and 3.4% faster for long-padding cases.

### Testing

This PR passes all existing string formatting tests. It also includes a number of additional internal_bench benchmarks that verify the claimed performance improvement.

I've run these benchmarks using my Pico2 Cortex M33 @ 300MHz, with the following results:

| test | original<br>718b28aad | updated<br>674d78fcb |
| - | - | - |
| internal_bench/strformat-1-int.py                    | 0.697 | 0.681 |
| internal_bench/strformat-2.1.1-int-pad5-space.py     | 0.720 | 0.713 |
| internal_bench/strformat-2.1.2-int-pad5-unusual.py   | 0.720 | 0.713 |
| internal_bench/strformat-2.1.3-int-pad5-center.py    | 0.718 | 0.714 |
| internal_bench/strformat-2.1.4-int-pad5-left.py      | 0.723 | 0.712 |
| internal_bench/strformat-2.2.1-int-pad20-space.py    | 0.779 | 0.788 |
| internal_bench/strformat-2.2.2-int-pad20-unusual.py  | 0.848 | 0.788 |
| internal_bench/strformat-2.2.3-int-pad20-center.py   | 0.848 | 0.786 |
| internal_bench/strformat-2.2.4-int-pad20-left.py     | 0.847 | 0.788 |
| internal_bench/strformat-2.3.1-int-pad100-space.py   | 0.977 | 0.979 |
| internal_bench/strformat-2.3.2-int-pad100-unusual.py | 1.429 | 0.979 |
| internal_bench/strformat-2.3.3-int-pad100-center.py  | 1.423 | 0.987 |
| internal_bench/strformat-2.3.4-int-pad100-left.py    | 1.417 | 0.990 |
| internal_bench/strformat-2.4.1-int-pad500-space.py   | 2.202 | 2.127 |
| internal_bench/strformat-2.4.2-int-pad500-unusual.py | 4.690 | 2.127 |
| internal_bench/strformat-2.4.3-int-pad500-center.py  | 4.658 | 2.144 |
| internal_bench/strformat-2.4.4-int-pad500-left.py    | 4.625 | 2.198 |

Note that the run-to-run variation I've observed testing this on my embedded board is in the sub-10us range; however there's also been another observed variation in the 5-8ms range related to the git repository state (i.e. building from a dirty workspace that still has staged changes leads to benchmark results nearly 8ms faster than building otherwise-identical code after committing those exact changes). Even if a similar variation is affecting this comparison, though, this is still enough to conclude that the performance in the long-padding and unusual-character cases is better, and that the performance for the short-padding cases is not worse.

### Trade-offs and Alternatives

I've done some cursory tests for alternate values of `PAD_BUF_SIZE`, but the results definitely won't generalize to other architectures, and probably not even to other implementations of the same architecture. The buffer size of 20 is chosen as the smallest size that easily admits a later implementation of #18092 to support padding with grouping characters, while not pessimizing the short-padding cases any more than required.

I've also explored alternatives involving using `alloca` for the padding buffer, but the conditionals and fallback logic needed to bound stack usage for the pathological cases end up pessimizing code size beyond what's reasonable for the very marginal additional speed gains.