### PR TITLE
tests/run-tests.py: Raise OSError on invalid file open for injected FS.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -88,10 +88,11 @@ class __FS:
     return ""
   def stat(self, path):
     if path == '__injected_test.mpy':
-      return tuple(0 for _ in range(10))
+      return (0,0,0,0,0,0,0,0,0,0)
     else:
-      raise OSError(-2) # ENOENT
+      raise OSError(2) # ENOENT
   def open(self, path, mode):
+    self.stat(path)
     return __File()
 vfs.mount(__FS(), '/__vfstest')
 os.chdir('/__vfstest')


### PR DESCRIPTION
### Summary

This makes sure that `open()` raises `OSError(ENOENT)` if the test script attempts to open a file that does not exist.

For example, the test `tests/ports/esp32/check_err_str.py` attempts to do this and this test currently fails when run with `--via-mpy` because the injected filesystem lets a file by any name be opened.

The fix here tries to be as minimal as possible, so includes a size optimisation for `stat()` to use a fixed 10-tuple.  It also fixes the `OSError` argument, which should be positive.

### Testing

Tested on ESP32_GENERIC, the test `tests/ports/esp32/check_err_str.py` now passes.

CI will test the rest.