### PR TITLE
mpconfig: Introduce SIZE_FMT.

### DIFF
--- a/ports/stm32/mpconfigport_nanbox.h
+++ b/ports/stm32/mpconfigport_nanbox.h
@@ -37,6 +37,7 @@
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
 #define HEX_FMT "%llx"
+#define SIZE_FMT "%lu"
 typedef int64_t mp_int_t;
 typedef uint64_t mp_uint_t;
 

--- a/ports/unix/variants/nanbox/mpconfigvariant.h
+++ b/ports/unix/variants/nanbox/mpconfigvariant.h
@@ -49,3 +49,4 @@ typedef uint64_t mp_uint_t;
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
 #define HEX_FMT "%llx"
+#define SIZE_FMT "%lu"

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2244,15 +2244,18 @@ typedef time_t mp_timestamp_t;
 #define UINT_FMT "%lu"
 #define INT_FMT "%ld"
 #define HEX_FMT "%lx"
+#define SIZE_FMT "%lu"
 #elif defined(_WIN64)
 #define UINT_FMT "%llu"
 #define INT_FMT "%lld"
 #define HEX_FMT "%llx"
+#define SIZE_FMT "%llu"
 #else
 // Archs where mp_int_t == int
 #define UINT_FMT "%u"
 #define INT_FMT "%d"
 #define HEX_FMT "%x"
+#define SIZE_FMT "%u"
 #endif
 #endif // INT_FMT
 

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1669,14 +1669,14 @@ mp_obj_t mp_parse_compile_execute(mp_lexer_t *lex, mp_parse_input_kind_t parse_i
 #endif // MICROPY_ENABLE_COMPILER
 
 MP_NORETURN void m_malloc_fail(size_t num_bytes) {
-    DEBUG_printf("memory allocation failed, allocating %u bytes\n", (uint)num_bytes);
+    DEBUG_printf("memory allocation failed, allocating " SIZE_FMT " bytes\n", num_bytes);
     #if MICROPY_ENABLE_GC
     if (gc_is_locked()) {
         mp_raise_msg(&mp_type_MemoryError, MP_ERROR_TEXT("memory allocation failed, heap is locked"));
     }
     #endif
     mp_raise_msg_varg(&mp_type_MemoryError,
-        MP_ERROR_TEXT("memory allocation failed, allocating %u bytes"), (uint)num_bytes);
+        MP_ERROR_TEXT("memory allocation failed, allocating " SIZE_FMT " bytes"), num_bytes);
 }
 
 #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NONE


### PR DESCRIPTION
### Summary

This is #17931 but introduces and uses SIZE_FMT.

### Testing

In a branch-of-a-branch, I tested this together with #17556 and no errors were flagged with mp_printf format strings in checked targets.

### Trade-offs and Alternatives

It makes the use site cleaner but makes more changes elsewhere to ensure the SIZE_FMT macro is properly defined. If there are more places that would use SIZE_FMT this becomes more useful but I didn't immediately identify any others.