### PR TITLE
py/emitglue: Reduce RAM footprint of frozen code and SYS_SETTRACE feature

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -633,15 +633,21 @@ static mp_obj_t extra_coverage(void) {
         // call mp_execute_bytecode with invalid bytecode (should raise NotImplementedError)
         mp_module_context_t context;
         mp_obj_fun_bc_t fun_bc;
+        const byte *bytecode = (const byte *)"\x01"; // just needed for n_state
+        fun_bc.base.type = &mp_type_fun_bc;
         fun_bc.context = &context;
+        #if !MICROPY_PY_SYS_SETTRACE
         fun_bc.child_table = NULL;
-        fun_bc.bytecode = (const byte *)"\x01"; // just needed for n_state
+        fun_bc.bytecode = bytecode;
+        #endif
         #if MICROPY_PY_SYS_SETTRACE
-        struct _mp_raw_code_t rc = {};
+        mp_raw_code_t rc = {};
+        rc.fun_data = bytecode;
+        rc.children = NULL;
         fun_bc.rc = &rc;
         #endif
         mp_code_state_t *code_state = m_new_obj_var(mp_code_state_t, state, mp_obj_t, 1);
-        code_state->fun_bc = &fun_bc;
+        code_state->fun_obj = &fun_bc;
         code_state->ip = (const byte *)"\x00"; // just needed for an invalid opcode
         code_state->sp = &code_state->state[0];
         code_state->exc_sp_idx = 0;

--- a/ports/unix/variants/longlong/mpconfigvariant.h
+++ b/ports/unix/variants/longlong/mpconfigvariant.h
@@ -37,6 +37,9 @@
 #define MICROPY_OBJ_REPR               (MICROPY_OBJ_REPR_C)
 #define MICROPY_FLOAT_IMPL             (MICROPY_FLOAT_IMPL_FLOAT)
 
+// Enable frozen function objects, as could be done for low RAM port
+#define MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC (1)
+
 // Set base feature level.
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 

--- a/py/bc.h
+++ b/py/bc.h
@@ -173,18 +173,25 @@
 #define MP_CODE_STATE_EXC_SP_IDX_FROM_PTR(exc_stack, exc_sp) ((exc_sp) + 1 - (exc_stack))
 #define MP_CODE_STATE_EXC_SP_IDX_TO_PTR(exc_stack, exc_sp_idx) ((exc_stack) + (exc_sp_idx) - 1)
 
-typedef struct _mp_bytecode_prelude_t {
+typedef struct _mp_prof_settrace_data_t {
+    #if MICROPY_PY_SYS_SETTRACE_USE_FULL_PRELUDE
     uint n_state;
-    uint n_exc_stack;
-    uint scope_flags;
-    uint n_pos_args;
-    uint n_kwonly_args;
-    uint n_def_pos_args;
+    uint16 n_exc_stack;
+    uint16 scope_flags;
+    uint16 n_pos_args;
+    uint16 n_kwonly_args;
+    uint16 n_def_pos_args;
+    uint16 line_of_definition_delta;    // line count between def stmt and first function stmt
     qstr qstr_block_name_idx;
+    #else
+    byte n_args;                        // n_pos_args + n_kwonly_args
+    byte line_of_definition_delta;      // line count between def stmt and first function stmt
+    qstr_short_t qstr_block_name_idx;
+    #endif
     const byte *line_info;
     const byte *line_info_top;
     const byte *opcodes;
-} mp_bytecode_prelude_t;
+} mp_prof_settrace_data_t;
 
 // Exception stack entry
 typedef struct _mp_exc_stack_t {

--- a/py/bc.h
+++ b/py/bc.h
@@ -239,11 +239,11 @@ typedef struct _mp_frozen_module_t {
 
 // State for an executing function.
 typedef struct _mp_code_state_t {
-    // The fun_bc entry points to the underlying function object that is being executed.
+    // The fun_obj entry points to the underlying function object that is being executed.
     // It is needed to access the start of bytecode and the const_table.
     // It is also needed to prevent the GC from reclaiming the bytecode during execution,
     // because the ip pointer below will always point to the interior of the bytecode.
-    struct _mp_obj_fun_bc_t *fun_bc;
+    void *fun_obj;
     const byte *ip;
     mp_obj_t *sp;
     uint16_t n_state;
@@ -264,7 +264,7 @@ typedef struct _mp_code_state_t {
 
 // State for an executing native function (based on mp_code_state_t).
 typedef struct _mp_code_state_native_t {
-    struct _mp_obj_fun_bc_t *fun_bc;
+    void *fun_obj;
     const byte *ip;
     mp_obj_t *sp;
     uint16_t n_state;

--- a/py/builtinevex.c
+++ b/py/builtinevex.c
@@ -57,14 +57,16 @@ static mp_obj_t code_execute(mp_obj_code_t *self, mp_obj_dict_t *globals, mp_obj
     // The call to mp_parse_compile_execute() in mp_builtin_compile() below passes
     // NULL for the globals, so repopulate that entry now with the correct globals.
     mp_obj_t module_fun = self->module_fun;
-    if (mp_obj_is_type(self->module_fun, &mp_type_fun_bc)
-        #if MICROPY_EMIT_NATIVE
-        || mp_obj_is_type(self->module_fun, &mp_type_fun_native)
-        #endif
-        ) {
+    if (mp_obj_is_type(module_fun, &mp_type_fun_bc)) {
         mp_obj_fun_bc_t *fun_bc = MP_OBJ_TO_PTR(module_fun);
         ((mp_module_context_t *)fun_bc->context)->module.globals = globals;
     }
+    #if MICROPY_EMIT_NATIVE
+    else if (mp_obj_is_type(module_fun, &mp_type_fun_native)) {
+        mp_obj_fun_native_t *fun_native = MP_OBJ_TO_PTR(module_fun);
+        ((mp_module_context_t *)fun_native->context)->module.globals = globals;
+    }
+    #endif
     #endif
 
     // execute code

--- a/py/dynruntime.h
+++ b/py/dynruntime.h
@@ -249,6 +249,10 @@ static inline void *mp_obj_malloc_helper_dyn(size_t num_bytes, const mp_obj_type
 #define mp_arg_parse_all_kw_array(n_pos, n_kw, args, n_allowed, allowed, out_vals) \
     (mp_fun_table.arg_parse_all_kw_array((n_pos), (n_kw), (args), (n_allowed), (allowed), (out_vals)))
 
+// This definition is not very nice, but this is required for backward compatibility with existing
+// user-written viper functions, which declares their first argument as `mp_obj_fun_bc_t *self`
+#define mp_obj_fun_bc_t mp_obj_fun_viper_t
+
 #define MP_DYNRUNTIME_INIT_ENTRY \
     mp_obj_t old_globals = mp_fun_table.swap_globals(self->context->module.globals); \
     mp_raw_code_truncated_t rc; \

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -218,7 +218,11 @@ static void emit_write_bytecode_byte_child(emit_t *emit, int stack_adj, byte b, 
     emit_write_bytecode_byte_const(emit, stack_adj, b,
         mp_emit_common_alloc_const_child(emit->emit_common, rc));
     #if MICROPY_PY_SYS_SETTRACE
-    rc->line_of_definition = emit->last_source_line;
+    // Temporarily save makefun source line into line_info (until mp_emit_glue_assign_bytecode).
+    // At this point, the kind of raw_code is not yet known, but we know that the storage is available.
+    // The proper specific value will anyway be overridden with the proper information when
+    // when the corresponding mp_emit_glue_assign_* function is invoked
+    rc->specific.bytecode.line_info = (const byte *)emit->last_source_line;
     #endif
 }
 

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -118,7 +118,12 @@ typedef union _mp_code_specific_data {
 typedef struct _mp_raw_code_t {
     uint8_t proto_fun_indicator[2];
     uint8_t kind; // of type mp_raw_code_kind_t; only 3 bits used
+    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC
+    uint8_t is_generator : 1;
+    uint8_t has_const_fun_obj : 1;
+    #else
     uint8_t is_generator;
+    #endif
     const void *fun_data;
     struct _mp_raw_code_t **children;
     #if MICROPY_PERSISTENT_CODE_SAVE
@@ -139,10 +144,18 @@ typedef struct _mp_raw_code_t {
 // Version of mp_raw_code_t but without the final native_asm entry, which is only need
 // when the kind is MP_CODE_NATIVE_ASM. So this struct can be used for frozen code when the
 // kind is MP_CODE_BYTECODE, MP_CODE_NATIVE_PY or MP_CODE_NATIVE_VIPER, to reduce its size.
+// This version of mp_raw_code_t also includes a variable-length field that can be used
+// to create a frozen mp_obj_fun_bc_t, which is not really part of mp_raw_code_t but
+// can be conveniently retrieved in this way without having to add an extra pointer.
 typedef struct _mp_raw_code_truncated_t {
     uint8_t proto_fun_indicator[2];
     uint8_t kind;
+    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC
+    uint8_t is_generator : 1;
+    uint8_t has_const_fun_obj : 1;
+    #else
     uint8_t is_generator;
+    #endif
     const void *fun_data;
     struct _mp_raw_code_t **children;
     #if MICROPY_PERSISTENT_CODE_SAVE
@@ -151,6 +164,10 @@ typedef struct _mp_raw_code_truncated_t {
     #endif
     #if MICROPY_HAS_SPECIFIC_UNION
     mp_code_specific_data specific;
+    #endif
+    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC
+    // Variable-length storage space for an optional mp_obj_fun_bc_t, when has_const_fun_obj is true
+    mp_const_obj_t fun_obj[];
     #endif
 } mp_raw_code_truncated_t;
 

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -67,6 +67,50 @@ static inline bool mp_proto_fun_is_bytecode(mp_proto_fun_t proto_fun) {
     return (header[0] | (header[1] << 8)) != (MP_PROTO_FUN_INDICATOR_RAW_CODE_0 | (MP_PROTO_FUN_INDICATOR_RAW_CODE_1 << 8));
 }
 
+// Type used to store the size of a function raw data (can be bytecode or native code)
+#if MICROPY_LIMIT_RAWCODE_SIZE
+typedef uint16_t mp_fun_data_size_t; // max 64KB, should easily cover most cases
+#else
+typedef uint32_t mp_fun_data_size_t; // aka unlimited
+#endif
+
+// Specific data required for native py functions: compact signature storage
+typedef struct _mp_native_py_rcdata_t {
+    uint16_t prelude_offset;
+} mp_native_py_rcdata_t;
+
+// Specific data required for inline asm functions: compact signature storage
+typedef struct _mp_native_asm_rcdata_t {
+    uint32_t n_pos_args : 8;
+    uint32_t type_sig : 24; // compressed as 2-bit types; ret is MSB, then arg0, arg1, etc
+} mp_native_asm_rcdata_t;
+
+#if MICROPY_PERSISTENT_CODE_SAVE
+#define MICROPY_HAS_SPECIFIC_UNION (MICROPY_PY_SYS_SETTRACE || MICROPY_EMIT_MACHINE_CODE || MICROPY_EMIT_INLINE_ASM)
+#else
+#define MICROPY_HAS_SPECIFIC_UNION (0)
+#endif
+
+#if MICROPY_HAS_SPECIFIC_UNION
+// The mp_raw_code_t struct needs to store different information depending on the function kind.
+// We use an union to avoid wasting memory in the case where this structure stays in memory
+// (in ROM from frozen code, and in RAM for bytecode when SYS_SETTRACE is active).
+typedef union _mp_code_specific_data {
+    // when kind is MP_CODE_BYTECODE
+    #if MICROPY_PY_SYS_SETTRACE
+    mp_prof_settrace_data_t bytecode;
+    #endif
+    // when kind is MP_CODE_NATIVE_PY
+    #if MICROPY_EMIT_MACHINE_CODE
+    mp_native_py_rcdata_t native_py;
+    #endif
+    // when kind is MP_CODE_NATIVE_ASM
+    #if MICROPY_EMIT_INLINE_ASM
+    mp_native_asm_rcdata_t native_asm;
+    #endif
+} mp_code_specific_data;
+#endif
+
 // The mp_raw_code_t struct appears in the following places:
 // compiled bytecode: instance in RAM, referenced by outer scope, usually freed after first (and only) use
 // mpy file: instance in RAM, created when .mpy file is loaded (same comments as above)
@@ -74,49 +118,39 @@ static inline bool mp_proto_fun_is_bytecode(mp_proto_fun_t proto_fun) {
 typedef struct _mp_raw_code_t {
     uint8_t proto_fun_indicator[2];
     uint8_t kind; // of type mp_raw_code_kind_t; only 3 bits used
-    bool is_generator;
+    uint8_t is_generator;
     const void *fun_data;
     struct _mp_raw_code_t **children;
     #if MICROPY_PERSISTENT_CODE_SAVE
-    uint32_t fun_data_len; // for mp_raw_code_save
+    mp_fun_data_size_t fun_data_len; // for mp_raw_code_save
     uint16_t n_children;
-    #if MICROPY_EMIT_MACHINE_CODE
-    uint16_t prelude_offset;
     #endif
-    #if MICROPY_PY_SYS_SETTRACE
-    // line_of_definition is a Python source line where the raw_code was
-    // created e.g. MP_BC_MAKE_FUNCTION. This is different from lineno info
-    // stored in prelude, which provides line number for first statement of
-    // a function. Required to properly implement "call" trace event.
-    uint32_t line_of_definition;
-    mp_bytecode_prelude_t prelude;
-    #endif
-    #endif
-    #if MICROPY_EMIT_INLINE_ASM
-    uint32_t asm_n_pos_args : 8;
-    uint32_t asm_type_sig : 24; // compressed as 2-bit types; ret is MSB, then arg0, arg1, etc
+    #if MICROPY_HAS_SPECIFIC_UNION
+    mp_code_specific_data specific;
+    #elif MICROPY_EMIT_INLINE_ASM
+    // Online asm needs the signature info even without MICROPY_PERSISTENT_CODE_SAVE,
+    // but to save space we add it separately only if we can't reuse the union.
+    union {
+        mp_native_asm_rcdata_t native_asm;
+    } specific;
     #endif
 } mp_raw_code_t;
 
-// Version of mp_raw_code_t but without the asm_n_pos_args/asm_type_sig entries, which are
-// only needed when the kind is MP_CODE_NATIVE_ASM.  So this struct can be used when the
+// Version of mp_raw_code_t but without the final native_asm entry, which is only need
+// when the kind is MP_CODE_NATIVE_ASM. So this struct can be used for frozen code when the
 // kind is MP_CODE_BYTECODE, MP_CODE_NATIVE_PY or MP_CODE_NATIVE_VIPER, to reduce its size.
 typedef struct _mp_raw_code_truncated_t {
     uint8_t proto_fun_indicator[2];
     uint8_t kind;
-    bool is_generator;
+    uint8_t is_generator;
     const void *fun_data;
     struct _mp_raw_code_t **children;
     #if MICROPY_PERSISTENT_CODE_SAVE
-    uint32_t fun_data_len;
+    mp_fun_data_size_t fun_data_len;
     uint16_t n_children;
-    #if MICROPY_EMIT_MACHINE_CODE
-    uint16_t prelude_offset;
     #endif
-    #if MICROPY_PY_SYS_SETTRACE
-    uint32_t line_of_definition;
-    mp_bytecode_prelude_t prelude;
-    #endif
+    #if MICROPY_HAS_SPECIFIC_UNION
+    mp_code_specific_data specific;
     #endif
 } mp_raw_code_truncated_t;
 

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -96,13 +96,13 @@
 #endif
 #define SIZEOF_CODE_STATE (sizeof(mp_code_state_native_t) / sizeof(uintptr_t))
 #define OFFSETOF_CODE_STATE_STATE (offsetof(mp_code_state_native_t, state) / sizeof(uintptr_t))
-#define OFFSETOF_CODE_STATE_FUN_BC (offsetof(mp_code_state_native_t, fun_bc) / sizeof(uintptr_t))
+#define OFFSETOF_CODE_STATE_FUN_OBJ (offsetof(mp_code_state_native_t, fun_obj) / sizeof(uintptr_t))
 #define OFFSETOF_CODE_STATE_IP (offsetof(mp_code_state_native_t, ip) / sizeof(uintptr_t))
 #define OFFSETOF_CODE_STATE_SP (offsetof(mp_code_state_native_t, sp) / sizeof(uintptr_t))
 #define OFFSETOF_CODE_STATE_N_STATE (offsetof(mp_code_state_native_t, n_state) / sizeof(uintptr_t))
-#define OFFSETOF_OBJ_FUN_BC_CONTEXT (offsetof(mp_obj_fun_bc_t, context) / sizeof(uintptr_t))
-#define OFFSETOF_OBJ_FUN_BC_CHILD_TABLE (offsetof(mp_obj_fun_bc_t, child_table) / sizeof(uintptr_t))
-#define OFFSETOF_OBJ_FUN_BC_BYTECODE (offsetof(mp_obj_fun_bc_t, bytecode) / sizeof(uintptr_t))
+#define OFFSETOF_OBJ_FUN_NATIVE_CONTEXT (offsetof(mp_obj_fun_native_t, context) / sizeof(uintptr_t))
+#define OFFSETOF_OBJ_FUN_NATIVE_CHILD_TABLE (offsetof(mp_obj_fun_native_t, child_table) / sizeof(uintptr_t))
+#define OFFSETOF_OBJ_FUN_NATIVE_BYTECODE (offsetof(mp_obj_fun_native_t, bytecode) / sizeof(uintptr_t))
 #define OFFSETOF_MODULE_CONTEXT_QSTR_TABLE (offsetof(mp_module_context_t, constants.qstr_table) / sizeof(uintptr_t))
 #define OFFSETOF_MODULE_CONTEXT_OBJ_TABLE (offsetof(mp_module_context_t, constants.obj_table) / sizeof(uintptr_t))
 #define OFFSETOF_MODULE_CONTEXT_GLOBALS (offsetof(mp_module_context_t, module.globals) / sizeof(uintptr_t))
@@ -142,7 +142,7 @@
 #define LOCAL_IDX_EXC_HANDLER_UNWIND(emit) (SIZEOF_NLR_BUF + 1) // this needs a dedicated variable outside nlr_buf_t
 #define LOCAL_IDX_THROW_VAL(emit) (SIZEOF_NLR_BUF + 2) // needs a dedicated variable outside nlr_buf_t, following inject_exc in py/vm.c
 #define LOCAL_IDX_RET_VAL(emit) (SIZEOF_NLR_BUF) // needed when NEED_GLOBAL_EXC_HANDLER is true
-#define LOCAL_IDX_FUN_OBJ(emit) ((emit)->code_state_start + OFFSETOF_CODE_STATE_FUN_BC)
+#define LOCAL_IDX_FUN_OBJ(emit) ((emit)->code_state_start + OFFSETOF_CODE_STATE_FUN_OBJ)
 #define LOCAL_IDX_OLD_GLOBALS(emit) ((emit)->code_state_start + OFFSETOF_CODE_STATE_IP)
 #define LOCAL_IDX_GEN_PC(emit) ((emit)->code_state_start + OFFSETOF_CODE_STATE_IP)
 #define LOCAL_IDX_LOCAL_VAR(emit, local_num) ((emit)->stack_start + (emit)->n_state - 1 - (local_num))
@@ -496,7 +496,7 @@ static void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
         #endif
 
         // Load REG_FUN_TABLE with a pointer to mp_fun_table, found in the const_table
-        ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_PARENT_ARG_1, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+        ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_PARENT_ARG_1, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
         #if MICROPY_PERSISTENT_CODE_SAVE
         ASM_LOAD_REG_REG_OFFSET(emit->as, REG_QSTR_TABLE, REG_FUN_TABLE, OFFSETOF_MODULE_CONTEXT_QSTR_TABLE);
         #endif
@@ -581,7 +581,7 @@ static void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
 
             // Load REG_FUN_TABLE with a pointer to mp_fun_table, found in the const_table
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_GENERATOR_STATE, LOCAL_IDX_FUN_OBJ(emit));
-            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
             #if MICROPY_PERSISTENT_CODE_SAVE
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_QSTR_TABLE, REG_TEMP0, OFFSETOF_MODULE_CONTEXT_QSTR_TABLE);
             #endif
@@ -604,14 +604,14 @@ static void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
             #endif
 
             // Load REG_FUN_TABLE with a pointer to mp_fun_table, found in the const_table
-            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_PARENT_ARG_1, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_PARENT_ARG_1, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
             #if MICROPY_PERSISTENT_CODE_SAVE
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_QSTR_TABLE, REG_FUN_TABLE, OFFSETOF_MODULE_CONTEXT_QSTR_TABLE);
             #endif
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_FUN_TABLE, OFFSETOF_MODULE_CONTEXT_OBJ_TABLE);
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_FUN_TABLE, REG_FUN_TABLE, fun_table_off);
 
-            // Set code_state.fun_bc
+            // Set code_state.fun_obj
             ASM_MOV_LOCAL_REG(emit->as, LOCAL_IDX_FUN_OBJ(emit), REG_PARENT_ARG_1);
 
             // Set code_state.n_state (only works on little endian targets due to n_state being uint16_t)
@@ -1150,7 +1150,7 @@ static void emit_load_reg_with_object(emit_t *emit, int reg, mp_obj_t obj) {
     emit->scope->scope_flags |= MP_SCOPE_FLAG_HASCONSTS;
     size_t table_off = mp_emit_common_use_const_obj(emit->emit_common, obj);
     emit_native_mov_reg_state(emit, REG_TEMP0, LOCAL_IDX_FUN_OBJ(emit));
-    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
     ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_MODULE_CONTEXT_OBJ_TABLE);
     ASM_LOAD_REG_REG_OFFSET(emit->as, reg, REG_TEMP0, table_off);
 }
@@ -1158,7 +1158,7 @@ static void emit_load_reg_with_object(emit_t *emit, int reg, mp_obj_t obj) {
 static void emit_load_reg_with_child(emit_t *emit, int reg, mp_raw_code_t *rc) {
     size_t table_off = mp_emit_common_alloc_const_child(emit->emit_common, rc);
     emit_native_mov_reg_state(emit, REG_TEMP0, LOCAL_IDX_FUN_OBJ(emit));
-    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_BC_CHILD_TABLE);
+    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_TEMP0, REG_TEMP0, OFFSETOF_OBJ_FUN_NATIVE_CHILD_TABLE);
     ASM_LOAD_REG_REG_OFFSET(emit->as, reg, REG_TEMP0, table_off);
 }
 
@@ -1203,7 +1203,7 @@ static void emit_native_global_exc_entry(emit_t *emit) {
         if (!(emit->scope->scope_flags & MP_SCOPE_FLAG_GENERATOR)) {
             // Set new globals
             emit_native_mov_reg_state(emit, REG_ARG_1, LOCAL_IDX_FUN_OBJ(emit));
-            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_1, REG_ARG_1, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+            ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_1, REG_ARG_1, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
             ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_1, REG_ARG_1, OFFSETOF_MODULE_CONTEXT_GLOBALS);
             emit_call(emit, MP_F_NATIVE_SWAP_GLOBALS);
 
@@ -2762,7 +2762,7 @@ static void emit_native_make_function(emit_t *emit, scope_t *scope, mp_uint_t n_
     // call runtime, with type info for args, or don't support dict/default params, or only support Python objects for them
     emit_native_pre(emit);
     emit_native_mov_reg_state(emit, REG_ARG_2, LOCAL_IDX_FUN_OBJ(emit));
-    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_2, REG_ARG_2, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_2, REG_ARG_2, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
     if (n_pos_defaults == 0 && n_kw_defaults == 0) {
         need_reg_all(emit);
         ASM_MOV_REG_IMM(emit->as, REG_ARG_3, 0);
@@ -2779,7 +2779,7 @@ static void emit_native_make_closure(emit_t *emit, scope_t *scope, mp_uint_t n_c
     // make function
     emit_native_pre(emit);
     emit_native_mov_reg_state(emit, REG_ARG_2, LOCAL_IDX_FUN_OBJ(emit));
-    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_2, REG_ARG_2, OFFSETOF_OBJ_FUN_BC_CONTEXT);
+    ASM_LOAD_REG_REG_OFFSET(emit->as, REG_ARG_2, REG_ARG_2, OFFSETOF_OBJ_FUN_NATIVE_CONTEXT);
     if (n_pos_defaults == 0 && n_kw_defaults == 0) {
         need_reg_all(emit);
         ASM_MOV_REG_IMM(emit->as, REG_ARG_3, 0);

--- a/py/frozenmod.h
+++ b/py/frozenmod.h
@@ -36,5 +36,6 @@ enum {
 };
 
 mp_import_stat_t mp_find_frozen_module(const char *str, int *frozen_type, void **data);
+void mp_gc_collect_frozen_globals(void);
 
 #endif // MICROPY_INCLUDED_PY_FROZENMOD_H

--- a/py/gc.c
+++ b/py/gc.c
@@ -31,6 +31,7 @@
 
 #include "py/gc.h"
 #include "py/runtime.h"
+#include "py/frozenmod.h"
 
 #if MICROPY_DEBUG_VALGRIND
 #include <valgrind/memcheck.h>
@@ -409,6 +410,10 @@ void gc_collect_start(void) {
     // Trace root pointers from the Python stack.
     ptrs = (void **)(void *)MP_STATE_THREAD(pystack_start);
     gc_collect_root(ptrs, (MP_STATE_THREAD(pystack_cur) - MP_STATE_THREAD(pystack_start)) / sizeof(void *));
+    #endif
+
+    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC
+    mp_gc_collect_frozen_globals();
     #endif
 }
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -531,6 +531,13 @@ typedef uint64_t mp_uint_t;
 // Convenience definition for whether any native or inline assembler emitter is enabled
 #define MICROPY_EMIT_MACHINE_CODE (MICROPY_EMIT_NATIVE || MICROPY_EMIT_INLINE_ASM)
 
+// Whether the size of raw_code for each function can be limited to 64 KB max.
+// Enabling this option can save 4 bytes per function and method in frozen code,
+// and in RAM for each dynamically loaded function when SYS_SETTRACE is enabled.
+#ifndef MICROPY_LIMIT_RAWCODE_SIZE
+#define MICROPY_LIMIT_RAWCODE_SIZE (1)
+#endif
+
 /*****************************************************************************/
 /* Compiler configuration                                                    */
 
@@ -1775,6 +1782,19 @@ typedef time_t mp_timestamp_t;
 // Whether to provide "sys.settrace" function
 #ifndef MICROPY_PY_SYS_SETTRACE
 #define MICROPY_PY_SYS_SETTRACE (0)
+#endif
+
+// Whether to enable optimizations to reduce the memory overhead of SYS_SETTRACE
+#ifndef MICROPY_PY_SYS_SETTRACE_REDUCE_MEM_USAGE
+#define MICROPY_PY_SYS_SETTRACE_REDUCE_MEM_USAGE (1)
+#endif
+
+// Whether each function prelude information should be stored in decoded form
+// for debugging, when SYS_SETTRACE is enabled.
+// This option requires 16 extra bytes for each function, either from
+// flash memory for frozen code or from RAM for dynamically loaded code.
+#ifndef MICROPY_PY_SYS_SETTRACE_USE_FULL_PRELUDE
+#define MICROPY_PY_SYS_SETTRACE_USE_FULL_PRELUDE (!MICROPY_PY_SYS_SETTRACE_REDUCE_MEM_USAGE)
 #endif
 
 // Whether to provide "sys.getsizeof" function

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1148,6 +1148,13 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_MODULE_FROZEN_MPY (0)
 #endif
 
+// Whether frozen modules as .mpy files should also freeze bytecode function objects to save RAM.
+// It saves 16 bytes of RAM per function, but costs 12 bytes of ROM per function when SYS_SETTRACE
+// is enabled, or 16/24 bytes of ROM per function or without SYS_SETTRACE, depending on the case.
+#ifndef MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC
+#define MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC (MICROPY_MODULE_FROZEN_MPY && MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
+#endif
+
 // Convenience macro for whether frozen modules are supported
 #ifndef MICROPY_MODULE_FROZEN
 #define MICROPY_MODULE_FROZEN (MICROPY_MODULE_FROZEN_STR || MICROPY_MODULE_FROZEN_MPY)

--- a/py/obj.h
+++ b/py/obj.h
@@ -1248,8 +1248,6 @@ typedef struct _mp_obj_fun_builtin_var_t {
     } fun;
 } mp_obj_fun_builtin_var_t;
 
-qstr mp_obj_fun_get_name(mp_const_obj_t fun);
-
 mp_obj_t mp_identity(mp_obj_t self);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_identity_obj);
 

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -34,6 +34,7 @@
 #include "py/objfun.h"
 #include "py/runtime.h"
 #include "py/bc.h"
+#include "py/emitglue.h"
 #include "py/cstack.h"
 
 #if MICROPY_DEBUG_VERBOSE // print debugging info
@@ -132,27 +133,6 @@ MP_DEFINE_CONST_OBJ_TYPE(
 /******************************************************************************/
 /* byte code functions                                                        */
 
-qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
-    const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
-    const byte *bc = fun->bytecode;
-
-    #if MICROPY_EMIT_NATIVE
-    if (fun->base.type == &mp_type_fun_native || fun->base.type == &mp_type_native_gen_wrap) {
-        bc = mp_obj_fun_native_get_prelude_ptr(fun);
-    }
-    #endif
-
-    MP_BC_PRELUDE_SIG_DECODE(bc);
-    MP_BC_PRELUDE_SIZE_DECODE(bc);
-
-    mp_uint_t name = mp_decode_uint_value(bc);
-    #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
-    name = fun->context->constants.qstr_table[name];
-    #endif
-
-    return name;
-}
-
 #if MICROPY_PY_FUNCTION_ATTRS_CODE
 static mp_obj_t fun_bc_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void)type;
@@ -178,9 +158,10 @@ static mp_obj_t fun_bc_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 #endif
 
 #if MICROPY_CPYTHON_COMPAT
-static void fun_bc_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
+// This function is also valid for NATIVE PYTHON functions
+static void mp_obj_fun_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
-    mp_obj_fun_bc_t *o = MP_OBJ_TO_PTR(o_in);
+    void *o = MP_OBJ_TO_PTR(o_in);
     mp_printf(print, "<function %q at 0x%p>", mp_obj_fun_get_name(o_in), o);
 }
 #endif
@@ -214,8 +195,8 @@ static void dump_args(const mp_obj_t *a, size_t sz) {
             + n_exc_stack * sizeof(mp_exc_stack_t);                \
     }
 
-#define INIT_CODESTATE(code_state, _fun_bc, _n_state, n_args, n_kw, args) \
-    code_state->fun_bc = _fun_bc; \
+#define INIT_CODESTATE(code_state, _fun_obj, _n_state, n_args, n_kw, args) \
+    code_state->fun_obj = _fun_obj; \
     code_state->n_state = _n_state; \
     mp_setup_code_state(code_state, n_args, n_kw, args); \
     code_state->old_globals = mp_globals_get();
@@ -226,7 +207,7 @@ mp_code_state_t *mp_obj_fun_bc_prepare_codestate(mp_obj_t self_in, size_t n_args
     mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
 
     size_t n_state, state_size;
-    DECODE_CODESTATE_SIZE(self->bytecode, n_state, state_size);
+    DECODE_CODESTATE_SIZE(MP_FUN_BC_GET_BYTECODE(self), n_state, state_size);
 
     mp_code_state_t *code_state;
     #if MICROPY_ENABLE_PYSTACK
@@ -264,7 +245,8 @@ static mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
     mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
 
     size_t n_state, state_size;
-    DECODE_CODESTATE_SIZE(self->bytecode, n_state, state_size);
+    const byte *bc = MP_FUN_BC_GET_BYTECODE(self);
+    DECODE_CODESTATE_SIZE(bc, n_state, state_size);
 
     // allocate state for locals and stack
     mp_code_state_t *code_state = NULL;
@@ -302,7 +284,7 @@ static mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
             assert(0);
         }
     }
-    const byte *bytecode_ptr = self->bytecode;
+    const byte *bytecode_ptr = MP_FUN_BC_GET_BYTECODE(self);
     size_t n_state_unused, n_exc_stack_unused, scope_flags_unused;
     size_t n_pos_args, n_kwonly_args, n_def_args_unused;
     MP_BC_PRELUDE_SIG_DECODE_INTO(bytecode_ptr, n_state_unused, n_exc_stack_unused,
@@ -353,36 +335,6 @@ static mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
     }
 }
 
-#if MICROPY_PY_FUNCTION_ATTRS
-void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    if (dest[0] != MP_OBJ_NULL) {
-        // not load attribute
-        return;
-    }
-    if (attr == MP_QSTR___name__) {
-        dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_get_name(self_in));
-    }
-    if (attr == MP_QSTR___globals__) {
-        mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
-        dest[0] = MP_OBJ_FROM_PTR(self->context->module.globals);
-    }
-    #if MICROPY_PY_FUNCTION_ATTRS_CODE
-    if (attr == MP_QSTR___code__) {
-        const mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
-        if ((self->base.type == &mp_type_fun_bc
-             || self->base.type == &mp_type_gen_wrap)
-            && self->child_table == NULL) {
-            #if MICROPY_PY_BUILTINS_CODE <= MICROPY_PY_BUILTINS_CODE_BASIC
-            dest[0] = mp_obj_new_code(self->context->constants, self->bytecode);
-            #else
-            dest[0] = mp_obj_new_code(self->context, self->rc, true);
-            #endif
-        }
-    }
-    #endif
-}
-#endif
-
 #if MICROPY_PY_FUNCTION_ATTRS_CODE
 #define FUN_BC_MAKE_NEW make_new, fun_bc_make_new,
 #else
@@ -390,13 +342,13 @@ void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 #endif
 
 #if MICROPY_CPYTHON_COMPAT
-#define FUN_BC_TYPE_PRINT print, fun_bc_print,
+#define FUN_BC_TYPE_PRINT print, mp_obj_fun_print,
 #else
 #define FUN_BC_TYPE_PRINT
 #endif
 
 #if MICROPY_PY_FUNCTION_ATTRS
-#define FUN_BC_TYPE_ATTR attr, mp_obj_fun_bc_attr,
+#define FUN_BC_TYPE_ATTR attr, mp_obj_fun_attr,
 #else
 #define FUN_BC_TYPE_ATTR
 #endif
@@ -411,11 +363,15 @@ MP_DEFINE_CONST_OBJ_TYPE(
     call, fun_bc_call
     );
 
-mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_module_context_t *context, struct _mp_raw_code_t *const *child_table) {
+/******************************************************************************/
+/* functions that support both byte code and native py functions              */
+
+mp_obj_t mp_obj_new_fun_py(const mp_obj_t *def_args, const byte *code, const mp_module_context_t *context, struct _mp_raw_code_t *const *child_table, const mp_obj_type_t *fun_type) {
     size_t n_def_args = 0;
     size_t n_extra_args = 0;
     mp_obj_tuple_t *def_pos_args = NULL;
     mp_obj_t def_kw_args = MP_OBJ_NULL;
+    mp_obj_t res;
     if (def_args != NULL && def_args[0] != MP_OBJ_NULL) {
         assert(mp_obj_is_type(def_args[0], &mp_type_tuple));
         def_pos_args = MP_OBJ_TO_PTR(def_args[0]);
@@ -427,38 +383,144 @@ mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_
         def_kw_args = def_args[1];
         n_extra_args += 1;
     }
-    mp_obj_fun_bc_t *o = mp_obj_malloc_var(mp_obj_fun_bc_t, extra_args, mp_obj_t, n_extra_args, &mp_type_fun_bc);
-    o->bytecode = code;
-    o->context = context;
-    o->child_table = child_table;
+    mp_obj_t *extra_args;
+    #if MICROPY_EMIT_NATIVE
+    if (fun_type == &mp_type_fun_bc || fun_type == &mp_type_gen_wrap)
+    #endif
+    {
+        mp_obj_fun_bc_t *fun_bc = mp_obj_malloc_var(mp_obj_fun_bc_t, extra_args, mp_obj_t, n_extra_args, fun_type);
+        fun_bc->context = context;
+        #if !MICROPY_PY_SYS_SETTRACE
+        fun_bc->bytecode = code;
+        fun_bc->child_table = child_table;
+        #endif
+        extra_args = fun_bc->extra_args;
+        res = MP_OBJ_FROM_PTR(fun_bc);
+    }
+    #if MICROPY_EMIT_NATIVE
+    else {
+        mp_obj_fun_native_t *fun_native = mp_obj_malloc_var(mp_obj_fun_native_t, extra_args, mp_obj_t, n_extra_args, fun_type);
+        fun_native->context = context;
+        fun_native->bytecode = code;
+        fun_native->child_table = child_table;
+        extra_args = fun_native->extra_args;
+        res = MP_OBJ_FROM_PTR(fun_native);
+    }
+    #endif
     if (def_pos_args != NULL) {
-        memcpy(o->extra_args, def_pos_args->items, n_def_args * sizeof(mp_obj_t));
+        memcpy(extra_args, def_pos_args->items, n_def_args * sizeof(mp_obj_t));
     }
     if (def_kw_args != MP_OBJ_NULL) {
-        o->extra_args[n_def_args] = def_kw_args;
+        extra_args[n_def_args] = def_kw_args;
     }
-    return MP_OBJ_FROM_PTR(o);
+    return res;
 }
 
+qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
+    #if MICROPY_EMIT_MACHINE_CODE
+    const mp_obj_base_t *o = MP_OBJ_TO_PTR(fun_in);
+    #endif
+    const byte *bc = NULL;
+    #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
+    const mp_module_context_t *context;
+    #endif
+
+    #if MICROPY_EMIT_MACHINE_CODE
+    if (o->type == &mp_type_fun_bc || o->type == &mp_type_gen_wrap)
+    #endif
+    {
+        const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
+        bc = MP_FUN_BC_GET_BYTECODE(fun);
+        #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
+        context = fun->context;
+        #endif
+    }
+    #if MICROPY_EMIT_NATIVE
+    else {
+        assert(o->type == &mp_type_fun_native || o->type == &mp_type_native_gen_wrap);
+        const mp_obj_fun_native_t *fun = MP_OBJ_TO_PTR(fun_in);
+        bc = mp_obj_fun_native_get_prelude_ptr(fun);
+        #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
+        context = fun->context;
+        #endif
+    }
+    #endif
+    // Ensure we were not given a Viper or inline asm function
+    assert(bc != NULL);
+
+    MP_BC_PRELUDE_SIG_DECODE(bc);
+    MP_BC_PRELUDE_SIZE_DECODE(bc);
+
+    mp_uint_t name = mp_decode_uint_value(bc);
+    #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
+    name = context->constants.qstr_table[name];
+    #endif
+
+    return name;
+}
+
+#if MICROPY_PY_FUNCTION_ATTRS
+void mp_obj_fun_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] != MP_OBJ_NULL) {
+        // not load attribute
+        return;
+    }
+    #if MICROPY_EMIT_NATIVE
+    const mp_obj_base_t *o = MP_OBJ_TO_PTR(self_in);
+    bool is_bc = (o->type == &mp_type_fun_bc || o->type == &mp_type_gen_wrap);
+    #else
+    bool is_bc = 1;
+    #endif
+
+    if (attr == MP_QSTR___name__) {
+        dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_get_name(self_in));
+    }
+    if (attr == MP_QSTR___globals__) {
+        const mp_module_context_t *context;
+        if (is_bc) {
+            mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+            context = self->context;
+        } else {
+            mp_obj_fun_native_t *self = MP_OBJ_TO_PTR(self_in);
+            context = self->context;
+        }
+        dest[0] = MP_OBJ_FROM_PTR(context->module.globals);
+    }
+    #if MICROPY_PY_FUNCTION_ATTRS_CODE
+    if (attr == MP_QSTR___code__ && is_bc) {
+        const mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+        if (MP_FUN_BC_GET_CHILDREN(self) == NULL) {
+            const mp_module_context_t *context = self->context;
+            #if MICROPY_PY_BUILTINS_CODE <= MICROPY_PY_BUILTINS_CODE_BASIC
+            dest[0] = mp_obj_new_code(context->constants, MP_FUN_BC_GET_BYTECODE(self));
+            #else
+            dest[0] = mp_obj_new_code(context, self->rc, true);
+            #endif
+        }
+    }
+    #endif
+}
+#endif
+
 /******************************************************************************/
