### PR TITLE
unix/modtime: Add type casting.

### DIFF
--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -189,7 +189,7 @@ static mp_obj_t mod_time_mktime(mp_obj_t tuple) {
         time.tm_isdst = -1; // auto-detect
     }
     time_t ret = mktime(&time);
-    if (ret == -1) {
+    if (ret == (time_t)-1) {
         mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("invalid mktime usage"));
     }
     return timeutils_obj_from_timestamp(ret);


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This adds type casting to avoid build errors with system where `time_t` is not signed integer.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Checked with `make -C ports/unix -j test` on Ubuntu 22.04



