### PR TITLE
py/stream: Use detailed error strings for TLS sockets.

### DIFF
--- a/extmod/machine_i2s.c
+++ b/extmod/machine_i2s.c
@@ -617,9 +617,9 @@ static mp_uint_t machine_i2s_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
     machine_i2s_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_uint_t ret;
     uintptr_t flags = arg;
-    self->io_mode = ASYNCIO; // a call to ioctl() is an indication that asyncio is being used
 
     if (request == MP_STREAM_POLL) {
+        self->io_mode = ASYNCIO; // a MP_STREAM_POLL request is an indication that asyncio is being used
         ret = 0;
 
         if (flags & MP_STREAM_POLL_RD) {

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1573,6 +1573,11 @@ static err_t _lwip_tcp_close_poll(void *arg, struct tcp_pcb *pcb) {
 }
 
 static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    if (request != MP_STREAM_POLL && request != MP_STREAM_CLOSE) {
+        *errcode = MP_EINVAL;
+        return MP_STREAM_ERROR;
+    }
+
     lwip_socket_obj_t *socket = MP_OBJ_TO_PTR(self_in);
     mp_uint_t ret;
 
@@ -1687,10 +1692,6 @@ static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
         socket->pcb.tcp = NULL;
         socket->state = _ERR_BADF;
         ret = 0;
-
-    } else {
-        *errcode = MP_EINVAL;
-        ret = MP_STREAM_ERROR;
     }
 
     MICROPY_PY_LWIP_EXIT

--- a/extmod/modtls_axtls.c
+++ b/extmod/modtls_axtls.c
@@ -390,6 +390,12 @@ static mp_uint_t ssl_socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t ar
         ssl_ctx_free(self->ssl_ctx);
         self->ssl_sock = NULL;
     }
+    #if MICROPY_STREAMS_DELEGATE_ERROR
+    else if (request == MP_STREAM_RAISE_ERROR) {
+        // Raise error with detailed error string
+        ssl_raise_error((int)arg);
+    }
+    #endif
 
     if (self->sock == MP_OBJ_NULL) {
         // Underlying socket may be null if the constructor raised an exception.

--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -870,7 +870,14 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
                 }
             }
         }
-    } else {
+    }
+    #if MICROPY_STREAMS_DELEGATE_ERROR
+    else if (request == MP_STREAM_RAISE_ERROR) {
+        // Raise error with detailed error string
+        mbedtls_raise_error((int)arg);
+    }
+    #endif
+    else {
         // Unsupported ioctl.
         *errcode = MP_EINVAL;
         return MP_STREAM_ERROR;

--- a/extmod/vfs_lfsx_file.c
+++ b/extmod/vfs_lfsx_file.c
@@ -152,11 +152,8 @@ static mp_uint_t MP_VFS_LFSx(file_write)(mp_obj_t self_in, const void *buf, mp_u
 static mp_uint_t MP_VFS_LFSx(file_ioctl)(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     MP_OBJ_VFS_LFSx_FILE *self = MP_OBJ_TO_PTR(self_in);
 
-    if (request != MP_STREAM_CLOSE) {
-        MP_VFS_LFSx(check_open)(self);
-    }
-
     if (request == MP_STREAM_SEEK) {
+        MP_VFS_LFSx(check_open)(self);
         struct mp_stream_seek_t *s = (struct mp_stream_seek_t *)(uintptr_t)arg;
         int res = LFSx_API(file_seek)(&self->vfs->lfs, &self->file, s->offset, s->whence);
         if (res < 0) {
@@ -171,6 +168,7 @@ static mp_uint_t MP_VFS_LFSx(file_ioctl)(mp_obj_t self_in, mp_uint_t request, ui
         s->offset = res;
         return 0;
     } else if (request == MP_STREAM_FLUSH) {
+        MP_VFS_LFSx(check_open)(self);
         int res = LFSx_API(file_sync)(&self->vfs->lfs, &self->file);
         if (res < 0) {
             *errcode = -res;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1097,6 +1097,12 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_STREAMS_POSIX_API (0)
 #endif
 
+// Whether to delegate error raising to stream implementations using the
+// MP_STREAM_RAISE_ERROR ioctl to support raising more detailed messages.
+#ifndef MICROPY_STREAMS_DELEGATE_ERROR
+#define MICROPY_STREAMS_DELEGATE_ERROR (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
 // Whether to process __all__ when importing all public symbols from a module.
 #ifndef MICROPY_MODULE___ALL__
 #define MICROPY_MODULE___ALL__ (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_BASIC_FEATURES)


### PR DESCRIPTION
### Summary

Both mbedTLS and axTLS have support for producing more detailed error strings. However, these are not used if the error is raised in stream protocol functions (read/write/ioctl).

```python
import io, tls
tls_socket = tls.SSLContext(tls.PROTOCOL_TLS_CLIENT).wrap_socket(io.BytesIO(), do_handshake_on_connect=False, server_hostname='')
tls_socket.read()
```

Without this PR:

```log
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: -29312
```

With this PR:

```log
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: (-29312, 'MBEDTLS_ERR_SSL_CONN_EOF')
```

Currently only implemented for TLS sockets since those already had helper functions for raising detailed exceptions, but can be easily implemented in any other stream.

Under the hood it's using a new `MP_STREAM_RAISE_ERROR` ioctl request to pass the error code back to the stream implementation which can raise a more detailed error. If the ioctl is not implemented, we fall back to the old behaviour and raise an OSError with the error code.

Some existing ioctl functions would throw exceptions in certain states regardless of whether the request is supported or not, and some would unconditionally modify certain state. Thus the first commit reworks all existing ioctl implementations to correctly completely ignore unsupported requests.

### Testing

So far only tested on the ESP32 port with the original ESP32 on a custom board. Will be happy to do some more testing if this feature is considered desirable.

### Trade-offs and Alternatives

I also tried two alternatives:

- Using ioctl, but adding a bit flag to the stream protocol to explicitly indicate the stream ioctl function supports raising errors.
  - Pro: We would not call ioctl for streams that do not support it.
  - Pro: This flag fits in the existing space for flags, thus wouldn't grow the struct.
  - Con: Having that extra flag is arguably messier since it increases the complexity for understanding the stream protocol, instead of this being grouped in as just another ioctl request.
  - Con: Fixing all existing ioctl implementations to let unsupported requests be a no-op is a good idea anyway regardless of the detailed error string feature.
- Adding an extra function pointer to the stream protocol struct which if set will be called with the error code.
  - Pro: The existing TLS functions for raising detailed errors can be used directly.
  - Con: Code size increase is significant.

This new functionality is gated behind the new `MICROPY_STREAMS_DELEGATE_ERROR` feature flag, which defaults to `MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES`. The rest of the code size increase comes from the fixes to the ioctl functions. Note there also already exists a feature flag for MbedTLS to not embed the error strings (`MBEDTLS_ERROR_C`), which has a more significant impact on code size.