### PR TITLE
py/objcode: Remove `mp_obj_code_t.lnotab` field from v2 preview.

### DIFF
--- a/py/objcode.c
+++ b/py/objcode.c
@@ -237,7 +237,9 @@ mp_obj_t mp_obj_new_code(const mp_module_context_t *context, const mp_raw_code_t
     o->context = context;
     o->rc = rc;
     o->dict_locals = mp_locals_get(); // this is a wrong! how to do this properly?
+    #if !MICROPY_PREVIEW_VERSION_2
     o->lnotab = MP_OBJ_NULL;
+    #endif
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/py/objcode.h
+++ b/py/objcode.h
@@ -75,12 +75,13 @@ static inline const void *mp_code_get_proto_fun(mp_obj_code_t *self) {
 #define MP_CODE_QSTR_MAP(context, idx) ((qstr)(context->constants.qstr_table[idx]))
 
 typedef struct _mp_obj_code_t {
-    // TODO this was 4 words
     mp_obj_base_t base;
     const mp_module_context_t *context;
     const mp_raw_code_t *rc;
     mp_obj_dict_t *dict_locals;
+    #if !MICROPY_PREVIEW_VERSION_2
     mp_obj_t lnotab;
+    #endif
 } mp_obj_code_t;
 
 mp_obj_t mp_obj_new_code(const mp_module_context_t *context, const mp_raw_code_t *rc, bool result_required);


### PR DESCRIPTION
### Summary
This field exists to cache the lnotab field removed from v2 in #17639 by ddf2c3afb17c0ea3dd678d02d9c2f01bed5a3020, and is now unused.

### Testing
Everything compiles correctly and all tests pass on both v2-preview and non-v2-preview builds of a unix variant with rom-level everything and settrace enabled (i.e. where this define would actually be felt).

