### PR TITLE
py/misc: Annotate allocators with alloc_size and malloc attributes.

### DIFF
--- a/py/gc.h
+++ b/py/gc.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include "py/mpprint.h"
+#include "py/misc.h"
 
 void gc_init(void *start, void *end);
 
@@ -62,10 +63,10 @@ enum {
     GC_ALLOC_FLAG_HAS_FINALISER = 1,
 };
 
-void *gc_alloc(size_t n_bytes, unsigned int alloc_flags);
 void gc_free(void *ptr); // does not call finaliser
+void *gc_alloc(size_t n_bytes, unsigned int alloc_flags) MP_ATTR_ALLOC_SIZE(1) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__) MP_ATTR_MALLOC(gc_free);
 size_t gc_nbytes(const void *ptr);
-void *gc_realloc(void *ptr, size_t n_bytes, bool allow_move);
+void *gc_realloc(void *ptr, size_t n_bytes, bool allow_move) MP_ATTR_ALLOC_SIZE(2) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__);
 
 typedef struct _gc_info_t {
     size_t total;

--- a/py/misc.h
+++ b/py/misc.h
@@ -51,6 +51,13 @@ typedef unsigned int uint;
 // This macro is supported by Clang and gcc>=14
 #define __has_feature(x) (0)
 #endif
+#ifndef __has_extension
+// This macro is supported by Clang and gcc>=14
+#define __has_extension(x) (0)
+#endif
+#ifndef __has_attribute
+#define __has_attribute(x) (0)
+#endif
 
 
 /** generic ops *************************************************/

--- a/py/misc.h
+++ b/py/misc.h
@@ -146,26 +146,32 @@ typedef unsigned int uint;
 #endif
 #define m_del_obj(type, ptr) (m_del(type, ptr, 1))
 
-void *m_malloc(size_t num_bytes);
-void *m_malloc_maybe(size_t num_bytes);
-void *m_malloc_with_finaliser(size_t num_bytes);
-void *m_malloc0(size_t num_bytes);
 #if MICROPY_MALLOC_USES_ALLOCATED_SIZE
-void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes);
-void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move);
 void m_free(void *ptr, size_t num_bytes);
 #else
-void *m_realloc(void *ptr, size_t new_num_bytes);
-void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move);
 void m_free(void *ptr);
+#endif
+#define MP_M_MALLOC_ATTRS MP_ATTR_ALLOC_SIZE(1) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__) MP_ATTR_MALLOC(m_free)
+void *m_malloc(size_t num_bytes) MP_M_MALLOC_ATTRS;
+void *m_malloc_maybe(size_t num_bytes) MP_M_MALLOC_ATTRS;
+void *m_malloc_with_finaliser(size_t num_bytes) MP_M_MALLOC_ATTRS;
+void *m_malloc0(size_t num_bytes) MP_M_MALLOC_ATTRS;
+#if MICROPY_MALLOC_USES_ALLOCATED_SIZE
+#define MP_M_REALLOC_ATTRS MP_ATTR_ALLOC_SIZE(3) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__)
+void *m_realloc(void *ptr, size_t old_num_bytes, size_t new_num_bytes) MP_M_REALLOC_ATTRS;
+void *m_realloc_maybe(void *ptr, size_t old_num_bytes, size_t new_num_bytes, bool allow_move) MP_M_REALLOC_ATTRS;
+#else
+#define MP_M_REALLOC_ATTRS MP_ATTR_ALLOC_SIZE(2) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__)
+void *m_realloc(void *ptr, size_t new_num_bytes) MP_M_REALLOC_ATTRS;
+void *m_realloc_maybe(void *ptr, size_t new_num_bytes, bool allow_move) MP_M_REALLOC_ATTRS;
 #endif
 MP_NORETURN void m_malloc_fail(size_t num_bytes);
 
 #if MICROPY_TRACKED_ALLOC
 // These alloc/free functions track the pointers in a linked list so the GC does not reclaim
 // them.  They can be used by code that requires traditional C malloc/free semantics.
-void *m_tracked_calloc(size_t nmemb, size_t size);
 void m_tracked_free(void *ptr_in);
+void *m_tracked_calloc(size_t nmemb, size_t size) MP_ATTR_ALLOC_SIZE(1, 2) MP_ATTR_ASSUME_ALIGNED(__BIGGEST_ALIGNMENT__) MP_ATTR_MALLOC(m_tracked_free);
 #endif
 
 #if MICROPY_MEM_STATS

--- a/py/misc.h
+++ b/py/misc.h
@@ -102,6 +102,27 @@ typedef unsigned int uint;
 
 /** memory allocation ******************************************/
 
+// indicate which malloc argument is the allocation size
+#if __has_attribute(__alloc_size__)
+#define MP_ATTR_ALLOC_SIZE(...) __attribute__((alloc_size(__VA_ARGS__)))
+#else
+#define MP_ATTR_ALLOC_SIZE(...)
+#endif
+
+// declare the alignment of the output pointer
+#if __has_attribute(__assume_aligned__)
+#define MP_ATTR_ASSUME_ALIGNED(alignment) __attribute__((assume_aligned(alignment)))
+#else
+#define MP_ATTR_ASSUME_ALIGNED(alignment)
+#endif
+
+// associate allocators with their corresponding free functions
+#if __has_attribute(__malloc__) && (defined(__GNUC__) ? __GNUC__ >= 11 : true)
+#define MP_ATTR_MALLOC(...) __attribute__((malloc(__VA_ARGS__)))
+#else
+#define MP_ATTR_MALLOC(...)
+#endif
+
 // TODO make a lazy m_renew that can increase by a smaller amount than requested (but by at least 1 more element)
 
 #define m_new(type, num) ((type *)(m_malloc(sizeof(type) * (num))))


### PR DESCRIPTION
### Summary
This PR updates the declarations for most of MicroPython's allocation functions to include the following GCC extension attributes as appropriate:

- [`malloc`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute), indicating that the pointer is to new uninitialized memory, and which is the corresponding free function.
- [`alloc_size`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005fsize-function-attribute), indicating which arguments to the allocators are the size arguments. 
- [`assume_aligned`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-assume_005faligned-function-attribute), indicating that the pointers returned are always suitably aligned for wide loads and stores.

This shouldn't change observable behavior, but should mildly improve efficiency across the board, and also help sanitizers better analyze MicroPython's memory management.

(Note that the free methods needed to be re-ordered to come first so they could be referenced in the attributes of the other allocators.)

### Testing
Tested against Unix and RP2; full test suite continues to pass.

### Trade-offs and Alternatives
It's not totally clear to me if `__BIGGEST_ALIGNMENT__` is actually valid here, even if all of the tests seem to pass. That's the guarantee made by standard `malloc` --- i.e. that the pointer returned has sufficient alignment to be cast to any other valid type --- so if it's not valid, that might be an issue itself worth fixing. (It's also not a macro that exists in MSVC, though it's ignored since MSVC also doesn't have attributes of the relevant sort either.)

