### PR TITLE
webassembly: fix cases where a JavaScript awaitable raises an error into a top-level await in Python

### DIFF
--- a/ports/webassembly/asyncio/core.py
+++ b/ports/webassembly/asyncio/core.py
@@ -243,8 +243,7 @@ def get_event_loop():
 
 
 def current_task():
-    if cur_task is None:
-        raise RuntimeError("no running event loop")
+    assert cur_task is not None
     return cur_task
 
 

--- a/ports/webassembly/objjsproxy.c
+++ b/ports/webassembly/objjsproxy.c
@@ -566,7 +566,8 @@ static mp_obj_t jsproxy_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf) {
         // decouples the task from the thenable and allows cancelling the task.
         if (mp_asyncio_context != MP_OBJ_NULL) {
             mp_obj_t cur_task = mp_obj_dict_get(mp_asyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR_cur_task));
-            if (cur_task != mp_const_none) {
+            mp_obj_t top_level_task = mp_obj_dict_get(mp_asyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR__top_level_task));
+            if (cur_task != top_level_task) {
                 mp_obj_t thenable_event_class = mp_obj_dict_get(mp_asyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR_ThenableEvent));
                 mp_obj_t thenable_event = mp_call_function_1(thenable_event_class, self_in);
                 mp_obj_t dest[2];

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs
@@ -117,6 +117,10 @@ async def main():
 
 # Test top-level waiting on a coro that catches.
 await main()
+
+# Test top-level waiting on a task that catches.
+t = asyncio.create_task(main())
+await t
 `);
 
 console.log("finished");

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs
@@ -88,3 +88,35 @@ print("top-level end")
 `);
 
 console.log("finished");
+
+/**********************************************************/
+// Top-level await's on a JavaScript function that throws.
+
+console.log("= TEST 4 ==========");
+
+globalThis.jsFail = async () => {
+    console.log("jsFail");
+    throw new Error("jsFail");
+};
+
+await mp.runPythonAsync(`
+import asyncio
+import js
+
+# Test top-level catching from a failed JS await.
+try:
+    await js.jsFail()
+except Exception as er:
+    print("caught exception:", type(er), type(er.args[0]), er.args[1:])
+
+async def main():
+    try:
+        await js.jsFail()
+    except Exception as er:
+        print("caught exception:", type(er), type(er.args[0]), er.args[1:])
+
+# Test top-level waiting on a coro that catches.
+await main()
+`);
+
+console.log("finished");

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
@@ -22,4 +22,6 @@ jsFail
 caught exception: <class 'JsException'> <class 'JsProxy'> ('Error', 'jsFail')
 jsFail
 caught exception: <class 'JsException'> <class 'JsProxy'> ('Error', 'jsFail')
+jsFail
+caught exception: <class 'JsException'> <class 'JsProxy'> ('Error', 'jsFail')
 finished

--- a/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
+++ b/tests/ports/webassembly/asyncio_top_level_await.mjs.exp
@@ -17,3 +17,9 @@ top-level wait task
 task end
 top-level end
 finished
+= TEST 4 ==========
+jsFail
+caught exception: <class 'JsException'> <class 'JsProxy'> ('Error', 'jsFail')
+jsFail
+caught exception: <class 'JsException'> <class 'JsProxy'> ('Error', 'jsFail')
+finished


### PR DESCRIPTION
### Summary

There are two fixes in this PR related to how JavaScript errors interact with top-level Python await:
1. await'ing on a JavaScript awaitable that ends up raising an error would not be caught on the Python side.  The fix here makes sure it is caught by Python.
2. If a JavaScript thenable/Promise that was part of an asyncio chain was rejected it would be ignored because the Python-side `ThenableEvent` did not register a handler for the rejection.  The fix here adds a handler for the rejection.
 
### Testing

Tests are added for both fixes, which fail prior to the fix and pass after (and will be tested by CI).

### Trade-offs and Alternatives

These are minor fixes that should have little impact on size and performance.