### PR TITLE
all: Simplify mp_int_t definition

### DIFF
--- a/docs/develop/porting.rst
+++ b/docs/develop/porting.rst
@@ -161,8 +161,6 @@ The following is an example of an ``mpconfigport.h`` file:
 
    // Type definitions for the specific machine.
 
-   typedef intptr_t mp_int_t; // must be pointer size
-   typedef uintptr_t mp_uint_t; // must be pointer size
    typedef long mp_off_t;
 
    // We need to provide a declaration/definition of alloca().

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -98,23 +98,6 @@
 
 // type definitions for the specific machine
 
-#ifdef __LP64__
-typedef long mp_int_t; // must be pointer size
-typedef unsigned long mp_uint_t; // must be pointer size
-#elif defined(__MINGW32__) && defined(_WIN64)
-#include <stdint.h>
-typedef __int64 mp_int_t;
-typedef unsigned __int64 mp_uint_t;
-#elif defined(_MSC_VER) && defined(_WIN64)
-typedef __int64 mp_int_t;
-typedef unsigned __int64 mp_uint_t;
-#else
-// These are definitions for machines where sizeof(int) == sizeof(void*),
-// regardless for actual size.
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
-#endif
-
 // Cannot include <sys/types.h>, as it may lead to symbol name clashes
 #if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)
 typedef long long mp_off_t;

--- a/ports/alif/boards/OPENMV_AE3/mpconfigboard.h
+++ b/ports/alif/boards/OPENMV_AE3/mpconfigboard.h
@@ -2,9 +2,6 @@
 #define MICROPY_HW_MCU_NAME         "AE302F80F55D5AE"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
-typedef intptr_t mp_off_t;
 
 #define MICROPY_HW_USB_MSC          (CORE_M55_HP)
 #define MICROPY_HW_ENABLE_HW_I2C    (1)

--- a/ports/alif/mpconfigport.h
+++ b/ports/alif/mpconfigport.h
@@ -191,12 +191,7 @@
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// Assume that if we already defined the obj repr then we also defined these items
-#ifndef MICROPY_OBJ_REPR
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
 typedef intptr_t mp_off_t;
-#endif
 
 // Board configuration settings.
 

--- a/ports/bare-arm/mpconfigport.h
+++ b/ports/bare-arm/mpconfigport.h
@@ -42,8 +42,6 @@
 
 // Type definitions for the specific machine
 
-typedef int32_t mp_int_t; // must be pointer size
-typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // Need to provide a declaration/definition of alloca()

--- a/ports/cc3200/mpconfigport.h
+++ b/ports/cc3200/mpconfigport.h
@@ -130,8 +130,6 @@
 #define MICROPY_MAKE_POINTER_CALLABLE(p)            ((void *)((mp_uint_t)(p) | 1))
 #define MP_SSIZE_MAX                                (0x7FFFFFFF)
 
-typedef int32_t mp_int_t;                           // must be pointer size
-typedef unsigned int mp_uint_t;                     // must be pointer size
 typedef long mp_off_t;
 
 #define MICROPY_EVENT_POLL_HOOK                     __WFI();

--- a/ports/embed/port/mpconfigport_common.h
+++ b/ports/embed/port/mpconfigport_common.h
@@ -28,8 +28,6 @@
 
 // Type definitions for the specific machine
 
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // Need to provide a declaration/definition of alloca()

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -337,8 +337,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 #define MICROPY_WRAP_MP_SCHED_EXCEPTION(f) IRAM_ATTR f
 #define MICROPY_WRAP_MP_SCHED_KEYBOARD_INTERRUPT(f) IRAM_ATTR f
 
-typedef int32_t mp_int_t; // must be pointer size
-typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 // ssize_t, off_t as required by POSIX-signatured functions in stream.h
 #include <sys/types.h>

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -184,15 +184,15 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
     return did_write ? ret : 0;
 }
 
