### PR TITLE
extmod/machine_mem: Support slices for reading/writing memory.

### DIFF
--- a/extmod/machine_mem.c
+++ b/extmod/machine_mem.c
@@ -24,9 +24,12 @@
  * THE SOFTWARE.
  */
 
+#include "py/binary.h"
+#include "py/objarray.h"
 #include "py/runtime.h"
 #include "py/objarray.h"
 #include "extmod/modmachine.h"
+#include <string.h>
 
 #if MICROPY_PY_MACHINE_MEMX
 
@@ -40,8 +43,7 @@
 // implementations, if the default implementation isn't used.
 
 #if !defined(MICROPY_MACHINE_MEM_GET_READ_ADDR) || !defined(MICROPY_MACHINE_MEM_GET_WRITE_ADDR)
-static uintptr_t machine_mem_get_addr(mp_obj_t addr_o, uint align) {
-    uintptr_t addr = mp_obj_get_int_truncated(addr_o);
+static uintptr_t machine_mem_get_addr(uintptr_t addr, uint align) {
     if ((addr & (align - 1)) != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("address %08x is not aligned to %d bytes"), addr, align);
     }
@@ -61,15 +63,63 @@ static void machine_mem_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     mp_printf(print, "<%u-bit memory>", 8 * self->elem_size);
 }
 