-/* native functions                                                           */
+/* native python functions                                                    */
 
 #if MICROPY_EMIT_NATIVE
 
 static mp_obj_t fun_native_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_cstack_check();
-    mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_fun_native_t *self = MP_OBJ_TO_PTR(self_in);
     mp_call_fun_t fun = mp_obj_fun_native_get_function_start(self);
     return fun(self_in, n_args, n_kw, args);
 }
 
 #if MICROPY_CPYTHON_COMPAT
-#define FUN_BC_TYPE_PRINT print, fun_bc_print,
+#define FUN_BC_TYPE_PRINT print, mp_obj_fun_print,
 #else
 #define FUN_BC_TYPE_PRINT
 #endif
 #if MICROPY_PY_FUNCTION_ATTRS
-#define FUN_BC_TYPE_ATTR attr, mp_obj_fun_bc_attr,
+#define FUN_BC_TYPE_ATTR attr, mp_obj_fun_attr,
 #else
 #define FUN_BC_TYPE_ATTR
 #endif
@@ -481,7 +543,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 static mp_obj_t fun_viper_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_cstack_check();
-    mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_fun_viper_t *self = MP_OBJ_TO_PTR(self_in);
     mp_call_fun_t fun = MICROPY_MAKE_POINTER_CALLABLE((void *)self->bytecode);
     return fun(self_in, n_args, n_kw, args);
 }

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -273,7 +273,7 @@ static mp_obj_t fun_bc_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const 
     INIT_CODESTATE(code_state, self, n_state, n_args, n_kw, args);
 
     // execute the byte code with the correct globals context
