### PR TITLE
rp2: Don't corrupt globals on asm_pio() exception.

### DIFF
--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -251,20 +251,21 @@ def asm_pio(**kw):
         old_gl = gl.copy()
         gl.clear()
 
-        gl.update(_pio_funcs)
-        for name in _pio_directives:
-            gl[name] = getattr(emit, name)
-        for name in _pio_instructions:
-            gl[name] = getattr(emit, name)
+        try:
+            gl.update(_pio_funcs)
+            for name in _pio_directives:
+                gl[name] = getattr(emit, name)
+            for name in _pio_instructions:
+                gl[name] = getattr(emit, name)
 
-        emit.start_pass(0)
-        f()
+            emit.start_pass(0)
+            f()
 
-        emit.start_pass(1)
-        f()
-
-        gl.clear()
-        gl.update(old_gl)
+            emit.start_pass(1)
+            f()
+        finally:
+            gl.clear()
+            gl.update(old_gl)
 
         return emit.prog
 


### PR DESCRIPTION
### Summary

The `rp2.asm_pio()` decorator saves and temporarily replaces the globals dictionary to allow the wrapped functions to reference PIO instructions and register names in a natural way, restoring them before returning the assembled program.

However, if an exception occurs while assembling the program, the globals are not changed back, leaving them corrupted. For example:

```python
>>> import rp2
>>> @rp2.asm_pio()
... def foo():
...     nop().side(1)
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "rp2.py", line 268, in dec
  File "<stdin>", line 3, in foo
  File "rp2.py", line 98, in side
PIOASMError: no sideset
>>> rp2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'rp2' isn't defined
>>> globals()
{'osr': 7, 'block': 33, 'pindirs': 4, 'x_not_y': 5, 'not_osre': 7,
 'wrap_target': <bound_method>, 'x_dec': 2, 'pin': 6, 'wait': <bound_method>,
 'mov': <bound_method>, 'irq': <bound_method>, 'set': <bound_method>, 'noblock': 1,
 'in_': <bound_method>, 'isr': 6, 'ifempty': 64, 'pins': 0, 'status': 5, 'y_dec': 4,
 'jmp': <bound_method>, 'pc': 5, 'label': <bound_method>, 'iffull': 64, 'clear': 64,
 'exec': 8, 'y': 2, 'x': 1, 'null': 3, 'wrap': <bound_method>,
 'rel': <function <lambda> at 0x2000f820>,
 'reverse': <function <lambda> at 0x2000f810>, 'gpio': 0, 'pull': <bound_method>,
 'nop': <bound_method>, 'not_y': 3, 'invert': <function <lambda> at 0x2000f800>,
 'word': <bound_method>, 'out': <bound_method>, 'not_x': 1, 'push': <bound_method>}
```

Wrap with try/finally to ensure they are always restored correctly. Once fixed:

```python
>>> import rp2
>>> @rp2.asm_pio()
... def foo():
...     nop().side(1)
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "rp2.py", line 265, in dec
  File "<stdin>", line 3, in foo
  File "rp2.py", line 94, in side
PIOASMError: no sideset
>>> rp2
<module 'rp2' from 'rp2.py'>
>>> globals()
{'machine': <module 'machine'>, 'rp2': <module 'rp2' from 'rp2.py'>, '__name__': '__main__'}
```

This bug was discovered while writing some new tests for the `rp2.asm_pio()` decorator: any PIO program that deliberately caused an exception (to test detection of error cases) made all the imported modules mysteriously vanish from scope, and `try: ... except rp2.PIOASMError:` always failed because rp2 didn't exist whenever the except block was executed!

### Testing

Tested on Pi Pico 2 and Pi Pico 2W.