+#if MICROPY_PY_MACHINE_MEMX_SLICE && MICROPY_PY_BUILTINS_SLICE
+static inline int machine_mem_typecode(machine_mem_obj_t *self) {
+    switch (self->elem_size) {
+        case 1:
+            return 'B';
+        case 2:
+            return 'H';
+        default:
+            return 'I';
+    }
+}
+#endif
+
 static mp_obj_t machine_mem_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-    // TODO support slice index to read/write multiple values at once
     machine_mem_obj_t *self = MP_OBJ_TO_PTR(self_in);
     if (value == MP_OBJ_NULL) {
         // delete
         return MP_OBJ_NULL; // op not supported
+    #if MICROPY_PY_MACHINE_MEMX_SLICE && MICROPY_PY_BUILTINS_SLICE
+    } else if (mp_obj_is_type(index, &mp_type_slice)) {
+        mp_bound_slice_t slice;
+        if (!mp_seq_get_fast_slice_indexes(INT32_MAX, index, &slice)) {
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("only slices with step=1 (aka None) are supported"));
+        }
+        if (value == MP_OBJ_SENTINEL) {
+            // load
+            #if MICROPY_PY_BUILTINS_MEMORYVIEW
+            return mp_obj_new_memoryview(
+                machine_mem_typecode(self) | MP_OBJ_ARRAY_TYPECODE_FLAG_RW,
+                (slice.stop - slice.start) / self->elem_size,
+                (void *)MICROPY_MACHINE_MEM_GET_READ_ADDR((uintptr_t)slice.start, self->elem_size)
+                );
+            #else
+            mp_raise_NotImplementedError(MP_ERROR_TEXT("memoryviews are not supported"));
+            #endif
+        } else {
+            // store
+            mp_buffer_info_t bufinfo;
+            mp_get_buffer_raise(value, &bufinfo, MP_BUFFER_READ);
+            if (
+                mp_binary_get_size('@', bufinfo.typecode, NULL) != self->elem_size
+                ||
+                bufinfo.len != (size_t)(slice.stop - slice.start)
+                ) {
+                mp_raise_ValueError(MP_ERROR_TEXT("lhs and rhs should be compatible"));
+            }
+            memcpy(
+                (void *)MICROPY_MACHINE_MEM_GET_READ_ADDR((uintptr_t)slice.start, self->elem_size),
+                bufinfo.buf,
+                bufinfo.len
+                );
+            return mp_const_none;
+        }
+    #endif
     } else if (value == MP_OBJ_SENTINEL) {
         // load
-        uintptr_t addr = MICROPY_MACHINE_MEM_GET_READ_ADDR(index, self->elem_size);
+        uintptr_t addr = MICROPY_MACHINE_MEM_GET_READ_ADDR(mp_obj_get_int_truncated(index), self->elem_size);
         uint32_t val;
         switch (self->elem_size) {
             case 1:
@@ -85,7 +135,7 @@ static mp_obj_t machine_mem_subscr(mp_obj_t self_in, mp_obj_t index, mp_obj_t va
         return mp_obj_new_int(val);
     } else {
         // store
-        uintptr_t addr = MICROPY_MACHINE_MEM_GET_WRITE_ADDR(index, self->elem_size);
+        uintptr_t addr = MICROPY_MACHINE_MEM_GET_WRITE_ADDR(mp_obj_get_int_truncated(index), self->elem_size);
         uint32_t val = mp_obj_get_int_truncated(value);
         switch (self->elem_size) {
             case 1:

--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -253,10 +253,10 @@ extern const mp_obj_type_t machine_usb_device_type;
 #endif
 
 #if defined(MICROPY_MACHINE_MEM_GET_READ_ADDR)
-uintptr_t MICROPY_MACHINE_MEM_GET_READ_ADDR(mp_obj_t addr_o, uint align);
+uintptr_t MICROPY_MACHINE_MEM_GET_READ_ADDR(uintptr_t addr, uint align);
 #endif
 #if defined(MICROPY_MACHINE_MEM_GET_WRITE_ADDR)
-uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(mp_obj_t addr_o, uint align);
+uintptr_t MICROPY_MACHINE_MEM_GET_WRITE_ADDR(uintptr_t addr, uint align);
 #endif
 
 MP_NORETURN mp_obj_t machine_bootloader(size_t n_args, const mp_obj_t *args);

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -36,8 +36,7 @@
 #define MICROPY_PAGE_MASK (MICROPY_PAGE_SIZE - 1)
 #endif
 
-uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
-    uintptr_t addr = mp_obj_get_int_truncated(addr_o);
+uintptr_t mod_machine_mem_get_addr(uintptr_t addr, uint align) {
     if ((addr & (align - 1)) != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("address %08x is not aligned to %d bytes"), addr, align);
     }

--- a/py/binary.c
+++ b/py/binary.c
@@ -304,6 +304,21 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
 // most 8 (for q and Q), so we will always be able to parse the given data
 // and fit it into a long long.
 long long mp_binary_get_int(size_t size, bool is_signed, bool big_endian, const byte *src) {
+    // If the requested endianness matches the native endianness and the memory address
+    // is aligned, we can read the entire integer using a cast instead of reading it as
+    // individual bytes. Besides being slightly more efficient it also makes reads from
+    // memory that is not byte-addressable work correctly.
+    if (big_endian == MP_ENDIANNESS_BIG && ((uintptr_t)src) % size == 0) {
+        switch (size) {
+            case 2:
+                return is_signed ? (uint64_t)*((int16_t *)src) : (uint64_t)*((uint16_t *)src);
+            case 4:
+                return is_signed ? (uint64_t)*((int32_t *)src) : (uint64_t)*((uint32_t *)src);
+            case 8:
+                return is_signed ? (uint64_t)*((int64_t *)src) : (uint64_t)*((uint64_t *)src);
+        }
+    }
+
     int delta;
     if (!big_endian) {
         delta = -1;

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2099,6 +2099,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_MACHINE_MEMX (MICROPY_PY_MACHINE)
 #endif
 
+// Whether "machine.mem8/16/32" objects support reading/writing slices
+#ifndef MICROPY_PY_MACHINE_MEMX_SLICE
+#define MICROPY_PY_MACHINE_MEMX_SLICE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Whether to provide the "machine.mem_backup" function
 #ifndef MICROPY_PY_MACHINE_MEM_BACKUP
 #define MICROPY_PY_MACHINE_MEM_BACKUP (0)

--- a/tests/extmod/machine1.py
+++ b/tests/extmod/machine1.py
@@ -22,15 +22,24 @@ class Test(unittest.TestCase):
         with self.assertRaises(ValueError):
             machine.mem16[1] = 1
 
+        with self.assertRaises(ValueError):
+            machine.mem32[2]
+
+        with self.assertRaises(ValueError):
+            machine.mem32[2] = 1
+
     def test_operations(self):
         with self.assertRaises(TypeError):
             del machine.mem8[0]
 
         with self.assertRaises(TypeError):
-            machine.mem8[0:1]
-
-        with self.assertRaises(TypeError):
             machine.mem8[0:1] = 10
+
+        with self.assertRaises(ValueError):
+            try:
+                machine.mem8[0:1] = bytes([0, 1, 2])
+            except TypeError:
+                raise ValueError("Slice support not enabled")
 
         with self.assertRaises(TypeError):
             machine.mem8["hello"]


### PR DESCRIPTION
### Summary

This implements support for reading/writing slices of memory through the `machine.mem{8,16,32}` objects. Reading is implemented by returning a memoryview.

After seeing the code size report, I concluded the slice support was not worth adding unconditionally. It is thus gated by the `MICROPY_PY_MACHINE_MEMX_SLICE` feature flag.

After testing on the ESP32-S3, I encountered an issues where certain registers require word-aligned reads. Thus, trying to use `struct.unpack` directly would fail because `mp_binary_get_int` reads one byte at a time, but copying the slice using `bytes(machine.mem8[...])` first worked because `memcpy` tries to copy entire words at once. To fix this I implemented an extra path in `mp_binary_get_int` that tries reading entire words when the alignment and endianness work out. This is the cause for most of the code size increase (as it isn't gated behind a feature flag).

### Testing

Tested on a few different ESP32 boards.

For example, instead of using the `time.ticks_ms()` method we can read out the time directly from the LAC timer / systimer peripheral register using `struct.unpack()`: 

```py
import machine, struct, time
# ESP32:
print('ticks_ms:', time.ticks_ms(), ', mem8:', struct.unpack('@Q', machine.mem8[0x3FF5F078:0x3FF5F080])[0] // 2000)
# ESP32-S3:
print('ticks_ms:', time.ticks_ms(), ', mem8:', sum(v << s for s, v in zip((32, 0), struct.unpack('@II', machine.mem8[0x60023040:0x60023048]))) // 16000)
```
```log
ticks_ms: 12769608 , mem8: 12769608
```

### Trade-offs and Alternatives

First tried implementing the buffer protocol for the `machine.mem{8,16,32}` objects; however did not include that here due to limitations in memoryview (length and offset fields have limited size, thus only allowing access to low memory addresses).

I also implemented a helper function `machine.ptr(some_object)`, which returns the pointer to a MicroPython object. See https://github.com/DvdGiessen/micropython/commit/d6262c388ea2ee0ae3e15588c18ae02c4242bdde.

```py
>>> data = 0xC0FFEECAFE
>>> data, hex(data)
(828927560446, '0xc0ffeecafe')
>>> machine.mem8[machine.ptr(data)+16:machine.ptr(data)+16+2] = b'\xDE\xC0'
>>> data, hex(data)
(828927557854, '0xc0ffeec0de')
```

Fun for a bit of poking around in the MicroPython internals interactively, but that does not seem useful enough for actual users, so I've left it out of this PR.