### PR TITLE
rp2/machine_pin: Add drive strength argument to machine.

### DIFF
--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -162,6 +162,39 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
     p4 = Pin(4, Pin.IN, Pin.PULL_UP) # enable internal pull-up resistor
     p5 = Pin(5, Pin.OUT, value=1) # set pin high on creation
 
+    p6 = Pin(6, Pin.OUT, drive=Pin.DRIVE_3) # nom. 12mA drive strength
+    p7 = Pin(7, Pin.OUT, drive=Pin.DRIVE_1|Pin.DRIVE_FAST) # high slew rate
+
+Four drive strengths are supported. As is common for microcontrollers,
+the RP2xxx datasheets label these with a nominal current
+(approximately the maximum current for which the output voltage can be
+guaranteed to remain at a TTL compatible level). **The short-circuit
+current will be much higher** and is not specified as either safe or
+to result in a current within a given range (so replacing the series
+resistor for driving a LED by merely selecting a low drive strength
+carries a risk). Additionally, the slew rate limitation can be
+disabled by bitwise OR of the intended drive strength constant with
+the ``Pin.DRIVE_FAST`` constant, for a total of 8 combinations of
+drive strength and slew rate settings:
+
+ - ``Pin.DRIVE_0``: nom. 2 mA
+ - ``Pin.DRIVE_1``: nom. 4 mA (default)
+ - ``Pin.DRIVE_2``: nom. 8 mA
+ - ``Pin.DRIVE_3``: nom. 12 mA
+ - ``Pin.DRIVE_0|Pin.DRIVE_FAST``: nom. 2 mA with fast (high) slew rate
+ - ``Pin.DRIVE_1|Pin.DRIVE_FAST``: nom. 4 mA with fast slew rate
+ - ``Pin.DRIVE_2|Pin.DRIVE_FAST``: nom. 8 mA with fast slew rate
+ - ``Pin.DRIVE_3|Pin.DRIVE_FAST``: nom. 12 mA with fast slew rate
+
+The default drive strength setting (nom. 4 mA with slow slew rate)
+corresponds to the power-on reset defaults of the RP2040 and RP235x
+chips. Note that choosing a fast slew rate may---in a circuit not
+designed for it---cause issues likely to surprise non-experts,
+e.g. ringing (voltage excursions potentially large enough to damage
+chips connected to it), signal integrity problems, and increased
+electromagnetic emanations (potentially interfering with other
+electronic devices, especially RF receivers).
+
 Programmable IO (PIO)
 ---------------------
 

--- a/ports/rp2/machine_pin.h
+++ b/ports/rp2/machine_pin.h
@@ -38,6 +38,27 @@ enum {
     MACHINE_PIN_MODE_ANALOG = 4
 };
 
