### PR TITLE
metrics: Tersely show the commits in the size report.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -128,13 +128,13 @@ function ci_code_size_build {
 
         # build reference, save to size0
         # ignore any errors with this build, in case master is failing
-        echo "BUILDING $(git log --oneline -1 ${REFERENCE})" > ~/size0
+        echo "BUILDING $(git log --format='%s [%h]' -1 ${REFERENCE})" > ~/size0
         code_size_build_step $REFERENCE ~/size0 true
         # build PR/branch, save to size1
         if _ci_is_git_merge "$COMPARISON"; then
-            echo "BUILDING merge of $(git log --oneline -1 ${COMPARISON}^2)"
+            echo "BUILDING $(git log --oneline -1 --format='%s [merge of %h]' ${COMPARISON}^2)"
         else
-            echo "BUILDING $(git log --oneline -1 ${COMPARISON})"
+            echo "BUILDING $(git log --oneline -1 --formta='%s [%h]' ${COMPARISON})"
         fi > ~/size1
         code_size_build_step $COMPARISON ~/size1 false
     )

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -80,6 +80,10 @@ function ci_code_size_setup {
     ci_picotool_setup
 }
 
+function _ci_is_git_merge {
+    [[ $(git log -1 --format=%P "$1" | wc -w) > 1 ]]
+}
+
 function ci_code_size_build {
     # check the following ports for the change in their code size
     # Override the list by setting PORTS_TO_CHECK in the environment before invoking ci.
@@ -112,21 +116,26 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
-            echo "Building ${COMMIT}..."
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s
             tools/metrics.py clean "$PORTS_TO_CHECK"
             # Allow errors from tools/metrics.py to propagate out of the pipe below.
             set -o pipefail
-            tools/metrics.py build "$PORTS_TO_CHECK" | tee $OUTFILE || $IGNORE_ERRORS
+            tools/metrics.py build "$PORTS_TO_CHECK" | tee -a $OUTFILE || $IGNORE_ERRORS
             return $?
         }
 
         # build reference, save to size0
         # ignore any errors with this build, in case master is failing
+        echo "BUILDING $(git log --oneline -1 ${REFERENCE})" > ~/size0
         code_size_build_step $REFERENCE ~/size0 true
         # build PR/branch, save to size1
+        if _ci_is_git_merge "$COMPARISON"; then
+            echo "BUILDING merge of $(git log --oneline -1 ${COMPARISON}^2)"
+        else
+            echo "BUILDING $(git log --oneline -1 ${COMPARISON})"
+        fi > ~/size1
         code_size_build_step $COMPARISON ~/size1 false
     )
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -98,8 +98,8 @@ function ci_code_size_build {
     # the code size impact would be if we merged this PR. During CI we are at a merge commit,
     # so this tests the merged PR against its merge base.
     # Override the refs by setting REFERENCE and/or COMPARISON in the environment before invoking ci.
-    : ${REFERENCE:=$(git rev-parse --short HEAD^1)}
     : ${COMPARISON:=$(git rev-parse --short HEAD)}
+    : ${REFERENCE:=$(git rev-parse --short ${COMPARISON}^1)}
 
     echo "Comparing sizes of reference ${REFERENCE} to ${COMPARISON}..."
     git log --oneline $REFERENCE..$COMPARISON

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -127,6 +127,8 @@ def read_build_log(filename):
     with open(filename) as f:
         for line in f:
             line = line.strip()
+            if line.startswith("BUILDING ") and "_ref" not in data:
+                data["_ref"] = line.removeprefix("BUILDING ")
             if line.strip() == "COMPUTING SIZES":
                 found_sizes = True
             elif found_sizes:
@@ -158,6 +160,10 @@ def do_diff(args):
     data1 = read_build_log(args[0])
     data2 = read_build_log(args[1])
 
+    ref1 = data1.pop("_ref", "(unknown ref)")
+    ref2 = data2.pop("_ref", "(unknown ref)")
+    print(f"Reference:  {ref1}")
+    print(f"Comparison: {ref2}")
     max_delta = None
     for key, value1 in data1.items():
         value2 = data2[key]


### PR DESCRIPTION
### Summary

In the size report, show information about the compared refs:
```
Reference:  00a926e99e zephyr/boards: Add PocketBeagle 2…
Comparison: 71ba57acca metrics: Tersely show the commits…
```

This will be helpful when checking which revision of the code size report comment on a PR corresponds to which revision of the code.

### Testing

I ran the ci.sh steps locally and inspected the output.