### PR TITLE
gitignore: Files created by ci.sh zepyhr.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ user.props
 
 # MacOS desktop metadata files
 .DS_Store
+
+# Created by ci.sh zephyr targets
+/.ccache
+/zephyrproject

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ user.props
 # Created by ci.sh zephyr targets
 /.ccache
 /zephyrproject
+
+# Created by ci.sh esp8266 targets
+/xtensa-lx106-elf-standalone.tar.gz
+/xtensa-lx106-elf/


### PR DESCRIPTION
### Summary

After locally building zephyr e.g., with `tools/ci.sh zephyr_setup zephyr_run_tests` these directories are created by the build system. However, they should never be tracked by git.

Not ignoring these files is inconvenient for developers ~~but could also lead to incorrectly marking builds as "`-dirty`" via git describe in makeversionhdr.py~~. (no, untracked files do not make a repo "dirty")

### Testing

Locally, `git status` stops showing the directories created for zephyr builds.

### Trade-offs and Alternatives

Individual developers _could_ add .git/info/exclude lines for these directories are created by normal build steps (not, say, by a specific IDE chosen by a particular developer) it seems reasonable to add to the project gitignore.
