### PR TITLE
rp2/pendsv.c: PendSV_Handler dispatch check.

### DIFF
--- a/ports/rp2/pendsv.c
+++ b/ports/rp2/pendsv.c
@@ -180,5 +180,7 @@ void PendSV_Handler(void) {
 
     #if MICROPY_PY_THREAD
     mp_thread_recursive_mutex_unlock(&pendsv_mutex);
+    // Check if a dispatch occurred while the interrupt was being serviced
+    pendsv_resume_run_dispatch();
     #endif
 }


### PR DESCRIPTION
If MICROPY_PY_THREAD is set, PendSV_Handler acquires a mutex and calls the dispatch functions. If pendsv_schedule_dispatch is called by a higher priority interrupt while the mutex is acquired by PendSV_Handler it's possible for the dispatch to not be triggered.

Add a check for dispatch calls at the end of PendSV_Handler once the mutex has been released.

Fixes #18365

### Summary

If an IRQ - that uses the dispatch mechanism - goes off while the pendsv interrupt has its mutex acquired, it stops the dispatch function happening. Fix is to just check if any dispatch functions need to be called after releasing the mutex.

### Testing

This change resolves the issue I was seeing (on a port in development)
Ran all tests / Wifi still works!

### Trade-offs and Alternatives

There's a small possibility that dispatch functions will be called more than needed.
The new check for dispatch functions may itself be blocked if another thread manages to call pendsv_suspend, but they will be serviced when pendsv_resume is called