-    mp_globals_set(self->context->module.globals);
+    mp_globals_set(mp_module_context_get_globals(self->context));
     mp_vm_return_kind_t vm_return_kind = mp_execute_bytecode(code_state, MP_OBJ_NULL);
     mp_globals_set(code_state->old_globals);
 
@@ -484,7 +484,7 @@ void mp_obj_fun_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             mp_obj_fun_native_t *self = MP_OBJ_TO_PTR(self_in);
             context = self->context;
         }
-        dest[0] = MP_OBJ_FROM_PTR(context->module.globals);
+        dest[0] = MP_OBJ_FROM_PTR(mp_module_context_get_globals(context));
     }
     #if MICROPY_PY_FUNCTION_ATTRS_CODE
     if (attr == MP_QSTR___code__ && is_bc) {

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -662,7 +662,7 @@ static void save_raw_code(mp_print_t *print, const mp_raw_code_t *rc) {
     #if MICROPY_EMIT_MACHINE_CODE
     if (rc->kind == MP_CODE_NATIVE_PY) {
         // Save prelude size
-        mp_print_uint(print, rc->prelude_offset);
+        mp_print_uint(print, rc->specific.native_py.prelude_offset);
     } else if (rc->kind == MP_CODE_NATIVE_VIPER || rc->kind == MP_CODE_NATIVE_ASM) {
         // Save basic scope info for viper and asm
         // Viper/asm functions don't support generator, variable args, or default keyword args
@@ -670,8 +670,8 @@ static void save_raw_code(mp_print_t *print, const mp_raw_code_t *rc) {
         mp_print_uint(print, 0);
         #if MICROPY_EMIT_INLINE_ASM
         if (rc->kind == MP_CODE_NATIVE_ASM) {
-            mp_print_uint(print, rc->asm_n_pos_args);
-            mp_print_uint(print, rc->asm_type_sig);
+            mp_print_uint(print, rc->specific.native_asm.n_pos_args);
+            mp_print_uint(print, rc->specific.native_asm.type_sig);
         }
         #endif
     }

--- a/py/profile.c
+++ b/py/profile.c
@@ -40,31 +40,35 @@
 #define prof_trace_cb MP_STATE_THREAD(prof_trace_callback)
 
 uint mp_prof_bytecode_lineno(const mp_raw_code_t *rc, size_t bc) {
-    const mp_bytecode_prelude_t *prelude = &rc->prelude;
-    return mp_bytecode_get_source_line(prelude->line_info, prelude->line_info_top, bc);
+    const mp_prof_settrace_data_t *settrace_data = &rc->specific.bytecode;
+    return mp_bytecode_get_source_line(settrace_data->line_info, settrace_data->line_info_top, bc);
 }
 
-void mp_prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude) {
+void mp_prof_extract_prelude(const byte *bytecode, mp_prof_settrace_data_t *settrace_data) {
     const byte *ip = bytecode;
 
     MP_BC_PRELUDE_SIG_DECODE(ip);
-    prelude->n_state = n_state;
-    prelude->n_exc_stack = n_exc_stack;
-    prelude->scope_flags = scope_flags;
-    prelude->n_pos_args = n_pos_args;
-    prelude->n_kwonly_args = n_kwonly_args;
-    prelude->n_def_pos_args = n_def_pos_args;
+    #if MICROPY_PY_SYS_SETTRACE_USE_FULL_PRELUDE
+    settrace_data->n_state = n_state;
+    settrace_data->n_exc_stack = n_exc_stack;
+    settrace_data->scope_flags = scope_flags;
+    settrace_data->n_pos_args = n_pos_args;
+    settrace_data->n_kwonly_args = n_kwonly_args;
+    settrace_data->n_def_pos_args = n_def_pos_args;
+    #else
+    settrace_data->n_args = n_pos_args + n_kwonly_args;
+    #endif
 
     MP_BC_PRELUDE_SIZE_DECODE(ip);
 
-    prelude->line_info_top = ip + n_info;
-    prelude->opcodes = ip + n_info + n_cell;
+    settrace_data->line_info_top = ip + n_info;
+    settrace_data->opcodes = ip + n_info + n_cell;
 
-    prelude->qstr_block_name_idx = mp_decode_uint_value(ip);
+    settrace_data->qstr_block_name_idx = mp_decode_uint_value(ip);
     for (size_t i = 0; i < 1 + n_pos_args + n_kwonly_args; ++i) {
         ip = mp_decode_uint_skip(ip);
     }
-    prelude->line_info = ip;
+    settrace_data->line_info = ip;
 }
 
 /******************************************************************************/
@@ -75,13 +79,13 @@ static void frame_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
     mp_obj_frame_t *frame = MP_OBJ_TO_PTR(o_in);
     mp_obj_code_t *code = frame->code;
     const mp_raw_code_t *rc = code->rc;
-    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    const mp_prof_settrace_data_t *settrace_data = &rc->specific.bytecode;
     mp_printf(print,
         "<frame at 0x%p, file '%q', line %d, code %q>",
         frame,
         MP_CODE_QSTR_MAP(code->context, 0),
         (int)frame->lineno,
-        MP_CODE_QSTR_MAP(code->context, prelude->qstr_block_name_idx)
+        MP_CODE_QSTR_MAP(code->context, settrace_data->qstr_block_name_idx)
         );
 }
 
@@ -139,12 +143,12 @@ mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state) {
     }
 
     const mp_raw_code_t *rc = code->rc;
-    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    const mp_prof_settrace_data_t *settrace_data = &rc->specific.bytecode;
     o->code_state = code_state;
     o->base.type = &mp_type_frame;
     o->back = NULL;
     o->code = code;
-    o->lasti = code_state->ip - prelude->opcodes;
+    o->lasti = code_state->ip - settrace_data->opcodes;
     o->lineno = mp_prof_bytecode_lineno(rc, o->lasti);
     o->trace_opcodes = false;
     o->callback = MP_OBJ_NULL;
@@ -201,10 +205,7 @@ mp_obj_t mp_prof_frame_enter(mp_code_state_t *code_state) {
         // which means it's a CALL event (not a GENERATOR)
         // so set the function definition line.
         const mp_raw_code_t *rc = code_state->fun_bc->rc;
-        frame->lineno = rc->line_of_definition;
-        if (!rc->line_of_definition) {
-            frame->lineno = mp_prof_bytecode_lineno(rc, 0);
-        }
+        frame->lineno = mp_prof_bytecode_lineno(rc, 0) - rc->specific.bytecode.line_of_definition_delta;
     }
     code_state->frame = frame;
 
@@ -239,11 +240,11 @@ mp_obj_t mp_prof_frame_update(const mp_code_state_t *code_state) {
     mp_obj_frame_t *o = frame;
     mp_obj_code_t *code = o->code;
     const mp_raw_code_t *rc = code->rc;
-    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    const mp_prof_settrace_data_t *settrace_data = &rc->specific.bytecode;
 
     assert(o->code_state == code_state);
 
-    o->lasti = code_state->ip - prelude->opcodes;
+    o->lasti = code_state->ip - settrace_data->opcodes;
     o->lineno = mp_prof_bytecode_lineno(rc, o->lasti);
 
     return MP_OBJ_FROM_PTR(o);
@@ -277,9 +278,9 @@ mp_obj_t mp_prof_instr_tick(mp_code_state_t *code_state, bool is_exception) {
 
     // SETTRACE event LINE
     const mp_raw_code_t *rc = code_state->fun_bc->rc;
-    const mp_bytecode_prelude_t *prelude = &rc->prelude;
+    const mp_prof_settrace_data_t *settrace_data = &rc->specific.bytecode;
     size_t prev_line_no = args->frame->lineno;
-    size_t current_line_no = mp_prof_bytecode_lineno(rc, code_state->ip - prelude->opcodes);
+    size_t current_line_no = mp_prof_bytecode_lineno(rc, code_state->ip - settrace_data->opcodes);
     if (prev_line_no != current_line_no) {
         args->frame->lineno = current_line_no;
         args->event = MP_OBJ_NEW_QSTR(MP_QSTR_line);

--- a/py/profile.h
+++ b/py/profile.h
@@ -46,7 +46,7 @@ typedef struct _mp_obj_frame_t {
 } mp_obj_frame_t;
 
 uint mp_prof_bytecode_lineno(const mp_raw_code_t *rc, size_t bc);
-void mp_prof_extract_prelude(const byte *bytecode, mp_bytecode_prelude_t *prelude);
+void mp_prof_extract_prelude(const byte *bytecode, mp_prof_settrace_data_t *settrace_data);
 
 mp_obj_t mp_obj_new_frame(const mp_code_state_t *code_state);
 

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -673,6 +673,11 @@ class CompiledModule:
         print("// - frozen file name: %s" % self.source_file.str)
         print("// - .mpy header: %s" % ":".join("%02x" % b for b in self.header))
         print()
+        print(
+            "extern const mp_frozen_module_t mp_frozen_module_t_%s; // defined below"
+            % self.escaped_name
+        )
+        print()
 
         self.raw_code.freeze()
         print()
@@ -680,7 +685,17 @@ class CompiledModule:
         self.freeze_constants()
 
         print()
-        print("static const mp_frozen_module_t frozen_module_%s = {" % self.escaped_name)
+        print("#if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC")
+        print("// Note: this is a variable (in RAM)")
+        print("mp_obj_dict_t *mp_globals_%s = NULL;" % self.escaped_name)
+        print("#endif")
+
+        print()
+        print("const mp_frozen_module_t mp_frozen_module_t_%s = {" % self.escaped_name)
+        print("    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC")
+        print("    .base = { &mp_type_module },")
+        print("    .globals_ref = &mp_globals_%s," % self.escaped_name)
+        print("    #endif")
         print("    .constants = {")
         if len(self.qstr_table):
             print(
@@ -837,6 +852,7 @@ class CompiledModule:
         # generate constant table
         print()
         print("// constant table")
+
         print(
             "static const mp_rom_obj_t const_obj_table_data_%s[%u] = {"
             % (self.escaped_name, len(self.obj_table))
@@ -861,7 +877,8 @@ class RawCode(object):
         MP_CODE_NATIVE_ASM: "MP_CODE_NATIVE_ASM",
     }
 
-    def __init__(self, parent_name, qstr_table, fun_data, prelude_offset, code_kind):
+    def __init__(self, module_name, parent_name, qstr_table, fun_data, prelude_offset, code_kind):
+        self.module_name = module_name
         self.qstr_table = qstr_table
         self.fun_data = fun_data
         self.prelude_offset = prelude_offset
@@ -922,24 +939,34 @@ class RawCode(object):
         else:
             raw_code_type = "mp_raw_code_truncated_t"
 
+        generate_objfun = self.code_kind == MP_CODE_BYTECODE and (
+            self.prelude_signature[4] + self.prelude_signature[5] == 0  # no def arg
+        )
+        module_context = "mp_frozen_module_t_%s," % self.module_name
+
+        if len(self.children):
+            children = "(void *)&children_%s," % self.escaped_name
+        elif prelude_ptr:
+            children = "(void *)%s," % prelude_ptr
+        else:
+            children = "NULL,"
+
         empty_children = len(self.children) == 0 and prelude_ptr is None
         generate_minimal = self.code_kind == MP_CODE_BYTECODE and empty_children
 
         if generate_minimal:
-            print("#if MICROPY_PERSISTENT_CODE_SAVE")
+            print("#if MICROPY_PERSISTENT_CODE_SAVE || MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC")
 
         print("static const %s proto_fun_%s = {" % (raw_code_type, self.escaped_name))
         print("    .proto_fun_indicator[0] = MP_PROTO_FUN_INDICATOR_RAW_CODE_0,")
         print("    .proto_fun_indicator[1] = MP_PROTO_FUN_INDICATOR_RAW_CODE_1,")
         print("    .kind = %s," % RawCode.code_kind_str[self.code_kind])
         print("    .is_generator = %d," % bool(self.scope_flags & MP_SCOPE_FLAG_GENERATOR))
+        print("    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC")
+        print("    .has_const_fun_obj = %d," % generate_objfun)
+        print("    #endif")
         print("    .fun_data = fun_data_%s," % self.escaped_name)
-        if len(self.children):
-            print("    .children = (void *)&children_%s," % self.escaped_name)
-        elif prelude_ptr:
-            print("    .children = (void *)%s," % prelude_ptr)
-        else:
-            print("    .children = NULL,")
+        print("    .children = %s" % children)
         print("    #if MICROPY_PERSISTENT_CODE_SAVE")
         print("    .fun_data_len = %u," % len(self.fun_data))
         print("    .n_children = %u," % len(self.children))
@@ -974,7 +1001,7 @@ class RawCode(object):
                 % (self.escaped_name, self.offset_opcodes)
             )
             print("        }")
-            print("    }")
+            print("    },")
             print("    #endif")
         elif self.code_kind == MP_CODE_NATIVE_PY:
             print("    #if MICROPY_EMIT_MACHINE_CODE && MICROPY_PERSISTENT_CODE_SAVE")
@@ -982,7 +1009,7 @@ class RawCode(object):
             print("        .native_py = {")
             print("            .prelude_offset = %u" % self.prelude_offset)
             print("        }")
-            print("    }")
+            print("    },")
             print("    #endif")
         elif self.code_kind == MP_CODE_NATIVE_ASM:
             print("    #if MICROPY_EMIT_INLINE_ASM")
@@ -991,7 +1018,23 @@ class RawCode(object):
             print("            .n_pos_args = %u," % self.n_pos_args)
             print("            .type_sig = %u" % type_sig)
             print("        }")
-            print("    }")
+            print("    },")
+            print("    #endif")
+        if generate_objfun:
+            print("    #if MICROPY_MODULE_FROZEN_MPY_FREEZE_FUN_BC")
+            print("    .fun_obj = {")
+            if self.scope_flags & MP_SCOPE_FLAG_GENERATOR:
+                print("        &mp_type_gen_wrap,                      // mp_obj_base_t base")
+            else:
+                print("        &mp_type_fun_bc,                        // mp_obj_base_t base")
+            print("        &%-39s// mp_module_context_t *context" % module_context)
+            print("        #if MICROPY_PY_SYS_SETTRACE")
+            print("        &proto_fun_%-29s// mp_raw_code_truncated_t *rc" % self.escaped_name)
+            print("        #else")
+            print("        %-40s// mp_raw_code_t child_table" % children)
+            print("        fun_data_%-31s// const byte *bytecode" % self.escaped_name)
+            print("        #endif")
+            print("    },")
             print("    #endif")
         print("};")
 
@@ -1006,10 +1049,10 @@ class RawCode(object):
 
 
 class RawCodeBytecode(RawCode):
-    def __init__(self, parent_name, qstr_table, obj_table, fun_data):
+    def __init__(self, module_name, parent_name, qstr_table, obj_table, fun_data):
         self.obj_table = obj_table
         super(RawCodeBytecode, self).__init__(
-            parent_name, qstr_table, fun_data, 0, MP_CODE_BYTECODE
+            module_name, parent_name, qstr_table, fun_data, 0, MP_CODE_BYTECODE
         )
 
     def disassemble(self):
@@ -1085,6 +1128,7 @@ class RawCodeBytecode(RawCode):
 class RawCodeNative(RawCode):
     def __init__(
         self,
+        module_name,
         parent_name,
         qstr_table,
         kind,
@@ -1095,7 +1139,7 @@ class RawCodeNative(RawCode):
         type_sig,
     ):
         super(RawCodeNative, self).__init__(
-            parent_name, qstr_table, fun_data, prelude_offset, kind
+            module_name, parent_name, qstr_table, fun_data, prelude_offset, kind
         )
 
         if kind in (MP_CODE_NATIVE_VIPER, MP_CODE_NATIVE_ASM):
@@ -1294,7 +1338,7 @@ def read_obj(reader, segments):
         return obj
 
 
-def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
+def read_raw_code(reader, module_name, parent_name, qstr_table, obj_table, segments):
     # Read raw code header.
     kind_len = reader.read_uint()
     kind = (kind_len & 3) + MP_CODE_BYTECODE
@@ -1308,7 +1352,7 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
 
     if kind == MP_CODE_BYTECODE:
         # Create bytecode raw code.
-        rc = RawCodeBytecode(parent_name, qstr_table, obj_table, fun_data)
+        rc = RawCodeBytecode(module_name, parent_name, qstr_table, obj_table, fun_data)
     else:
         # Create native raw code.
         native_scope_flags = 0
@@ -1343,6 +1387,7 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
                 native_type_sig = reader.read_uint()
 
         rc = RawCodeNative(
+            module_name,
             parent_name,
             qstr_table,
             kind,
@@ -1369,7 +1414,9 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
         # Read all the child raw codes.
         n_children = reader.read_uint()
         for _ in range(n_children):
-            rc.children.append(read_raw_code(reader, parent_name, qstr_table, obj_table, segments))
+            rc.children.append(
+                read_raw_code(reader, module_name, parent_name, qstr_table, obj_table, segments)
+            )
 
     return rc
 
@@ -1423,7 +1470,9 @@ def read_mpy(filename):
 
         # Read the outer raw code, which will in turn read all its children.
         raw_code_file_offset = reader.tell()
-        raw_code = read_raw_code(reader, cm_escaped_name, qstr_table, obj_table, segments)
+        raw_code = read_raw_code(
+            reader, cm_escaped_name, cm_escaped_name, qstr_table, obj_table, segments
+        )
 
     # Create the outer-level compiled module representing the whole .mpy file.
     return CompiledModule(
@@ -1588,7 +1637,7 @@ def freeze_mpy(firmware_qstr_idents, compiled_modules):
     print()
     print("const mp_frozen_module_t *const mp_frozen_mpy_content[] = {")
     for cm in compiled_modules:
-        print("    &frozen_module_%s," % cm.escaped_name)
+        print("    &mp_frozen_module_t_%s," % cm.escaped_name)
     print("};")
     mp_frozen_mpy_content_size = len(compiled_modules * 4)
 


### PR DESCRIPTION
### Summary

My MicroPython port has relatively large flash storage, but not much RAM (only 100 KB is available for MicroPython heap). Therefore I rely on frozen modules to save RAM. My port includes SYS_SETTRACE to allow the end user to debug their own code using Visual Studio Code.

Examining my runtime heap map in detail, I realised that frozen functions use a significant amount of RAM: 32 bytes per function or method. This equated to 20 KB of RAM when importing my main library.

Further investigation revealed a significant waste of ROM and RAM when enabling SYS_SETTRACE. This pull request attempts to address this issue:

- the first commit reduces the footprint of the `mp_raw_code_t` structure, which uses unnecessary ROM space in frozen code, but also uses RAM for dynamically loaded functions. Depending on the port options, this may also reduce the code footprint for builds not using SYS_SETTRACE.
- the second commit solves the problem of `mp_obj_fun_bc_t` objects using two GC units instead of one when SYS_SETTRACE is enabled. This requires the use of a different structure for each kind of function object, instead of just two types as it is currently the case, so some assumptions about the usage of function objects had to be made more explicit.
- the third commit goes one step further by adding support for frozen `mp_obj_fun_bc_t` objects, not using any RAM. This improvement may benefit to any port with frozen modules, even when SYS_SETTRACE is not enabled. The price to pay for this is of course a bit of ROM, and the use of an indirect pointer to load the module globals dictionary.

edit on 2025-10-31: this third commit has been updated based on the alternative implementation that I had considered in my first submit, i.e. frozing the `mp_module_context_t` object as well, with just the pointer to the module-specific globals dictionary in RAM. This results in simpler code so I think this is preferable. The first version is still available on my repository for reference if needed.

### Testing

The code has been extensively tested on my port, executing both frozen and runtime code.

I started from a build with 185 KB of rodata for frozen modules. Loading my main frozen library used 36KB RAM (for defining classes involving about 600 methods). After the optimizations, I ended up with 162 KB of rodata for frozen modules, and only 17KB RAM used after loading my main library.

So the total savings in my case are 20 KB flash, 20 KB RAM.

I have enabled the new features for some configurations of CI tests to be sure they are covered.

### Trade-offs and Alternatives

There are other ways to somehow reduce the RAM footprint of frozen modules, such as lazy loading (as done in asyncio for instance). I have gone that way first, but ultimately: 
- there was still way to much RAM wasted once I had loaded the libraries that I needed
- the lazy loading solution tends to defeat type checking algorithms used by IDE
- the lazy loading solution breaks if the user uses a star import
- cross references between multiple classes is really tricky to implement properly with the lazy loading method
So ultimately, freezing `mp_obj_fun_bc_t` objects was a much cleaner solution.
