### PR TITLE
Add Extra GCC Attributes for ASAN and Debugging

### DIFF
--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -567,7 +567,7 @@ static mp_obj_t mod_socket_inet_ntop(mp_obj_t family_in, mp_obj_t binaddr_in) {
     if (inet_ntop(family, bufinfo.buf, vstr.buf, vstr.len) == NULL) {
         mp_raise_OSError(errno);
     }
-    vstr.len = strlen(vstr.buf);
+    vstr.len = strnlen(vstr.buf, vstr.len);
     return mp_obj_new_str_from_utf8_vstr(&vstr);
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(mod_socket_inet_ntop_obj, mod_socket_inet_ntop);

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -258,15 +258,15 @@ struct _emit_t {
     bool do_viper_types;
 
     mp_uint_t local_vtype_alloc;
-    MP_ATTR_COUNTED_BY(local_vtype_alloc) vtype_kind_t *local_vtype;
+    MP_ATTR_PTR_COUNTED_BY(local_vtype_alloc) vtype_kind_t *local_vtype;
 
     mp_uint_t stack_info_alloc;
-    MP_ATTR_COUNTED_BY(stack_info_alloc) stack_info_t *stack_info;
+    MP_ATTR_PTR_COUNTED_BY(stack_info_alloc) stack_info_t *stack_info;
     vtype_kind_t saved_stack_vtype;
 
     size_t exc_stack_alloc;
     size_t exc_stack_size;
-    MP_ATTR_COUNTED_BY(exc_stack_alloc) exc_stack_entry_t *exc_stack;
+    MP_ATTR_PTR_COUNTED_BY(exc_stack_alloc) exc_stack_entry_t *exc_stack;
 
     int prelude_offset;
     int prelude_ptr_index;

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -50,6 +50,7 @@
 #include "py/nativeglue.h"
 #include "py/objfun.h"
 #include "py/objstr.h"
+#include "py/misc.h"
 
 #if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
@@ -257,15 +258,15 @@ struct _emit_t {
     bool do_viper_types;
 
     mp_uint_t local_vtype_alloc;
-    vtype_kind_t *local_vtype;
+    MP_ATTR_COUNTED_BY(local_vtype_alloc) vtype_kind_t *local_vtype;
 
     mp_uint_t stack_info_alloc;
-    stack_info_t *stack_info;
+    MP_ATTR_COUNTED_BY(stack_info_alloc) stack_info_t *stack_info;
     vtype_kind_t saved_stack_vtype;
 
     size_t exc_stack_alloc;
     size_t exc_stack_size;
-    exc_stack_entry_t *exc_stack;
+    MP_ATTR_COUNTED_BY(exc_stack_alloc) exc_stack_entry_t *exc_stack;
 
     int prelude_offset;
     int prelude_ptr_index;

--- a/py/gc.h
+++ b/py/gc.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include "py/mpprint.h"
+#include "py/misc.h"
 
 void gc_init(void *start, void *end);
 
@@ -62,10 +63,10 @@ enum {
     GC_ALLOC_FLAG_HAS_FINALISER = 1,
 };
 
-void *gc_alloc(size_t n_bytes, unsigned int alloc_flags);
 void gc_free(void *ptr); // does not call finaliser
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(gc_free, 1) void *gc_alloc(size_t n_bytes, unsigned int alloc_flags);
 size_t gc_nbytes(const void *ptr);
-void *gc_realloc(void *ptr, size_t n_bytes, bool allow_move);
+MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(gc_free, 1) void *gc_realloc(void *ptr, size_t n_bytes, bool allow_move);
 
 typedef struct _gc_info_t {
     size_t total;

--- a/py/malloc.c
+++ b/py/malloc.c
@@ -241,8 +241,9 @@ typedef struct _m_tracked_node_t {
     struct _m_tracked_node_t *next;
     #if MICROPY_TRACKED_ALLOC_STORE_SIZE
     uintptr_t size;
+    MP_ATTR_COUNTED_BY(size)
     #endif
-    uint8_t data[];
+    MP_ATTR_NONSTRING uint8_t data[];
 } m_tracked_node_t;
 
 #if MICROPY_DEBUG_VERBOSE

--- a/py/misc.h
+++ b/py/misc.h
@@ -259,7 +259,7 @@ mp_uint_t unichar_xdigit_value(unichar c);
 typedef struct _vstr_t {
     size_t alloc;
     size_t len;
-    char *buf;
+    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING char *buf;
     bool fixed_buf;
 } vstr_t;
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -156,26 +156,29 @@ typedef unsigned int uint;
 #endif
 #define m_del_obj(type, ptr) (m_del(type, ptr, 1))
 
-void *m_malloc(size_t num_bytes);
-void *m_malloc_maybe(size_t num_bytes);
-void *m_malloc_with_finaliser(size_t num_bytes);
-void *m_malloc0(size_t num_bytes);
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
-void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);
 void m_free(void *ptr, size_t num_bytes);
 #else
-void *m_realloc(void *ptr, size_t new_num_bytes);
-void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move);
 void m_free(void *ptr);
+#endif
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) void *m_malloc_maybe(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc_with_finaliser(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc0(size_t num_bytes);
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
+MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);
+#else
+MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc(void *ptr, size_t new_num_bytes);
+MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move);
 #endif
 MP_NORETURN void m_malloc_fail(size_t num_bytes);
 
 #if MICROPY_TRACKED_ALLOC
 // These alloc/free functions track the pointers in a linked list so the GC does not reclaim
 // them.  They can be used by code that requires traditional C malloc/free semantics.
-void *m_tracked_calloc(size_t nmemb, size_t size);
 void m_tracked_free(void *ptr_in);
+MP_ATTR_ALLOC_SIZE(1, 2) MP_ATTR_MALLOC MP_ATTR_MFREE(m_tracked_free, 1) void *m_tracked_calloc(size_t nmemb, size_t size);
 #endif
 
 #if MICROPY_MEM_STATS

--- a/py/misc.h
+++ b/py/misc.h
@@ -192,6 +192,22 @@ size_t m_get_peak_bytes_allocated(void);
 // align ptr to the nearest multiple of "alignment"
 #define MP_ALIGN(ptr, alignment) (void *)(((uintptr_t)(ptr) + ((alignment) - 1)) & ~((alignment) - 1))
 
+// associate struct flex and pointer members to corresponding length fields
+#if __has_attribute(counted_by)
+#define MP_ATTR_COUNTED_BY(count) __attribute__((counted_by(count)))
+#elif defined(_MSC_VER)
+#define MP_ATTR_COUNTED_BY(count) _Field_size_(count)
+#else
+#define MP_ATTR_COUNTED_BY(count)
+#endif
+
+// annotate char arrays or pointers that are meant to contain null bytes
+#if __has_attribute(nonstring)
+#define MP_ATTR_NONSTRING __attribute__((nonstring))
+#else
+#define MP_ATTR_NONSTRING
+#endif
+
 /** unichar / UTF-8 *********************************************/
 
 #if MICROPY_PY_BUILTINS_STR_UNICODE

--- a/py/misc.h
+++ b/py/misc.h
@@ -161,16 +161,16 @@ void m_free(void *ptr, size_t num_bytes);
 #else
 void m_free(void *ptr);
 #endif
-MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) void *m_malloc(size_t num_bytes);
 MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) void *m_malloc_maybe(size_t num_bytes);
-MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc_with_finaliser(size_t num_bytes);
-MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_malloc0(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) void *m_malloc_with_finaliser(size_t num_bytes);
+MP_ATTR_ALLOC_SIZE(1) MP_ATTR_MALLOC MP_ATTR_MFREE(m_free, 1) void *m_malloc0(size_t num_bytes);
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
-MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);
+MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
+MP_ATTR_ALLOC_SIZE(3) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);
 #else
-MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc(void *ptr, size_t new_num_bytes);
-MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move);
+MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) void *m_realloc(void *ptr, size_t new_num_bytes);
+MP_ATTR_ALLOC_SIZE(2) MP_ATTR_MFREE(m_free, 1) MP_ATTR_RETURNS_NONNULL void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move);
 #endif
 MP_NORETURN void m_malloc_fail(size_t num_bytes);
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -195,13 +195,20 @@ size_t m_get_peak_bytes_allocated(void);
 // align ptr to the nearest multiple of "alignment"
 #define MP_ALIGN(ptr, alignment) (void *)(((uintptr_t)(ptr) + ((alignment) - 1)) & ~((alignment) - 1))
 
-// associate struct flex and pointer members to corresponding length fields
+// associate struct flex members to corresponding length fields
 #if __has_attribute(counted_by)
 #define MP_ATTR_COUNTED_BY(count) __attribute__((counted_by(count)))
 #elif defined(_MSC_VER)
 #define MP_ATTR_COUNTED_BY(count) _Field_size_(count)
 #else
 #define MP_ATTR_COUNTED_BY(count)
