### PR TITLE
mimxrt: Add initial PSRAM implementation.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -265,6 +265,7 @@ SRC_C += \
 	network_lan.c \
 	pendsv.c \
 	pin.c \
+	psram.c \
 	sdcard.c \
 	sdio.c \
 	systick.c \

--- a/ports/mimxrt/boards/TEENSY41/mpconfigboard.h
+++ b/ports/mimxrt/boards/TEENSY41/mpconfigboard.h
@@ -136,3 +136,6 @@
     { IOMUXC_GPIO_B1_11_ENET_RX_ER, 0, 0xB0E9u }, \
     { IOMUXC_GPIO_B1_15_ENET_MDIO, 0, 0xB0E9u }, \
     { IOMUXC_GPIO_B1_14_ENET_MDC, 0, 0xB0E9u },
+
+// Enable PSRAM support
+#define MICROPY_HW_ENABLE_PSRAM (1)

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -37,6 +37,7 @@
 #include "ticks.h"
 #include "led.h"
 #include "pendsv.h"
+#include "psram.h"
 #include "modmachine.h"
 #include "modmimxrt.h"
 
@@ -66,6 +67,10 @@ int main(void) {
     board_init();
     ticks_init();
     pendsv_init();
+
+    #if MICROPY_HW_ENABLE_PSRAM
+    size_t psram_size = configure_external_ram();
+    #endif
 
     #if MICROPY_PY_LWIP
     // lwIP doesn't allow to reinitialise itself by subsequent calls to this function
@@ -101,7 +106,20 @@ int main(void) {
 
         mp_cstack_init_with_top(&_estack, &_estack - &_sstack);
 
+        #if MICROPY_HW_ENABLE_PSRAM
+        if(psram_size) {
+            #if MICROPY_GC_SPLIT_HEAP
+            gc_init(&_gc_heap_start, &_gc_heap_end);
+            gc_add((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_size));
+            #else
+            gc_init((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_size));
+            #endif
+        } else {
+            gc_init(&_gc_heap_start, &_gc_heap_end);
+        }
+        #else
         gc_init(&_gc_heap_start, &_gc_heap_end);
+        #endif
         mp_init();
 
         #if MICROPY_PY_NETWORK

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -107,7 +107,7 @@ int main(void) {
         mp_cstack_init_with_top(&_estack, &_estack - &_sstack);
 
         #if MICROPY_HW_ENABLE_PSRAM
-        if(psram_size) {
+        if (psram_size) {
             #if MICROPY_GC_SPLIT_HEAP
             gc_init(&_gc_heap_start, &_gc_heap_end);
             gc_add((void *)PSRAM_BASE, (void *)(PSRAM_BASE + psram_size));

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -35,13 +35,20 @@ uint32_t trng_random_u32(void);
 // Config level
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_FULL_FEATURES)
 
+#ifndef MICROPY_HW_ENABLE_PSRAM
+#define MICROPY_HW_ENABLE_PSRAM (0)
+#endif
+
 // Memory allocation policies
-#if MICROPY_HW_SDRAM_AVAIL
+#if MICROPY_HW_SDRAM_AVAIL || MICROPY_HW_ENABLE_PSRAM
 #define MICROPY_GC_STACK_ENTRY_TYPE         uint32_t
 #else
 #define MICROPY_GC_STACK_ENTRY_TYPE         uint16_t
 #endif
 #define MICROPY_ALLOC_PATH_MAX              (256)
+#ifndef MICROPY_GC_SPLIT_HEAP
+#define MICROPY_GC_SPLIT_HEAP               MICROPY_HW_ENABLE_PSRAM
+#endif
 
 // MicroPython emitters
 #define MICROPY_PERSISTENT_CODE_LOAD        (1)

--- a/ports/mimxrt/psram.c
+++ b/ports/mimxrt/psram.c
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Paul Stoffregen
- *               2025 Dryw Wade
+ *               2026 Dryw Wade
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,13 +13,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * 2. If the Software is incorporated into a build system that allows
- * selection among a list of target devices, then similar target
- * devices manufactured by PJRC.COM must be included in the list of
- * target devices and selectable in the same manner.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/ports/mimxrt/psram.c
+++ b/ports/mimxrt/psram.c
@@ -1,0 +1,258 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Paul Stoffregen
+ *                    Dryw Wade
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+
+#if MICROPY_HW_ENABLE_PSRAM
+
+// Copied from here:
+// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/avr/pgmspace.h#L31
+#define FLASHMEM __attribute__((section(".flashmem")))
+
+// These #defines are from here:
+// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/imxrt.h
+#define CCM_CCGR_ON				3
+#define FLEXSPI_MCR2_CLRLEARNPHASE(x)		((uint32_t)(x<<14))
+#define FLEXSPI_LUTKEY_VALUE			((uint32_t)0x5AF05AF0)
+#define FLEXSPI_LUT_INSTRUCTION(opcode, pads, operand) ((uint32_t)(\
+	(((opcode) & 0x3F) << 10) | (((pads) & 0x03) << 8) | ((operand) & 0xFF)))
+#define FLEXSPI_LUT_OPCODE_CMD_SDR		0x01
+#define FLEXSPI_LUT_OPCODE_RADDR_SDR		0x02
+#define FLEXSPI_LUT_OPCODE_WRITE_SDR		0x08
+#define FLEXSPI_LUT_OPCODE_READ_SDR		0x09
+#define FLEXSPI_LUT_OPCODE_DUMMY_SDR		0x0C
+#define FLEXSPI_LUT_NUM_PADS_1			0x00
+#define FLEXSPI_LUT_NUM_PADS_4			0x02
+
+// The rest of the implementation is adapted from here:
+// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/startup.c#L379-L587
+// Modified to use #define's from:
+// `lib/nxp_driver/sdk/devices/MIMXRT1062/MIMXRT1062.h`
+#define LUT0(opcode, pads, operand) (FLEXSPI_LUT_INSTRUCTION((opcode), (pads), (operand)))
+#define LUT1(opcode, pads, operand) (FLEXSPI_LUT_INSTRUCTION((opcode), (pads), (operand)) << 16)
+#define CMD_SDR         FLEXSPI_LUT_OPCODE_CMD_SDR
+#define ADDR_SDR        FLEXSPI_LUT_OPCODE_RADDR_SDR
+#define READ_SDR        FLEXSPI_LUT_OPCODE_READ_SDR
+#define WRITE_SDR       FLEXSPI_LUT_OPCODE_WRITE_SDR
+#define DUMMY_SDR       FLEXSPI_LUT_OPCODE_DUMMY_SDR
+#define PINS1           FLEXSPI_LUT_NUM_PADS_1
+#define PINS4           FLEXSPI_LUT_NUM_PADS_4
+
+FLASHMEM static void flexspi2_command(uint32_t index, uint32_t addr)
+{
+	FLEXSPI2->IPCR0 = addr;
+	FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(index);
+	FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
+	while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))); // wait
+	FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1);
+}
+
+FLASHMEM static uint32_t flexspi2_psram_id(uint32_t addr)
+{
+	FLEXSPI2->IPCR0 = addr;
+	FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(3) | FLEXSPI_IPCR1_IDATSZ(4);
+	FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
+	while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))); // wait
+	uint32_t id = FLEXSPI2->RFDR[0];
+	FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1) | FLEXSPI_INTR_IPRXWA(1);
+	return id;
+}
+
+/**
+ * \return size of PSRAM in MBytes, or 0 if not present
+ */
+FLASHMEM static uint8_t flexspi2_psram_size(uint32_t addr)
+{
+	uint8_t result = 0; // assume we don't have PSRAM at this address
+	flexspi2_command(0, addr); // exit quad mode
+	flexspi2_command(1, addr); // reset enable
+	flexspi2_command(2, addr); // reset (is this really necessary?)
+	uint32_t id = flexspi2_psram_id(addr);
+
+	switch (id & 0xFFFF)
+	{
+		default:
+			break;
+
+		case 0x5D0D: // AP / Ipus / ESP / Lyontek
+			result = 8;
+			break;
+
+		case 0x5D9D: // ISSI
+			switch ((id >> 21) & 0x7) // get size (Datasheet Table 6.2)
+			{
+				case 0b011: 
+					result = 8;
+					break;
+				case 0b100: 
+					result = 16;
+					break;
+			}
+			break;
+	}
+
+	return result;
+}
+
+FLASHMEM size_t configure_external_ram()
+{
+	// initialize pins
+	IOMUXC->SW_PAD_CTL_PAD[22] = 0x1B0F9; // 100K pullup, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[23] = 0x110F9; // keeper, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[24] = 0x1B0F9; // 100K pullup, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[25] = 0x100F9; // strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[26] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[27] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[28] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
+	IOMUXC->SW_PAD_CTL_PAD[29] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
+
+	IOMUXC->SW_MUX_CTL_PAD[22] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SS1_B (Flash)
+	IOMUXC->SW_MUX_CTL_PAD[23] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DQS
+	IOMUXC->SW_MUX_CTL_PAD[24] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SS0_B (RAM)
+	IOMUXC->SW_MUX_CTL_PAD[25] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SCLK
+	IOMUXC->SW_MUX_CTL_PAD[26] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA0
+	IOMUXC->SW_MUX_CTL_PAD[27] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA1
+	IOMUXC->SW_MUX_CTL_PAD[28] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA2
+	IOMUXC->SW_MUX_CTL_PAD[29] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA3
+
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_DQS_FA_SELECT_INPUT] = 1; // GPIO_EMC_23 for Mode: ALT8, pg 986
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT0_SELECT_INPUT] = 1; // GPIO_EMC_26 for Mode: ALT8
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT1_SELECT_INPUT] = 1; // GPIO_EMC_27 for Mode: ALT8
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT2_SELECT_INPUT] = 1; // GPIO_EMC_28 for Mode: ALT8
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT3_SELECT_INPUT] = 1; // GPIO_EMC_29 for Mode: ALT8
+	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_SCK_FA_SELECT_INPUT] = 1; // GPIO_EMC_25 for Mode: ALT8
+
+	// turn on clock  (QSPI flash & PSRAM chips usually spec max clock 100 to 133 MHz)
+	CCM->CBCMR = (CCM->CBCMR & ~(CCM_CBCMR_FLEXSPI2_PODF_MASK | CCM_CBCMR_FLEXSPI2_CLK_SEL_MASK))
+		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 88.0 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(0); // 99.0 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(6) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 102.9 MHz
+		| CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 105.6 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 110.8 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 120.0 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 132.0 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 144.0 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 166.2 MHz
+		//| CCM_CBCMR_FLEXSPI2_PODF(2) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 176.0 MHz
+	CCM->CCGR7 |= CCM_CCGR7_CG1(CCM_CCGR_ON);
+
+	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_MDIS(1);
+	FLEXSPI2->MCR0 = (FLEXSPI2->MCR0 & ~(FLEXSPI_MCR0_AHBGRANTWAIT_MASK
+		 | FLEXSPI_MCR0_IPGRANTWAIT_MASK | FLEXSPI_MCR0_SCKFREERUNEN(1)
+		 | FLEXSPI_MCR0_COMBINATIONEN(1) | FLEXSPI_MCR0_DOZEEN(1)
+		 | FLEXSPI_MCR0_HSEN(1) | FLEXSPI_MCR0_ATDFEN(1) | FLEXSPI_MCR0_ARDFEN(1)
+		 | FLEXSPI_MCR0_RXCLKSRC_MASK | FLEXSPI_MCR0_SWRESET(1)))
+		| FLEXSPI_MCR0_AHBGRANTWAIT(0xFF) | FLEXSPI_MCR0_IPGRANTWAIT(0xFF)
+		| FLEXSPI_MCR0_RXCLKSRC(1) | FLEXSPI_MCR0_MDIS(1);
+	FLEXSPI2->MCR1 = FLEXSPI_MCR1_SEQWAIT(0xFFFF) | FLEXSPI_MCR1_AHBBUSWAIT(0xFFFF);
+	FLEXSPI2->MCR2 = (FLEXSPI->MCR2 & ~(FLEXSPI_MCR2_RESUMEWAIT_MASK
+		 | FLEXSPI_MCR2_SCKBDIFFOPT(1) | FLEXSPI_MCR2_SAMEDEVICEEN(1)
+		 | FLEXSPI_MCR2_CLRLEARNPHASE(1) | FLEXSPI_MCR2_CLRAHBBUFOPT(1)))
+		| FLEXSPI_MCR2_RESUMEWAIT(0x20) /*| FLEXSPI_MCR2_SAMEDEVICEEN*/;
+
+	FLEXSPI2->AHBCR = FLEXSPI2->AHBCR & ~(FLEXSPI_AHBCR_READADDROPT(1) | FLEXSPI_AHBCR_PREFETCHEN(1)
+		| FLEXSPI_AHBCR_BUFFERABLEEN(1) | FLEXSPI_AHBCR_CACHABLEEN(1));
+	uint32_t mask = (FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK
+		| FLEXSPI_AHBRXBUFCR0_MSTRID_MASK | FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK);
+	FLEXSPI2->AHBRXBUFCR0[0] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
+		| FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
+	FLEXSPI2->AHBRXBUFCR0[1] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
+		| FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
+	FLEXSPI2->AHBRXBUFCR0[2] = mask;
+	FLEXSPI2->AHBRXBUFCR0[3] = mask;
+
+	// RX watermark = one 64 bit line
+	FLEXSPI2->IPRXFCR = (FLEXSPI->IPRXFCR & 0xFFFFFFC0) | FLEXSPI_IPRXFCR_CLRIPRXF(1);
+	// TX watermark = one 64 bit line
+	FLEXSPI2->IPTXFCR = (FLEXSPI->IPTXFCR & 0xFFFFFFC0) | FLEXSPI_IPTXFCR_CLRIPTXF(1);
+
+	FLEXSPI2->INTEN = 0;
+	FLEXSPI2->FLSHCR1[0] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
+		| FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
+	FLEXSPI2->FLSHCR2[0] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
+		| FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
+
+	FLEXSPI2->FLSHCR1[1] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
+		| FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
+	FLEXSPI2->FLSHCR2[1] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
+		| FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
+
+	FLEXSPI2->MCR0 &= ~FLEXSPI_MCR0_MDIS(1);
+
+	FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
+	FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
+	volatile uint32_t *luttable = &FLEXSPI2->LUT[0];
+	for (int i=0; i < 64; i++) luttable[i] = 0;
+	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_SWRESET(1);
+	while (FLEXSPI2->MCR0 & FLEXSPI_MCR0_SWRESET(1)) ; // wait
+
+	FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
+	FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
+
+	// cmd index 0 = exit QPI mode
+	FLEXSPI2->LUT[0] = LUT0(CMD_SDR, PINS4, 0xF5);
+	// cmd index 1 = reset enable
+	FLEXSPI2->LUT[4] = LUT0(CMD_SDR, PINS1, 0x66);
+	// cmd index 2 = reset
+	FLEXSPI2->LUT[8] = LUT0(CMD_SDR, PINS1, 0x99);
+	// cmd index 3 = read ID bytes
+	FLEXSPI2->LUT[12] = LUT0(CMD_SDR, PINS1, 0x9F) | LUT1(DUMMY_SDR, PINS1, 24);
+	FLEXSPI2->LUT[13] = LUT0(READ_SDR, PINS1, 1);
+	// cmd index 4 = enter QPI mode
+	FLEXSPI2->LUT[16] = LUT0(CMD_SDR, PINS1, 0x35);
+	// cmd index 5 = read QPI
+	FLEXSPI2->LUT[20] = LUT0(CMD_SDR, PINS4, 0xEB) | LUT1(ADDR_SDR, PINS4, 24);
+	FLEXSPI2->LUT[21] = LUT0(DUMMY_SDR, PINS4, 6) | LUT1(READ_SDR, PINS4, 1);
+	// cmd index 6 = write QPI
+	FLEXSPI2->LUT[24] = LUT0(CMD_SDR, PINS4, 0x38) | LUT1(ADDR_SDR, PINS4, 24);
+	FLEXSPI2->LUT[25] = LUT0(WRITE_SDR, PINS4, 1);
+
+    // Detected PSRAM size in MB
+    uint8_t external_psram_size = 0;
+
+	// look for the first PSRAM chip
+	uint8_t size1 = flexspi2_psram_size(0);
+	if (size1 > 0) {
+		FLEXSPI2->FLSHCR0[0] = size1 << 10;
+		flexspi2_command(4, 0); // enter QPI mode
+		// look for a second PSRAM chip
+		uint8_t size2 = flexspi2_psram_size(size1 << 20);
+		external_psram_size = size1 + size2;
+		if (size2 > 0) {
+			FLEXSPI2->FLSHCR0[1] = size2 << 10;
+			flexspi2_command(4, size1 << 20);  // enter QPI mode
+		}
+	} else {
+		// No PSRAM
+		external_psram_size = 0;
+	}
+
+    // Return the size of the PSRAM in bytes
+    return external_psram_size * 0x100000;
+}
+
+#endif

