### PR TITLE
tools/ci: Fix typo of pipefail.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -241,7 +241,7 @@ function ci_esp32_build_c2_c6 {
 function ci_esp8266_setup {
     sudo pip3 install pyserial esptool==3.3.1 pyelftools ar
     wget https://micropython.org/resources/xtensa-lx106-elf-standalone.tar.gz
-    (set -o pipefile; zcat xtensa-lx106-elf-standalone.tar.gz | tar x)
+    (set -o pipefail; zcat xtensa-lx106-elf-standalone.tar.gz | tar x)
     # Remove this esptool.py so pip version is used instead
     rm xtensa-lx106-elf/bin/esptool.py
 }


### PR DESCRIPTION
### Summary

Regression from typo in 449866cb0af3fc547df6538a6552517cc8974616 - PR #18033.