+#endif
+
+// associate struct pointer members to corresponding length fields
+#if __has_attribute(counted_by) && (defined(__GNUC__) && __GNUC__ >= 16)
+#define MP_ATTR_PTR_COUNTED_BY(count) __attribute__((counted_by(count)))
+#else
+#define MP_ATTR_PTR_COUNTED_BY(count)
 #endif
 
 // annotate char arrays or pointers that are meant to contain null bytes
@@ -259,7 +266,7 @@ mp_uint_t unichar_xdigit_value(unichar c);
 typedef struct _vstr_t {
     size_t alloc;
     size_t len;
-    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING char *buf;
+    MP_ATTR_PTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING char *buf;
     bool fixed_buf;
 } vstr_t;
 

--- a/py/misc.h
+++ b/py/misc.h
@@ -103,6 +103,36 @@ typedef unsigned int uint;
 
 /** memory allocation ******************************************/
 
+// annotate malloc return size for better ASAN and debug info
+#if __has_attribute(alloc_size)
+#define MP_ATTR_ALLOC_SIZE(...) __attribute__((alloc_size(__VA_ARGS__)))
+#else
+#define MP_ATTR_ALLOC_SIZE(...)
+#endif
+
+// annotate malloc methods for better ASAN and debug info
+#if __has_attribute(malloc)
+#define MP_ATTR_MALLOC __attribute__((malloc))
+#else
+#define MP_ATTR_MALLOC
+#endif
+
+// annotate associated free methods for better ASAN and debug info
+#if  __has_attribute(malloc) && ((defined(__clang__) && __clang_major >= 15) || (defined(__GNUC__) && __GNUC__ >= 11))
+#define MP_ATTR_MFREE(...) __attribute__((malloc(__VA_ARGS__)))
+#else
+#define MP_ATTR_MFREE(...)
+#endif
+
+// annotate infallible mallocs for better ASAN and debug info
+#if __has_attribute(returns_nonnull) || (defined(__GNUC__) && __GNUC__ >= 9)
+#define MP_ATTR_RETURNS_NONNULL __attribute__((returns_nonnull))
+#elif defined(_MSC_VER)
+#define MP_ATTR_RETURNS_NONNULL _Ret_notnull_
+#else
+#define MP_ATTR_RETURNS_NONNULL
+#endif
+
 // TODO make a lazy m_renew that can increase by a smaller amount than requested (but by at least 1 more element)
 
 #define m_new(type, num) ((type *)(m_malloc(sizeof(type) * (num))))

--- a/py/misc.h
+++ b/py/misc.h
@@ -52,6 +52,13 @@ typedef unsigned int uint;
 // This macro is supported by Clang and gcc>=14
 #define __has_feature(x) (0)
 #endif
+#ifndef __has_extension
+// This macro is supported by Clang and gcc>=14
+#define __has_extension(x) (0)
+#endif
+#ifndef __has_attribute
+#define __has_attribute(x) (0)
+#endif
 
 
 /** generic ops *************************************************/