--- a/ports/mimxrt/psram.c
+++ b/ports/mimxrt/psram.c
@@ -3,8 +3,8 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2025 Paul Stoffregen
- *                    Dryw Wade
+ * Copyright (c) 2019 Paul Stoffregen
+ *               2025 Dryw Wade
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,230 +26,209 @@
  */
 
 #include "py/mphal.h"
+#include "fsl_flexspi.h"
 
 #if MICROPY_HW_ENABLE_PSRAM
 
-// Copied from here:
-// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/avr/pgmspace.h#L31
-#define FLASHMEM __attribute__((section(".flashmem")))
-
 // These #defines are from here:
-// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/imxrt.h
-#define CCM_CCGR_ON				3
-#define FLEXSPI_MCR2_CLRLEARNPHASE(x)		((uint32_t)(x<<14))
-#define FLEXSPI_LUTKEY_VALUE			((uint32_t)0x5AF05AF0)
-#define FLEXSPI_LUT_INSTRUCTION(opcode, pads, operand) ((uint32_t)(\
-	(((opcode) & 0x3F) << 10) | (((pads) & 0x03) << 8) | ((operand) & 0xFF)))
-#define FLEXSPI_LUT_OPCODE_CMD_SDR		0x01
-#define FLEXSPI_LUT_OPCODE_RADDR_SDR		0x02
-#define FLEXSPI_LUT_OPCODE_WRITE_SDR		0x08
-#define FLEXSPI_LUT_OPCODE_READ_SDR		0x09
-#define FLEXSPI_LUT_OPCODE_DUMMY_SDR		0x0C
-#define FLEXSPI_LUT_NUM_PADS_1			0x00
-#define FLEXSPI_LUT_NUM_PADS_4			0x02
+// https://github.com/PaulStoffregen/cores/blob/10025393e83ca9f4dc5646643a41cb2f32022ae4/teensy4/imxrt.h
+#define CCM_CCGR_ON                             3
+#define FLEXSPI_MCR2_CLRLEARNPHASE(x)           ((uint32_t)(x << 14))
+#define FLEXSPI_LUTKEY_VALUE                    ((uint32_t)0x5AF05AF0)
 
 // The rest of the implementation is adapted from here:
