### PR TITLE
ci: Add esp32 to code size report

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -30,6 +30,30 @@ jobs:
         fetch-depth: 100
     - name: Install packages
       run: tools/ci.sh code_size_setup
+
+    # Needs to be kept in synch with ports_esp32.yml
+    - id: idf_ver
+      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
+      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
+    - name: Cached ESP-IDF install
+      id: cache_esp_idf
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./esp-idf/
+          ~/.espressif/
+          !~/.espressif/dist/
+          ~/.cache/pip/
+        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
+    - name: Install ESP-IDF packages
+      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
+      run: tools/ci.sh esp32_idf_setup
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: code_size
+
     - name: Build
       run: tools/ci.sh code_size_build
     - name: Compute code size difference

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -36,8 +36,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - id: idf_ver
-      name: Read the ESP-IDF version (including Python version)
-      run: source tools/ci.sh && echo "IDF_VER=${IDF_VER}-py${PYTHON_VER}" | tee "$GITHUB_OUTPUT"
+      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
+      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
 
     - name: Cached ESP-IDF install
       id: cache_esp_idf

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
 
+    # Needs to be kept in synch with code_size.yml
     - id: idf_ver
       name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
       run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
@@ -54,6 +55,7 @@ jobs:
       if: steps.cache_esp_idf.outputs.cache-hit != 'true'
       run: tools/ci.sh esp32_idf_setup
 
+    # Needs to be kept in synch with code_size.yml
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
       with:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -206,6 +206,10 @@ PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
 
 export IDF_CCACHE_ENABLE=1
 
+function ci_esp32_idf_ver {
+    echo "IDF_VER=${IDF_VER}-py${PYTHON_VER}"
+}
+
 function ci_esp32_idf_setup {
     echo "Using ESP-IDF version $IDF_VER"
     git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -87,7 +87,7 @@ function _ci_is_git_merge {
 function ci_code_size_build {
     # check the following ports for the change in their code size
     # Override the list by setting PORTS_TO_CHECK in the environment before invoking ci.
-    : ${PORTS_TO_CHECK:=bmusxpdv}
+    : ${PORTS_TO_CHECK:=bmus3xpdv}
     
     SUBMODULES="lib/asf4 lib/berkeley-db-1.xx lib/btstack lib/cyw43-driver lib/lwip lib/mbedtls lib/micropython-lib lib/nxp_driver lib/pico-sdk lib/stm32lib lib/tinyusb"
 


### PR DESCRIPTION
### Summary

Add an esp32 build (specifically ESP32_GENERIC) to the ci "sizecheck". This should succeed in CI now that #18033 has been merged.

### Testing

Locally I ran `PORTS_TO_CHECK=3m ci code_size_build code_size_report` and it reported
```
  mpy-cross:    +0 +0.000% 
      esp32:    +0 +0.000% ESP32_GENERIC
minimal x86:    +0 +0.000% 
```

### Trade-offs and Alternatives

Damien noted in #18033 that this adds time to an already lengthy task within the CI build. Checking on the reported build time to compare it with  is a good idea, even if there's a lot of run to run variance (or at least that's what I've experienced in the past with other github actions runs.

I noticed how esp32 is using ccache and it occurs to me that if we could apply ccache to the other builds it might help in the case that the reference and comparison builds are "fairly alike", but that's scope creep.