### PR TITLE
mimxrt: Make linker scripts configurable.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -56,7 +56,7 @@ MCUX_SDK_DIR = lib/nxp_driver/sdk
 MCU_DIR = $(MCUX_SDK_DIR)/devices/$(MCU_SERIES)
 
 # Select linker scripts based on MCU_SERIES
-LD_FILES = boards/$(MCU_SERIES).ld boards/common.ld
+LD_FILES ?= boards/$(MCU_SERIES).ld boards/common.ld
 
 # Parameter configurations for generation
 AF_FILE = boards/$(MCU_SERIES)_af.csv
@@ -573,7 +573,7 @@ $(HEADER_BUILD)/qstrdefs.generated.h: $(BOARD_DIR)/mpconfigboard.h
 $(GEN_FLEXRAM_CONFIG_SRC): $(HEADER_BUILD)
 	$(ECHO) "Create $@"
 	$(Q)$(PYTHON) $(MAKE_FLEXRAM_LD) -d $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE).h \
-		-f $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE)_features.h -l boards/$(MCU_SERIES).ld -c $(MCU_SERIES) > $@
+		-f $(TOP)/$(MCU_DIR)/$(MCU_SERIES)$(MCU_CORE)_features.h $(addprefix -l,$(LD_FILES)) -c $(MCU_SERIES) > $@
 
 # Use a pattern rule here so that make will only call make-pins.py once to make
 # both pins_gen.c and pins.h

--- a/ports/mimxrt/boards/make-flexram-config.py
+++ b/ports/mimxrt/boards/make-flexram-config.py
@@ -55,9 +55,14 @@ ocram_min_size = 0x00010000  # 64 KB
 
 
 # Value parser
-def mimxrt_default_parser(defines_file, features_file, ld_script):
-    with open(ld_script, "r") as input_file:
-        input_str = input_file.read()
+def mimxrt_default_parser(defines_file, features_file, ld_scripts):
+    input_str = ""
+    if ld_scripts is None:
+        # Default linker script
+        ld_scripts = ["boards/MIMXRT1021.ld"]
+    for ld_script in ld_scripts:
+        with open(ld_script, "r") as input_file:
+            input_str += input_file.read()
     #
     ocram_match = re.search(ocram_regex, input_str, re.MULTILINE)
     dtcm_match = re.search(dtcm_regex, input_str, re.MULTILINE)
@@ -249,7 +254,9 @@ if __name__ == "__main__":
         "--ld_file",
         dest="linker_file",
         help="Path to the aggregated linker-script",
-        default="MIMXRT1021.ld",
+        action="append",
+        # Can't specify default here when using 'append' action, see
+        # https://github.com/python/cpython/issues/60603
     )
     parser.add_argument(
         "-c", "--controller", dest="controller", help="Controller name", default="MIMXRT1021"


### PR DESCRIPTION
### Summary

Similar to #17029, but for the `mimxrt` port!

Can simply add `LD_FILE_BOARD` and/or `LD_FILE_COMMON` (which replaces the previous `LD_FILES`) to a board's `mpconfigboard.mk` to change the linker scripts, such as to change the region sizes, or change the contents for each section. Example usage:

```
LD_FILE_BOARD = $(BOARD_DIR)/my_board.ld
LD_FILE_COMMON = $(BOARD_DIR)/my_common.ld
```

### Testing

I'm working on a [project](https://github.com/sparkfun/micropython-opencv) that adds a few MB to the firmware size, and requires a few hundred kB more RAM. Before this change, the linker complained about overflowing memory regions. With this change, I'm able to change the region sizes to make the linker happy (and the code runs too!).
