### PR TITLE
misc: Use "static inline" in definitions.

### DIFF
--- a/ports/renesas-ra/ra/ra_gpio.h
+++ b/ports/renesas-ra/ra/ra_gpio.h
@@ -171,12 +171,12 @@ uint32_t ra_gpio_get_pull(uint32_t pin);
 uint32_t ra_gpio_get_af(uint32_t pin);
 uint32_t ra_gpio_get_drive(uint32_t pin);
 
-inline static void pwpr_unprotect(void) {
+static inline void pwpr_unprotect(void) {
     _PWPR &= (uint8_t) ~0x80;
     _PWPR |= (uint8_t)0x40;
 }
 
-inline static void pwpr_protect(void) {
+static inline void pwpr_protect(void) {
     _PWPR &= (uint8_t) ~0x40;
     _PWPR |= (uint8_t)0x80;
 }

--- a/ports/rp2/mutex_extra.h
+++ b/ports/rp2/mutex_extra.h
@@ -44,11 +44,11 @@ typedef struct {
     recursive_mutex_t mutex;
 } recursive_mutex_nowait_t;
 
-inline static void recursive_mutex_nowait_init(recursive_mutex_nowait_t *mtx) {
+static inline void recursive_mutex_nowait_init(recursive_mutex_nowait_t *mtx) {
     recursive_mutex_init(&mtx->mutex);
 }
 
-inline static bool recursive_mutex_nowait_try_enter(recursive_mutex_nowait_t *mtx, uint32_t *owner_out) {
+static inline bool recursive_mutex_nowait_try_enter(recursive_mutex_nowait_t *mtx, uint32_t *owner_out) {
     return recursive_mutex_try_enter(&mtx->mutex, owner_out);
 }
 

--- a/ports/stm32/dma.h
+++ b/ports/stm32/dma.h
@@ -205,11 +205,11 @@ void dma_unprotect_rx_region(void *dest, size_t len);
 
 #else
 
-inline static void dma_protect_rx_region(uint8_t *dest, size_t len) {
+static inline void dma_protect_rx_region(uint8_t *dest, size_t len) {
     // No-ops on targets without D-Cache.
 }
 
-inline static void dma_unprotect_rx_region(void *dest, size_t len) {
+static inline void dma_unprotect_rx_region(void *dest, size_t len) {
 
 }
 

--- a/py/cstack.h
+++ b/py/cstack.h
@@ -35,7 +35,7 @@
 
 void mp_cstack_init_with_sp_here(size_t stack_size);
 
-inline static void mp_cstack_init_with_top(void *top, size_t stack_size) {
+static inline void mp_cstack_init_with_top(void *top, size_t stack_size) {
     MP_STATE_THREAD(stack_top) = (char *)top;
 
     #if MICROPY_STACK_CHECK
@@ -54,7 +54,7 @@ void mp_cstack_check(void);
 
 #else
 
-inline static void mp_cstack_check(void) {
+static inline void mp_cstack_check(void) {
     // No-op when stack checking is disabled
 }
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -506,7 +506,7 @@ inline static bool mp_mul_ll_overflow(long long int x, long long int y, long lon
 #if __has_builtin(__builtin_saddll_overflow) || MP_GCC_HAS_BUILTIN_OVERFLOW
 #define mp_add_ll_overflow __builtin_saddll_overflow
 #else
-inline static bool mp_add_ll_overflow(long long int lhs, long long int rhs, long long int *res) {
+static inline bool mp_add_ll_overflow(long long int lhs, long long int rhs, long long int *res) {
     bool overflow;
 
     if (rhs > 0) {
@@ -526,7 +526,7 @@ inline static bool mp_add_ll_overflow(long long int lhs, long long int rhs, long
 #if __has_builtin(__builtin_ssubll_overflow) || MP_GCC_HAS_BUILTIN_OVERFLOW
 #define mp_sub_ll_overflow __builtin_ssubll_overflow
 #else
-inline static bool mp_sub_ll_overflow(long long int lhs, long long int rhs, long long int *res) {
+static inline bool mp_sub_ll_overflow(long long int lhs, long long int rhs, long long int *res) {
     bool overflow;
 
     if (rhs > 0) {

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -138,7 +138,7 @@ extern const mp_obj_type_t mp_type_usb_device_builtin_default;
 extern const mp_obj_type_t mp_type_usb_device_builtin_none;
 
 // Return true if any built-in driver is enabled
-inline static bool mp_usb_device_builtin_enabled(const mp_obj_usb_device_t *usbd) {
+static inline bool mp_usb_device_builtin_enabled(const mp_obj_usb_device_t *usbd) {
     return usbd->builtin_driver != MP_OBJ_FROM_PTR(&mp_type_usb_device_builtin_none);
 }
 


### PR DESCRIPTION


### Summary

In #17754 Damien noted that I used non-prevailing "inline static" instead of the standard "static inline", possibly due to a nearby nonstandard usage. Fix instances of "inline static" across the tree.

### Testing

Should be no difference, but CI will know.

### Trade-offs and Alternatives

I looked but didn't see an uncrustify cfg to enforce order among qualifiers like these.