### PR TITLE
alif/boards/OPENMV_AE3: Fix switch name to match OpenMV RT1062 and N6.

### DIFF
--- a/ports/alif/boards/OPENMV_AE3/pins.csv
+++ b/ports/alif/boards/OPENMV_AE3/pins.csv
@@ -8,7 +8,7 @@ LED_GREEN,P6_3
 LED_BLUE,P6_0
 
 # User switch
-USR_SW,P15_7
+SW,P15_7
 
 # Flash on OSPI0
 FLASH_RESET,P3_3


### PR DESCRIPTION
Fix the switch name to match the OpenMV Cam RT1062 (already released to public) and OpenMV N6.