### PR TITLE
Adjust Pins used to allow tests on ESP32-C3.

### DIFF
--- a/tests/extmod/machine_i2s_rate.py
+++ b/tests/extmod/machine_i2s_rate.py
@@ -26,7 +26,11 @@ elif "mimxrt" in sys.platform:
         (2, Pin("D4"), Pin("D3"), Pin("D2"), None),
     )
 elif "esp32" in sys.platform:
-    i2s_instances = ((0, Pin(18), Pin(19), Pin(21), Pin(14)),)
+    try:
+        i2s_instances = ((0, Pin(18), Pin(19), Pin(21), Pin(14)),)
+    except ValueError:
+        # fallback to lower pin number for ESP32-C3
+        i2s_instances = ((0, Pin(6), Pin(7), Pin(10), Pin(11)),)
     # Allow for small additional RTOS overhead
     MAX_DELTA_MS = 8
 


### PR DESCRIPTION
### Summary

Changed the pin numbers used for the I2S rate testing as the pin numbers used were incompatible with the limited GPIO pins availalbe on the ESP32-C3 , causing the tests to fail 

### Testing

Ran the updated test against:
- ESP32_GENERIC
- ESP32_GENERIC_C3
- ESP32_GENERIC_S2
- ESP32_GENERIC_S3

### Trade-offs and Alternatives

Could use `sys.implementation._machine or ._build` to determine the board the tests is run on and adjust the pins based on that, rather than through exception handling.