--- a/py/modio.c
+++ b/py/modio.c
@@ -34,6 +34,7 @@
 #include "py/objarray.h"
 #include "py/objstringio.h"
 #include "py/frozenmod.h"
+#include "py/misc.h"
 
 #if MICROPY_PY_IO
 
@@ -113,7 +114,7 @@ typedef struct _mp_obj_bufwriter_t {
     mp_obj_t stream;
     size_t alloc;
     size_t len;
-    byte buf[0];
+    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING byte buf[];
 } mp_obj_bufwriter_t;
 
 static mp_obj_t bufwriter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -102,7 +102,7 @@ typedef struct _mp_state_mem_area_t {
     struct _mp_state_mem_area_t *next;
     #endif
 
-    byte *gc_alloc_table_start;
+    MP_ATTR_COUNTED_BY(gc_alloc_table_byte_len) MP_ATTR_NONSTRING byte *gc_alloc_table_start;
     size_t gc_alloc_table_byte_len;
     #if MICROPY_ENABLE_FINALISER
     byte *gc_finaliser_table_start;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -102,8 +102,8 @@ typedef struct _mp_state_mem_area_t {
     struct _mp_state_mem_area_t *next;
     #endif
 
-    MP_ATTR_COUNTED_BY(gc_alloc_table_byte_len) MP_ATTR_NONSTRING byte *gc_alloc_table_start;
     size_t gc_alloc_table_byte_len;
+    MP_ATTR_COUNTED_BY(gc_alloc_table_byte_len) MP_ATTR_NONSTRING byte *gc_alloc_table_start;
     #if MICROPY_ENABLE_FINALISER
     byte *gc_finaliser_table_start;
     #endif

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -103,7 +103,7 @@ typedef struct _mp_state_mem_area_t {
     #endif
 
     size_t gc_alloc_table_byte_len;
-    MP_ATTR_COUNTED_BY(gc_alloc_table_byte_len) MP_ATTR_NONSTRING byte *gc_alloc_table_start;
+    MP_ATTR_PTR_COUNTED_BY(gc_alloc_table_byte_len) MP_ATTR_NONSTRING byte *gc_alloc_table_start;
     #if MICROPY_ENABLE_FINALISER
     byte *gc_finaliser_table_start;
     #endif

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -96,7 +96,7 @@ typedef struct _mpz_t {
     size_t fixed_dig : 1; // flag, 'dig' buffer cannot be reallocated
     size_t alloc : (8 * sizeof(size_t) - 2); // number of entries allocated in 'dig'
     size_t len; // number of entries used in 'dig'
-    mpz_dig_t *dig;
+    MP_ATTR_COUNTED_BY(alloc) mpz_dig_t *dig;
 } mpz_t;
 
 // convenience macro to declare an mpz with a digit array from the stack, initialised by an integer

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -96,7 +96,7 @@ typedef struct _mpz_t {
     size_t fixed_dig : 1; // flag, 'dig' buffer cannot be reallocated
     size_t alloc : (8 * sizeof(size_t) - 2); // number of entries allocated in 'dig'
     size_t len; // number of entries used in 'dig'
-    MP_ATTR_COUNTED_BY(alloc) mpz_dig_t *dig;
+    MP_ATTR_PTR_COUNTED_BY(alloc) mpz_dig_t *dig;
 } mpz_t;
 
 // convenience macro to declare an mpz with a digit array from the stack, initialised by an integer

--- a/py/obj.h
+++ b/py/obj.h
@@ -484,7 +484,7 @@ typedef struct _mp_map_t {
     size_t is_ordered : 1;  // if set, table is an ordered array, not a hash map
     size_t used : (8 * sizeof(size_t) - 3);
     size_t alloc;
-    mp_map_elem_t *table;
+    MP_ATTR_COUNTED_BY(alloc) mp_map_elem_t *table;
 } mp_map_t;
 
 // mp_set_lookup requires these constants to have the values they do
@@ -512,7 +512,7 @@ void mp_map_dump(mp_map_t *map);
 typedef struct _mp_set_t {
     size_t alloc;
     size_t used;
-    mp_obj_t *table;
+    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *table;
 } mp_set_t;
 
 static inline bool mp_set_slot_is_filled(const mp_set_t *set, size_t pos) {

--- a/py/obj.h
+++ b/py/obj.h
@@ -484,7 +484,7 @@ typedef struct _mp_map_t {
     size_t is_ordered : 1;  // if set, table is an ordered array, not a hash map
     size_t used : (8 * sizeof(size_t) - 3);
     size_t alloc;
-    MP_ATTR_COUNTED_BY(alloc) mp_map_elem_t *table;
+    MP_ATTR_PTR_COUNTED_BY(alloc) mp_map_elem_t *table;
 } mp_map_t;
 
 // mp_set_lookup requires these constants to have the values they do
@@ -512,7 +512,7 @@ void mp_map_dump(mp_map_t *map);
 typedef struct _mp_set_t {
     size_t alloc;
     size_t used;
-    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *table;
+    MP_ATTR_PTR_COUNTED_BY(alloc) mp_obj_t *table;
 } mp_set_t;
 
 static inline bool mp_set_slot_is_filled(const mp_set_t *set, size_t pos) {

--- a/py/objclosure.c
+++ b/py/objclosure.c
@@ -28,12 +28,13 @@
 
 #include "py/obj.h"
 #include "py/runtime.h"
+#include "py/misc.h"
 
 typedef struct _mp_obj_closure_t {
     mp_obj_base_t base;
     mp_obj_t fun;
     size_t n_closed;
-    mp_obj_t closed[];
+    MP_ATTR_COUNTED_BY(n_closed) mp_obj_t closed[];
 } mp_obj_closure_t;
 
 static mp_obj_t closure_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -36,7 +36,7 @@ typedef struct _mp_obj_deque_t {
     size_t alloc;
     size_t i_get;
     size_t i_put;
-    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *items;
+    MP_ATTR_PTR_COUNTED_BY(alloc) mp_obj_t *items;
     uint32_t flags;
     #define FLAG_CHECK_OVERFLOW 1
 } mp_obj_deque_t;

--- a/py/objdeque.c
+++ b/py/objdeque.c
@@ -27,6 +27,7 @@
 #include <unistd.h> // for ssize_t
 
 #include "py/runtime.h"
+#include "py/misc.h"
 
 #if MICROPY_PY_COLLECTIONS_DEQUE
 
@@ -35,7 +36,7 @@ typedef struct _mp_obj_deque_t {
     size_t alloc;
     size_t i_get;
     size_t i_put;
-    mp_obj_t *items;
+    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *items;
     uint32_t flags;
     #define FLAG_CHECK_OVERFLOW 1
 } mp_obj_deque_t;

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -37,6 +37,7 @@
 #include "py/runtime.h"
 #include "py/gc.h"
 #include "py/mperrno.h"
+#include "py/misc.h"
 
 #if MICROPY_ROM_TEXT_COMPRESSION && !defined(NO_QSTR)
 // Extract the MP_MAX_UNCOMPRESSED_TEXT_LEN macro from "genhdr/compressed.data.h".
@@ -436,7 +437,7 @@ struct _exc_printer_t {
     bool allow_realloc;
     size_t alloc;
     size_t len;
-    byte *buf;
+    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING byte *buf;
 };
 
 static void exc_add_strn(void *data, const char *str, size_t len) {

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -437,7 +437,7 @@ struct _exc_printer_t {
     bool allow_realloc;
     size_t alloc;
     size_t len;
-    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING byte *buf;
+    MP_ATTR_PTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING byte *buf;
 };
 
 static void exc_add_strn(void *data, const char *str, size_t len) {

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -33,7 +33,7 @@ typedef struct _mp_obj_list_t {
     mp_obj_base_t base;
     size_t alloc;
     size_t len;
-    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *items;
+    MP_ATTR_PTR_COUNTED_BY(alloc) mp_obj_t *items;
 } mp_obj_list_t;
 
 void mp_obj_list_init(mp_obj_list_t *o, size_t n);

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -27,12 +27,13 @@
 #define MICROPY_INCLUDED_PY_OBJLIST_H
 
 #include "py/obj.h"
+#include "py/misc.h"
 
 typedef struct _mp_obj_list_t {
     mp_obj_base_t base;
     size_t alloc;
     size_t len;
-    mp_obj_t *items;
+    MP_ATTR_COUNTED_BY(alloc) mp_obj_t *items;
 } mp_obj_list_t;
 
 void mp_obj_list_init(mp_obj_list_t *o, size_t n);

--- a/py/objmap.c
+++ b/py/objmap.c
@@ -28,12 +28,13 @@
 #include <assert.h>
 
 #include "py/runtime.h"
+#include "py/misc.h"
 
 typedef struct _mp_obj_map_t {
     mp_obj_base_t base;
     size_t n_iters;
     mp_obj_t fun;
-    mp_obj_t iters[];
+    MP_ATTR_COUNTED_BY(n_iters) mp_obj_t iters[];
 } mp_obj_map_t;
 
 static mp_obj_t map_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/py/objnamedtuple.h
+++ b/py/objnamedtuple.h
@@ -27,13 +27,14 @@
 #define MICROPY_INCLUDED_PY_OBJNAMEDTUPLE_H
 
 #include "py/objtuple.h"
+#include "py/misc.h"
 
 typedef struct _mp_obj_namedtuple_type_t {
     // This is a mp_obj_type_t with eight slots.
     mp_obj_empty_type_t base;
     void *slots[8];
     size_t n_fields;
-    qstr fields[];
+    MP_ATTR_COUNTED_BY(n_fields) qstr fields[];
 } mp_obj_namedtuple_type_t;
 
 typedef struct _mp_obj_namedtuple_t {

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_PY_OBJTUPLE_H
 
 #include "py/obj.h"
+#include "py/misc.h"
 
 // type check is done on getiter method to allow tuple, namedtuple, attrtuple
 #define mp_obj_is_tuple_compatible(o) (MP_OBJ_TYPE_GET_SLOT_OR_NULL(mp_obj_get_type(o), iter) == mp_obj_tuple_getiter)
@@ -34,13 +35,13 @@
 typedef struct _mp_obj_tuple_t {
     mp_obj_base_t base;
     size_t len;
-    mp_obj_t items[];
+    MP_ATTR_COUNTED_BY(len) mp_obj_t items[];
 } mp_obj_tuple_t;
 
 typedef struct _mp_rom_obj_tuple_t {
     mp_obj_base_t base;
     size_t len;
-    mp_rom_obj_t items[];
+    MP_ATTR_COUNTED_BY(len) mp_rom_obj_t items[];
 } mp_rom_obj_tuple_t;
 
 void mp_obj_tuple_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind);

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -29,11 +29,12 @@
 
 #include "py/objtuple.h"
 #include "py/runtime.h"
+#include "py/misc.h"
 
 typedef struct _mp_obj_zip_t {
     mp_obj_base_t base;
     size_t n_iters;
-    mp_obj_t iters[];
+    MP_ATTR_COUNTED_BY(n_iters) mp_obj_t iters[];
 } mp_obj_zip_t;
 
 static mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {

--- a/py/parse.c
+++ b/py/parse.c
@@ -38,6 +38,7 @@
 #include "py/objint.h"
 #include "py/objstr.h"
 #include "py/builtin.h"
+#include "py/misc.h"
 
 #if MICROPY_ENABLE_COMPILER
 
@@ -220,17 +221,17 @@ typedef struct _mp_parse_chunk_t {
         size_t used;
         struct _mp_parse_chunk_t *next;
     } union_;
-    byte data[];
+    MP_ATTR_COUNTED_BY(alloc) MP_ATTR_NONSTRING byte data[];
 } mp_parse_chunk_t;
 
 typedef struct _parser_t {
     size_t rule_stack_alloc;
     size_t rule_stack_top;
-    rule_stack_t *rule_stack;
+    MP_ATTR_COUNTED_BY(rule_stack_alloc) rule_stack_t *rule_stack;
 
     size_t result_stack_alloc;
     size_t result_stack_top;
-    mp_parse_node_t *result_stack;
+    MP_ATTR_COUNTED_BY(result_stack_alloc) mp_parse_node_t *result_stack;
 
     mp_lexer_t *lexer;
 

--- a/py/parse.c
+++ b/py/parse.c
@@ -227,11 +227,11 @@ typedef struct _mp_parse_chunk_t {
 typedef struct _parser_t {
     size_t rule_stack_alloc;
     size_t rule_stack_top;
-    MP_ATTR_COUNTED_BY(rule_stack_alloc) rule_stack_t *rule_stack;
+    MP_ATTR_PTR_COUNTED_BY(rule_stack_alloc) rule_stack_t *rule_stack;
 
     size_t result_stack_alloc;
     size_t result_stack_top;
-    MP_ATTR_COUNTED_BY(result_stack_alloc) mp_parse_node_t *result_stack;
+    MP_ATTR_PTR_COUNTED_BY(result_stack_alloc) mp_parse_node_t *result_stack;
 
     mp_lexer_t *lexer;
 

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -770,7 +770,7 @@ void mp_raw_code_save_file(mp_compiled_module_t *cm, qstr filename) {
 typedef struct _bit_vector_t {
     size_t max_bit_set;
     size_t alloc;
-    MP_ATTR_COUNTED_BY(alloc) uintptr_t *bits;
+    MP_ATTR_PTR_COUNTED_BY(alloc) uintptr_t *bits;
 } bit_vector_t;
 
 static void bit_vector_init(bit_vector_t *self) {

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -35,6 +35,7 @@
 #include "py/bc0.h"
 #include "py/objstr.h"
 #include "py/mpthread.h"
+#include "py/misc.h"
 
 #if MICROPY_PERSISTENT_CODE_LOAD || MICROPY_PERSISTENT_CODE_SAVE
 
@@ -769,7 +770,7 @@ void mp_raw_code_save_file(mp_compiled_module_t *cm, qstr filename) {
 typedef struct _bit_vector_t {
     size_t max_bit_set;
     size_t alloc;
-    uintptr_t *bits;
+    MP_ATTR_COUNTED_BY(alloc) uintptr_t *bits;
 } bit_vector_t;
 
 static void bit_vector_init(bit_vector_t *self) {

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -85,10 +85,10 @@ typedef struct _qstr_pool_t {
     size_t alloc;
     size_t len;
     #if MICROPY_QSTR_BYTES_IN_HASH
-    qstr_hash_t *hashes;
+    MP_ATTR_COUNTED_BY(alloc) qstr_hash_t *hashes;
     #endif
-    qstr_len_t *lengths;
-    const char *qstrs[];
+    MP_ATTR_COUNTED_BY(alloc) qstr_len_t *lengths;
+    MP_ATTR_COUNTED_BY(alloc) const char *qstrs[];
 } qstr_pool_t;
 
 #define QSTR_TOTAL() (MP_STATE_VM(last_pool)->total_prev_len + MP_STATE_VM(last_pool)->len)

--- a/py/qstr.h
+++ b/py/qstr.h
@@ -85,10 +85,10 @@ typedef struct _qstr_pool_t {
     size_t alloc;
     size_t len;
     #if MICROPY_QSTR_BYTES_IN_HASH
-    MP_ATTR_COUNTED_BY(alloc) qstr_hash_t *hashes;
+    MP_ATTR_PTR_COUNTED_BY(alloc) qstr_hash_t *hashes;
     #endif
-    MP_ATTR_COUNTED_BY(alloc) qstr_len_t *lengths;
-    MP_ATTR_COUNTED_BY(alloc) const char *qstrs[];
+    MP_ATTR_PTR_COUNTED_BY(alloc) qstr_len_t *lengths;
+    MP_ATTR_PTR_COUNTED_BY(alloc) const char *qstrs[];
 } qstr_pool_t;
 
 #define QSTR_TOTAL() (MP_STATE_VM(last_pool)->total_prev_len + MP_STATE_VM(last_pool)->len)

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -222,7 +222,7 @@ mp_obj_t mp_call_function_2_protected(mp_obj_t fun, mp_obj_t arg1, mp_obj_t arg2
 typedef struct _mp_call_args_t {
     mp_obj_t fun;
     size_t n_args, n_kw, n_alloc;
-    MP_ATTR_COUNTED_BY(n_alloc) mp_obj_t *args;
+    MP_ATTR_PTR_COUNTED_BY(n_alloc) mp_obj_t *args;
 } mp_call_args_t;
 
 #if MICROPY_STACKLESS

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -29,6 +29,7 @@
 #include "py/mpstate.h"
 #include "py/pystack.h"
 #include "py/cstack.h"
+#include "py/misc.h"
 
 // Initialize an nlr_jump_callback_node_call_function_1_t struct for use with
 // nlr_push_jump_callback(&ctx.callback, mp_call_function_1_from_nlr_jump_callback);
@@ -221,7 +222,7 @@ mp_obj_t mp_call_function_2_protected(mp_obj_t fun, mp_obj_t arg1, mp_obj_t arg2
 typedef struct _mp_call_args_t {
     mp_obj_t fun;
     size_t n_args, n_kw, n_alloc;
-    mp_obj_t *args;
+    MP_ATTR_COUNTED_BY(n_alloc) mp_obj_t *args;
 } mp_call_args_t;
 
 #if MICROPY_STACKLESS

--- a/py/scope.h
+++ b/py/scope.h
@@ -91,7 +91,7 @@ typedef struct _scope_t {
     uint16_t exc_stack_size; // maximum size of the exception stack
     uint16_t id_info_alloc;
     uint16_t id_info_len;
-    MP_ATTR_COUNTED_BY(id_info_alloc) id_info_t *id_info;
+    MP_ATTR_PTR_COUNTED_BY(id_info_alloc) id_info_t *id_info;
 } scope_t;
 
 scope_t *scope_new(scope_kind_t kind, mp_parse_node_t pn, mp_uint_t emit_options);

--- a/py/scope.h
+++ b/py/scope.h
@@ -28,6 +28,7 @@
 
 #include "py/parse.h"
 #include "py/emitglue.h"
+#include "py/misc.h"
 
 typedef enum {
     ID_INFO_KIND_UNDECIDED,
@@ -90,7 +91,7 @@ typedef struct _scope_t {
     uint16_t exc_stack_size; // maximum size of the exception stack
     uint16_t id_info_alloc;
     uint16_t id_info_len;
-    id_info_t *id_info;
+    MP_ATTR_COUNTED_BY(id_info_alloc) id_info_t *id_info;
 } scope_t;
 
 scope_t *scope_new(scope_kind_t kind, mp_parse_node_t pn, mp_uint_t emit_options);


### PR DESCRIPTION
### Summary
This PR adds a number of extra `__attribute__((...))`s to a number of functions and struct members.

Notably:
- It adds the `malloc`, `alloc_size`, and `returns_nonnull` as appropriate to all of micropython's allocator methods (the `m_alloc` and `gc_alloc` families).
- It adds the `counted_by` attribute to any struct array pointers or flex arrays that have an obvious sibling member describing their allocated size.
- It adds the `nonstring` attribute to any string-like struct members that are meant to be interpreted with a length field rather than as a null-terminated string.

These annotations will help the compiler generate better code, help static analyzers and address santizers catch a wider range of potential out-of-bound access errors, and allow debuggers to pick up on and display the full contents of micropython's data structures rather than just their head elements.

### Testing
Testing is ongoing. There are a lot of compiler versions and build configurations that need to be verified here.

### Trade-offs and Alternatives

Probably more instances of the relevant patterns that could also be annotated this way...