-uint32_t mp_hal_ticks_ms(void) {
+mp_uint_t mp_hal_ticks_ms(void) {
     return esp_timer_get_time() / 1000;
 }
 
-uint32_t mp_hal_ticks_us(void) {
+mp_uint_t mp_hal_ticks_us(void) {
     return esp_timer_get_time();
 }
 
-void mp_hal_delay_ms(uint32_t ms) {
+void mp_hal_delay_ms(mp_uint_t ms) {
     uint64_t us = (uint64_t)ms * 1000ULL;
     uint64_t dt;
     uint64_t t0 = esp_timer_get_time();
@@ -220,7 +220,7 @@ void mp_hal_delay_ms(uint32_t ms) {
     }
 }
 
-void mp_hal_delay_us(uint32_t us) {
+void mp_hal_delay_us(mp_uint_t us) {
     // these constants are tested for a 240MHz clock
     const uint32_t this_overhead = 5;
     const uint32_t pend_overhead = 150;

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -82,18 +82,18 @@ static inline void mp_end_atomic_section(mp_uint_t state) {
 #define MICROPY_BEGIN_ATOMIC_SECTION() mp_begin_atomic_section()
 #define MICROPY_END_ATOMIC_SECTION(state) mp_end_atomic_section(state)
 
-uint32_t mp_hal_ticks_us(void);
-__attribute__((always_inline)) static inline uint32_t mp_hal_ticks_cpu(void) {
+mp_uint_t mp_hal_ticks_us(void);
+__attribute__((always_inline)) static inline mp_uint_t mp_hal_ticks_cpu(void) {
     uint32_t ccount;
     #if CONFIG_IDF_TARGET_ARCH_RISCV
     __asm__ __volatile__ ("csrr %0, 0x7E2" : "=r" (ccount)); // Machine Performance Counter Value
     #else
     __asm__ __volatile__ ("rsr %0,ccount" : "=a" (ccount));
     #endif
-    return ccount;
+    return (mp_uint_t)ccount;
 }
 
-void mp_hal_delay_us(uint32_t);
+void mp_hal_delay_us(mp_uint_t);
 #define mp_hal_delay_us_fast(us) esp_rom_delay_us(us)
 void mp_hal_set_interrupt_char(int c);
 uint32_t mp_hal_get_cpu_freq(void);

--- a/ports/esp8266/esp_mphal.c
+++ b/ports/esp8266/esp_mphal.c
@@ -50,7 +50,7 @@ void mp_hal_init(void) {
     uart_attached_to_dupterm = 0;
 }
 
-void MP_FASTCODE(mp_hal_delay_us)(uint32_t us) {
+void MP_FASTCODE(mp_hal_delay_us)(mp_uint_t us) {
     uint32_t start = system_get_time();
     while (system_get_time() - start < us) {
         mp_event_handle_nowait();

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -57,17 +57,17 @@ extern int uart_attached_to_dupterm;
 void mp_hal_init(void);
 void mp_hal_rtc_init(void);
 
-__attribute__((always_inline)) static inline uint32_t mp_hal_ticks_us(void) {
+__attribute__((always_inline)) static inline mp_uint_t mp_hal_ticks_us(void) {
     return system_get_time();
 }
 
-__attribute__((always_inline)) static inline uint32_t mp_hal_ticks_cpu(void) {
+__attribute__((always_inline)) static inline mp_uint_t mp_hal_ticks_cpu(void) {
     uint32_t ccount;
     __asm__ __volatile__ ("rsr %0,ccount" : "=a" (ccount));
-    return ccount;
+    return (mp_uint_t)ccount;
 }
 
-void mp_hal_delay_us(uint32_t);
+void mp_hal_delay_us(mp_uint_t);
 void mp_hal_set_interrupt_char(int c);
 uint32_t mp_hal_get_cpu_freq(void);
 

--- a/ports/esp8266/mpconfigport.h
+++ b/ports/esp8266/mpconfigport.h
@@ -153,8 +153,6 @@
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-typedef int32_t mp_int_t; // must be pointer size
-typedef uint32_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 typedef uint32_t sys_prot_t; // for modlwip
 // ssize_t, off_t as required by POSIX-signatured functions in stream.h

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -231,8 +231,6 @@ extern const struct _mp_obj_type_t network_lan_type;
     ((uint32_t)((uint8_t *)addr + size + 0x1f) & ~0x1f) - ((uint32_t)addr & ~0x1f)))
 
 #define MP_SSIZE_MAX (0x7fffffff)
-typedef int mp_int_t; // must be pointer size
-typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // Need an implementation of the log2 function which is not a macro.

--- a/ports/minimal/mpconfigport.h
+++ b/ports/minimal/mpconfigport.h
@@ -29,8 +29,6 @@
 
 // type definitions for the specific machine
 
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // We need to provide a declaration/definition of alloca()

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -337,8 +337,6 @@ void *nrf_native_code_commit(void *, unsigned int, void *);
 
 #define HEX2_FMT "%02x"
 
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #if MICROPY_HW_ENABLE_RNG

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -77,9 +77,6 @@
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
 
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
-
 typedef int mp_off_t;
 
 // extra builtin names to add to the global namespace

--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -92,9 +92,6 @@
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
-// This port is 64-bit
-typedef signed long mp_int_t; // must be pointer size
-typedef unsigned long mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // extra built in names to add to the global namespace

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -70,12 +70,8 @@
 
 #if defined(__riscv) && (__riscv_xlen == 64)
 #define MP_SSIZE_MAX (0x7fffffffffffffff)
-typedef int64_t mp_int_t; // must be pointer size
-typedef uint64_t mp_uint_t; // must be pointer size
 #else
 #define MP_SSIZE_MAX (0x7fffffff)
-typedef int32_t mp_int_t; // must be pointer size
-typedef uint32_t mp_uint_t; // must be pointer size
 #endif
 
 typedef long mp_off_t;

--- a/ports/renesas-ra/mpconfigport.h
+++ b/ports/renesas-ra/mpconfigport.h
@@ -234,12 +234,6 @@
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// Assume that if we already defined the obj repr then we also defined these items
-#ifndef MICROPY_OBJ_REPR
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
-#endif
-
 typedef long mp_off_t;
 
 #if MICROPY_PY_THREAD

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -279,8 +279,6 @@
 #endif
 
 #define MP_SSIZE_MAX (0x7fffffff)
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
 typedef intptr_t mp_off_t;
 
 // We need to provide a declaration/definition of alloca()

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -175,8 +175,6 @@
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MP_SSIZE_MAX (0x7fffffff)
-typedef int mp_int_t; // must be pointer size
-typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 // Need an implementation of the log2 function which is not a macro.

--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-giga-r1-wifi"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-typedef int mp_int_t;               // must be pointer size
-typedef unsigned int mp_uint_t;     // must be pointer size
 
 #define MICROPY_FATFS_EXFAT         (1)
 #define MICROPY_HW_ENABLE_RTC       (1)

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-nicla-vision"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-typedef int mp_int_t;               // must be pointer size
-typedef unsigned int mp_uint_t;     // must be pointer size
 
 #define MICROPY_FATFS_EXFAT         (1)
 #define MICROPY_HW_ENABLE_RTC       (1)

--- a/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-opta"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-typedef int mp_int_t;               // must be pointer size
-typedef unsigned int mp_uint_t;     // must be pointer size
 
 #define MICROPY_FATFS_EXFAT         (1)
 #define MICROPY_HW_ENABLE_RTC       (1)

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -12,8 +12,6 @@
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-portenta-h7"
 
 #define MICROPY_OBJ_REPR            (MICROPY_OBJ_REPR_C)
-typedef int mp_int_t;               // must be pointer size
-typedef unsigned int mp_uint_t;     // must be pointer size
 
 #define MICROPY_FATFS_EXFAT         (1)
 #define MICROPY_HW_ENABLE_RTC       (1)

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -229,12 +229,6 @@ extern const struct _mp_obj_type_t network_lan_type;
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// Assume that if we already defined the obj repr then we also defined these items
-#ifndef MICROPY_OBJ_REPR
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
-#endif
-
 typedef long mp_off_t;
 
 #if MICROPY_PY_THREAD

--- a/ports/stm32/mpconfigport_nanbox.h
+++ b/ports/stm32/mpconfigport_nanbox.h
@@ -33,13 +33,5 @@
 #define MICROPY_EMIT_THUMB (0)
 #define MICROPY_EMIT_INLINE_THUMB (0)
 
-// Types needed for nan-boxing
-#define UINT_FMT "%llu"
-#define INT_FMT "%lld"
-#define HEX_FMT "%llx"
-#define SIZE_FMT "%lu"
-typedef int64_t mp_int_t;
-typedef uint64_t mp_uint_t;
-
 // Include base configuration file for rest of configuration
 #include <mpconfigport.h>

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -73,21 +73,6 @@
     #define MICROPY_EMIT_ARM        (1)
 #endif
 
-// Type definitions for the specific machine based on the word size.
-#ifndef MICROPY_OBJ_REPR
-#ifdef __LP64__
-typedef long mp_int_t; // must be pointer size
-typedef unsigned long mp_uint_t; // must be pointer size
-#else
-// These are definitions for machines where sizeof(int) == sizeof(void*),
-// regardless of actual size.
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
-#endif
-#else
-// Assume that if we already defined the obj repr then we also defined types.
-#endif
-
 // Cannot include <sys/types.h>, as it may lead to symbol name clashes
 #if _FILE_OFFSET_BITS == 64 && !defined(__LP64__)
 typedef long long mp_off_t;

--- a/ports/unix/variants/longlong/mpconfigvariant.h
+++ b/ports/unix/variants/longlong/mpconfigvariant.h
@@ -36,8 +36,6 @@
 
 #define MICROPY_OBJ_REPR               (MICROPY_OBJ_REPR_C)
 #define MICROPY_FLOAT_IMPL             (MICROPY_FLOAT_IMPL_FLOAT)
-typedef int mp_int_t;
-typedef unsigned int mp_uint_t;
 
 // Set base feature level.
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)

--- a/ports/unix/variants/nanbox/mpconfigvariant.h
+++ b/ports/unix/variants/nanbox/mpconfigvariant.h
@@ -41,12 +41,3 @@
 #define MICROPY_EMIT_X64 (0)
 #define MICROPY_EMIT_THUMB (0)
 #define MICROPY_EMIT_ARM (0)
-
-#include <stdint.h>
-
-typedef int64_t mp_int_t;
-typedef uint64_t mp_uint_t;
-#define UINT_FMT "%llu"
-#define INT_FMT "%lld"
-#define HEX_FMT "%llx"
-#define SIZE_FMT "%lu"

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -102,12 +102,6 @@
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// This port is intended to be 32-bit, but unfortunately, int32_t for
-// different targets may be defined in different ways - either as int
-// or as long. This requires different printf formatting specifiers
-// to print such value. So, we avoid int32_t and use int directly.
-typedef int mp_int_t; // must be pointer size
-typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #define MICROPY_HW_BOARD_NAME "JS"

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -185,22 +185,8 @@ extern const struct _mp_print_t mp_stderr_print;
 
 // type definitions for the specific machine
 
-#if defined(__MINGW32__) && defined(__LP64__)
-typedef long mp_int_t; // must be pointer size
-typedef unsigned long mp_uint_t; // must be pointer size
-#elif defined(__MINGW32__) && defined(_WIN64)
-#include <stdint.h>
-typedef __int64 mp_int_t;
-typedef unsigned __int64 mp_uint_t;
+#if defined(__MINGW32__) && defined(_WIN64)
 #define MP_SSIZE_MAX __INT64_MAX__
-#elif defined(_MSC_VER) && defined(_WIN64)
-typedef __int64 mp_int_t;
-typedef unsigned __int64 mp_uint_t;
-#else
-// These are definitions for machines where sizeof(int) == sizeof(void*),
-// regardless for actual size.
-typedef int mp_int_t; // must be pointer size
-typedef unsigned int mp_uint_t; // must be pointer size
 #endif
 
 typedef long suseconds_t;

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -150,8 +150,6 @@ void mp_hal_signal_event(void);
 #define MICROPY_PY_MACHINE_ADC_READ_UV (1)
 #endif
 
-typedef intptr_t mp_int_t; // must be pointer size
-typedef uintptr_t mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #define MP_STATE_PORT MP_STATE_VM

--- a/ports/zephyr/mpconfigport_minimal.h
+++ b/ports/zephyr/mpconfigport_minimal.h
@@ -72,8 +72,6 @@
 #define MICROPY_HW_MCU_NAME "unknown-cpu"
 #endif
 
-typedef int mp_int_t; // must be pointer size
-typedef unsigned mp_uint_t; // must be pointer size
 typedef long mp_off_t;
 
 #define MP_STATE_PORT MP_STATE_VM

--- a/py/misc.h
+++ b/py/misc.h
@@ -456,15 +456,15 @@ static inline uint32_t mp_clz_mpi(mp_int_t x) {
     }
     return zeroes;
     #else
-    MP_STATIC_ASSERT(sizeof(mp_int_t) == sizeof(long long)
-        || sizeof(mp_int_t) == sizeof(long));
-
-    // ugly, but should compile to single intrinsic unless O0 is set
-    if (mp_check(sizeof(mp_int_t) == sizeof(long))) {
-        return mp_clzl((unsigned long)x);
-    } else {
-        return mp_clzll((unsigned long long)x);
-    }
+    #if MP_INT_MAX == INT_MAX
+    return mp_clz((unsigned)x);
+    #elif MP_INT_MAX == LONG_MAX
+    return mp_clzl((unsigned long)x);
+    #elif MP_INT_MAX == LLONG_MAX
+    return mp_clzll((unsigned long long)x);
+    #else
+    #error Unexpected MP_INT_MAX value
+    #endif
     #endif
 }
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -26,6 +26,15 @@
 #ifndef MICROPY_INCLUDED_PY_MPCONFIG_H
 #define MICROPY_INCLUDED_PY_MPCONFIG_H
 
+#include <stdint.h>
+
+#if defined(__cplusplus) // Required on at least one compiler to get ULLONG_MAX
+#include <climits>
+#else
+#include <limits.h>
+#endif
+
+
 // Current version of MicroPython. This is used by sys.implementation.version
 // as well as a fallback to generate MICROPY_GIT_TAG if the git repo or tags
 // are unavailable.
@@ -160,6 +169,78 @@
 #ifndef MICROPY_OBJ_IMMEDIATE_OBJS
 #define MICROPY_OBJ_IMMEDIATE_OBJS (MICROPY_OBJ_REPR != MICROPY_OBJ_REPR_D)
 #endif
+
+// Definition of the `mp_int_t` and `mp_uint_t` types and associated macros.
+// Normally, it suffices for the platform to do nothing: A type as wide
+// as a pointer is chosen, unless nanboxing (REPR_D) is selected, in
+// which case a 64-bit type is chosen to match the assumed size of
+// double-precision floats.
+//
+// In the case of exceptions, the port, board, or variant must define
+// MP_INT_TYPE as MP_INT_TYPE_OTHER and provide all the typedefs and
+// defines.
+#define MP_INT_TYPE_INTPTR (0)
+#define MP_INT_TYPE_INT64 (1)
+#define MP_INT_TYPE_OTHER (2)
+
+#if !defined(MP_INT_TYPE)
+#if MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D
+#define MP_INT_TYPE (MP_INT_TYPE_INT64)
+#else
+#define MP_INT_TYPE (MP_INT_TYPE_INTPTR)
+#endif
+#endif
+
+#if MP_INT_TYPE == MP_INT_TYPE_INTPTR
+typedef intptr_t mp_int_t;
+typedef uintptr_t mp_uint_t;
+#define MP_INT_MAX INTPTR_MAX
+#define MP_INT_MIN INTPTR_MIN
+#define MP_UINT_MAX INTPTR_UMAX
+#elif MP_INT_TYPE == MP_INT_TYPE_INT64
+typedef int64_t mp_int_t;
+typedef uint64_t mp_uint_t;
+#define MP_INT_MAX INT64_MAX
+#define MP_INT_MIN INT64_MIN
+#define MP_UINT_MAX INT64_UMAX
+#endif
+
+// mp_printf format support for mp_int_t. In the unusual case that MP_INT_MAX doesn't
+// match any of the standard C types (int/long/long long), provide all 3
+// macros. Otherwise, rely on these automatic definitions.
+#if !defined(INT_FMT)
+#if MP_INT_MAX == INT_MAX
+#define INT_FMT "%d"
+#define UINT_FMT "%u"
+#define HEX_FMT "%x"
+#elif MP_INT_MAX == LONG_MAX
+#define INT_FMT "%ld"
+#define UINT_FMT "%lu"
+#define HEX_FMT "%lx"
+#elif MP_INT_MAX == LLONG_MAX
+#define INT_FMT "%lld"
+#define UINT_FMT "%llu"
+#define HEX_FMT "%llx"
+#else
+#error Unexpected MP_INT_MAX value
+#endif
+#endif
+
+// mp_printf format support for size_t. In the unusual case that SIZE_MAX doesn't
+// match any of the standard C types (int/long/long long), provide a
+// macro. Otherwise, rely on these automatic definitions.
+#if !defined(SIZE_FMT)
+#if SIZE_MAX == UINT_MAX
+#define SIZE_FMT "%u"
+#elif SIZE_MAX == ULONG_MAX
+#define SIZE_FMT "%lu"
+#elif SIZE_MAX == ULLONG_MAX
+#define SIZE_FMT "%llu"
+#else
+#error Unexpected SIZE_MAX value
+#endif
+#endif
+
 
 /*****************************************************************************/
 /* Memory allocation policy                                                  */
@@ -2236,28 +2317,6 @@ typedef time_t mp_timestamp_t;
 #ifndef MP_SSIZE_MAX
 #define MP_SSIZE_MAX SSIZE_MAX
 #endif
-
-// printf format spec to use for mp_int_t and friends
-#ifndef INT_FMT
-#if defined(__LP64__)
-// Archs where mp_int_t == long, long != int
-#define UINT_FMT "%lu"
-#define INT_FMT "%ld"
-#define HEX_FMT "%lx"
-#define SIZE_FMT "%lu"
-#elif defined(_WIN64)
-#define UINT_FMT "%llu"
-#define INT_FMT "%lld"
-#define HEX_FMT "%llx"
-#define SIZE_FMT "%llu"
-#else
-// Archs where mp_int_t == int
-#define UINT_FMT "%u"
-#define INT_FMT "%d"
-#define HEX_FMT "%x"
-#define SIZE_FMT "%u"
-#endif
-#endif // INT_FMT
 
 // Modifier for function which doesn't return
 #ifndef MP_NORETURN

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -482,7 +482,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
         }
 
         // parse long and long long specifiers (only where they make a difference)
-        #if defined(MICROPY_UNIX_COVERAGE) || (LONG_MAX > INT_MAX)
+        #if (MP_INT_MAX > INT_MAX && MP_INT_MAX == LONG_MAX) || defined(MICROPY_UNIX_COVERAGE)
         #define SUPPORT_L_FORMAT (1)
         #else
         #define SUPPORT_L_FORMAT (0)
@@ -491,7 +491,7 @@ int mp_vprintf(const mp_print_t *print, const char *fmt, va_list args) {
         bool long_arg = false;
         #endif
 
-        #if (MICROPY_OBJ_REPR == MICROPY_OBJ_REPR_D) || defined(_WIN64) || defined(MICROPY_UNIX_COVERAGE)
+        #if (MP_INT_MAX > LONG_MAX) || defined(MICROPY_UNIX_COVERAGE)
         #define SUPPORT_LL_FORMAT (1)
         #else
         #define SUPPORT_LL_FORMAT (0)

--- a/py/runtime_utils.c
+++ b/py/runtime_utils.c
@@ -77,10 +77,6 @@ bool mp_mul_ll_overflow(long long int x, long long int y, long long int *res) {
     return overflow;
 }
 
-#define MP_UINT_MAX (~(mp_uint_t)0)
-#define MP_INT_MAX ((mp_int_t)(MP_UINT_MAX >> 1))
-#define MP_INT_MIN (-MP_INT_MAX - 1)
-
 bool mp_mul_mp_int_t_overflow(mp_int_t x, mp_int_t y, mp_int_t *res) {
     // Check for multiply overflow; see CERT INT32-C
     if (x > 0) { // x is positive

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -940,6 +940,7 @@ function ci_windows_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/windows submodules
     make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
+    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=x86_64-w64-mingw32- BUILD=build-standard-w64
 }
 
 ########################################################################################


### PR DESCRIPTION

### Summary

Assuming proper C99 language support, we can select "the int type as big as a pointer" (most of the time) or "the 64-bit int type" (nanboxing with REPR_D), and then define everything else automatically.

### Testing

Primarily relying on CI checks. Once it is green on CI and no unexpected size changes are observed, it should probably be spot checked on a few systems.

### Trade-offs and Alternatives

I hope this ends up being a nice simplification but if it turns out to have twists I didn't anticipate I'll probably just close up the PR.