### PR TITLE
py/misc: Fix builds with non-ilp32 toolchains.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -446,11 +446,11 @@ static inline uint32_t mp_clz_mpi(mp_int_t x) {
     }
     return zeroes;
     #else
-    MP_STATIC_ASSERT(sizeof(mp_int_t) == sizeof(long long)
-        || sizeof(mp_int_t) == sizeof(long));
+    MP_STATIC_ASSERT(sizeof(mp_int_t) <= sizeof(long long)
+        || sizeof(mp_int_t) <= sizeof(long));
 
     // ugly, but should compile to single intrinsic unless O0 is set
-    if (mp_check(sizeof(mp_int_t) == sizeof(long))) {
+    if (mp_check(sizeof(mp_int_t) <= sizeof(long))) {
         return mp_clzl((unsigned long)x);
     } else {
         return mp_clzll((unsigned long long)x);


### PR DESCRIPTION
### Summary

This commit fixes a static assertion in "mp_clz_mpi" that stops builds on toolchains that do not follow the ilp32 data model.

The code assumes that sizeof(mp_int_t) is either equal to sizeof(long) or sizeof(long long), which is correct for ilp32 and lp64 data models (where sizeof(int) == sizeof(long)).

Toolchains that do not follow that, like Ubuntu's packaged Xtensa toolchain, break the build.  For that toolchain ints and pointers are 32 bits wide and everything else is 64 bits wide instead.

### Testing

This came up whilst working on the QEMU port targetting Xtensa CPUs, and that's currently neither finished nor in a releasable state.  If you want to test this specific change locally you can spin up an Ubuntu 24.04 VM, install the Ubuntu-supplied `gcc-xtensa-lx106` Xtensa compiler package  [1] and then attempt to compile the following C source file with `xtensa-lx106-elf-gcc` - just ignore all the linking errors:

```c
#include <stdint.h>
#include <stdbool.h>

#define MP_STATIC_ASSERT(cond) ((void)sizeof(char[1 - 2 * !(cond)]))

typedef int32_t mp_int_t;
static inline uint32_t mp_clz_mpi();

int main(void) {
    return mp_clz_mpi();
}

static inline bool mp_check(bool value) {
    return value;
}

static inline uint32_t mp_clz_mpi() {
    MP_STATIC_ASSERT(sizeof(mp_int_t) == sizeof(long long)
        || sizeof(mp_int_t) == sizeof(long));

    // ugly, but should compile to single intrinsic unless O0 is set
    if (mp_check(sizeof(mp_int_t) <= sizeof(long))) {
        return 100;
    } else {
        return 200;
    }
}
```

The static assertion will trigger (relevant code is taken verbatim from `py/misc.h`), and then replacing the static assertion checks from strict equality to less-than-or-equal as this PR does will let compilation succeed.

Ubuntu's Picolibc package for Xtensa (`picolibc-xtensa-lx106-elf`) was built without `-mtext-section-literals` so it's broken in its own way - otherwise I might have attempted to get the minimal port to build and link with that data model as part of the CI process.

[1] This is what I planned to use to build the QEMU port with, but I'll probably use Espressif's Xtensa toolchain to build that going forward.  I'll need to see how GitHub action caching works so I won't download the ESP32S3 toolchain on every CI run, though.

### Trade-offs and Alternatives

These changes will now guard against *interesting* toolchains or configurations where sizeof(mp_int_t) is larger than sizeof(long)/sizeof(long long), but I can't think of any instance of those in the wild.