-// https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/startup.c#L379-L587
-// Modified to use #define's from:
-// `lib/nxp_driver/sdk/devices/MIMXRT1062/MIMXRT1062.h`
-#define LUT0(opcode, pads, operand) (FLEXSPI_LUT_INSTRUCTION((opcode), (pads), (operand)))
-#define LUT1(opcode, pads, operand) (FLEXSPI_LUT_INSTRUCTION((opcode), (pads), (operand)) << 16)
-#define CMD_SDR         FLEXSPI_LUT_OPCODE_CMD_SDR
-#define ADDR_SDR        FLEXSPI_LUT_OPCODE_RADDR_SDR
-#define READ_SDR        FLEXSPI_LUT_OPCODE_READ_SDR
-#define WRITE_SDR       FLEXSPI_LUT_OPCODE_WRITE_SDR
-#define DUMMY_SDR       FLEXSPI_LUT_OPCODE_DUMMY_SDR
-#define PINS1           FLEXSPI_LUT_NUM_PADS_1
-#define PINS4           FLEXSPI_LUT_NUM_PADS_4
-
-FLASHMEM static void flexspi2_command(uint32_t index, uint32_t addr)
-{
-	FLEXSPI2->IPCR0 = addr;
-	FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(index);
-	FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
-	while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))); // wait
-	FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1);
+// https://github.com/PaulStoffregen/cores/blob/10025393e83ca9f4dc5646643a41cb2f32022ae4/teensy4/startup.c#L421-L615
+static void flexspi2_command(uint32_t index, uint32_t addr) {
+    FLEXSPI2->IPCR0 = addr;
+    FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(index);
+    FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
+    while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))) {
+        ;                                                      // wait
+    }
+    FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1);
 }
 
