### PR TITLE
stm32/boards/OPENMV_N6: Switch to object REPR_C.

### DIFF
--- a/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
+++ b/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
@@ -3,7 +3,10 @@
 
 #define MICROPY_GC_STACK_ENTRY_TYPE uint32_t
 #define MICROPY_ALLOC_GC_STACK_SIZE (128)
-#define MICROPY_FATFS_EXFAT         (1)
+
+#define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
+typedef int mp_int_t;               // must be pointer size
+typedef unsigned int mp_uint_t;     // must be pointer size
 
 #define MICROPY_HW_ENABLE_INTERNAL_FLASH_STORAGE (0)
 #define MICROPY_HW_HAS_SWITCH       (0)
@@ -15,6 +18,7 @@
 #define MICROPY_HW_ENABLE_USB       (1)
 #define MICROPY_HW_ENABLE_SDCARD    (1)
 #define MICROPY_PY_PYB_LEGACY       (0)
+#define MICROPY_FATFS_EXFAT         (1)
 
 #define MICROPY_BOARD_ENTER_BOOTLOADER board_enter_bootloader
 #define MICROPY_BOARD_EARLY_INIT    board_early_init


### PR DESCRIPTION
### Summary

I'm not sure how we missed it, but we must use REPR_C because we alloc many float arrays, as explained before.

### Testing

Builds fine, as it should.