### PR TITLE
py/errno: Add strerror() to provide user-friendly OSError messages.

### DIFF
--- a/ports/unix/variants/mpconfigvariant_common.h
+++ b/ports/unix/variants/mpconfigvariant_common.h
@@ -86,6 +86,7 @@
 #define MICROPY_ERROR_REPORTING     (MICROPY_ERROR_REPORTING_DETAILED)
 #define MICROPY_WARNINGS               (1)
 #define MICROPY_PY_STR_BYTES_CMP_WARN  (1)
+#define MICROPY_PY_STRERROR            (1)
 
 // Configure the "sys" module with features not usually enabled on bare-metal.
 #define MICROPY_PY_SYS_ATEXIT          (1)

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -165,6 +165,7 @@
 #define MICROPY_ERROR_PRINTER       (&mp_stderr_print)
 #define MICROPY_WARNINGS            (1)
 #define MICROPY_PY_STR_BYTES_CMP_WARN (1)
+#define MICROPY_PY_STRERROR         (1)
 
 // VFS stat functions should return time values relative to 1970/1/1
 #define MICROPY_EPOCH_IS_1970       (1)

--- a/py/moderrno.c
+++ b/py/moderrno.c
@@ -102,6 +102,15 @@ const mp_obj_module_t mp_module_errno = {
 MP_REGISTER_EXTENSIBLE_MODULE(MP_QSTR_errno, mp_module_errno);
 
 qstr mp_errno_to_str(mp_obj_t errno_val) {
+    #if MICROPY_PY_STRERROR
+    mp_int_t errno_int;
+    if (mp_obj_get_int_maybe(errno_val, &errno_int) && errno_int > 0) {
+        char *msg = strerror(errno_int);
+        if (msg) {
+            return qstr_from_str(msg);
+        }
+    }
+    #endif
     #if MICROPY_PY_ERRNO_ERRORCODE
     // We have the errorcode dict so can do a lookup using the hash map
     mp_map_elem_t *elem = mp_map_lookup((mp_map_t *)&errorcode_dict.map, errno_val, MP_MAP_LOOKUP);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1750,6 +1750,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_SELECT_SELECT (1)
 #endif
 
+// Whether to use strerror() to provide user-friendly OSError messages.
+#ifndef MICROPY_PY_STRERROR
+#define MICROPY_PY_STRERROR (0)
+#endif
+
 // Whether to provide the "time" module
 #ifndef MICROPY_PY_TIME
 #define MICROPY_PY_TIME (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_BASIC_FEATURES)

--- a/tests/basics/errno1.py
+++ b/tests/basics/errno1.py
@@ -11,14 +11,14 @@ print(type(errno.EIO))
 
 # check that errors are rendered in a nice way
 msg = str(OSError(errno.EIO))
-print(msg[:7], msg[-5:])
+print(msg[:7])
 msg = str(OSError(errno.EIO, "details"))
-print(msg[:7], msg[-14:])
+print(msg[:7], msg[-7:])
 msg = str(OSError(errno.EIO, "details", "more details"))
 print(msg[:1], msg[-28:])
 
 # check that unknown errno is still rendered
-print(str(OSError(9999)))
+print(str(OSError(-9999)))
 
 # this tests a failed constant lookup in errno
 errno = errno

--- a/tests/basics/errno1.py.exp
+++ b/tests/basics/errno1.py.exp
@@ -1,6 +1,6 @@
 <class 'int'>
-[Errno  ] EIO
-[Errno  ] EIO: details
+[Errno 
+[Errno  details
 ( , 'details', 'more details')
-9999
+-9999
 errno

--- a/tests/extmod/vfs_blockdev_invalid.py
+++ b/tests/extmod/vfs_blockdev_invalid.py
@@ -2,6 +2,7 @@
 
 try:
     import vfs
+    import errno
 
     vfs.VfsFat
     vfs.VfsLfs2
@@ -70,6 +71,8 @@ def test(vfs_class):
         try:
             with fs.open("test", "r") as f:
                 print("opened")
+        except OSError as e:
+            print(type(e), errno.errorcode.get(e.errno))
         except Exception as e:
             print(type(e), e)
 
@@ -81,6 +84,8 @@ def test(vfs_class):
                 bdev.read_res = res
                 print("read 1", f.read(1))
                 print("read rest", f.read())
+        except OSError as e:
+            print(type(e), errno.errorcode.get(e.errno))
         except Exception as e:
             print(type(e), e)
 

--- a/tests/extmod/vfs_blockdev_invalid.py.exp
+++ b/tests/extmod/vfs_blockdev_invalid.py.exp
@@ -2,13 +2,13 @@
 opened
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> EIO
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-<class 'OSError'> [Errno 22] EINVAL
+<class 'OSError'> EINVAL
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-<class 'OSError'> [Errno 22] EINVAL
+<class 'OSError'> EINVAL
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 <class 'TypeError'> can't convert str to int
@@ -18,11 +18,11 @@ read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 opened
 read 1 a
 read rest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-<class 'OSError'> [Errno 5] EIO
-<class 'OSError'> [Errno 5] EIO
-<class 'OSError'> [Errno 5] EIO
-<class 'OSError'> [Errno 5] EIO
-<class 'OSError'> [Errno 5] EIO
-<class 'OSError'> [Errno 5] EIO
+<class 'OSError'> EIO
+<class 'OSError'> EIO
+<class 'OSError'> EIO
+<class 'OSError'> EIO
+<class 'OSError'> EIO
+<class 'OSError'> EIO
 <class 'TypeError'> can't convert str to int
 <class 'TypeError'> can't convert str to int

--- a/tests/extmod/vfs_lfs_error.py
+++ b/tests/extmod/vfs_lfs_error.py
@@ -10,6 +10,10 @@ except (ImportError, AttributeError):
     raise SystemExit
 
 
+def oserror_name(ex):
+    return errno.errorcode.get(ex.errno)
+
+
 class RAMBlockDevice:
     ERASE_BLOCK_SIZE = 1024
 
@@ -61,51 +65,51 @@ def test(bdev, vfs_class):
     try:
         fs.ilistdir("noexist")
     except OSError as er:
-        print("ilistdir OSError", er)
+        print("ilistdir OSError", oserror_name(er))
 
     # remove
     try:
         fs.remove("noexist")
     except OSError as er:
-        print("remove OSError", er)
+        print("remove OSError", oserror_name(er))
 
     # rmdir
     try:
         fs.rmdir("noexist")
     except OSError as er:
-        print("rmdir OSError", er)
+        print("rmdir OSError", oserror_name(er))
 
     # rename
     try:
         fs.rename("noexist", "somethingelse")
     except OSError as er:
-        print("rename OSError", er)
+        print("rename OSError", oserror_name(er))
 
     # mkdir
     try:
         fs.mkdir("testdir")
     except OSError as er:
-        print("mkdir OSError", er)
+        print("mkdir OSError", oserror_name(er))
 
     # chdir to nonexistent
     try:
         fs.chdir("noexist")
     except OSError as er:
-        print("chdir OSError", er)
+        print("chdir OSError", oserror_name(er))
     print(fs.getcwd())  # check still at root
 
     # chdir to file
     try:
         fs.chdir("testfile")
     except OSError as er:
-        print("chdir OSError", er)
+        print("chdir OSError", oserror_name(er))
     print(fs.getcwd())  # check still at root
 
     # stat
     try:
         fs.stat("noexist")
     except OSError as er:
-        print("stat OSError", er)
+        print("stat OSError", oserror_name(er))
 
     # error during seek
     with fs.open("testfile", "r") as f:
@@ -113,7 +117,7 @@ def test(bdev, vfs_class):
         try:
             f.seek(1 << 30, 1)  # SEEK_CUR
         except OSError as er:
-            print("seek OSError", er)
+            print("seek OSError", oserror_name(er))
 
 
 bdev = RAMBlockDevice(30)

--- a/tests/extmod/vfs_lfs_error.py.exp
+++ b/tests/extmod/vfs_lfs_error.py.exp
@@ -1,28 +1,28 @@
 test <class 'VfsLfs1'>
 mkfs OSError True
 mount OSError True
-ilistdir OSError [Errno 2] ENOENT
-remove OSError [Errno 2] ENOENT
-rmdir OSError [Errno 2] ENOENT
-rename OSError [Errno 2] ENOENT
-mkdir OSError [Errno 17] EEXIST
-chdir OSError [Errno 2] ENOENT
+ilistdir OSError ENOENT
+remove OSError ENOENT
+rmdir OSError ENOENT
+rename OSError ENOENT
+mkdir OSError EEXIST
+chdir OSError ENOENT
 /
-chdir OSError [Errno 2] ENOENT
+chdir OSError ENOENT
 /
-stat OSError [Errno 2] ENOENT
-seek OSError [Errno 22] EINVAL
+stat OSError ENOENT
+seek OSError EINVAL
 test <class 'VfsLfs2'>
 mkfs OSError True
 mount OSError True
-ilistdir OSError [Errno 2] ENOENT
-remove OSError [Errno 2] ENOENT
-rmdir OSError [Errno 2] ENOENT
-rename OSError [Errno 2] ENOENT
-mkdir OSError [Errno 17] EEXIST
-chdir OSError [Errno 2] ENOENT
+ilistdir OSError ENOENT
+remove OSError ENOENT
+rmdir OSError ENOENT
+rename OSError ENOENT
+mkdir OSError EEXIST
+chdir OSError ENOENT
 /
-chdir OSError [Errno 2] ENOENT
+chdir OSError ENOENT
 /
-stat OSError [Errno 2] ENOENT
-seek OSError [Errno 22] EINVAL
+stat OSError ENOENT
+seek OSError EINVAL


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
Introduce the `MICROPY_PY_STRERROR` macro to control whether `strerror()` is used to provide OSError messages.

This feature is useful on the Unix port. As MicroPython is usually dynamically linked with libc on Unix systems, using `strerror()` does not significantly increase the binary size in these cases.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

```
make CFLAGS_EXTRA=-DMICROPY_PY_STRERROR=1
```

```
MicroPython v1.27.0-preview.284.g5b92eee562 on 2025-10-07; linux [GCC 14.2.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> open('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 2] No such file or directory
```

Before:

```
MicroPython v1.27.0-preview.284.g5b92eee562 on 2025-10-07; linux [GCC 14.2.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> open('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 2] ENOENT
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

<del>This feature is disabled by default, as it breaks test cases which use `except OSError as e: print(e)`.</del>

<del>Otherwise I would set it to `MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_FULL_FEATURES` and enable it by default on Unix port.</del>

This feature is enabled by default on Unix and Windows port, and is disabled on all other ports.