### PR TITLE
libm_dbl: Work when DBL_EPSILON is in <float.h>.

### DIFF
--- a/lib/libm_dbl/libm.h
+++ b/lib/libm_dbl/libm.h
@@ -89,7 +89,9 @@ do {                                              \
   (d) = __u.f;                                    \
 } while (0)
 
+#if !defined(DBL_EPSILON)
 #define DBL_EPSILON 2.22044604925031308085e-16
+#endif
 
 int __rem_pio2(double, double*);
 int __rem_pio2_large(double*, double*, int, int, int);


### PR DESCRIPTION
### Summary
This fixes a diagnostic like:
```
../../lib/libm_dbl/libm.h:92:9: error: "DBL_EPSILON" redefined [-Werror]
/usr/lib/gcc/arm-none-eabi/14.2.1/include/float.h:114:9: note: this is the location of the previous definition
```
when building MPS2_AN500 (qemu port) on Debian Trixie.

### Testing

I built the cited port & board locally.