### PR TITLE
tests: Add Ctrl-C interrupt tests for REPL and execution.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/cmdline/repl_autoindent.py",
   "tests/cmdline/repl_basic.py",
   "tests/cmdline/repl_cont.py",
+  "tests/cmdline/repl_ctrl_c_interrupt.py",
   "tests/cmdline/repl_emacs_keys.py",
   "tests/cmdline/repl_paste.py",
   "tests/cmdline/repl_words_move.py",

--- a/tests/cmdline/repl_ctrl_c_interrupt.py
+++ b/tests/cmdline/repl_ctrl_c_interrupt.py
@@ -1,0 +1,9 @@
+# Test that Ctrl-C interrupts running code
+
+# Test paste mode Ctrl-C cancel
+{\x05}
+print('paste mode')
+{\x03}
+
+# Verify REPL works
+print('REPL works')

--- a/tests/cmdline/repl_ctrl_c_interrupt.py.exp
+++ b/tests/cmdline/repl_ctrl_c_interrupt.py.exp
@@ -1,0 +1,16 @@
+MicroPython \.\+ version
+Type "help()" for more information.
+>>> # Test that Ctrl-C interrupts running code
+>>> 
+>>> # Test paste mode Ctrl-C cancel
+>>> 
+paste mode; Ctrl-C to cancel, Ctrl-D to finish
+=== 
+=== print('paste mode')
+=== 
+>>> 
+>>> 
+>>> # Verify REPL works
+>>> print('REPL works')
+REPL works
+>>> 

--- a/tests/ports/unix/itest_ctrl_c_interrupt.py
+++ b/tests/ports/unix/itest_ctrl_c_interrupt.py
@@ -1,0 +1,58 @@
+"""
+Test that Ctrl-C interrupts running code in the REPL.
+
+This test is run by run-tests.py which sets up a PTY with ISIG enabled
+and spawns MicroPython with the PTY as its controlling terminal.
+
+Globals provided by run-tests.py:
+- master: PTY master file descriptor
+- read_until_quiet: Function to read from PTY until no data for timeout seconds
+"""
+
+import os
+import time
+
+
+# Wait for banner
+time.sleep(0.2)
+banner = read_until_quiet(master)
+
+if b"MicroPython" not in banner:
+    print("SKIP")
+    raise SystemExit
+
+# Check if time module is available
+os.write(master, b"import time\n")
+time.sleep(0.05)
+check_output = read_until_quiet(master, timeout=0.05)
+if b"ImportError" in check_output:
+    print("SKIP")
+    raise SystemExit
+
+# Start a long-running operation
+os.write(master, b"time.sleep(30)\n")
+time.sleep(0.1)  # Give it time to start sleeping
+
+# Send Ctrl-C byte (0x03) through the terminal
+# This tests that the terminal mode allows SIGINT generation
+os.write(master, b"\x03")
+
+# Read output
+time.sleep(0.2)
+output = read_until_quiet(master, timeout=0.1)
+
+# Check for KeyboardInterrupt
+if b"KeyboardInterrupt" in output:
+    print("PASS: Ctrl-C interrupted execution")
+else:
+    print("FAIL: No KeyboardInterrupt found")
+
+# Verify REPL still works
+os.write(master, b"print('OK')\n")
+time.sleep(0.1)
+output = read_until_quiet(master)
+
+if b"OK" in output:
+    print("PASS: REPL functional after interrupt")
+else:
+    print("FAIL: REPL not functional")

--- a/tests/ports/unix/itest_ctrl_c_interrupt.py.exp
+++ b/tests/ports/unix/itest_ctrl_c_interrupt.py.exp
@@ -1,0 +1,2 @@
+PASS: Ctrl-C interrupted execution
+PASS: REPL functional after interrupt


### PR DESCRIPTION
### Summary

Unix port tests of paste mode Ctrl-C cancellation and Ctrl-C interruption during code execution to validate behavior.

### Testing

These are tests for existing behavior that was lacking coverage and to catch the failure that was manually detected in https://github.com/micropython/micropython/pull/12802

### Trade-offs and Alternatives

This does introduce a new class of tests in run-tests.py which is currently only used for this one test, it's debatable whether it's worth the extra code added?