-FLASHMEM static uint32_t flexspi2_psram_id(uint32_t addr)
-{
-	FLEXSPI2->IPCR0 = addr;
-	FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(3) | FLEXSPI_IPCR1_IDATSZ(4);
-	FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
-	while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))); // wait
-	uint32_t id = FLEXSPI2->RFDR[0];
-	FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1) | FLEXSPI_INTR_IPRXWA(1);
-	return id;
+static uint32_t flexspi2_psram_id(uint32_t addr) {
+    FLEXSPI2->IPCR0 = addr;
+    FLEXSPI2->IPCR1 = FLEXSPI_IPCR1_ISEQID(3) | FLEXSPI_IPCR1_IDATSZ(4);
+    FLEXSPI2->IPCMD = FLEXSPI_IPCMD_TRG(1);
+    while (!(FLEXSPI2->INTR & FLEXSPI_INTR_IPCMDDONE(1))) {
+        ;                                                      // wait
+    }
+    uint32_t id = FLEXSPI2->RFDR[0];
+    FLEXSPI2->INTR = FLEXSPI_INTR_IPCMDDONE(1) | FLEXSPI_INTR_IPRXWA(1);
+    return id;
 }
 
 /**
  * \return size of PSRAM in MBytes, or 0 if not present
  */
-FLASHMEM static uint8_t flexspi2_psram_size(uint32_t addr)
-{
-	uint8_t result = 0; // assume we don't have PSRAM at this address
-	flexspi2_command(0, addr); // exit quad mode
-	flexspi2_command(1, addr); // reset enable
-	flexspi2_command(2, addr); // reset (is this really necessary?)
-	uint32_t id = flexspi2_psram_id(addr);
+static uint8_t flexspi2_psram_size(uint32_t addr) {
+    uint8_t result = 0;     // assume we don't have PSRAM at this address
+    flexspi2_command(0, addr);     // exit quad mode
+    flexspi2_command(1, addr);     // reset enable
+    flexspi2_command(2, addr);     // reset (is this really necessary?)
+    uint32_t id = flexspi2_psram_id(addr);
 
-	switch (id & 0xFFFF)
-	{
-		default:
-			break;
+    switch (id & 0xFFFF)
+    {
+        default:
+            break;
 
-		case 0x5D0D: // AP / Ipus / ESP / Lyontek
-			result = 8;
-			break;
+        case 0x5D0D:         // AP / Ipus / ESP / Lyontek
+            result = 8;
+            break;
 
-		case 0x5D9D: // ISSI
-			switch ((id >> 21) & 0x7) // get size (Datasheet Table 6.2)
-			{
-				case 0b011: 
-					result = 8;
-					break;
-				case 0b100: 
-					result = 16;
-					break;
-			}
-			break;
-	}
+        case 0x5D9D:         // ISSI
+            switch ((id >> 21) & 0x7)             // get size (Datasheet Table 6.2)
+            {
+                case 0b011:
+                    result = 8;
+                    break;
+                case 0b100:
+                    result = 16;
+                    break;
+            }
+            break;
+    }
 
-	return result;
+    return result;
 }
 
-FLASHMEM size_t configure_external_ram()
-{
-	// initialize pins
-	IOMUXC->SW_PAD_CTL_PAD[22] = 0x1B0F9; // 100K pullup, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[23] = 0x110F9; // keeper, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[24] = 0x1B0F9; // 100K pullup, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[25] = 0x100F9; // strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[26] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[27] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[28] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
-	IOMUXC->SW_PAD_CTL_PAD[29] = 0x170F9; // 47K pullup, strong drive, max speed, hyst
+size_t configure_external_ram() {
+    // initialize pins
+    IOMUXC->SW_PAD_CTL_PAD[22] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[23] = 0x110F9;     // keeper, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[24] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[25] = 0x100F9;     // strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[26] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[27] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[28] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[29] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
 
-	IOMUXC->SW_MUX_CTL_PAD[22] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SS1_B (Flash)
-	IOMUXC->SW_MUX_CTL_PAD[23] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DQS
-	IOMUXC->SW_MUX_CTL_PAD[24] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SS0_B (RAM)
-	IOMUXC->SW_MUX_CTL_PAD[25] = 8 | 0x10; // ALT1 = FLEXSPI2_A_SCLK
-	IOMUXC->SW_MUX_CTL_PAD[26] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA0
-	IOMUXC->SW_MUX_CTL_PAD[27] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA1
-	IOMUXC->SW_MUX_CTL_PAD[28] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA2
-	IOMUXC->SW_MUX_CTL_PAD[29] = 8 | 0x10; // ALT1 = FLEXSPI2_A_DATA3
+    IOMUXC->SW_MUX_CTL_PAD[22] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS1_B (Flash)
+    IOMUXC->SW_MUX_CTL_PAD[23] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DQS
+    IOMUXC->SW_MUX_CTL_PAD[24] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS0_B (RAM)
+    IOMUXC->SW_MUX_CTL_PAD[25] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SCLK
+    IOMUXC->SW_MUX_CTL_PAD[26] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA0
+    IOMUXC->SW_MUX_CTL_PAD[27] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA1
+    IOMUXC->SW_MUX_CTL_PAD[28] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA2
+    IOMUXC->SW_MUX_CTL_PAD[29] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA3
 
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_DQS_FA_SELECT_INPUT] = 1; // GPIO_EMC_23 for Mode: ALT8, pg 986
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT0_SELECT_INPUT] = 1; // GPIO_EMC_26 for Mode: ALT8
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT1_SELECT_INPUT] = 1; // GPIO_EMC_27 for Mode: ALT8
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT2_SELECT_INPUT] = 1; // GPIO_EMC_28 for Mode: ALT8
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT3_SELECT_INPUT] = 1; // GPIO_EMC_29 for Mode: ALT8
-	IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_SCK_FA_SELECT_INPUT] = 1; // GPIO_EMC_25 for Mode: ALT8
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_DQS_FA_SELECT_INPUT] = 1;     // GPIO_EMC_23 for Mode: ALT8, pg 986
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT0_SELECT_INPUT] = 1;     // GPIO_EMC_26 for Mode: ALT8
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT1_SELECT_INPUT] = 1;     // GPIO_EMC_27 for Mode: ALT8
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT2_SELECT_INPUT] = 1;     // GPIO_EMC_28 for Mode: ALT8
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT3_SELECT_INPUT] = 1;     // GPIO_EMC_29 for Mode: ALT8
+    IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_SCK_FA_SELECT_INPUT] = 1;     // GPIO_EMC_25 for Mode: ALT8
 
