### PR TITLE
extmod.mk: Allow prebuilt MBEDTLS.

### DIFF
--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -242,6 +242,11 @@ SRC_THIRDPARTY_C += $(addprefix $(AXTLS_DIR)/,\
 	crypto/sha1.c \
 	)
 else ifeq ($(MICROPY_SSL_MBEDTLS),1)
+ifeq (${MBEDTLS_PREBUILT},1)     # Use prebuilt mbedtls
+MBEDTLS_CONFIG_FILE ?= \"mbedtls/mbedtls_config_port.h\"
+CFLAGS_EXTMOD += -DMICROPY_SSL_MBEDTLS=1
+CFLAGS_EXTMOD += -DMBEDTLS_CONFIG_FILE=$(MBEDTLS_CONFIG_FILE)
+else                             # Use mbedtls submodule
 MBEDTLS_DIR = lib/mbedtls
 MBEDTLS_CONFIG_FILE ?= \"mbedtls/mbedtls_config_port.h\"
 GIT_SUBMODULES += $(MBEDTLS_DIR)
@@ -327,6 +332,7 @@ SRC_THIRDPARTY_C += $(addprefix $(MBEDTLS_DIR)/library/,\
 	x509write_crt.c \
 	x509write_csr.c \
 	)
+endif
 endif
 endif
 


### PR DESCRIPTION

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

Some systems might have MBEDTLS ported, this allows using that instead of submodule.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

Checked locally using UNIX port on Ubuntu 22.04.





