### PR TITLE
mpy-cross: Make the debug emitter work again.

### DIFF
--- a/.github/workflows/mpy_format.yml
+++ b/.github/workflows/mpy_format.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '.github/workflows/*.yml'
       - 'examples/**'
+      - 'mpy-cross/**'
+      - 'py/**'
       - 'tests/**'
       - 'tools/**'
 
@@ -22,3 +24,5 @@ jobs:
       run: tools/ci.sh mpy_format_setup
     - name: Test mpy-tool.py
       run: tools/ci.sh mpy_format_test
+    - name: Test mpy-cross debug emitter
+      run: tools/ci.sh mpy_cross_debug_emitter

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -173,6 +173,15 @@ function ci_mpy_format_test {
     $micropython ./tools/mpy-tool.py -x -d examples/natmod/features1/features1.mpy
 }
 
+function ci_mpy_cross_debug_emitter {
+    make ${MAKEOPTS} -C mpy-cross
+    mpy_cross=./mpy-cross/build/mpy-cross
+
+    # Make sure the debug emitter does not crash or fail for simple files
+    $mpy_cross -X emit=native -march=debug ./tests/basics/0prelim.py | \
+	    grep -E "ENTRY|EXIT" | wc -l | grep "^2$"
+}
+
 ########################################################################################
 # ports/cc3200
 


### PR DESCRIPTION
### Summary

This PR fixes a regression introduced in 1b92bda5b8e5e2db8e57c4b7134930e52bc5207a when adding RV64 support, in which a new architecture was added to mpy-cross but it had no matching native emitter entry point table entry.

The result was that the architecture emitter entry point would be correctly calculated according to the native architecture index, but if the emitters entry points table was not updated to match the new number of architectures an out of bound access may be performed.

Unfortunately adding RV64IMC shifted the debug emitter index further down the table, that wasn't updated to reflect the lack of an emitter for RV64.  Adding a NULL entry there would cause a NULL pointer access as there was no need to perform any check about the emitter entry point function's validity until now.

### Testing

Running `mpy-cross -X emit=native -march=debug <file>` on current `master` would crash with a segment violation on Unix/x64.  With the changes of this PR `mpy-cross` wouldn't crash any more and the compiled module output was printed to STDOUT.  In addition, attempting to compile native code for RV64 triggers an error letting the user know there's no emitter for the chosen architecture.

To prevent situations like this in the future, a new test workflow has been added to make sure the debug emitter doesn't crash and reports output that seems correct.  The test simply runs the debug emitter for `tests/basics/0prelim.py` and checks whether the command doesn't report an error and that the output contains an `ENTRY` and an `EXIT` line.

I thought about reusing `.github/workflows/mpy_format.yml` but then the trigger patterns would need to be extended to also cover `py/**` and `mpy-cross/**` making those checks run on more commits than needed.

### Trade-offs and Alternatives

This could be implemented almost entirely within mpy-cross except for a new NULL entry in the emitter entry points table, although it is not a generic solution.  Being generic, however, doesn't lessen the footprint impact on MicroPython's core.  If that's unacceptable I can re-implement this PR to leave the compiler alone and add the necessary checks exclusively inside mpy-cross.