### PR TITLE
tests/ports/rp2: Add some tests for the PIO assembler.

### DIFF
--- a/tests/ports/rp2/rp2_pioasm.py
+++ b/tests/ports/rp2/rp2_pioasm.py
@@ -1,0 +1,178 @@
+import rp2
+
+@rp2.asm_pio()
+def ops1():
+    label("wait")
+    wait(0, gpio, 9)
+    wait(1, pin, 23)
+    wait(1, irq, 1)
+    jmp("out")
+
+    label("in_")
+    in_(pins, 18)
+    in_(x, 25)
+    in_(y, 31)
+    in_(null, 2)
+    in_(isr, 26)
+    in_(osr, 30)
+    jmp(not_x, "push")
+    jmp(x_dec, "wait")
+
+    label("out")
+    out(pins, 24)
+    out(x, 11)
+    out(y, 25)
+    out(null, 17)
+    out(isr, 25)
+    out(osr, 1)
+    jmp("in_")
+
+    label("push")
+    push()
+    push(block)
+    push(noblock)
+    push(iffull)
+    push(iffull, block)
+    push(iffull, noblock)
+    jmp(not_y, "wait")
+    jmp(y_dec, "out")
+print("ops1:", ops1)
+
+@rp2.asm_pio()
+def ops2():
+    label("pull")
+    pull()
+    pull(block)
+    pull(noblock)
+    pull(ifempty)
+    pull(ifempty, block)
+    pull(ifempty, noblock)
+    jmp(x_not_y, "irq")
+
+    wrap_target()
+    label("mov")
+    mov(pins, y)
+    mov(x, reverse(exec))
+    mov(y, invert(pc))
+    mov(exec, isr)
+    mov(pc, reverse(osr))
+    mov(isr, invert(pins))
+    mov(osr, x)
+    nop()
+    jmp(not_osre, "set")
+
+    label("irq")
+    irq(3)
+    irq(rel(0))
+    irq(block, 7)
+    irq(clear, rel(1))
+    jmp(pin, "mov")
+
+    wrap()
+    label("set")
+    set(pins, 9)
+    set(x, 2)
+    set(y, 30)
+    set(pindirs, 11)
+print("ops2:", ops2)
+
+@rp2.asm_pio(sideset_init=[rp2.PIO.OUT_LOW] * 3)
+def side1():
+    label("side")
+    out(x, 23).side(3).delay(3)
+    jmp(y_dec, "side").side(2)
+    mov(osr, reverse(x)).side(1)[1]
+print("side1:", side1)
+
+try:
+    @rp2.asm_pio(sideset_init=[rp2.PIO.OUT_LOW] * 1)
+    def side2():
+        label("side")
+        out(x, 23).side(3).delay(3)
+        jmp(y_dec, "side").side(2)
+        mov(osr, reverse(x)).side(1)[1]
+    print("side2:", side2)
+except rp2.PIOASMError:
+    print("side2: overflow correctly detected")
+
+try:
+    @rp2.asm_pio(sideset_init=[rp2.PIO.OUT_LOW] * 3)
+    def side3():
+        label("side")
+        out(x, 23).side(3).delay(3)
+        jmp(y_dec, "side")
+        mov(osr, reverse(x)).side(1)[1]
+    print("side3:", side3)
+except rp2.PIOASMError:
+    print("side3: overflow correctly detected")
+
+@rp2.asm_pio(
+    out_init=[rp2.PIO.OUT_HIGH] * 7,
+    set_init=[rp2.PIO.OUT_HIGH, rp2.PIO.OUT_LOW] * 2,
+)
+def init1():
+    nop()
+print("init1:", init1)
+
+@rp2.asm_pio(
+    out_init=[rp2.PIO.OUT_LOW, rp2.PIO.OUT_HIGH] * 3,
+    set_init=[rp2.PIO.OUT_LOW] * 5,
+)
+def init2():
+    nop()
+print("init2:", init2)
+
+@rp2.asm_pio(side_pindir=True)
+def pindir1():
+    nop()
+print("pindir1:", pindir1)
+
+@rp2.asm_pio(side_pindir=False)
+def pindir2():
+    nop()
+print("pindir2:", pindir2)
+
+@rp2.asm_pio(autopush=True, push_thresh=23)
+def autopush1():
+    nop()
+print("autopush1:", autopush1)
+
+@rp2.asm_pio(autopush=False, push_thresh=5)
+def autopush2():
+    nop()
+print("autopush2:", autopush2)
+
+@rp2.asm_pio(autopull=True, pull_thresh=13)
+def autopull1():
+    nop()
+print("autopull1:", autopull1)
+
+@rp2.asm_pio(autopull=False, pull_thresh=31)
+def autopull2():
+    nop()
+print("autopull2:", autopull2)
+
+@rp2.asm_pio(in_shiftdir=rp2.PIO.SHIFT_LEFT, out_shiftdir=rp2.PIO.SHIFT_RIGHT)
+def shiftdir1():
+    nop()
+print("shiftdir1:", shiftdir1)
+
+@rp2.asm_pio(in_shiftdir=rp2.PIO.SHIFT_RIGHT, out_shiftdir=rp2.PIO.SHIFT_LEFT)
+def shiftdir2():
+    nop()
+print("shiftdir2:", shiftdir2)
+
+@rp2.asm_pio(fifo_join=rp2.PIO.JOIN_RX)
+def join1():
+    nop()
+print("join1:", join1)
+
+@rp2.asm_pio(fifo_join=rp2.PIO.JOIN_TX)
+def join2():
+    nop()
+print("join2:", join2)
+
+@rp2.asm_pio(fifo_join=rp2.PIO.JOIN_NONE)
+def join3():
+    nop()
+print("join3:", join3)

