### PR TITLE
tools/autobuild: Use same length Git hash abbreviation in file names.

### DIFF
--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -61,7 +61,7 @@ make -C mpy-cross
 # where SEMVER is vX.Y.Z or vX.Y.Z-preview.N.gHASH or vX.Y.Z-preview.N.gHASH.dirty
 FW_DATE=$(date '+%Y%m%d')
 # same logic as makeversionhdr.py, convert git-describe output into semver-compatible
-FW_GIT_TAG="$(git describe --tags --dirty --always --match 'v[1-9].*')"
+FW_GIT_TAG="$(git describe --tags --dirty --always --match 'v[1-9].*' --abbrev=10)"
 FW_SEMVER_MAJOR_MINOR_PATCH="$(echo $FW_GIT_TAG | cut -d'-' -f1)"
 FW_SEMVER_PRERELEASE="$(echo $FW_GIT_TAG | cut -s -d'-' -f2-)"
 if [ -z "$FW_SEMVER_PRERELEASE" ]; then


### PR DESCRIPTION
A tiny follow-up to #17832 in which we configured the Git hash abbreviation length. This change makes the version string used in filenames consistent with the one used in code.