### PR TITLE
tests/serial_test: Allow up to 2 seconds between bytes.

### DIFF
--- a/tests/serial_test.py
+++ b/tests/serial_test.py
@@ -103,6 +103,11 @@ def read_test(ser_repl, ser_data, bufsize, nbuf):
 
     assert bufsize % 256 == 0  # for verify to work
 
+    # how long to wait for data from device
+    # (if UART TX is also enabled then it can take 1.4s to send
+    # out a 16KB butter at 115200bps)
+    READ_TIMEOUT_S = 2
+
     # Load and run the read_test_script.
     ser_repl.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
     drain_input(ser_repl)
@@ -121,7 +126,7 @@ def read_test(ser_repl, ser_data, bufsize, nbuf):
     while remain:
         t0 = time.monotonic_ns()
         while ser_data.inWaiting() == 0:
-            if time.monotonic_ns() - t0 > 1e9:
+            if time.monotonic_ns() - t0 > READ_TIMEOUT_S * 1e9:
                 # timeout waiting for data from device
                 break
             time.sleep(0.0001)


### PR DESCRIPTION
### Summary

On esp32 port when UART TX is also enabled then this will write output first. For the 16384 byte read test this takes around 1.4 seconds to send, so the USB read times out on the host. Workaround by increasing the timeout in the test.

*This work was funded through GitHub Sponsors.*

### Testing

* Verified `serial_test.py` fails the 16384 byte read test on `ESP32_GENERIC_S3` board due to timeout, and passes with this change.

### Trade-offs and Alternatives

* Ideally the implementation of `mp_hal_stdout_tx_strn` would try to buffer bytes into all of the output streams (UART, USB, dupterm, etc) in parallel. The USB performance would still be low with UART enabled, but it wouldn't have this latency for large writes (and could still be slightly faster, currently read_test is 0.080Mbit but I think it could be closer to 0.115Mbit with this change). This is hard to get right, though.