### PR TITLE
tests: Move ports/esp32/resolve_on_connect.py to net_inet.

### DIFF
--- a/tests/net_inet/resolve_on_connect.py
+++ b/tests/net_inet/resolve_on_connect.py
@@ -8,51 +8,31 @@ if sys.implementation.name == "micropython" and sys.platform != "esp32":
     raise SystemExit
 
 import socket
+import unittest
 
 
-def test_bind_resolves_0_0_0_0():
-    s = socket.socket()
-    try:
-        s.bind(("0.0.0.0", 31245))
-        print("bind actually bound")
+class Test(unittest.TestCase):
+    def test_bind_resolves_0_0_0_0(self):
+        s = socket.socket()
+        self.assertEqual(s.bind(("0.0.0.0", 31245)), None)
         s.close()
-    except Exception as e:
-        print("bind raised", e)
 
-
-def test_bind_resolves_localhost():
-    s = socket.socket()
-    try:
-        s.bind(("localhost", 31245))
-        print("bind actually bound")
+    def test_bind_resolves_localhost(self):
+        s = socket.socket()
+        self.assertEqual(s.bind(("localhost", 31245)), None)
         s.close()
-    except Exception as e:
-        print("bind raised", e)
 
-
-def test_connect_resolves():
-    s = socket.socket()
-    try:
-        s.connect(("micropython.org", 80))
-        print("connect actually connected")
+    def test_connect_resolves(self):
+        s = socket.socket()
+        self.assertEqual(s.connect(("micropython.org", 80)), None)
         s.close()
-    except Exception as e:
-        print("connect raised", e)
 
-
-def test_connect_non_existent():
-    s = socket.socket()
-    try:
-        s.connect(("nonexistent.example.com", 80))
-        print("connect actually connected")
+    def test_connect_non_existent(self):
+        s = socket.socket()
+        with self.assertRaises(OSError):
+            s.connect(("nonexistent.example.com", 80))
         s.close()
-    except OSError as e:
-        print("connect raised OSError")
-    except Exception as e:
-        print("connect raised", e)
 
 
-test_funs = [n for n in dir() if n.startswith("test_")]
-for f in sorted(test_funs):
-    print("--", f, end=": ")
-    eval(f + "()")
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/net_inet/resolve_on_connect.py
+++ b/tests/net_inet/resolve_on_connect.py
@@ -1,11 +1,13 @@
-# Test that the esp32's socket module performs DNS resolutions on bind and connect
+# Test that the socket module performs DNS resolutions on bind and connect.
+# Currenty only the esp32 port does this, so the test is restricted to that port.
+
 import sys
 
 if sys.implementation.name == "micropython" and sys.platform != "esp32":
     print("SKIP")
     raise SystemExit
 
-import socket, sys
+import socket
 
 
 def test_bind_resolves_0_0_0_0():


### PR DESCRIPTION
### Summary

The main reason for moving this test is that it needs internet connection to pass.  So putting it in `net_inet` makes sure it's alongside other tests that need the internet.

Also, it's a general test that could eventually run on other ports, if/when they support doing an address resolution as part of `socket.connect()`.

### Testing

Tested on ESP32_GENERIC, this test passes when the board has internet connection.

Tested on RPI_PICO2_W, this test is correctly skipped.