### PR TITLE
tools/ci.sh: Build all stm32 MCU families in stm32 CI functions.

### DIFF
--- a/.github/workflows/ports_stm32.yml
+++ b/.github/workflows/ports_stm32.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Install packages
-      run: tools/ci.sh stm32_setup
+      run: tools/ci.sh stm32_setup && tools/ci.sh stm32_path >> $GITHUB_PATH
     - name: Build ci_${{matrix.ci_func }}
       run: tools/ci.sh ${{ matrix.ci_func }}
 

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -301,6 +301,8 @@ void DebugMon_Handler(void) {
 /*  file (startup_stm32f4xx.s).                                               */
 /******************************************************************************/
 
+#if MICROPY_HW_STM_USB_STACK || MICROPY_HW_TINYUSB_STACK
+
 #if defined(STM32G0)
 
 #if MICROPY_HW_USB_FS
@@ -498,6 +500,8 @@ void OTG_HS_WKUP_IRQHandler(void) {
 #endif
 
 #endif // !defined(STM32L0)
+
+#endif // MICROPY_HW_STM_USB_STACK || MICROPY_HW_TINYUSB_STACK
 
 /**
   * @brief  This function handles PPP interrupt request.

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -36,7 +36,7 @@
 #include "irq.h"
 #include "usb.h"
 
-#if MICROPY_HW_USB_FS || MICROPY_HW_USB_HS
+#if MICROPY_HW_STM_USB_STACK || MICROPY_HW_TINYUSB_STACK
 
 #if BUILDING_MBOOT
 // TinyUSB not used in mboot

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -494,10 +494,17 @@ function ci_samd_build {
 # ports/stm32
 
 function ci_stm32_setup {
-    ci_gcc_arm_setup
+    # Use a recent version of the ARM toolchain, to work with Cortex-M55.
+    wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz
+    xzcat arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz | tar x
+
     pip3 install pyelftools
     pip3 install ar
     pip3 install pyhy
+}
+
+function ci_stm32_path {
+    echo $(pwd)/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi/bin
 }
 
 function ci_stm32_pyb_build {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -508,6 +508,8 @@ function ci_stm32_path {
 }
 
 function ci_stm32_pyb_build {
+    # This function builds the following MCU families: F4, F7.
+
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/stm32 MICROPY_PY_NETWORK_WIZNET5K=5200 submodules
     make ${MAKEOPTS} -C ports/stm32 BOARD=PYBD_SF2 submodules
@@ -522,6 +524,8 @@ function ci_stm32_pyb_build {
 }
 
 function ci_stm32_nucleo_build {
+    # This function builds the following MCU families: F0, H5, H7, L0, L4, WB.
+
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_H743ZI submodules
     git submodule update --init lib/mynewt-nimble
@@ -548,9 +552,17 @@ function ci_stm32_nucleo_build {
 }
 
 function ci_stm32_misc_build {
+    # This function builds the following MCU families: G0, G4, H7, L1, N6, U5, WL.
+
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/stm32 BOARD=ARDUINO_GIGA submodules
     make ${MAKEOPTS} -C ports/stm32 BOARD=ARDUINO_GIGA
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G0B1RE
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_G474RE
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_L152RE
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_N657X0
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_U5A5ZJ_Q
+    make ${MAKEOPTS} -C ports/stm32 BOARD=NUCLEO_WL55
 }
 
 ########################################################################################


### PR DESCRIPTION
### Summary

Currently the CI for stm32 only tests building about half of the available MCU families.  This PR adds the remaining families to the stm32 CI jobs.

We have had regressions in the past on certain MCUs that were not caught by the CI.  This change will prevent most regressions in that regard.

### Testing

To be tested by CI.

### Trade-offs and Alternatives

This adds time to the CI... but it's in a parallel job so hopefully isn't too much of a burden.

