### PR TITLE
shared/tinyusb: Add macro to override TinyUSB callbacks.

### DIFF
--- a/shared/tinyusb/mp_usbd.c
+++ b/shared/tinyusb/mp_usbd.c
@@ -44,7 +44,7 @@ void mp_usbd_task_callback(mp_sched_node_t *node) {
 #endif // !MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
 
 // Schedule the TinyUSB task on demand, when there is a new USB device event
-TU_ATTR_FAST_FUNC void tud_event_hook_cb(uint8_t rhport, uint32_t eventid, bool in_isr) {
+TU_ATTR_FAST_FUNC void MICROPY_WRAP_TUD_EVENT_HOOK_CB(tud_event_hook_cb)(uint8_t rhport, uint32_t eventid, bool in_isr) {
     mp_usbd_schedule_task();
     mp_hal_wake_main_task_from_isr();
 }

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -29,6 +29,22 @@
 
 #include "py/mpconfig.h"
 
+#ifndef MICROPY_WRAP_TUD_SOF_CB
+#define MICROPY_WRAP_TUD_SOF_CB(name) name
+#endif
+
+#ifndef MICROPY_WRAP_TUD_CDC_RX_CB
+#define MICROPY_WRAP_TUD_CDC_RX_CB(name) name
+#endif
+
+#ifndef MICROPY_WRAP_TUD_CDC_LINE_STATE_CB
+#define MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(name) name
+#endif
+
+#ifndef MICROPY_WRAP_TUD_EVENT_HOOK_CB
+#define MICROPY_WRAP_TUD_EVENT_HOOK_CB(name) name
+#endif
+
 #if MICROPY_HW_ENABLE_USBDEV
 
 #include "py/obj.h"

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -68,7 +68,7 @@ uintptr_t mp_usbd_cdc_poll_interfaces(uintptr_t poll_flags) {
     return ret;
 }
 
-void tud_cdc_rx_cb(uint8_t itf) {
+void MICROPY_WRAP_TUD_CDC_RX_CB(tud_cdc_rx_cb)(uint8_t itf) {
     // consume pending USB data immediately to free usb buffer and keep the endpoint from stalling.
     // in case the ringbuffer is full, mark the CDC interface that need attention later on for polling
     cdc_itf_pending &= ~(1 << itf);
@@ -141,7 +141,7 @@ mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len) {
     return i;
 }
 
-void tud_sof_cb(uint32_t frame_count) {
+void MICROPY_WRAP_TUD_SOF_CB(tud_sof_cb)(uint32_t frame_count) {
     if (--cdc_connected_flush_delay < 0) {
         // Finished on-connection delay, disable SOF interrupt again.
         tud_sof_cb_enable(false);
@@ -172,7 +172,7 @@ static struct {
 } prev_line_state = {0};
 #endif
 
-void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
+void MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(tud_cdc_line_state_cb)(uint8_t itf, bool dtr, bool rts) {
     #if MICROPY_HW_USB_CDC && !MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC
     if (dtr) {
         // A host application has started to open the cdc serial port.

--- a/shared/tinyusb/mp_usbd_cdc.h
+++ b/shared/tinyusb/mp_usbd_cdc.h
@@ -27,6 +27,8 @@
 #ifndef MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H
 #define MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H
 
+#include "mp_usbd.h"
+
 #ifndef MICROPY_HW_USB_CDC_TX_TIMEOUT
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 #endif
@@ -38,7 +40,7 @@
 #endif
 
 uintptr_t mp_usbd_cdc_poll_interfaces(uintptr_t poll_flags);
-void tud_cdc_rx_cb(uint8_t itf);
+void MICROPY_WRAP_TUD_CDC_RX_CB(tud_cdc_rx_cb)(uint8_t itf);
 mp_uint_t mp_usbd_cdc_tx_strn(const char *str, mp_uint_t len);
 
 #endif // MICROPY_INCLUDED_SHARED_TINYUSB_MP_USBD_CDC_H


### PR DESCRIPTION
### Summary

I need to redirect some of the TinyUSB callbacks, but MicroPython implements them exclusively. So far I've been using linker `--wrap` with great success, sadly TinyUSB 0.19.0 adds weak symbols for callbacks which breaks the `--wrap` trick.
This patch adds `MICROPY_TINYUSB_CALLBACK` macro that by default expands to the callback name unchanged. Users can define this macro to add a prefix (e.g., mp_) to callback implementations, to redirect or completely override MicroPython's TinyUSB callbacks.

### Other changes

Add hook to mp_usbd_task. This adds an empty hook that gets called when running the USB task.

### Testing

`MICROPY_TINYUSB_CALLBACK` macro expands to the callback name unchanged, I've double checked the map file and in both cases (default, or defined to `mp_`) the symbols have the right names. Let me know if more testing needed.

### Trade-offs and Alternatives

This is the most direct way I could think of, however:

* `--wrap` no longer works with TinyUSB 0.19.0.
* `objcopy` to rename symbols. I had a hard time trying to get this to work, it requires complex rules somewhere, but might be a viable option if this is closed.
* Hooks?
```C
  // In mp_usbd_cdc.c
  void tud_cdc_rx_cb(uint8_t itf) {
      // Call user hook if registered
      if (mp_usbd_cdc_rx_hook != NULL) {
          if (mp_usbd_cdc_rx_hook(itf)) {
              return; // Hook handled it
          }
      }
      // Default implementation
      mp_usbd_cdc_rx_cb_default(itf);
  }
```
* `MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC` seems to have been needed at some point, but it requires a full implementation of those callbacks. I only need to redirect/override some of them.

* Make mp callbacks weak?
1- Rename those callbacks to `mp_tud_cdc_x`
2- Implement `tud_cdc_`  as yet another weak symbol that calls `mp_tud_cdc_x`
3- Now we can provide strong symbols that override them, and call `mp_tud_cdc_x` if needed.

This depends on the link order, I think the shared MP objects always come first though.