### PR TITLE
rp2: Add missing RP2350 RISC-V builds

### DIFF
--- a/ports/rp2/boards/RPI_PICO2_W/board.json
+++ b/ports/rp2/boards/RPI_PICO2_W/board.json
@@ -17,5 +17,8 @@
     "product": "Pico 2 W",
     "thumbnail": "",
     "url": "https://www.raspberrypi.com/products/raspberry-pi-pico-2/",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "Raspberry Pi"
 }

--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/board.json
@@ -21,5 +21,8 @@
     "product": "IoT Node LoRaWAN RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/26060",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigvariant.cmake
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigvariant.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350")

--- a/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigvariant_RISCV.cmake
+++ b/ports/rp2/boards/SPARKFUN_IOTNODE_LORAWAN_RP2350/mpconfigvariant_RISCV.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350-riscv")

--- a/ports/rp2/boards/SPARKFUN_IOTREDBOARD_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_IOTREDBOARD_RP2350/board.json
@@ -22,5 +22,8 @@
     "product": "SparkFun IoT RedBoard RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/sparkfun-iot-redboard-rp2350.html",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/board.json
@@ -18,5 +18,8 @@
     "product": "Pro Micro RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/24870",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/mpconfigvariant.cmake
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/mpconfigvariant.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350")

--- a/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/mpconfigvariant_RISCV.cmake
+++ b/ports/rp2/boards/SPARKFUN_PROMICRO_RP2350/mpconfigvariant_RISCV.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350-riscv")

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/board.json
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/board.json
@@ -23,5 +23,8 @@
     "product": "Thing Plus RP2350",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/products/25134",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/mpconfigvariant.cmake
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/mpconfigvariant.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350")

--- a/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/mpconfigvariant_RISCV.cmake
+++ b/ports/rp2/boards/SPARKFUN_THINGPLUS_RP2350/mpconfigvariant_RISCV.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350-riscv")

--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/board.json
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/board.json
@@ -21,5 +21,8 @@
     "product": "XRP Controller",
     "thumbnail": "",
     "url": "https://www.sparkfun.com/sparkfun-experiential-robotics-platform-xrp-controller.html",
+    "variants": {
+        "RISCV": "RISC-V CPU mode"
+    },
     "vendor": "SparkFun"
 }

--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/mpconfigvariant.cmake
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/mpconfigvariant.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350")

--- a/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/mpconfigvariant_RISCV.cmake
+++ b/ports/rp2/boards/SPARKFUN_XRP_CONTROLLER/mpconfigvariant_RISCV.cmake
@@ -1,0 +1,1 @@
+set(PICO_PLATFORM "rp2350-riscv")


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

There are multiple RP2350 boards missing RISC-V builds. Some were missing entries in their `board.json` or a CMake file altogether. This pull request fixes that

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I have built and tested on a Pico 2W but am unable to test on any other boards at this time. Please let me know if I missed any boards or something isn't quite right.