-	// turn on clock  (QSPI flash & PSRAM chips usually spec max clock 100 to 133 MHz)
-	CCM->CBCMR = (CCM->CBCMR & ~(CCM_CBCMR_FLEXSPI2_PODF_MASK | CCM_CBCMR_FLEXSPI2_CLK_SEL_MASK))
-		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 88.0 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(0); // 99.0 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(6) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 102.9 MHz
-		| CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 105.6 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 110.8 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 120.0 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 132.0 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 144.0 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 166.2 MHz
-		//| CCM_CBCMR_FLEXSPI2_PODF(2) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 176.0 MHz
-	CCM->CCGR7 |= CCM_CCGR7_CG1(CCM_CCGR_ON);
+    // turn on clock  (QSPI flash & PSRAM chips usually spec max clock 100 to 133 MHz)
+    CCM->CBCMR = (CCM->CBCMR & ~(CCM_CBCMR_FLEXSPI2_PODF_MASK | CCM_CBCMR_FLEXSPI2_CLK_SEL_MASK))
+        // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 88.0 MHz
+        // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(0); // 99.0 MHz
+        // | CCM_CBCMR_FLEXSPI2_PODF(6) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 102.9 MHz
+        | CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3);         // 105.6 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 110.8 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 120.0 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 132.0 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 144.0 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 166.2 MHz
+    // | CCM_CBCMR_FLEXSPI2_PODF(2) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 176.0 MHz
+    CCM->CCGR7 |= CCM_CCGR7_CG1(CCM_CCGR_ON);
 
-	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_MDIS(1);
-	FLEXSPI2->MCR0 = (FLEXSPI2->MCR0 & ~(FLEXSPI_MCR0_AHBGRANTWAIT_MASK
-		 | FLEXSPI_MCR0_IPGRANTWAIT_MASK | FLEXSPI_MCR0_SCKFREERUNEN(1)
-		 | FLEXSPI_MCR0_COMBINATIONEN(1) | FLEXSPI_MCR0_DOZEEN(1)
-		 | FLEXSPI_MCR0_HSEN(1) | FLEXSPI_MCR0_ATDFEN(1) | FLEXSPI_MCR0_ARDFEN(1)
-		 | FLEXSPI_MCR0_RXCLKSRC_MASK | FLEXSPI_MCR0_SWRESET(1)))
-		| FLEXSPI_MCR0_AHBGRANTWAIT(0xFF) | FLEXSPI_MCR0_IPGRANTWAIT(0xFF)
-		| FLEXSPI_MCR0_RXCLKSRC(1) | FLEXSPI_MCR0_MDIS(1);
-	FLEXSPI2->MCR1 = FLEXSPI_MCR1_SEQWAIT(0xFFFF) | FLEXSPI_MCR1_AHBBUSWAIT(0xFFFF);
-	FLEXSPI2->MCR2 = (FLEXSPI->MCR2 & ~(FLEXSPI_MCR2_RESUMEWAIT_MASK
-		 | FLEXSPI_MCR2_SCKBDIFFOPT(1) | FLEXSPI_MCR2_SAMEDEVICEEN(1)
-		 | FLEXSPI_MCR2_CLRLEARNPHASE(1) | FLEXSPI_MCR2_CLRAHBBUFOPT(1)))
-		| FLEXSPI_MCR2_RESUMEWAIT(0x20) /*| FLEXSPI_MCR2_SAMEDEVICEEN*/;
+    FLEXSPI2->MCR0 |= FLEXSPI_MCR0_MDIS(1);
+    FLEXSPI2->MCR0 = (FLEXSPI2->MCR0 & ~(FLEXSPI_MCR0_AHBGRANTWAIT_MASK
+        | FLEXSPI_MCR0_IPGRANTWAIT_MASK | FLEXSPI_MCR0_SCKFREERUNEN(1)
+        | FLEXSPI_MCR0_COMBINATIONEN(1) | FLEXSPI_MCR0_DOZEEN(1)
+        | FLEXSPI_MCR0_HSEN(1) | FLEXSPI_MCR0_ATDFEN(1) | FLEXSPI_MCR0_ARDFEN(1)
+        | FLEXSPI_MCR0_RXCLKSRC_MASK | FLEXSPI_MCR0_SWRESET(1)))
+        | FLEXSPI_MCR0_AHBGRANTWAIT(0xFF) | FLEXSPI_MCR0_IPGRANTWAIT(0xFF)
+        | FLEXSPI_MCR0_RXCLKSRC(1) | FLEXSPI_MCR0_MDIS(1);
+    FLEXSPI2->MCR1 = FLEXSPI_MCR1_SEQWAIT(0xFFFF) | FLEXSPI_MCR1_AHBBUSWAIT(0xFFFF);
+    FLEXSPI2->MCR2 = (FLEXSPI->MCR2 & ~(FLEXSPI_MCR2_RESUMEWAIT_MASK
+        | FLEXSPI_MCR2_SCKBDIFFOPT(1) | FLEXSPI_MCR2_SAMEDEVICEEN(1)
+        | FLEXSPI_MCR2_CLRLEARNPHASE(1) | FLEXSPI_MCR2_CLRAHBBUFOPT(1)))
+        | FLEXSPI_MCR2_RESUMEWAIT(0x20) /*| FLEXSPI_MCR2_SAMEDEVICEEN*/;
 
