### PR TITLE
qemu: support mpremote mount.

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -110,6 +110,7 @@ LDFLAGS += -mabi=$(RV32_ABI) -march=$(RV32_ARCH) -Wl,-EL
 SRC_C += \
 	mcu/rv32/interrupts.c \
 	mcu/rv32/startup.c \
+	mcu/riscv/ticks.c \
 
 SRC_BOARD_O += mcu/rv32/entrypoint.o
 
@@ -143,6 +144,7 @@ LDFLAGS += -mabi=$(RV64_ABI) -march=$(RV64_ARCH) -Wl,-EL -mcmodel=medany
 SRC_C += \
 	mcu/rv64/interrupts.c \
 	mcu/rv64/startup.c \
+	mcu/riscv/ticks.c \
 
 SRC_BOARD_O += mcu/rv64/entrypoint.o
 

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -77,6 +77,7 @@ LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 SRC_C += \
 	mcu/arm/errorhandler.c \
 	mcu/arm/startup.c \
+	mcu/arm/ticks.c \
 	shared/runtime/semihosting_arm.c \
 
 endif

--- a/ports/qemu/boards/MPS3_AN547/mpconfigboard.mk
+++ b/ports/qemu/boards/MPS3_AN547/mpconfigboard.mk
@@ -1,0 +1,16 @@
+QEMU_ARCH = arm
+QEMU_MACHINE = mps3-an547
+
+CFLAGS += -mthumb -mcpu=cortex-m55 -mfloat-abi=hard -mfpu=fpv5-d16
+CFLAGS += -DQEMU_SOC_MPS3
+CFLAGS += -DMICROPY_HW_MCU_NAME='"Cortex-M55"'
+CFLAGS += -DCPU_FREQ_HZ=32000000
+
+LDSCRIPT = mcu/arm/mps3.ld
+
+SRC_BOARD_O = shared/runtime/gchelper_generic.o
+
+MPY_CROSS_FLAGS += -march=armv7emdp
+
+MICROPY_FLOAT_IMPL ?= double
+SUPPORTS_HARDWARE_FP_DOUBLE ?= 1

--- a/ports/qemu/mcu/arm/errorhandler.c
+++ b/ports/qemu/mcu/arm/errorhandler.c
@@ -191,7 +191,7 @@ __attribute__((naked)) MP_NORETURN void PendSV_Handler(void) {
     exception_handler(PENDING_SV);
 }
 
-__attribute__((naked)) MP_NORETURN void SysTick_Handler(void) {
+__attribute__((naked, weak)) MP_NORETURN void SysTick_Handler(void) {
     exception_handler(SYSTEM_TICK);
 }
 

--- a/ports/qemu/mcu/arm/mps3.ld
+++ b/ports/qemu/mcu/arm/mps3.ld
@@ -1,0 +1,49 @@
+/* This file is part of the MicroPython project, http://micropython.org/
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Damien P. George
+ */
+
+MEMORY
+{
+    ITCM : ORIGIN = 0x00000000, LENGTH = 512K
+    RAM  : ORIGIN = 0x01000000, LENGTH = 2M
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .isr_vector : {
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > ITCM
+
+    .text : {
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+        *(.ARM.exidx*)
+        . = ALIGN(4);
+        _etext = .;
+        _sidata = _etext;
+    } > RAM
+
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } >RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } >RAM
+}

