### PR TITLE
mpremote: Add automatic PTY device detection for QEMU

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -35,7 +35,7 @@
 # Once the API is stabilised, the idea is that mpremote can be used both
 # as a command line tool and a library for interacting with devices.
 
-import ast, io, os, re, struct, sys, time
+import ast, io, os, re, stat, struct, sys, time
 import serial
 import serial.tools.list_ports
 from errno import EPERM, ENOTTY
@@ -105,6 +105,20 @@ class SerialTransport(Transport):
         if delayed:
             print("")
 
+        self.is_pty = self._is_pty_device(device)
+
+    @staticmethod
+    def _is_pty_device(device):
+        """Detect if device is a PTY (pseudo-terminal), e.g. used by QEMU."""
+        if device.startswith("/dev/pts/"):
+            try:
+                st = os.stat(device)
+                if stat.S_ISCHR(st.st_mode) and os.major(st.st_rdev) == 136:
+                    return True
+            except (OSError, AttributeError):
+                pass
+        return False
+
     def close(self):
         # ESP Windows quirk: Prevent target from resetting when Windows clears DTR before RTS
         try:
@@ -140,8 +154,10 @@ class SerialTransport(Transport):
         while True:
             if data.endswith(ending):
                 break
-            elif self.serial.inWaiting() > 0:
+            new_data = None
+            if self.is_pty or self.serial.inWaiting() > 0:
                 new_data = self.serial.read(1)
+            if new_data:
                 if data_consumer:
                     data_consumer(new_data)
                     data = new_data

--- a/tools/pyboard.py
+++ b/tools/pyboard.py
@@ -70,6 +70,7 @@ Or:
 import ast
 import errno
 import os
+import stat
 import struct
 import sys
 import time
@@ -333,6 +334,23 @@ class Pyboard:
             if delayed:
                 print("")
 
+        if device.startswith("execpty:"):
+            self.is_pty = True
+        else:
+            self.is_pty = self._is_pty_device(device)
+
+    @staticmethod
+    def _is_pty_device(device):
+        """Detect if device is a PTY (pseudo-terminal), e.g. used by QEMU."""
+        if device.startswith("/dev/pts/"):
+            try:
+                st = os.stat(device)
+                if stat.S_ISCHR(st.st_mode) and os.major(st.st_rdev) == 136:
+                    return True
+            except (OSError, AttributeError):
+                pass
+        return False
+
     def close(self):
         self.serial.close()
 
@@ -358,8 +376,10 @@ class Pyboard:
         while True:
             if data.endswith(ending):
                 break
-            elif self.serial.inWaiting() > 0:
+            new_data = None
+            if self.is_pty or self.serial.inWaiting() > 0:
                 new_data = self.serial.read(1)
+            if new_data:
                 if data_consumer:
                     data_consumer(new_data)
                     data = new_data


### PR DESCRIPTION
### Summary

This change addresses hangs when mpremote and pyboard.py communicate with PTY devices, particularly QEMU serial ports. PTY devices' `inWaiting()` method returns timing-dependent results and can report zero bytes available even when data is buffered. This causes mpremote/pyboard.py to wait indefinitely for data that will never be indicated as available.

The fix implements PTY device detection (Linux Unix98 PTY path `/dev/pts/N` with major device number 136) and uses blocking reads with pyserial's `interCharTimeout` for these devices. For regular serial devices, the existing `inWaiting()` polling behavior is preserved.

This change originated from OpenMV's downstream patch (https://github.com/openmv/openmv/blob/master/tools/mpremote-qemu-serial.patch) that resolved similar issues with QEMU testing.

### Testing

Tested on QEMU MPS2-AN385 port with stress test (3 iterations of 50-second sleep loops, 150 seconds total):
- With fix: completed successfully
- Without fix: hung after 90 seconds

Tested with real-world filesystem workload (12 PPM/PGM image files, 512KB heap):
- With fix: all files processed in 1m59s
- Without fix: hung on 4th file after 10 minutes

OpenMV project reports all 81 tests now pass on QEMU.

Also fixed `execpty:` device type handling in pyboard.py (used by QEMU CI tests) which was incorrectly marked as non-PTY, causing 6-hour CI hangs.

### Trade-offs and Alternatives

The PTY detection uses Linux-specific major device number check (136) and Unix98 PTY path pattern. Detection failures fall back to standard serial behavior, so non-Linux platforms or unusual configurations remain functional but may still experience PTY timing issues.

Blocking reads add 1-second `interCharTimeout` per byte on PTY devices. This is acceptable since PTY communication is typically local with low latency. The timeout ensures responsiveness if the remote end becomes unresponsive.