-	FLEXSPI2->AHBCR = FLEXSPI2->AHBCR & ~(FLEXSPI_AHBCR_READADDROPT(1) | FLEXSPI_AHBCR_PREFETCHEN(1)
-		| FLEXSPI_AHBCR_BUFFERABLEEN(1) | FLEXSPI_AHBCR_CACHABLEEN(1));
-	uint32_t mask = (FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK
-		| FLEXSPI_AHBRXBUFCR0_MSTRID_MASK | FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK);
-	FLEXSPI2->AHBRXBUFCR0[0] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
-		| FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
-	FLEXSPI2->AHBRXBUFCR0[1] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
-		| FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
-	FLEXSPI2->AHBRXBUFCR0[2] = mask;
-	FLEXSPI2->AHBRXBUFCR0[3] = mask;
+    FLEXSPI2->AHBCR = FLEXSPI2->AHBCR & ~(FLEXSPI_AHBCR_READADDROPT(1) | FLEXSPI_AHBCR_PREFETCHEN(1)
+        | FLEXSPI_AHBCR_BUFFERABLEEN(1) | FLEXSPI_AHBCR_CACHABLEEN(1));
+    uint32_t mask = (FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_PRIORITY_MASK
+        | FLEXSPI_AHBRXBUFCR0_MSTRID_MASK | FLEXSPI_AHBRXBUFCR0_BUFSZ_MASK);
+    FLEXSPI2->AHBRXBUFCR0[0] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
+        | FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
+    FLEXSPI2->AHBRXBUFCR0[1] = (FLEXSPI2->AHBRXBUFCR0[0] & ~mask)
+        | FLEXSPI_AHBRXBUFCR0_PREFETCHEN(1) | FLEXSPI_AHBRXBUFCR0_BUFSZ(64);
+    FLEXSPI2->AHBRXBUFCR0[2] = mask;
+    FLEXSPI2->AHBRXBUFCR0[3] = mask;
 
-	// RX watermark = one 64 bit line
-	FLEXSPI2->IPRXFCR = (FLEXSPI->IPRXFCR & 0xFFFFFFC0) | FLEXSPI_IPRXFCR_CLRIPRXF(1);
-	// TX watermark = one 64 bit line
-	FLEXSPI2->IPTXFCR = (FLEXSPI->IPTXFCR & 0xFFFFFFC0) | FLEXSPI_IPTXFCR_CLRIPTXF(1);
+    // RX watermark = one 64 bit line
+    FLEXSPI2->IPRXFCR = (FLEXSPI->IPRXFCR & 0xFFFFFFC0) | FLEXSPI_IPRXFCR_CLRIPRXF(1);
+    // TX watermark = one 64 bit line
+    FLEXSPI2->IPTXFCR = (FLEXSPI->IPTXFCR & 0xFFFFFFC0) | FLEXSPI_IPTXFCR_CLRIPTXF(1);
 
-	FLEXSPI2->INTEN = 0;
-	FLEXSPI2->FLSHCR1[0] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
-		| FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
-	FLEXSPI2->FLSHCR2[0] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
-		| FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
+    FLEXSPI2->INTEN = 0;
+    FLEXSPI2->FLSHCR1[0] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
+        | FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
+    FLEXSPI2->FLSHCR2[0] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
+        | FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
 
-	FLEXSPI2->FLSHCR1[1] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
-		| FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
-	FLEXSPI2->FLSHCR2[1] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
-		| FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
+    FLEXSPI2->FLSHCR1[1] = FLEXSPI_FLSHCR1_CSINTERVAL(0)
+        | FLEXSPI_FLSHCR1_TCSH(1) | FLEXSPI_FLSHCR1_TCSS(1);
+    FLEXSPI2->FLSHCR2[1] = FLEXSPI_FLSHCR2_AWRSEQID(6) | FLEXSPI_FLSHCR2_AWRSEQNUM(0)
+        | FLEXSPI_FLSHCR2_ARDSEQID(5) | FLEXSPI_FLSHCR2_ARDSEQNUM(0);
 
-	FLEXSPI2->MCR0 &= ~FLEXSPI_MCR0_MDIS(1);
+    FLEXSPI2->MCR0 &= ~FLEXSPI_MCR0_MDIS(1);
 
-	FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
-	FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
-	volatile uint32_t *luttable = &FLEXSPI2->LUT[0];
-	for (int i=0; i < 64; i++) luttable[i] = 0;
-	FLEXSPI2->MCR0 |= FLEXSPI_MCR0_SWRESET(1);
-	while (FLEXSPI2->MCR0 & FLEXSPI_MCR0_SWRESET(1)) ; // wait
+    FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
+    FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
+    volatile uint32_t *luttable = &FLEXSPI2->LUT[0];
+    for (int i = 0; i < 64; i++) { luttable[i] = 0;
+    }
+    FLEXSPI2->MCR0 |= FLEXSPI_MCR0_SWRESET(1);
+    while (FLEXSPI2->MCR0 & FLEXSPI_MCR0_SWRESET(1)) {
+        ;                                                  // wait
 
-	FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
-	FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
+    }
+    FLEXSPI2->LUTKEY = FLEXSPI_LUTKEY_VALUE;
+    FLEXSPI2->LUTCR = FLEXSPI_LUTCR_UNLOCK(1);
 
