### PR TITLE
py/obj: Add requirement for 4-byte alignment

### DIFF
--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -73,7 +73,7 @@
 // The xc16 compiler doesn't seem to respect alignment (!!) so we
 // need to use instead an object representation that allows for
 // 2-byte aligned pointers (see config setting above).
-// #define MICROPY_OBJ_BASE_ALIGNMENT  __attribute__((aligned(4)))
+// #define MICROPY_OBJ_BASE_ALIGNMENT  4
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2101,10 +2101,13 @@ typedef time_t mp_timestamp_t;
 
 // All uPy objects in ROM must be aligned on at least a 4 byte boundary
 // so that the small-int/qstr/pointer distinction can be made.  For machines
-// that don't do this (eg 16-bit CPU), define the following macro to something
-// like __attribute__((aligned(4))).
-#ifndef MICROPY_OBJ_BASE_ALIGNMENT
-#define MICROPY_OBJ_BASE_ALIGNMENT
+// that don't do this (eg 16-bit CPU), define MICROPY_OBJ_BASE_ALIGNMENT as 4.
+#if defined(MICROPY_OBJ_BASE_ALIGNMENT)
+#define MICROPY_OBJ_BASE_ALIGNMENT_ATTR __attribute__((aligned(MICROPY_OBJ_BASE_ALIGNMENT)))
+#elif defined(__BIGGEST_ALIGNMENT__) && __BIGGEST_ALIGNMENT__ < 4
+#define MICROPY_OBJ_BASE_ALIGNMENT_ATTR __attribute__((4))
+#else
+#define MICROPY_OBJ_BASE_ALIGNMENT_ATTR /* default alignment */
 #endif
 
 // String used for the banner, and sys.version additional information

--- a/py/obj.c
+++ b/py/obj.c
@@ -37,6 +37,20 @@
 #include "py/cstack.h"
 #include "py/stream.h" // for mp_obj_print
 
+// This function exists only for compile-time static alignment assertions.
+#if !defined(_MSC_VER)
+__attribute__((unused))
+#endif
+static void test_alignment(void) {
+    struct {
+        char x;
+        mp_obj_type_t y;
+    } a;
+    // If the following assertion fails, it means uPy objects are not properly aligned.
+    // Consider defining MICROPY_OBJ_BASE_ALIGNMENT to be at least 4.
+    MP_STATIC_ASSERT((intptr_t)&a.y - (intptr_t)&a.x >= 4);
+}
+
 // Allocates an object and also sets type, for mp_obj_malloc{,_var} macros.
 MP_NOINLINE void *mp_obj_malloc_helper(size_t num_bytes, const mp_obj_type_t *type) {
     mp_obj_base_t *base = (mp_obj_base_t *)m_malloc(num_bytes);

--- a/py/obj.h
+++ b/py/obj.h
@@ -52,7 +52,7 @@ typedef struct _mp_obj_type_t mp_obj_type_t;
 // Anything that wants to be a concrete MicroPython object must have mp_obj_base_t
 // as its first member (small ints, qstr objs and inline floats are not concrete).
 struct _mp_obj_base_t {
-    const mp_obj_type_t *type MICROPY_OBJ_BASE_ALIGNMENT;
+    const mp_obj_type_t *type MICROPY_OBJ_BASE_ALIGNMENT_ATTR;
 };
 typedef struct _mp_obj_base_t mp_obj_base_t;
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<del>This change checks `__BIGGEST_ALIGNMENT__` and produces a compile-time error if the maximum alignment is less than 4 bytes. On m68k platforms, an additional message advises using `-malign-int` to enable 4-byte alignment.</del>

<del>This ensures correct operation of object tagging schemes that require at least 4-byte alignment.</del>

Add a compile-time static assertion to ensure uPy objects are aligned to at least a 4-byte boundary.

Change the MICROPY_OBJ_BASE_ALIGNMENT macro to a numeric value, making it easier to define via CFLAGS in Makefiles.

Reference: https://wiki.debian.org/M68k/Alignment
> On m68k, the default alignment has been traditionally 2 bytes instead of 4 bytes. This originates in the design of the original 68000 CPU which used an external 16-bit data bus such that data words with a length of 1 or 2 bytes could be handled by the data bus in one clock cycle instead of two. Starting with the 68020 CPU, the external data bus was extended to 32 bits and the previously used 2 bytes default alignment was no longer necessary to optimize performance of the data bus.

Related issue: #18183

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Tested on Linux, m68k-linux-gnu-gcc (Debian 14.2.0-19) 14.2.0

Successful build, REPL launched without errors.