--- a/tests/ports/rp2/rp2_pioasm.py.exp
+++ b/tests/ports/rp2/rp2_pioasm.py.exp
@@ -1,0 +1,18 @@
+ops1: [array('H', [8201, 8375, 8385, 12, 16402, 16441, 16479, 16482, 16602, 16638, 51, 64, 24600, 24619, 24665, 24689, 24793, 24801, 4, 32800, 32800, 32768, 32864, 32864, 32832, 96, 140]), -1, -1, -1, 106496, 0, None, None, None]
+ops2: [array('H', [32928, 32928, 32896, 32992, 32992, 32960, 176, 40962, 41016, 41037, 41094, 41143, 41160, 41185, 41026, 245, 49155, 49168, 49191, 49233, 199, 57353, 57378, 57438, 57483]), -1, -1, -1, 82816, 0, None, None, None]
+side1: [array('H', [28471, 2176, 42481]), -1, -1, -1, 8192, 0, None, None, [2, 2, 2]]
+side2: overflow correctly detected
+side3: overflow correctly detected
+init1: [array('H', [41026]), -1, -1, -1, 0, 0, [3, 3, 3, 3, 3, 3, 3], [3, 2, 3, 2], None]
+init2: [array('H', [41026]), -1, -1, -1, 0, 0, [2, 3, 2, 3, 2, 3], [2, 2, 2, 2, 2], None]
+pindir1: [array('H', [41026]), -1, -1, -1, 536870912, 0, None, None, None]
+pindir2: [array('H', [41026]), -1, -1, -1, 0, 0, None, None, None]
+autopush1: [array('H', [41026]), -1, -1, -1, 0, 24182784, None, None, None]
+autopush2: [array('H', [41026]), -1, -1, -1, 0, 5242880, None, None, None]
+autopull1: [array('H', [41026]), -1, -1, -1, 0, 436338688, None, None, None]
+autopull2: [array('H', [41026]), -1, -1, -1, 0, 1040187392, None, None, None]
+shiftdir1: [array('H', [41026]), -1, -1, -1, 0, 524288, None, None, None]
+shiftdir2: [array('H', [41026]), -1, -1, -1, 0, 262144, None, None, None]
+join1: [array('H', [41026]), -1, -1, -1, 0, 2147483648, None, None, None]
+join2: [array('H', [41026]), -1, -1, -1, 0, 1073741824, None, None, None]
+join3: [array('H', [41026]), -1, -1, -1, 0, 0, None, None, None]


### PR DESCRIPTION
### Summary

Take a first cut at some tests for rp2 `asm_pio()` decorator.

Check the result of assembling some nonsense test programs, constructed to exercise all variants of every instruction, forward and backward jumps with every condition type, wrapping, side-setting and delays, pin initialisation, autopush and autopull settings, shift directions and FIFO join.

### Testing

Tested on Pico 2 and Pico 2W, but also requires the `asm_pio()` bugfix from https://github.com/micropython/micropython/pull/18300 to work.

At the moment, the .exp file is generated from micropython itself, but once the test is settled in final form, I'll convert to pico sdk format, manually check the generated object code in the test against what the sdk assembler produces, and hand-inspect the other parameters based on my understanding of the representation of a pio program in rp2.py.

### Trade-offs and Alternatives

These tests are an early draft. Any suggestions for improvements or extra things to test gratefully received! I'm not testing the new `execctrl=` feature from https://github.com/micropython/micropython/pull/18133 yet as this hasn't landed in mainline. 