-	// cmd index 0 = exit QPI mode
-	FLEXSPI2->LUT[0] = LUT0(CMD_SDR, PINS4, 0xF5);
-	// cmd index 1 = reset enable
-	FLEXSPI2->LUT[4] = LUT0(CMD_SDR, PINS1, 0x66);
-	// cmd index 2 = reset
-	FLEXSPI2->LUT[8] = LUT0(CMD_SDR, PINS1, 0x99);
-	// cmd index 3 = read ID bytes
-	FLEXSPI2->LUT[12] = LUT0(CMD_SDR, PINS1, 0x9F) | LUT1(DUMMY_SDR, PINS1, 24);
-	FLEXSPI2->LUT[13] = LUT0(READ_SDR, PINS1, 1);
-	// cmd index 4 = enter QPI mode
-	FLEXSPI2->LUT[16] = LUT0(CMD_SDR, PINS1, 0x35);
-	// cmd index 5 = read QPI
-	FLEXSPI2->LUT[20] = LUT0(CMD_SDR, PINS4, 0xEB) | LUT1(ADDR_SDR, PINS4, 24);
-	FLEXSPI2->LUT[21] = LUT0(DUMMY_SDR, PINS4, 6) | LUT1(READ_SDR, PINS4, 1);
-	// cmd index 6 = write QPI
-	FLEXSPI2->LUT[24] = LUT0(CMD_SDR, PINS4, 0x38) | LUT1(ADDR_SDR, PINS4, 24);
-	FLEXSPI2->LUT[25] = LUT0(WRITE_SDR, PINS4, 1);
+    // cmd index 0 = exit QPI mode
+    FLEXSPI2->LUT[0] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_4PAD, 0xF5, 0, 0, 0);
+    // cmd index 1 = reset enable
+    FLEXSPI2->LUT[4] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x66, 0, 0, 0);
+    // cmd index 2 = reset
+    FLEXSPI2->LUT[8] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x99, 0, 0, 0);
+    // cmd index 3 = read ID bytes
+    FLEXSPI2->LUT[12] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x9F, kFLEXSPI_Command_DUMMY_SDR, kFLEXSPI_1PAD, 24);
+    FLEXSPI2->LUT[13] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_READ_SDR, kFLEXSPI_1PAD, 1, 0, 0, 0);
+    // cmd index 4 = enter QPI mode
+    FLEXSPI2->LUT[16] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_1PAD, 0x35, 0, 0, 0);
+    // cmd index 5 = read QPI
+    FLEXSPI2->LUT[20] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_4PAD, 0xEB, kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_4PAD, 24);
+    FLEXSPI2->LUT[21] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_DUMMY_SDR, kFLEXSPI_4PAD, 6, kFLEXSPI_Command_READ_SDR, kFLEXSPI_4PAD, 1);
+    // cmd index 6 = write QPI
+    FLEXSPI2->LUT[24] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_SDR, kFLEXSPI_4PAD, 0x38, kFLEXSPI_Command_RADDR_SDR, kFLEXSPI_4PAD, 24);
+    FLEXSPI2->LUT[25] = FLEXSPI_LUT_SEQ(kFLEXSPI_Command_WRITE_SDR, kFLEXSPI_4PAD, 1, 0, 0, 0);
 
     // Detected PSRAM size in MB
     uint8_t external_psram_size = 0;
 
-	// look for the first PSRAM chip
-	uint8_t size1 = flexspi2_psram_size(0);
-	if (size1 > 0) {
-		FLEXSPI2->FLSHCR0[0] = size1 << 10;
-		flexspi2_command(4, 0); // enter QPI mode
-		// look for a second PSRAM chip
-		uint8_t size2 = flexspi2_psram_size(size1 << 20);
-		external_psram_size = size1 + size2;
-		if (size2 > 0) {
-			FLEXSPI2->FLSHCR0[1] = size2 << 10;
-			flexspi2_command(4, size1 << 20);  // enter QPI mode
-		}
-	} else {
-		// No PSRAM
-		external_psram_size = 0;
-	}
+    // look for the first PSRAM chip
+    uint8_t size1 = flexspi2_psram_size(0);
+    if (size1 > 0) {
+        FLEXSPI2->FLSHCR0[0] = size1 << 10;
+        flexspi2_command(4, 0);         // enter QPI mode
+        // look for a second PSRAM chip
+        uint8_t size2 = flexspi2_psram_size(size1 << 20);
+        external_psram_size = size1 + size2;
+        if (size2 > 0) {
+            FLEXSPI2->FLSHCR0[1] = size2 << 10;
+            flexspi2_command(4, size1 << 20);              // enter QPI mode
+        }
+    } else {
+        // No PSRAM
+        external_psram_size = 0;
+    }
 
     // Return the size of the PSRAM in bytes
     return external_psram_size * 0x100000;

--- a/ports/mimxrt/psram.c
+++ b/ports/mimxrt/psram.c
@@ -13,8 +13,13 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -32,7 +37,6 @@
 
 // These #defines are from here:
 // https://github.com/PaulStoffregen/cores/blob/10025393e83ca9f4dc5646643a41cb2f32022ae4/teensy4/imxrt.h
-#define CCM_CCGR_ON                             3
 #define FLEXSPI_MCR2_CLRLEARNPHASE(x)           ((uint32_t)(x << 14))
 #define FLEXSPI_LUTKEY_VALUE                    ((uint32_t)0x5AF05AF0)
 
@@ -97,23 +101,23 @@ static uint8_t flexspi2_psram_size(uint32_t addr) {
 
 size_t configure_external_ram() {
     // initialize pins
-    IOMUXC->SW_PAD_CTL_PAD[22] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[23] = 0x110F9;     // keeper, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[24] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[25] = 0x100F9;     // strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[26] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[27] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[28] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
-    IOMUXC->SW_PAD_CTL_PAD[29] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23] = 0x110F9;     // keeper, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24] = 0x1B0F9;     // 100K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25] = 0x100F9;     // strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
+    IOMUXC->SW_PAD_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29] = 0x170F9;     // 47K pullup, strong drive, max speed, hyst
 
-    IOMUXC->SW_MUX_CTL_PAD[22] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS1_B (Flash)
-    IOMUXC->SW_MUX_CTL_PAD[23] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DQS
-    IOMUXC->SW_MUX_CTL_PAD[24] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS0_B (RAM)
-    IOMUXC->SW_MUX_CTL_PAD[25] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SCLK
-    IOMUXC->SW_MUX_CTL_PAD[26] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA0
-    IOMUXC->SW_MUX_CTL_PAD[27] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA1
-    IOMUXC->SW_MUX_CTL_PAD[28] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA2
-    IOMUXC->SW_MUX_CTL_PAD[29] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA3
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_22] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS1_B (Flash)
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_23] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DQS
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_24] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SS0_B (RAM)
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_25] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_SCLK
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_26] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA0
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_27] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA1
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_28] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA2
+    IOMUXC->SW_MUX_CTL_PAD[kIOMUXC_SW_MUX_CTL_PAD_GPIO_EMC_29] = 8 | 0x10;     // ALT1 = FLEXSPI2_A_DATA3
 
     IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_DQS_FA_SELECT_INPUT] = 1;     // GPIO_EMC_23 for Mode: ALT8, pg 986
     IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_IO_FA_BIT0_SELECT_INPUT] = 1;     // GPIO_EMC_26 for Mode: ALT8
