### PR TITLE
powerpc, qemu: remove definitions of _FMT macros, to use defaults instead

### DIFF
--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -93,12 +93,8 @@
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 // This port is 64-bit
-#define UINT_FMT "%lu"
-#define INT_FMT "%ld"
-#define HEX_FMT "%lx"
 typedef signed long mp_int_t; // must be pointer size
 typedef unsigned long mp_uint_t; // must be pointer size
-
 typedef long mp_off_t;
 
 // extra built in names to add to the global namespace

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -78,10 +78,6 @@ typedef int32_t mp_int_t; // must be pointer size
 typedef uint32_t mp_uint_t; // must be pointer size
 #endif
 
-#define UINT_FMT "%lu"
-#define INT_FMT "%ld"
-#define HEX_FMT "%lx"
-
 typedef long mp_off_t;
 
 // We need to provide a declaration/definition of alloca()


### PR DESCRIPTION
### Summary

Remove custom declarations of _FMT macros in powerpc and qemu ports.  The defaults in `py/mpconfig.h` should work for these ports, and this cleans up the code.

### Testing

To be tested by CI.

### Trade-offs and Alternatives

Hopefully this is an obvious minor clean up with no downsides.