### PR TITLE
windows/msvc: Make the PP defs for manifest freezing global.

### DIFF
--- a/ports/windows/msvc/common.props
+++ b/ports/windows/msvc/common.props
@@ -23,6 +23,7 @@
     <ClCompile>
       <AdditionalIncludeDirectories>$(PyIncDirs);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_USE_MATH_DEFINES;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(FrozenManifest)' != ''">MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;MPZ_DIG_SIZE=16;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <WarningLevel>Level1</WarningLevel>
       <ExceptionHandling>false</ExceptionHandling>

--- a/ports/windows/msvc/genhdr.targets
+++ b/ports/windows/msvc/genhdr.targets
@@ -168,9 +168,6 @@ using(var outFile = System.IO.File.CreateText(OutputFile)) {
   <Target Name="FreezeModules" Condition="'$(FrozenManifest)' != ''" DependsOnTargets="MakeQstrData;MakeRootPointers" Inputs="$(FrozenManifest)" Outputs="$(PyBuildDir)frozen_content.c">
     <ItemGroup>
       <ClCompile Include="$(PyBuildDir)frozen_content.c"/>
-      <ClCompile>
-        <PreprocessorDefinitions>MICROPY_MODULE_FROZEN_MPY=1;MICROPY_QSTR_EXTRA_POOL=mp_qstr_frozen_const_pool;MPZ_DIG_SIZE=16;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      </ClCompile>
     </ItemGroup>
     <Exec Command="$(PyPython) $(PyBaseDir)tools\makemanifest.py -v MPY_DIR=$(PyBaseDir) -v MPY_LIB_DIR=$(PyBaseDir)/lib/micropython-lib -v PORT_DIR=$(PyWinDir) -o $(PyBuildDir)frozen_content.c -b $(PyBuildDir) $(FrozenManifest)"/>
     <WriteLinesToFile File="$(TLogLocation)frozen.read.1.tlog" Lines="$(FrozenManifest)" Overwrite="True"/>


### PR DESCRIPTION
### Summary

This is consistent with the other ports (see py/mkrules.mk) and makes more sense overall because it makes everything which is compiled use the same flags; until now all compilation steps which ran before or in absence of FreezeModules (e.g. qstr generation, compiling a single file on the command line or in the IDE) would use different PP defs.  This didn't happen to cause any issues apparently but it's just more consistent/safer to not do that. 

### Testing

In the presence of a manifest file i.e. the FrozenManifest variable being set, IDEs will now parse the codebase with the correct PP defs, so for example will treat MICROPY_MODULE_FROZEN_MPY as 1 etc. Also compiling a single file without the module freezing having been invoked will now use the same flags.