@@ -123,18 +127,27 @@ size_t configure_external_ram() {
     IOMUXC->SELECT_INPUT_1[kIOMUXC_FLEXSPI2_IPP_IND_SCK_FA_SELECT_INPUT] = 1;     // GPIO_EMC_25 for Mode: ALT8
 
     // turn on clock  (QSPI flash & PSRAM chips usually spec max clock 100 to 133 MHz)
-    CCM->CBCMR = (CCM->CBCMR & ~(CCM_CBCMR_FLEXSPI2_PODF_MASK | CCM_CBCMR_FLEXSPI2_CLK_SEL_MASK))
-        // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 88.0 MHz
-        // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(0); // 99.0 MHz
-        // | CCM_CBCMR_FLEXSPI2_PODF(6) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 102.9 MHz
-        | CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3);         // 105.6 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 110.8 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(5) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 120.0 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 132.0 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(4) | CCM_CBCMR_FLEXSPI2_CLK_SEL(1); // 144.0 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(3) | CCM_CBCMR_FLEXSPI2_CLK_SEL(2); // 166.2 MHz
-    // | CCM_CBCMR_FLEXSPI2_PODF(2) | CCM_CBCMR_FLEXSPI2_CLK_SEL(3); // 176.0 MHz
-    CCM->CCGR7 |= CCM_CCGR7_CG1(CCM_CCGR_ON);
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 5); // 88.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 3); // 88.0 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 3); // 99.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 0); // 99.0 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 6); // 102.9 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1); // 102.9 MHz
+    CLOCK_SetDiv(kCLOCK_Flexspi2Div, 4); // 105.6 MHz
+    CLOCK_SetMux(kCLOCK_Flexspi2Mux, 3); // 105.6 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 5); // 110.8 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 2); // 110.8 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 5); // 120.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1); // 120.0 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 3); // 132.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 3); // 132.0 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 4); // 144.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 1); // 144.0 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 3); // 166.2 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 2); // 166.2 MHz
+    // CLOCK_SetDiv(kCLOCK_Flexspi2Div, 2); // 176.0 MHz
+    // CLOCK_SetMux(kCLOCK_Flexspi2Mux, 3); // 176.0 MHz
+    CLOCK_EnableClock(kCLOCK_FlexSpi2);
 
     FLEXSPI2->MCR0 |= FLEXSPI_MCR0_MDIS(1);
     FLEXSPI2->MCR0 = (FLEXSPI2->MCR0 & ~(FLEXSPI_MCR0_AHBGRANTWAIT_MASK

--- a/ports/mimxrt/psram.h
+++ b/ports/mimxrt/psram.h
@@ -4,7 +4,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Paul Stoffregen
- *               2025 Dryw Wade
+ *               2026 Dryw Wade
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -13,13 +13,8 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * 1. The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * 2. If the Software is incorporated into a build system that allows
- * selection among a list of target devices, then similar target
- * devices manufactured by PJRC.COM must be included in the list of
- * target devices and selectable in the same manner.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/ports/mimxrt/psram.h
+++ b/ports/mimxrt/psram.h
@@ -13,8 +13,13 @@
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/ports/mimxrt/psram.h
+++ b/ports/mimxrt/psram.h
@@ -3,8 +3,8 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2025 Paul Stoffregen
- *                    Dryw Wade
+ * Copyright (c) 2019 Paul Stoffregen
+ *               2025 Dryw Wade
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/ports/mimxrt/psram.h
+++ b/ports/mimxrt/psram.h
@@ -1,0 +1,36 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Paul Stoffregen
+ *                    Dryw Wade
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_MIMXRT_PSRAM_H
+#define MICROPY_INCLUDED_MIMXRT_PSRAM_H
+
+#define PSRAM_BASE (0x70000000)
+
+// Configures external PSRAM if available, returns  size in bytes (0 if none).
+size_t configure_external_ram();
+
+#endif // MICROPY_INCLUDED_MIMXRT_PSRAM_H


### PR DESCRIPTION
### Summary

PSRAM support for Teensy 4.1 and other `mimxrt` boards! Resolves #18281

This implementation is a copy of the [Arduino core PSRAM implementation here](https://github.com/PaulStoffregen/cores/blob/a23cade55c7530cce43c641ec3ddb8b7f83148a8/teensy4/startup.c#L379-L587). I modified the implementation to use the `#define`s from [`lib/nxp_driver/sdk/devices/MIMXRT1062/MIMXRT1062.h`](https://github.com/micropython/nxp_driver/blob/master/sdk/devices/MIMXRT1062/MIMXRT1062.h) where possible instead of the huge [`imxrt.h`](https://github.com/PaulStoffregen/cores/blob/master/teensy4/imxrt.h). However there's still about a dozen that I had to copy over from `imxrt.h` that currently live in `psram.c`; happy to change/move these if there's a better solution!

The MicroPython side of things is a copy of the `rp2` PSRAM PR (#15620). I have not looked into whether `MICROPY_ALLOC_GC_STACK_SIZE` needs to be increased nor if any clock timings need to change, like was done in the `rp2` PR. There may be other edge cases that need to be addressed, but I'm new to Teensy/mimxrt, so don't know what to look for :slightly_smiling_face:

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

The following test code prints the total amount of memory seen by the garbage collector, then performs a memory test with a small and large `bytearray` to demonstrate the split heap working.

```
import gc
import uctypes

gc.collect()
print("Initial GC free (MiB):", gc.mem_free() / 1024 / 1024)

def test(size):
    gc.collect()
    b = bytearray(size)
    print("Test size:", size, "location: 0x{:X}".format(uctypes.addressof(b)), end=' ')
    for i in range(size):
        b[i] = i & 0xFF
    for i in range(size):
        if b[i] != (i & 0xFF):
            print("Fail at", i)
            return
    print("Pass!")

test(10)
test(10_000_000)
```

Testing with a single 16MiB chip, the GC shows over 16MiB available. The small array is allocated in the `0x20000000` range (DTCM), and the large array is allocated in the `0x70000000` range (PSRAM). All behaves as I'd expect!

```
Initial GC free (MiB): 16.358551025390626
Test size: 10 location: 0x20204720 Pass!
Test size: 10000000 location: 0x7005DD00 Pass!
```

Note that `test(10_000_000)` takes ~25 seconds on my end.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

There could be an argument for PSRAM support being enabled by default, at least for Teensy 4.1 (set `#define MICROPY_HW_ENABLE_PSRAM (1)` in `boards/TEENSY41/mpconfigboard.h`). This implementation auto-detects the presence and size of 1 or 2 PSRAM chips if they're soldered, meaning a user wouldn't need to flash different firmware.

Building on my end, enabling PSRAM increases the firmware size from 626992 to 628064 bytes (+1072 / +0.17%), so I'll defer to others whether it's worth enabling it by default. If not, might be nice to create a variant with PSRAM enabled so it's easy to get from the [Teensy 4.1 download page](https://micropython.org/download/TEENSY41/).