### PR TITLE
tests/extmod/time_res.py: Properly skip functions not in time module.

### DIFF
--- a/tests/extmod/time_res.py
+++ b/tests/extmod/time_res.py
@@ -37,9 +37,12 @@ def test():
         time.sleep_ms(100)
         for func_name, _ in EXPECTED_MAP:
             try:
-                time_func = getattr(time, func_name, None) or globals()[func_name]
+                if func_name.endswith("_time"):
+                    time_func = globals()[func_name]
+                else:
+                    time_func = getattr(time, func_name)
                 now = time_func()  # may raise AttributeError
-            except (KeyError, AttributeError):
+            except AttributeError:
                 continue
             try:
                 results_map[func_name].add(now)


### PR DESCRIPTION
### Summary

If `time.time` doesn't exist (because `MICROPY_PY_TIME_TIME_TIME_NS` is disabled, eg on the nrf port), it tries to use `globals()['time']` which is the time module itself, and that causes the test to fail.  Instead it should just skip `time.time`.

### Testing

Tested as part of Octoprobe #17782.