+enum {
+    MACHINE_PIN_DRIVE_0 = GPIO_DRIVE_STRENGTH_2MA,
+    MACHINE_PIN_DRIVE_1 = GPIO_DRIVE_STRENGTH_4MA,
+    MACHINE_PIN_DRIVE_2 = GPIO_DRIVE_STRENGTH_8MA,
+    MACHINE_PIN_DRIVE_3 = GPIO_DRIVE_STRENGTH_12MA,
+    MACHINE_PIN_DRIVE_FAST = 4
+};
+#define MACHINE_PIN_DRIVE_DEFAULT GPIO_DRIVE_STRENGTH_4MA
+#define MACHINE_PIN_DRIVE_MAX MACHINE_PIN_DRIVE_3
+#define MACHINE_PIN_DRIVE_MASK 3
+// assert that the bit mask is correct
+// (meaning the Pico SDK has not changed the drive strength values)
+#define static_assert_mask(x, mask) static_assert(x == (x & mask))
+static_assert_mask(MACHINE_PIN_DRIVE_0, MACHINE_PIN_DRIVE_MASK);
+static_assert_mask(MACHINE_PIN_DRIVE_1, MACHINE_PIN_DRIVE_MASK);
+static_assert_mask(MACHINE_PIN_DRIVE_2, MACHINE_PIN_DRIVE_MASK);
+static_assert_mask(MACHINE_PIN_DRIVE_3, MACHINE_PIN_DRIVE_MASK);
+#undef static_assert_mask
+// assert that MACHINE_PIN_DRIVE_FAST is independent of drive strength
+static_assert(0 == (MACHINE_PIN_DRIVE_FAST & MACHINE_PIN_DRIVE_MASK));
+
 typedef struct _machine_pin_af_obj_t {
     mp_obj_base_t base;
     qstr name;

--- a/tests/ports/rp2/rp2_machine_pin.py
+++ b/tests/ports/rp2/rp2_machine_pin.py
@@ -1,0 +1,16 @@
+# Test construction and re-initialization of machine.Pin objects.
+
+from machine import Pin
+
+pin = Pin(0, Pin.IN)
+
+for resistor in [None, Pin.PULL_UP, Pin.PULL_DOWN, Pin.PULL_UP | Pin.PULL_DOWN]:
+    pin.init(Pin.IN, pull=resistor)
+    print(pin)
+
+for slew in [0, Pin.DRIVE_FAST]:
+    for strength in [Pin.DRIVE_0, Pin.DRIVE_1, Pin.DRIVE_2, Pin.DRIVE_3]:
+        pin.init(Pin.OUT, pull=None, drive=strength | slew)
+        print(pin)
+
+pin.init(Pin.IN, pull=None)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary: Drive strength option for rp2 machine.Pin

This PR adds drive strength selection to the rp2 port by implementing more of the documented but (in the rp2 port) missing machine.Pin functionality.

It also allows enabling the fast slew rate option on rp2 pins by treating the `drive` strength argument of `machine.Pin` as a bit mask with a position for `machine.Pin.DRIVE_FAST`. This (so far) appears to be unique amongst ports (but also possibly the first time a port supports adjusting a pin's slew rate).

### Testing

#### Untested Aspects

**The new test file might require review**: I do not understand how to automatically trigger tests in this port (or any ports other than the UNIX port) and could not verify that some automatic test will not fail on my new test script (meant to be run using `mpremote run`).

**The documentation might require review**: I tried to familiarize myself with the documentation syntax and remain unsure if I have correctly applied it.

**Slew rate selection remains untested**.

#### Tested Aspects

I used a RPI_PICO build on an (unsupported) SEEED-XIAO-RP2040 board.

1. Instantiation and reconfiguration using machine.Pin(..) and Pin.init(..) works as tested in the new file tests/ports/rp2/rp2_machine_pin.py.

2. The different drive strengths result in different pin currents / loaded pin output voltages, as verified using the following MicroPython code:
```
# Test drive strength of machine.Pin objects using ADC

from machine import Pin, ADC
from time import sleep_us

def delay(duration_us = 15000):
    sleep_us(duration_us)

def adc_sample(adc, rep=2000):
    sample = 0
    for i in range(rep):
        sample += adc.read_u16() >> 4
    return (sample / (4095 * rep))

def test_drive(pins_pull, weak_pull = True, invert = False):
    LVL = ["LOW", "HIGH"]
    lvl_drive = LVL[1] if invert else LVL[0]
    lvl_pull = LVL[0] if invert else LVL[1]
    print(f'Testing drive strength of {lvl_drive} level outputs in a voltage divider countered by ', end='')
    if weak_pull:
        print("internal pull-ups/downs.")
    else:
        print("nom. 2mA strong outputs.")
    for pp in pins_pull:
        if weak_pull:
            pp.init(Pin.IN, pull = Pin.PULL_DOWN if invert else Pin.PULL_UP)
        else:
            pp.init(Pin.OUT, pull=None, drive=Pin.DRIVE_0, value=0 if invert else 1)
    for strength in [Pin.DRIVE_0, Pin.DRIVE_1, Pin.DRIVE_2, Pin.DRIVE_3]:
        pin.init(Pin.OUT, pull = None, drive = strength, value=1 if invert else 0)
        delay()
        sample = adc_sample(adc)
        l, h = sample, 1.0 - sample
        print(f'drive={strength}: Voltage {100.0*sample:7.3f}% VREF (ratio of eff. resistances: 1:{h/l:7.3f} = {l/h:7.3f}:1)')

# Use Pin "GPIO26" aka "ADC chan. 0" to measure the resulting voltage
# from driving it at various strengths whilst using GPIO27 (to be
# electrically connected/shortened to GPIO26 externally) to build a
# voltage divider in 2 ways: Using internal weak pull up resistors
# (which allow barely enough current to flow to measure a
# monotonously changing difference between drive strength), and using
# the weakest drive strength (which hopefully will not damage or age
# the chip prematurely).
try:
    print("INSTRUCTIONS: GPIO26 (XIAO D0) should be shorted to GPIO27 (XIAO D1).")
    print("The following approximates VREF as equal to the IO supply voltage.")
    adc = ADC(0)
    pin = Pin(26, Pin.IN)
    otherpins = [Pin(gpio, Pin.IN, pull = Pin.PULL_UP) for gpio in [27]]
    for weak in (True, False):
        for invert in (False, True):
            test_drive(otherpins, weak, invert)
finally:
    # reset pin to default drive strength, then to input
    pin.init(Pin.OUT)
    pin.init(Pin.IN)
```

### Test Results
I include a sample output of the above test script in case it helps anyone lacking any empirical data on RP2040 pins drive strengths.
```
INSTRUCTIONS: GPIO26 (XIAO D0) should be shorted to GPIO27 (XIAO D1).
The following approximates VREF as equal to the IO supply voltage.
Testing drive strength of LOW level outputs in a voltage divider countered by internal pull-ups/downs.
drive=0: Voltage   0.619% VREF (ratio of eff. resistances: 1:160.666 =   0.006:1)
drive=1: Voltage   0.595% VREF (ratio of eff. resistances: 1:167.166 =   0.006:1)
drive=2: Voltage   0.580% VREF (ratio of eff. resistances: 1:171.512 =   0.006:1)
drive=3: Voltage   0.570% VREF (ratio of eff. resistances: 1:174.450 =   0.006:1)
Testing drive strength of HIGH level outputs in a voltage divider countered by internal pull-ups/downs.
drive=0: Voltage  99.687% VREF (ratio of eff. resistances: 1:  0.003 = 318.408:1)
drive=1: Voltage  99.720% VREF (ratio of eff. resistances: 1:  0.003 = 355.833:1)
drive=2: Voltage  99.749% VREF (ratio of eff. resistances: 1:  0.003 = 397.272:1)
drive=3: Voltage  99.756% VREF (ratio of eff. resistances: 1:  0.002 = 408.270:1)
Testing drive strength of LOW level outputs in a voltage divider countered by nom. 2mA strong outputs.
drive=0: Voltage  33.717% VREF (ratio of eff. resistances: 1:  1.966 =   0.509:1)
drive=1: Voltage  21.048% VREF (ratio of eff. resistances: 1:  3.751 =   0.267:1)
drive=2: Voltage  12.479% VREF (ratio of eff. resistances: 1:  7.014 =   0.143:1)
drive=3: Voltage  10.576% VREF (ratio of eff. resistances: 1:  8.455 =   0.118:1)
Testing drive strength of HIGH level outputs in a voltage divider countered by nom. 2mA strong outputs.
drive=0: Voltage  34.348% VREF (ratio of eff. resistances: 1:  1.911 =   0.523:1)
drive=1: Voltage  55.931% VREF (ratio of eff. resistances: 1:  0.788 =   1.269:1)
drive=2: Voltage  77.211% VREF (ratio of eff. resistances: 1:  0.295 =   3.388:1)
drive=3: Voltage  81.378% VREF (ratio of eff. resistances: 1:  0.229 =   4.370:1)
```

### Trade-offs and Alternatives

Alternatives:
1. The slew rate could be set in a separate argument from the drive strength.
2. In the chosen approach of combining (current) drive strength and (speed/slew rate) drive strength into a single argument, the bit order (which aspect is controlled by the LSBs) could be swapped.

Trade-offs:
1. There is very little extra code (and hence code size) and the port's machine.Pin class gets closer to the documented (not port specific) functionality.
3. Having a new keyword argument would alter the API and would likely incur a very slight additional code size growth, but it would be cleaner in terms of cleanly separating functionality. It also would not break the (natural) assumption that increasing drive strength parameters correspond to monotonically increasing strength which is broken at the step from `Pin.DRIVE_3` (an integer constant of value 3 and meaning of a nom. 12 mA drive strength with slow/default slew rate) to `Pin.DRIVE_0 | Pin.DRIVE_FAST` (with integer value 4 and meaning of a nom. 2 mA drive strength with fast slew rate).