### PR TITLE
README: Add new section defining port Tier levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,28 +98,74 @@ development and testing of MicroPython itself, as well as providing
 lightweight alternative to CPython on these platforms (in particular on
 embedded Linux systems).
 
-The ["minimal"](ports/minimal) port provides an example of a very basic
-MicroPython port and can be compiled as both a standalone Linux binary as
-well as for ARM Cortex M4. Start with this if you want to port MicroPython to
-another microcontroller. Additionally the ["bare-arm"](ports/bare-arm) port
-is an example of the absolute minimum configuration, and is used to keep
-track of the code size of the core runtime and VM.
+Over twenty different MicroPython ports are provided in this repository,
+split across three
+[MicroPython Support Tiers](https://docs.micropython.org/en/latest/develop/support_tiers.html).
 
-In addition, the following ports are provided in this repository:
- - [cc3200](ports/cc3200) -- Texas Instruments CC3200 (including PyCom WiPy).
- - [esp32](ports/esp32) -- Espressif ESP32 SoC (including ESP32S2, ESP32S3, ESP32C3, ESP32C6).
- - [esp8266](ports/esp8266) -- Espressif ESP8266 SoC.
- - [mimxrt](ports/mimxrt) -- NXP m.iMX RT (including Teensy 4.x).
- - [nrf](ports/nrf) -- Nordic Semiconductor nRF51 and nRF52.
- - [pic16bit](ports/pic16bit) -- Microchip PIC 16-bit.
- - [powerpc](ports/powerpc) -- IBM PowerPC (including Microwatt)
- - [qemu](ports/qemu) -- QEMU-based emulated target (for testing)
- - [renesas-ra](ports/renesas-ra) -- Renesas RA family.
- - [rp2](ports/rp2) -- Raspberry Pi RP2040 (including Pico and Pico W).
- - [samd](ports/samd) -- Microchip (formerly Atmel) SAMD21 and SAMD51.
- - [stm32](ports/stm32) -- STMicroelectronics STM32 family (including F0, F4, F7, G0, G4, H7, L0, L4, WB)
- - [webassembly](ports/webassembly) -- Emscripten port targeting browsers and NodeJS.
- - [zephyr](ports/zephyr) -- Zephyr RTOS.
+Tier 1 Ports
+============
+
+👑 Ports in [Tier 1](https://docs.micropython.org/en/latest/develop/support_tiers.html)
+are mature and have the most active development, support and testing:
+
+| Port                     | Target                                                                                 | Quick Reference                                                      |
+|--------------------------|----------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| [esp32](ports/esp32)*    | Espressif ESP32 SoCs (ESP32, ESP32S2, ESP32S3, ESP32C3, ESP32C6)                       | [here](https://docs.micropython.org/en/latest/esp32/quickref.html)   |
+| [mimxrt](ports/mimxrt)   | NXP m.iMX RT                                                                           | [here](https://docs.micropython.org/en/latest/mimxrt/quickref.html)  |
+| [rp2](ports/rp2)         | Raspberry Pi RP2040 and RP2350                                                         | [here](https://docs.micropython.org/en/latest/rp2/quickref.html)     |
+| [samd](ports/samd)       | Microchip (formerly Atmel) SAMD21 and SAMD51                                           | [here](https://docs.micropython.org/en/latest/samd/quickref.html)    |
+| [stm32](ports/stm32)     | STMicroelectronics STM32 MCUs (F0, F4, F7, G0, G4, H5, H7, L0, L1, L4, N6, WB, WL)     | [here](https://docs.micropython.org/en/latest/pyboard/quickref.html) |
+| [unix](ports/unix)       | Linux, BSD, macOS, WSL                                                                 | [here](https://docs.micropython.org/en/latest/unix/quickref.html)    |
+| [windows](ports/windows) | Microsoft Windows                                                                      | [here](https://docs.micropython.org/en/latest/unix/quickref.html)    |
+
+An asterisk indicates that the port has ongoing financial support from the vendor.
+
+Tier 2 Ports
+============
+
+✔ Ports in [Tier 2](https://docs.micropython.org/en/latest/develop/support_tiers.html)
+are less mature and less actively developed and tested than Tier 1, but
+still fully supported:
+
+| Port                             | Target                                                      | Quick Reference                                                         |
+|----------------------------------|-------------------------------------------------------------|-------------------------------------------------------------------------|
+| [alif](ports/alif)               | Alif Semiconductor Ensemble MCUs (E3, E7)                   |                                                                         |
+| [embed](ports/embed)             | Generates a set of .c/.h files for embedding into a project |                                                                         |
+| [nrf](ports/nrf)                 | Nordic Semiconductor nRF51 and nRF52                        |                                                                         |
+| [renesas-ra](ports/renesas-ra)   | Renesas RA family                                           | [here](https://docs.micropython.org/en/latest/renesas-ra/quickref.html) |
+| [webassembly](ports/webassembly) | Emscripten port targeting browsers and NodeJS               |                                                                         |
+| [zephyr](ports/zephyr)           | Zephyr RTOS                                                 | [here](https://docs.micropython.org/en/latest/zephyr/quickref.html)     |
+
+Tier 3 Ports
+============
+
+Ports in [Tier 3](https://docs.micropython.org/en/latest/develop/support_tiers.html)
+are built in CI but not regularly tested by the MicroPython maintainers:
+
+| Port                       | Target                                                            | Quick Reference                                                         |
+|----------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------|
+| [cc3200](ports/cc3200)     | Texas Instruments CC3200                                          | [For WiPy](https://docs.micropython.org/en/latest/wipy/quickref.html)   |
+| [esp8266](ports/esp8266)   | Espressif ESP8266 SoC                                             | [here](https://docs.micropython.org/en/latest/esp8266/quickref.html)    |
+| [pic16bit](ports/pic16bit) | Microchip PIC 16-bit                                              |                                                                         |
+| [powerpc](ports/powerpc)   | IBM PowerPC (including Microwatt)                                 |                                                                         |
+
+Additional Ports
+================
+
+In addition to the above there is a Tier M containing ports that are used
+primarily for maintenance, development and testing:
+
+- The ["bare-arm"](ports/bare-arm) port is an example of the absolute minimum
+  configuration that still includes the compiler, and is used to keep track
+  of the code size of the core runtime and VM.
+
+- The ["minimal"](ports/minimal) port provides an example of a very basic
+  MicroPython port and can be compiled as both a standalone Linux binary as
+  well as for ARM Cortex-M4. Start with this if you want to port MicroPython
+  to another microcontroller.
+
+- The [qemu](ports/qemu) port is a QEMU-based emulated target for Cortex-A,
+  Cortex-M, RISC-V 32-bit and RISC-V 64-bit architectures.
 
 The MicroPython cross-compiler, mpy-cross
 -----------------------------------------

--- a/docs/develop/index.rst
+++ b/docs/develop/index.rst
@@ -24,3 +24,4 @@ MicroPython to a new platform and implementing a core MicroPython library.
    publiccapi.rst
    extendingmicropython.rst
    porting.rst
+   support_tiers.rst

--- a/docs/develop/support_tiers.rst
+++ b/docs/develop/support_tiers.rst
@@ -1,0 +1,68 @@
+MicroPython Support Tiers
+=========================
+
+MicroPython operates with a set of Support Tier levels for the various ports.
+Tiers 1, 2 and 3 are the main Tier levels with Tier 1 being the most mature and
+actively maintained.  There is also Tier M for additional ports used primarily
+for maintenance, development and testing. These Tier levels are defined in the
+table below.
+
+.. table::
+  :widths: 40 9 9 9 9
+
+  +-----------------------------------------------+--------+--------+--------+--------+
+  |                                               | Tier 1 | Tier 2 | Tier 3 | Tier M |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | builds pass under CI                          | ✔      | ✔      | ✔      | ✔      |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | tests run under CI (where possible)           | ✔      | ✔      | ✔      | ✔      |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | actively maintained                           | ✔      | ✔      |        | ✔      |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | stable Python API                             | ✔      | ✔      |        |        |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | new features actively developed               | ✔      | ✔      |        |        |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | tested on hardware for releases               | ✔      | ✔      |        |        |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | prioritized bug reports                       | ✔      |        |        | ✔      |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | regressions warrant a patch release           | ✔      |        |        | ✔      |
+  +-----------------------------------------------+--------+--------+--------+--------+
+  | has port-specific documentation               | ✔      |        |        |        |
+  +-----------------------------------------------+--------+--------+--------+--------+
+
+Lower Tiers may tick more boxes, but the above table defines the minimum requirements
+for a port to belong to a Tier.
+
+Tier 1 ports:
+
+  - esp32
+  - mimxrt
+  - rp2
+  - samd
+  - stm32
+  - unix
+  - windows
+
+Tier 2 ports:
+
+  - alif
+  - embed
+  - nrf
+  - renesas-ra
+  - webassembly
+  - zephyr
+
+Tier 3 ports:
+
+  - cc3200
+  - esp8266
+  - pic16bit
+  - powerpc
+
+Tier M ports:
+
+  - bare-arm
+  - minimal
+  - qemu


### PR DESCRIPTION
### Summary

MicroPython has quite a few ports now (20 of them), but not all are in the same stage of development.  This PR attempts to define port Tier levels and assign a Tier to each of the existing ports.

The main aim here is to set expectations for the level of support and development each port gets.  And also lower the bar of entry for new ports (eg PSOC #16705) so they can enter at a low Tier and gradually rise up to Tier 1.

The Tiers are defined in terms of properties like "stable API" and "tested on hardware for a release".  I wanted to be able to distinguish between ports like the following:
- stm32: very mature and still actively developed
- alif: new and upcoming and well maintained
- esp8266: old and still going strong, but not many new features
- qemu: primarily a testing port

I think there's still a lot of room for defining the Tier levels, and which port goes under which Tier, so please provide feedback!

See prior art here:
- https://peps.python.org/pep-0011/
- https://doc.rust-lang.org/rustc/target-tier-policy.html

### Trade-offs and Alternatives

This is quite a subjective set of Tiers, but I tried to make it somewhat concrete by having a table showing the properties for each Tier.  Still, we need to choose reasonable properties and assign them well.

I'm not sure if this belongs in the top-level README or the docs, or maybe both.

We could call it "Class" or "Group".  But I think "Tier" is better and is more widely used.