### PR TITLE
github/workflows: Free up more disk space on zephyr workflow.

### DIFF
--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -28,11 +28,14 @@ jobs:
     - uses: jlumbroso/free-disk-space@main
       with:
         # Only free up a few things so this step runs quickly.
+        # (android would save 9.6GiB, but takes about 13m)
+        # (large-packages would save 4.6GiB, but takes about 3m)
         android: false
         dotnet: true
         haskell: true
         large-packages: false
         docker-images: false
+        tool-cache: true
         swap-storage: false
     - uses: actions/checkout@v5
     - id: versions


### PR DESCRIPTION
### Summary

Zephyr CI is currently failing, because the runner is out of space.

Free up some more space using the existing plugin.

Fixes issue #18290.

### Testing

Tested by CI.