### PR TITLE
py/emitnative: Optimise register clearing.

### DIFF
--- a/py/asmarm.h
+++ b/py/asmarm.h
@@ -230,6 +230,8 @@ void asm_arm_bx_reg(asm_arm_t *as, uint reg_src);
 #define ASM_STORE16_REG_REG_REG(as, reg_val, reg_base, reg_index) asm_arm_strh_reg_reg_reg((as), (reg_val), (reg_base), (reg_index))
 #define ASM_STORE32_REG_REG_REG(as, reg_val, reg_base, reg_index) asm_arm_str_reg_reg_reg((as), (reg_val), (reg_base), (reg_index))
 
+#define ASM_CLR_REG(as, reg_dest) asm_arm_eor_reg_reg_reg((as), (reg_dest), (reg_dest), (reg_dest))
+
 #endif // GENERIC_ASM_API
 
 #endif // MICROPY_INCLUDED_PY_ASMARM_H

--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -804,7 +804,7 @@ void asm_rv32_emit_store_reg_reg_offset(asm_rv32_t *state, mp_uint_t source, mp_
 #define ASM_STORE32_REG_REG_OFFSET(state, rd, rs, offset) asm_rv32_emit_store_reg_reg_offset(state, rd, rs, offset, 2)
 #define ASM_SUB_REG_REG(state, rd, rs) asm_rv32_opcode_sub(state, rd, rd, rs)
 #define ASM_XOR_REG_REG(state, rd, rs) asm_rv32_emit_optimised_xor(state, rd, rs)
-#define ASM_CLR_REG(state, rd)
+#define ASM_CLR_REG(state, rd) asm_rv32_emit_optimised_xor(state, rd, rd)
 #define ASM_LOAD8_REG_REG_REG(state, rd, rs1, rs2) asm_rv32_emit_load_reg_reg_reg(state, rd, rs1, rs2, 0)
 #define ASM_LOAD16_REG_REG_REG(state, rd, rs1, rs2) asm_rv32_emit_load_reg_reg_reg(state, rd, rs1, rs2, 1)
 #define ASM_LOAD32_REG_REG_REG(state, rd, rs1, rs2) asm_rv32_emit_load_reg_reg_reg(state, rd, rs1, rs2, 2)

--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -485,6 +485,8 @@ void asm_thumb_b_rel12(asm_thumb_t *as, int rel);
         asm_thumb_str_rlo_rlo_rlo((as), (reg_val), (reg_base), (reg_index)); \
     } while (0)
 
+#define ASM_CLR_REG(as, reg_dest) asm_thumb_mov_rlo_i8((as), (reg_dest), 0)
+
 #endif // GENERIC_ASM_API
 
 #endif // MICROPY_INCLUDED_PY_ASMTHUMB_H

--- a/py/asmx64.h
+++ b/py/asmx64.h
@@ -221,6 +221,8 @@ void asm_x64_call_ind(asm_x64_t *as, size_t fun_id, int temp_r32);
 #define ASM_STORE32_REG_REG(as, reg_src, reg_base) ASM_STORE32_REG_REG_OFFSET((as), (reg_src), (reg_base), 0)
 #define ASM_STORE32_REG_REG_OFFSET(as, reg_src, reg_base, dword_offset) asm_x64_mov_r32_to_mem32((as), (reg_src), (reg_base), 4 * (dword_offset))
 
+#define ASM_CLR_REG(as, reg_dest) asm_x64_xor_r64_r64((as), (reg_dest), (reg_dest))
+
 #endif // GENERIC_ASM_API
 
 #endif // MICROPY_INCLUDED_PY_ASMX64_H

--- a/py/asmx86.h
+++ b/py/asmx86.h
@@ -216,6 +216,8 @@ void asm_x86_call_ind(asm_x86_t *as, size_t fun_id, mp_uint_t n_args, int temp_r
 #define ASM_STORE32_REG_REG(as, reg_src, reg_base) ASM_STORE32_REG_REG_OFFSET((as), (reg_src), (reg_base), 0)
 #define ASM_STORE32_REG_REG_OFFSET(as, reg_src, reg_base, dword_offset) asm_x86_mov_r32_to_mem32((as), (reg_src), (reg_base), 4 * (dword_offset))
 
+#define ASM_CLR_REG(as, reg_dest) asm_x86_xor_r32_r32((as), (reg_dest), (reg_dest))
+
 #endif // GENERIC_ASM_API
 
 #endif // MICROPY_INCLUDED_PY_ASMX86_H

--- a/py/asmxtensa.h
+++ b/py/asmxtensa.h
@@ -464,6 +464,8 @@ void asm_xtensa_l32r(asm_xtensa_t *as, mp_uint_t reg, mp_uint_t label);
         asm_xtensa_op_s32i_n((as), (reg_val), (reg_base), 0); \
     } while (0)
 
+#define ASM_CLR_REG(as, reg_dest) asm_xtensa_op_movi_n((as), (reg_dest), 0)
+
 #endif // GENERIC_ASM_API
 
 #endif // MICROPY_INCLUDED_PY_ASMXTENSA_H

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -271,6 +271,9 @@ static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int r
 #define ASM_STORE32_REG_REG(as, reg_src, reg_base) \
     asm_debug_reg_reg(as, "store32", reg_src, reg_base)
 
+#define ASM_CLR_REG(as, reg_dest) \
+    asm_debug_reg(as, "clr", reg_dest)
+
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (5) // rbx
 


### PR DESCRIPTION
### Summary

This PR introduces a new generic ASM API function to clear a register (i.e. clearing all the registers' bits).

The native emitter used to perform a XOR operation to clear a given register, but different platform have more optimised method to achieve the same result taking up less space - either for the generated code or for the code generator itself.

Arm, RV32, X86, and X64 already had an already optimised generator and generated optimised code.  The code generator when build for Thumb takes less space generating a constant immediate move rather than a XOR operation, even though both operations would distill down to a single narrow opcode.  On Xtensa the situation is almost the same as Thumb, with the exception that a constant immediate move would take one byte less than a XOR operation.

Thumb builds should shrink down by a small amount (QEMU/MPS2_AN385 is 24 bytes smaller, for example), whilst the ESP8266 port should be 16 bytes smaller.  QEMU/VIRT_RV32 and ESP32_GENERIC builds should show no size changes.

### Testing

The full test suite passed locally on QEMU for SABRELITE, MPS2_AN385, and VIRT_RV32.  On my repo's branch CI passes for Unix/x86 and Unix/x64.  Xtensa and Xtensawin pass the test suite without additional failures (see Octoprobe run 359).