--- a/ports/qemu/mcu/arm/startup.c
+++ b/ports/qemu/mcu/arm/startup.c
@@ -47,7 +47,7 @@ __attribute__((naked)) void Reset_Handler(void) {
     for (uint32_t *dest = &_sbss; dest < &_ebss;) {
         *dest++ = 0;
     }
-    #if MICROPY_HW_FPU && defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH == 7
+    #if MICROPY_HW_FPU && defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH >= 7
     // initialise the FPU (full access to CP10 and CP11, as per B3.2.20)
     *((volatile uint32_t *)0xE000ED88) |= 0x00F00000;
     __asm volatile ("dsb");

--- a/ports/qemu/mcu/arm/startup.c
+++ b/ports/qemu/mcu/arm/startup.c
@@ -118,6 +118,9 @@ const uint32_t isr_vector[] __attribute__((section(".isr_vector"))) = {
 void _start(void) {
     mp_semihosting_init();
 
+    extern void ticks_init(void);
+    ticks_init();
+
     // Enable the UART
     uart_init();
 

--- a/ports/qemu/mcu/arm/ticks.c
+++ b/ports/qemu/mcu/arm/ticks.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+// CPU frequency
+#ifndef CPU_FREQ_HZ
+#define CPU_FREQ_HZ             25000000u
+#endif
+
+// SysTick registers
+#define SYSTICK_BASE            0xE000E010
+#define SYSTICK_CSR             (*(volatile uint32_t *)(SYSTICK_BASE + 0x00))
+#define SYSTICK_RVR             (*(volatile uint32_t *)(SYSTICK_BASE + 0x04))
+#define SYSTICK_CVR             (*(volatile uint32_t *)(SYSTICK_BASE + 0x08))
+
+// SysTick config bits
+#define SYSTICK_CSR_ENABLE      (1 << 0)
+#define SYSTICK_CSR_TICKINT     (1 << 1)
+#define SYSTICK_CSR_CLKSOURCE   (1 << 2)
+
+static volatile uint32_t _ticks_ms = 0;
+#if defined(__ARM_ARCH_ISA_ARM)
+static volatile uint32_t _ticks_us = 0;
+#endif
+
+void ticks_init(void) {
+    #if !defined(__ARM_ARCH_ISA_ARM)
+    // Configure SysTick: reload at 1ms intervals (Cortex-M)
+    SYSTICK_CVR = 0;
+    SYSTICK_RVR = (CPU_FREQ_HZ / 1000) - 1;
+    SYSTICK_CSR = SYSTICK_CSR_ENABLE | SYSTICK_CSR_TICKINT | SYSTICK_CSR_CLKSOURCE;
+    #endif
+}
+
+uintptr_t ticks_ms(void) {
+    #if defined(__ARM_ARCH_ISA_ARM)
+    return _ticks_us++ / 1000;
+    #else
+    return _ticks_ms;
+    #endif
+}
+
+uintptr_t ticks_us(void) {
+    #if defined(__ARM_ARCH_ISA_ARM)
+    return _ticks_us++;
+    #else
+    // Get current values atomically
+    uint32_t ms = _ticks_ms;
+    uint32_t cvr = SYSTICK_CVR;
+
+    // Calculate microseconds from the down-counter
+    uint32_t elapsed_cycles = SYSTICK_RVR - cvr;
+    uint32_t us_fraction = (elapsed_cycles * 1000) / (CPU_FREQ_HZ / 1000);
+
+    return (ms * 1000) + us_fraction;
+    #endif
+}
+
+void SysTick_Handler(void) {
+    _ticks_ms++;
+}

--- a/ports/qemu/mcu/riscv/ticks.c
+++ b/ports/qemu/mcu/riscv/ticks.c
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Ibrahim Abdelkader <iabdalkader@openmv.io>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <stdint.h>
+
+// RISC-V timebase frequency for QEMU
+#ifndef TIMEBASE_FREQ_HZ
+#define TIMEBASE_FREQ_HZ        10000000u
+#endif
+
+static uint64_t ticks_get_ticks(void) {
+    #if __riscv_xlen < 64
+    uint32_t ticks_lo = 0;
+    uint32_t ticks_hi = 0;
+    uint32_t rollover = 0;
+    do {
+        __asm volatile (
+            "rdtimeh %0 \n"
+            "rdtime  %1 \n"
+            "rdtimeh %2 \n"
+            : "=r" (ticks_hi), "=r" (ticks_lo), "=r" (rollover)
+            :
+            :
+            );
+    } while (ticks_hi != rollover);
+    return ((uint64_t)(ticks_hi) << 32ULL) | (uint64_t)(ticks_lo);
+    #else
+    uint64_t ticks = 0;
+    __asm volatile (
+        "rdtime %0 \n"
+        : "=r" (ticks)
+        :
+        :
+        );
+    return ticks;
+    #endif
+}
+
+uintptr_t ticks_ms(void) {
+    return (uintptr_t)(ticks_get_ticks() / (TIMEBASE_FREQ_HZ / 1000));
+}
+
+uintptr_t ticks_us(void) {
+    return (uintptr_t)(ticks_get_ticks() / (TIMEBASE_FREQ_HZ / 1000000));
+}

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -54,9 +54,6 @@
 #define MICROPY_LONGINT_IMPL        (MICROPY_LONGINT_IMPL_MPZ)
 #define MICROPY_WARNINGS            (1)
 #define MICROPY_PY_SYS_PLATFORM     "qemu"
-#define MICROPY_PY_SYS_STDIO_BUFFER (0)
-#define MICROPY_PY_SELECT           (0)
-#define MICROPY_PY_TIME             (0)
 #define MICROPY_PY_ASYNCIO          (0)
 #define MICROPY_PY_MACHINE          (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE "ports/qemu/modmachine.c"

--- a/ports/qemu/mphalport.c
+++ b/ports/qemu/mphalport.c
@@ -25,6 +25,7 @@
  */
 
 #include "py/mphal.h"
+#include "py/stream.h"
 #include "shared/runtime/semihosting_arm.h"
 #include "uart.h"
 
@@ -32,8 +33,15 @@
 #define USE_UART (1)
 #define USE_SEMIHOSTING (0)
 
+uintptr_t ticks_ms(void);
+uintptr_t ticks_us(void);
+
 uintptr_t mp_hal_stdio_poll(uintptr_t poll_flags) {
-    // Not implemented.
+    #if USE_UART
+    if ((poll_flags & MP_STREAM_POLL_RD) && uart_rx_any()) {
+        return MP_STREAM_POLL_RD;
+    }
+    #endif
     return 0;
 }
 
@@ -63,4 +71,28 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     mp_semihosting_tx_strn(str, len);
     #endif
     return len;
+}
+
+mp_uint_t mp_hal_ticks_ms(void) {
+    return ticks_ms();
+}
+
+mp_uint_t mp_hal_ticks_us(void) {
+    return ticks_us();
+}
+
+void mp_hal_delay_ms(mp_uint_t ms) {
+    mp_uint_t start = mp_hal_ticks_ms();
+    while (mp_hal_ticks_ms() - start < ms) {
+    }
+}
+
+void mp_hal_delay_us(mp_uint_t us) {
+    mp_uint_t start = mp_hal_ticks_us();
+    while (mp_hal_ticks_us() - start < us) {
+    }
+}
+
+mp_uint_t mp_hal_ticks_cpu(void) {
+    return 0;
 }

--- a/ports/qemu/uart.c
+++ b/ports/qemu/uart.c
@@ -108,7 +108,7 @@ void uart_tx_strn(const char *buf, size_t len) {
     }
 }
 
-#elif defined(QEMU_SOC_MPS2)
+#elif defined(QEMU_SOC_MPS2) || defined(QEMU_SOC_MPS3)
 
 #define UART_STATE_TXFULL (1 << 0)
 #define UART_STATE_RXFULL (1 << 1)
@@ -124,7 +124,11 @@ typedef struct _UART_t {
     volatile uint32_t BAUDDIV;
 } UART_t;
 
+#if defined(QEMU_SOC_MPS3)
+#define UART0 ((UART_t *)(0x49303000))
+#else
 #define UART0 ((UART_t *)(0x40004000))
+#endif
 
 void uart_init(void) {
     UART0->BAUDDIV = 16;

--- a/ports/qemu/uart.c
+++ b/ports/qemu/uart.c
@@ -57,6 +57,10 @@ int uart_rx_chr(void) {
     return UART0->DR;
 }
 
+int uart_rx_any(void) {
+    return UART0->SR & UART_SR_RXNE;
+}
+
 void uart_tx_strn(const char *buf, size_t len) {
     for (size_t i = 0; i < len; ++i) {
         UART0->DR = buf[i];
@@ -94,6 +98,10 @@ int uart_rx_chr(void) {
     return UART0->RXD;
 }
 
+int uart_rx_any(void) {
+    return UART0->RXDRDY ? 1 : 0;
+}
+
 void uart_tx_strn(const char *buf, size_t len) {
     for (size_t i = 0; i < len; ++i) {
         UART0->TXD = buf[i];
@@ -128,6 +136,10 @@ int uart_rx_chr(void) {
         return UART_RX_NO_CHAR;
     }
     return UART0->DATA;
+}
+
+int uart_rx_any(void) {
+    return UART0->STATE & UART_STATE_RXFULL;
 }
 
 void uart_tx_strn(const char *buf, size_t len) {
@@ -170,6 +182,10 @@ int uart_rx_chr(void) {
     return UART1->URXD & 0xff;
 }
 
+int uart_rx_any(void) {
+    return !(UART1->UTS1 & UART_UTS1_RXEMPTY);
+}
+
 void uart_tx_strn(const char *buf, size_t len) {
     for (size_t i = 0; i < len; ++i) {
         UART1->UTXD = buf[i];
@@ -198,6 +214,10 @@ int uart_rx_chr(void) {
         return UART0->DR;
     }
     return UART_RX_NO_CHAR;
+}
+
+int uart_rx_any(void) {
+    return UART0->LSR & UART_LSR_DR;
 }
 
 void uart_tx_strn(const char *buffer, size_t length) {

--- a/ports/qemu/uart.h
+++ b/ports/qemu/uart.h
@@ -33,6 +33,7 @@
 
 void uart_init(void);
 int uart_rx_chr(void);
+int uart_rx_any(void);
 void uart_tx_strn(const char *buf, size_t len);
 
 #endif // MICROPY_INCLUDED_QEMU_ARM_UART_H


### PR DESCRIPTION
### Summary

This PR enables `mpremote mount` to work on qemu. This requires: time/ticks (via SysTick) for select/poll and uart_any for poll.

### Testing

```
micropython/ports/qemu  qemu_mpremote ❯ mpremote connect /dev/pts/10 mount .

Local directory . is mounted at /remote
Connected to MicroPython at /dev/pts/10
Use Ctrl-] or Ctrl-x to exit this shell
>
MicroPython v1.27.0-preview.313.g1ccdb5166d.dirty on 2025-10-11; mps2-an500 with Cortex-M7
Type "help()" for more information.
>>> import os
>>> os.listdir()
['qstrdefsport.h', 'test-frzmpy', 'boards', 'mpconfigport.h', 'mphalport.c', 'mcu', 'build-MPS2_AN500', 'uart.h', 'Makefile', 'README.md', 'mphalport.h', 'uart.c', 'modmachine.c', 'main.c', 'Dockerfile.riscv']
>>>
```

Additionally, this add support for MPS3 and board config files.
```
MPY: soft reboot
MicroPython v1.27.0-preview.322.ga54c3fdd26.dirty on 2025-10-14; mps3-an547 with Cortex-M55
Type "help()" for more information.
>>>
```
### Trade-offs and Alternatives

My goal is to use qemu in CI to run unit-tests, which require access to some test files. I think https://github.com/micropython/micropython/pull/15851 is a better approach, however some changes here might still be useful (for example, if `time` is imported and used in some scripts).