### PR TITLE
lib/stm32lib: Update WB to v1.23.0.

### DIFF
--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -4,7 +4,7 @@
 
 extern uint8_t mp_hal_unique_id_address[12];
 
-// F0-1.9.0+F4-1.16.0+F7-1.7.0+G0-1.5.1+G4-1.3.0+H7-1.6.0+L0-1.11.2+L4-1.17.0+WB-1.10.0+WL-1.1.0
+// F0-1.9.0+F4-1.16.0+F7-1.7.0+G0-1.5.1+G4-1.3.0+H5-1.0.0+H7-1.11.0+L0-1.11.2+L1-1.10.3+L4-1.17.0+N6-1.2.0+U5-1.8.0+WB-1.23.0+WL-1.1.0
 #if defined(STM32F0)
 #define MICROPY_PLATFORM_VERSION "HAL1.9.0"
 #elif defined(STM32F4)
@@ -25,8 +25,12 @@ extern uint8_t mp_hal_unique_id_address[12];
 #define MICROPY_PLATFORM_VERSION "HAL1.10.3"
 #elif defined(STM32L4)
 #define MICROPY_PLATFORM_VERSION "HAL1.17.0"
+#elif defined(STM32N6)
+#define MICROPY_PLATFORM_VERSION "HAL1.2.0"
+#elif defined(STM32U5)
+#define MICROPY_PLATFORM_VERSION "HAL1.8.0"
 #elif defined(STM32WB)
-#define MICROPY_PLATFORM_VERSION "HAL1.10.0"
+#define MICROPY_PLATFORM_VERSION "HAL1.23.0"
 #elif defined(STM32WL)
 #define MICROPY_PLATFORM_VERSION "HAL1.1.0"
 #endif


### PR DESCRIPTION
### Summary

Update the stm32lib submodule to bring in STM32CubeWB v1.23.0 (updating from v1.10.0).

This update follows the vendor/work branch workflow and includes:
- Import of STM32CubeWB v1.23.0 vendor code on the vendor branch
- All 48 MicroPython-specific patches successfully rebased onto the new vendor code
- New device support: STM32WB10xx, STM32WB15xx, STM32WB1Mxx
- New file added: `STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smbus_ex.c`
- USB pass-by-reference optimization (commit 46cdeaf0) re-applied on top of new import

The stm32lib submodule update is tracked at: https://github.com/micropython/stm32lib/pull/27

The instructions followed are more explicitely described in https://github.com/micropython/stm32lib/pull/28

### Testing

The rebase completed successfully with no conflicts. All 48 patches applied cleanly.

This update of the WB libraries has been used in https://github.com/micropython/micropython/pull/15592 and provides fixes needed for the current version of TinyUSB.

No other hardware peripherals have been explicitely tested at this stage.

### Trade-offs and Alternatives

This is a vendor library update that brings bug fixes and new device support from ST. The submodule points to the work branch which includes all MicroPython customizations, maintaining compatibility with
 the existing port while gaining upstream improvements.