### PR TITLE
docs/collections: Document OrderedDict.popitem()'s CPython differences.

### DIFF
--- a/docs/library/collections.rst
+++ b/docs/library/collections.rst
@@ -101,3 +101,19 @@ Classes
         a 2
         w 5
         b 3
+
+    .. method:: OrderedDict.popitem()
+
+        Remove and return a (key, value) pair from the dictionary.
+        Pairs are returned in LIFO order.
+
+        .. admonition:: Difference to CPython
+            :class: attention
+
+            ``OrderedDict.popitem()`` does not support the ``last=False`` argument and
+            will always remove and return the last item if present.
+
+            A workaround for this is to use ``pop(<first_key>)`` to remove the first item::
+
+                first_key = next(iter(d))
+                d.pop(first_key)


### PR DESCRIPTION
### Summary

Documents difference with CPython and a document workaround provided by @anitschke.

`OrderedDict.popitem()` does not support the `last=False` argument and will always remove and return the last item if present.

closes https://github.com/micropython/micropython/issues/18370

### Testing

Tested locally using `sphinx-autobuild ./docs ./docs/build/html`

### Trade-offs and Alternatives

- no `cpydiff` tests has been added to avoid duplication
- the functionality could be implemented at a cost of approx 230 bytes on the unix port, but this seems quite large for a feature that is not often used , and for which a workaround is avaialable.
https://github.com/micropython/micropython/issues/18370#issuecomment-3491948812
