### PR TITLE
Fix crash throwing an incompletely constructed exception

### DIFF
--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -553,7 +553,14 @@ bool mp_obj_is_exception_type(mp_obj_t self_in) {
 
 // return true if the given object is an instance of an exception type
 bool mp_obj_is_exception_instance(mp_obj_t self_in) {
-    return mp_obj_is_exception_type(MP_OBJ_FROM_PTR(mp_obj_get_type(self_in)));
+    if (mp_obj_is_native_exception_instance(self_in)) {
+        return true;
+    }
+    if (!mp_obj_is_exception_type(MP_OBJ_FROM_PTR(mp_obj_get_type(self_in)))) {
+        return false;
+    }
+    mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
+    return self->subobj[0] != MP_OBJ_FROM_PTR((void *)&mp_native_base_init_wrapper_obj);
 }
 
 // Return true if exception (type or instance) is a subclass of given

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -93,7 +93,7 @@ static mp_obj_t native_base_init_wrapper(size_t n_args, const mp_obj_t *args, mp
     self->subobj[0] = MP_OBJ_TYPE_GET_SLOT(native_base, make_new)(native_base, n_args - 1, kw_args->used, args + 1);
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_KW(native_base_init_wrapper_obj, 1, native_base_init_wrapper);
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_native_base_init_wrapper_obj, 1, native_base_init_wrapper);
 
 #if !MICROPY_CPYTHON_COMPAT
 static
@@ -107,7 +107,7 @@ mp_obj_instance_t *mp_obj_new_instance(const mp_obj_type_t *class, const mp_obj_
     // object.  It doesn't matter which object, so long as it can be uniquely
     // distinguished from a native class that is initialised.
     if (num_native_bases != 0) {
-        o->subobj[0] = MP_OBJ_FROM_PTR(&native_base_init_wrapper_obj);
+        o->subobj[0] = MP_OBJ_FROM_PTR(&mp_native_base_init_wrapper_obj);
     }
     return o;
 }
@@ -173,7 +173,7 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
                         // If we're dealing with native base class, then it applies to native sub-object
                         obj_obj = obj->subobj[0];
                         #if MICROPY_BUILTIN_METHOD_CHECK_SELF_ARG
-                        if (obj_obj == MP_OBJ_FROM_PTR(&native_base_init_wrapper_obj)) {
+                        if (obj_obj == MP_OBJ_FROM_PTR(&mp_native_base_init_wrapper_obj)) {
                             // But we shouldn't attempt lookups on object that is not yet instantiated.
                             mp_raise_msg(&mp_type_AttributeError, MP_ERROR_TEXT("call super().__init__() first"));
                         }
@@ -369,7 +369,7 @@ static mp_obj_t mp_obj_instance_make_new(const mp_obj_type_t *self, size_t n_arg
 
     // If the type had a native base that was not explicitly initialised
     // (constructed) by the Python __init__() method then construct it now.
-    if (native_base != NULL && o->subobj[0] == MP_OBJ_FROM_PTR(&native_base_init_wrapper_obj)) {
+    if (native_base != NULL && o->subobj[0] == MP_OBJ_FROM_PTR(&mp_native_base_init_wrapper_obj)) {
         o->subobj[0] = MP_OBJ_TYPE_GET_SLOT(native_base, make_new)(native_base, n_args, n_kw, args);
     }
 
@@ -1400,7 +1400,7 @@ static void super_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     if (dest[0] != MP_OBJ_NULL) {
         if (dest[0] == MP_OBJ_SENTINEL) {
             // Looked up native __init__ so defer to it
-            dest[0] = MP_OBJ_FROM_PTR(&native_base_init_wrapper_obj);
+            dest[0] = MP_OBJ_FROM_PTR(&mp_native_base_init_wrapper_obj);
             dest[1] = self->obj;
         }
         return;

--- a/py/objtype.h
+++ b/py/objtype.h
@@ -52,4 +52,6 @@ mp_obj_t mp_obj_instance_call(mp_obj_t self_in, size_t n_args, size_t n_kw, cons
 // this needs to be exposed for mp_getiter
 mp_obj_t mp_obj_instance_getiter(mp_obj_t self_in, mp_obj_iter_buf_t *iter_buf);
 
+MP_DECLARE_CONST_FUN_OBJ_KW(mp_native_base_init_wrapper_obj);
+
 #endif // MICROPY_INCLUDED_PY_OBJTYPE_H

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1508,7 +1508,7 @@ mp_obj_t mp_make_raise_obj(mp_obj_t o) {
     }
 
     if (mp_obj_is_exception_instance(o)) {
-        // o is an instance of an exception, so use it as the exception
+        // o is an fully-constructed instance of an exception, so use it as the exception
         return o;
     } else {
         // o cannot be used as an exception, so return a type error (which will be raised by the caller)

--- a/tests/cpydiff/core_exception_construction.py
+++ b/tests/cpydiff/core_exception_construction.py
@@ -1,0 +1,28 @@
+"""
+categories: Core,Exceptions
+description: Throwing a derived exception class instance in its `__init__` without first calling ``super().__init__`` is a TypeError
+cause: In MicroPython, an object is incompletely constructed if it does not call its superclass init function or return normally from its ``__init__``. This prevents its usage in some circumstances.
+workaround: Call the superclass `__init__` method before raising the exception.
+"""
+
+
+class C(Exception):
+    def __init__(self):
+        raise self
+
+
+class C1(Exception):
+    def __init__(self):
+        super().__init__()
+        raise self
+
+
+try:
+    C()
+except Exception as e:
+    print(type(e).__name__)
+
+try:
+    C1()
+except Exception as e:
+    print(type(e).__name__)

--- a/tests/micropython/incomplete_exc.py
+++ b/tests/micropython/incomplete_exc.py
@@ -1,0 +1,37 @@
+class C(Exception):
+    def __init__(self):
+        raise self
+
+
+class C1(C):
+    pass
+
+
+class B:
+    pass
+
+
+class C2(B, Exception):
+    def __init__(self):
+        raise self
+
+
+class C3(Exception, B):
+    def __init__(self):
+        raise self
+
+
+class D(Exception):
+    pass
+
+
+class C4(D):
+    def __init__(self):
+        raise self
+
+
+for cls in C, C1, C2, C3, C4:
+    try:
+        cls()
+    except TypeError as e:
+        print("TypeError")

--- a/tests/micropython/incomplete_exc.py.exp
+++ b/tests/micropython/incomplete_exc.py.exp
@@ -1,0 +1,5 @@
+TypeError
+TypeError
+TypeError
+TypeError
+TypeError


### PR DESCRIPTION
### Summary

This fixes my version of the reproducer for #17117, by preventing an incompletely constructed exception from actually being raised. 

### Testing

I added a test to the testsuite and it passed on the unix standard build.

### Trade-offs and Alternatives

In the comments on 17117, there's a link to a different fix in vm.c (to avoid trying to set the traceback info while unwinding) but I think avoiding throwing such an exception in the first place is preferable.

I tried placing the check in mp_obj_is_exception_instance instead, on the theory it might be better (catch more sites where such an object could escape). However, it wasn't a clear size win.

Since the reproducer I found involved throwing an exception from its own constructor, I considered catching exceptions that propagated from a constructor and ensuring `super().__init__` was called, similar to the non-error case. However, this would likely have been more code AND it wouldn't fix the case where the exception was thrown *and caught* within the constructor itself. Plus, we don't have the original reproducer for 17117 and maybe it found another way to do the same thing.