### PR TITLE
mimxrt/eth: Add DP83867 PHY driver support.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -113,6 +113,7 @@ SRC_ETH_C += \
 	$(MCUX_SDK_DIR)/drivers/enet/fsl_enet.c \
 	hal/phy/device/phydp83825/fsl_phydp83825.c \
 	hal/phy/device/phydp83848/fsl_phydp83848.c \
+	hal/phy/device/phydp83867/fsl_phydp83867.c \
 	hal/phy/device/phyksz8081/fsl_phyksz8081.c \
 	hal/phy/device/phylan8720/fsl_phylan8720.c \
 	hal/phy/device/phyrtl8211f/fsl_phyrtl8211f.c \

--- a/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
@@ -167,9 +167,7 @@
     { IOMUXC_GPIO_AD_33_ENET_MDIO, 0, 0x06u }, \
     { IOMUXC_GPIO_AD_32_ENET_MDC, 0, 0x06u },
 
-// A second ETH port is present.
-#define ENET_DUAL_PORT         (1)
-// 1G Transceiver Phy Parameters
+// 1G Transceiver Phy Parameters (second ETH port)
 #define ENET_1_PHY_ADDRESS     (1)
 #define ENET_1_PHY             RTL8211F
 #define ENET_1_PHY_OPS         phyrtl8211f_ops

--- a/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
@@ -175,10 +175,6 @@
 #define ENET_1_PHY_OPS         phyrtl8211f_ops
 
 // 1G Ethernet PIN definitions
-// No INT pin for ENET_1G
-#define ENET_1_RESET_PIN       &pin_GPIO_DISP_B2_13
-#define ENET_1_INT_PIN         NULL
-
 #define IOMUX_TABLE_ENET_1 \
     { IOMUXC_GPIO_DISP_B1_00_ENET_1G_RX_EN, 0, 0x08U }, \
     { IOMUXC_GPIO_DISP_B1_01_ENET_1G_RX_CLK, 0, 0x08U }, \

--- a/ports/mimxrt/eth.c
+++ b/ports/mimxrt/eth.c
@@ -44,6 +44,7 @@
 #include "hal/phy/device/phyksz8081/fsl_phyksz8081.h"
 #include "hal/phy/device/phydp83825/fsl_phydp83825.h"
 #include "hal/phy/device/phydp83848/fsl_phydp83848.h"
+#include "hal/phy/device/phydp83867/fsl_phydp83867.h"
 #include "hal/phy/device/phylan8720/fsl_phylan8720.h"
 #include "hal/phy/device/phyrtl8211f/fsl_phyrtl8211f.h"
 
@@ -422,7 +423,7 @@ void eth_init_1(eth_t *self, int eth_id, const phy_operations_t *phy_ops, int ph
     uint32_t source_clock = eth_clock_init(eth_id, phy_clock);
 
     const machine_pin_obj_t *reset_pin = NULL;
-    #if defined(pin_ENET_1_INT)
+    #if defined(pin_ENET_1_RESET)
     reset_pin = pin_ENET_1_RESET;
     #endif
     const machine_pin_obj_t *int_pin = NULL;

--- a/ports/mimxrt/eth.h
+++ b/ports/mimxrt/eth.h
@@ -47,6 +47,7 @@ enum {
     PHY_KSZ8081 = 0,
     PHY_DP83825,
     PHY_DP83848,
+    PHY_DP83867,
     PHY_LAN8720,
     PHY_RTL8211F,
 };

--- a/ports/mimxrt/eth.h
+++ b/ports/mimxrt/eth.h
@@ -28,11 +28,14 @@
 #define MICROPY_INCLUDED_MIMXRT_ETH_H
 
 typedef struct _eth_t eth_t;
-extern eth_t eth_instance0;
-extern eth_t eth_instance1;
-void eth_init_0(eth_t *self, int mac_idx, const phy_operations_t *phy_ops, int phy_addr, bool phy_clock);
 
-#if defined(ENET_DUAL_PORT)
+#if defined(ENET_PHY_ADDRESS)
+extern eth_t eth_instance0;
+void eth_init_0(eth_t *self, int mac_idx, const phy_operations_t *phy_ops, int phy_addr, bool phy_clock);
+#endif
+
+#if defined(ENET_1_PHY_ADDRESS)
+extern eth_t eth_instance1;
 void eth_init_1(eth_t *self, int mac_idx, const phy_operations_t *phy_ops, int phy_addr, bool phy_clock);
 #endif
 

--- a/ports/mimxrt/hal/phy/device/phydp83867/fsl_phydp83867.c
+++ b/ports/mimxrt/hal/phy/device/phydp83867/fsl_phydp83867.c
@@ -1,0 +1,302 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "fsl_phydp83867.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief Defines the PHY DP83867 vendor defined registers. */
+#define PHY_PHYSTS_REG          0x11U /*!< The PHY Status register. */
+
+/*! @brief Defines the PHY DP83867 ID number. */
+#define PHY_CONTROL_ID1         0x2000U /*!< The PHY ID1 (upper 16 bits). */
+#define PHY_CONTROL_ID2         0xA231U /*!< The PHY ID2 (lower 16 bits). */
+#define PHY_FULL_ID             0x2000A231U /*!< Full PHY ID. */
+
+/*! @brief Defines the mask flag in PHYSTS register. */
+#define PHY_PHYSTS_LINKSTATUS_MASK  0x0400U /*!< The PHY link status mask. */
+#define PHY_PHYSTS_LINKSPEED_MASK   0xC000U /*!< The PHY link speed mask. */
+#define PHY_PHYSTS_LINKDUPLEX_MASK  0x2000U /*!< The PHY link duplex mask. */
+#define PHY_PHYSTS_LINKSPEED_SHIFT  14U     /*!< The link speed shift */
+
+/*! @brief Link speed values from PHYSTS register. */
+#define PHY_PHYSTS_LINKSPEED_10M    0U /*!< 10M link speed. */
+#define PHY_PHYSTS_LINKSPEED_100M   1U /*!< 100M link speed. */
+#define PHY_PHYSTS_LINKSPEED_1000M  2U /*!< 1000M link speed. */
+
+/*! @brief Defines the timeout macro. */
+#define PHY_READID_TIMEOUT_COUNT    1000U
+
+/*******************************************************************************
+ * Prototypes
+ ******************************************************************************/
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+
+const phy_operations_t phydp83867_ops = {.phyInit = PHY_DP83867_Init,
+                                         .phyWrite = PHY_DP83867_Write,
+                                         .phyRead = PHY_DP83867_Read,
+                                         .getAutoNegoStatus = PHY_DP83867_GetAutoNegotiationStatus,
+                                         .getLinkStatus = PHY_DP83867_GetLinkStatus,
+                                         .getLinkSpeedDuplex = PHY_DP83867_GetLinkSpeedDuplex,
+                                         .setLinkSpeedDuplex = PHY_DP83867_SetLinkSpeedDuplex,
+                                         .enableLoopback = PHY_DP83867_EnableLoopback};
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+
+status_t PHY_DP83867_Init(phy_handle_t *handle, const phy_config_t *config) {
+    uint32_t counter = PHY_READID_TIMEOUT_COUNT;
+    status_t result;
+    uint32_t regValue = 0U;
+
+
+    /* Init MDIO interface. */
+    MDIO_Init(handle->mdioHandle);
+
+    /* Assign phy address. */
+    handle->phyAddr = config->phyAddr;
+
+
+    /* Check PHY ID. */
+    do
+    {
+        result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_ID1_REG, &regValue);
+        if (result != kStatus_Success) {
+            return result;
+        }
+        counter--;
+    } while ((regValue != PHY_CONTROL_ID1) && (counter != 0U));
+
+    if (counter == 0U) {
+        return kStatus_Fail;
+    }
+
+
+    /* Reset PHY. */
+    result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, PHY_BCTL_RESET_MASK);
+    if (result != kStatus_Success) {
+        return result;
+    }
+
+
+    /* Wait for reset to complete */
+    counter = PHY_READID_TIMEOUT_COUNT;
+    do {
+        result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, &regValue);
+        if (result != kStatus_Success) {
+            return result;
+        }
+        counter--;
+    } while ((regValue & PHY_BCTL_RESET_MASK) && (counter != 0U));
+
+    if (counter == 0U) {
+        return kStatus_Fail;
+    }
+
+
+    if (config->autoNeg) {
+        /* Set the auto-negotiation. */
+        result =
+            MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_AUTONEG_ADVERTISE_REG,
+                PHY_100BASETX_FULLDUPLEX_MASK | PHY_100BASETX_HALFDUPLEX_MASK | PHY_10BASETX_FULLDUPLEX_MASK |
+                PHY_10BASETX_HALFDUPLEX_MASK | PHY_IEEE802_3_SELECTOR_MASK);
+        if (result == kStatus_Success) {
+            result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_1000BASET_CONTROL_REG,
+                PHY_1000BASET_FULLDUPLEX_MASK);
+            if (result == kStatus_Success) {
+                result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, &regValue);
+                if (result == kStatus_Success) {
+                    result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG,
+                        (regValue | PHY_BCTL_AUTONEG_MASK | PHY_BCTL_RESTART_AUTONEG_MASK));
+                }
+            }
+        }
+    } else {
+        /* Disable isolate mode */
+        result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, &regValue);
+        if (result != kStatus_Success) {
+            return result;
+        }
+        regValue &= ~PHY_BCTL_ISOLATE_MASK;
+        result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, regValue);
+        if (result != kStatus_Success) {
+            return result;
+        }
+
+        /* Disable the auto-negotiation and set user-defined speed/duplex configuration. */
+        result = PHY_DP83867_SetLinkSpeedDuplex(handle, config->speed, config->duplex);
+    }
+
+
+    return result;
+}
+
+status_t PHY_DP83867_Write(phy_handle_t *handle, uint32_t phyReg, uint32_t data) {
+    return MDIO_Write(handle->mdioHandle, handle->phyAddr, phyReg, data);
+}
+
+status_t PHY_DP83867_Read(phy_handle_t *handle, uint32_t phyReg, uint32_t *dataPtr) {
+    return MDIO_Read(handle->mdioHandle, handle->phyAddr, phyReg, dataPtr);
+}
+
+status_t PHY_DP83867_GetAutoNegotiationStatus(phy_handle_t *handle, bool *status) {
+    assert(status);
+
+    status_t result;
+    uint32_t regValue;
+
+    *status = false;
+
+    /* Check auto negotiation complete. */
+    result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICSTATUS_REG, &regValue);
+    if (result == kStatus_Success) {
+        if ((regValue & PHY_BSTATUS_AUTONEGCOMP_MASK) != 0U) {
+            *status = true;
+        }
+    }
+    return result;
+}
+
+status_t PHY_DP83867_GetLinkStatus(phy_handle_t *handle, bool *status) {
+    assert(status);
+
+    status_t result;
+    uint32_t regValue;
+
+    /* Read the PHY Status register. */
+    result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_PHYSTS_REG, &regValue);
+    if (result == kStatus_Success) {
+        if ((PHY_PHYSTS_LINKSTATUS_MASK & regValue) != 0U) {
+            /* Link up. */
+            *status = true;
+        } else {
+            /* Link down. */
+            *status = false;
+        }
+    }
+    return result;
+}
+
+status_t PHY_DP83867_GetLinkSpeedDuplex(phy_handle_t *handle, phy_speed_t *speed, phy_duplex_t *duplex) {
+    assert(!((speed == NULL) && (duplex == NULL)));
+
+    status_t result;
+    uint32_t regValue;
+
+    /* Read the status register. */
+    result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_PHYSTS_REG, &regValue);
+    if (result == kStatus_Success) {
+        if (speed != NULL) {
+            switch ((regValue & PHY_PHYSTS_LINKSPEED_MASK) >> PHY_PHYSTS_LINKSPEED_SHIFT)
+            {
+                case PHY_PHYSTS_LINKSPEED_10M:
+                    *speed = kPHY_Speed10M;
+                    break;
+                case PHY_PHYSTS_LINKSPEED_100M:
+                    *speed = kPHY_Speed100M;
+                    break;
+                case PHY_PHYSTS_LINKSPEED_1000M:
+                    *speed = kPHY_Speed1000M;
+                    break;
+                default:
+                    *speed = kPHY_Speed10M;
+                    break;
+            }
+        }
+
+        if (duplex != NULL) {
+            if ((regValue & PHY_PHYSTS_LINKDUPLEX_MASK) != 0U) {
+                *duplex = kPHY_FullDuplex;
+            } else {
+                *duplex = kPHY_HalfDuplex;
+            }
+        }
+    }
+    return result;
+}
+
+status_t PHY_DP83867_SetLinkSpeedDuplex(phy_handle_t *handle, phy_speed_t speed, phy_duplex_t duplex) {
+    status_t result;
+    uint32_t regValue;
+
+    result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, &regValue);
+    if (result == kStatus_Success) {
+        /* Disable the auto-negotiation and set according to user-defined configuration. */
+        regValue &= ~PHY_BCTL_AUTONEG_MASK;
+        if (speed == kPHY_Speed1000M) {
+            regValue &= ~PHY_BCTL_SPEED0_MASK;
+            regValue |= PHY_BCTL_SPEED1_MASK;
+        } else if (speed == kPHY_Speed100M) {
+            regValue |= PHY_BCTL_SPEED0_MASK;
+            regValue &= ~PHY_BCTL_SPEED1_MASK;
+        } else {
+            regValue &= ~PHY_BCTL_SPEED0_MASK;
+            regValue &= ~PHY_BCTL_SPEED1_MASK;
+        }
+        if (duplex == kPHY_FullDuplex) {
+            regValue |= PHY_BCTL_DUPLEX_MASK;
+        } else {
+            regValue &= ~PHY_BCTL_DUPLEX_MASK;
+        }
+        result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, regValue);
+    }
+    return result;
+}
+
+status_t PHY_DP83867_EnableLoopback(phy_handle_t *handle, phy_loop_t mode, phy_speed_t speed, bool enable) {
+    /* This PHY only supports local loopback. */
+    assert(mode == kPHY_LocalLoop);
+
+    status_t result;
+    uint32_t regValue;
+
+    /* Set the loop mode. */
+    if (enable) {
+        if (speed == kPHY_Speed1000M) {
+            regValue = PHY_BCTL_SPEED1_MASK | PHY_BCTL_DUPLEX_MASK | PHY_BCTL_LOOP_MASK;
+        } else if (speed == kPHY_Speed100M) {
+            regValue = PHY_BCTL_SPEED0_MASK | PHY_BCTL_DUPLEX_MASK | PHY_BCTL_LOOP_MASK;
+        } else {
+            regValue = PHY_BCTL_DUPLEX_MASK | PHY_BCTL_LOOP_MASK;
+        }
+        result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, regValue);
+    } else {
+        /* First read the current status in control register. */
+        result = MDIO_Read(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG, &regValue);
+        if (result == kStatus_Success) {
+            regValue &= ~PHY_BCTL_LOOP_MASK;
+            result = MDIO_Write(handle->mdioHandle, handle->phyAddr, PHY_BASICCONTROL_REG,
+                (regValue | PHY_BCTL_RESTART_AUTONEG_MASK));
+        }
+    }
+    return result;
+}

--- a/ports/mimxrt/hal/phy/device/phydp83867/fsl_phydp83867.h
+++ b/ports/mimxrt/hal/phy/device/phydp83867/fsl_phydp83867.h
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _FSL_PHYDP83867_H_
+#define _FSL_PHYDP83867_H_
+
+#include "fsl_phy.h"
+
+/*!
+ * @addtogroup phy_driver
+ * @{
+ */
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+
+/*! @brief PHY operations structure. */
+extern const phy_operations_t phydp83867_ops;
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*!
+ * @name PHY Driver
+ * @{
+ */
+
+/*!
+ * @brief Initializes PHY.
+ *
+ *  This function initialize PHY.
+ *
+ * @param handle       PHY device handle.
+ * @param config       Pointer to structure of phy_config_t.
+ * @retval kStatus_Success  PHY initialization succeeds
+ * @retval kStatus_Fail  PHY initialization fails
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_Init(phy_handle_t *handle, const phy_config_t *config);
+
+/*!
+ * @brief PHY Write function. This function writes data over the SMI to
+ * the specified PHY register. This function is called by all PHY interfaces.
+ *
+ * @param handle  PHY device handle.
+ * @param phyReg  The PHY register.
+ * @param data    The data written to the PHY register.
+ * @retval kStatus_Success     PHY write success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_Write(phy_handle_t *handle, uint32_t phyReg, uint32_t data);
+
+/*!
+ * @brief PHY Read function. This interface reads data over the SMI from the
+ * specified PHY register. This function is called by all PHY interfaces.
+ *
+ * @param handle   PHY device handle.
+ * @param phyReg   The PHY register.
+ * @param dataPtr  The address to store the data read from the PHY register.
+ * @retval kStatus_Success  PHY read success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_Read(phy_handle_t *handle, uint32_t phyReg, uint32_t *dataPtr);
+
+/*!
+ * @brief Gets the PHY auto-negotiation status.
+ *
+ * @param handle   PHY device handle.
+ * @param status   The auto-negotiation status of the PHY.
+ *         - true the auto-negotiation is over.
+ *         - false the auto-negotiation is on-going or not started.
+ * @retval kStatus_Success   PHY gets status success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_GetAutoNegotiationStatus(phy_handle_t *handle, bool *status);
+
+/*!
+ * @brief Gets the PHY link status.
+ *
+ * @param handle   PHY device handle.
+ * @param status   The link up or down status of the PHY.
+ *         - true the link is up.
+ *         - false the link is down.
+ * @retval kStatus_Success   PHY gets link status success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_GetLinkStatus(phy_handle_t *handle, bool *status);
+
+/*!
+ * @brief Gets the PHY link speed and duplex.
+ *
+ * @brief This function gets the speed and duplex mode of PHY. User can give one of speed
+ * and duplex address parameter and set the other as NULL if only wants to get one of them.
+ *
+ * @param handle   PHY device handle.
+ * @param speed    The address of PHY link speed.
+ * @param duplex   The link duplex of PHY.
+ * @retval kStatus_Success   PHY gets link speed and duplex success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_GetLinkSpeedDuplex(phy_handle_t *handle, phy_speed_t *speed, phy_duplex_t *duplex);
+
+/*!
+ * @brief Sets the PHY link speed and duplex.
+ *
+ * @param handle   PHY device handle.
+ * @param speed    Specified PHY link speed.
+ * @param duplex   Specified PHY link duplex.
+ * @retval kStatus_Success   PHY gets status success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_SetLinkSpeedDuplex(phy_handle_t *handle, phy_speed_t speed, phy_duplex_t duplex);
+
+/*!
+ * @brief Enables/disables PHY loopback.
+ *
+ * @param handle   PHY device handle.
+ * @param mode     The loopback mode to be enabled, please see "phy_loop_t".
+ * All loopback modes should not be set together, when one loopback mode is set
+ * another should be disabled.
+ * @param speed    PHY speed for loopback mode.
+ * @param enable   True to enable, false to disable.
+ * @retval kStatus_Success  PHY loopback success
+ * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
+ */
+status_t PHY_DP83867_EnableLoopback(phy_handle_t *handle, phy_loop_t mode, phy_speed_t speed, bool enable);
+
+/* @} */
+
+#if defined(__cplusplus)
+}
+#endif
+
+/*! @}*/
+
+#endif /* _FSL_PHYDP83867_H_ */

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -179,7 +179,7 @@ uint32_t trng_random_u32(void);
 
 // Hooks to add builtins
 
-#if defined(IOMUX_TABLE_ENET)
+#if defined(ENET_PHY_ADDRESS) || defined(ENET_1_PHY_ADDRESS)
 extern const struct _mp_obj_type_t network_lan_type;
 #define MICROPY_HW_NIC_ETH                  { MP_ROM_QSTR(MP_QSTR_LAN), MP_ROM_PTR(&network_lan_type) },
 #else

--- a/ports/mimxrt/network_lan.c
+++ b/ports/mimxrt/network_lan.c
@@ -28,7 +28,7 @@
 #include "py/mphal.h"
 #include "extmod/modnetwork.h"
 
-#if defined(IOMUX_TABLE_ENET)
+#if defined(ENET_PHY_ADDRESS) || defined(ENET_1_PHY_ADDRESS)
 
 #include "fsl_phy.h"
 #include "eth.h"
@@ -55,9 +55,13 @@ typedef struct _network_lan_obj_t {
     eth_t *eth;
 } network_lan_obj_t;
 
+// Forward declaration of the type
+extern const mp_obj_type_t network_lan_type;
 
+#if defined(ENET_PHY_ADDRESS)
 static const network_lan_obj_t network_lan_eth0 = { { &network_lan_type }, &eth_instance0 };
-#if defined(ENET_DUAL_PORT)
+#endif
+#if defined(ENET_1_PHY_ADDRESS)
 static const network_lan_obj_t network_lan_eth1 = { { &network_lan_type }, &eth_instance1 };
 #endif
 
@@ -65,8 +69,19 @@ static void network_lan_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     network_lan_obj_t *self = MP_OBJ_TO_PTR(self_in);
     struct netif *netif = eth_netif(self->eth);
     int status = eth_link_status(self->eth);
+    int eth_id = 0;
+    #if defined(ENET_PHY_ADDRESS)
+    if (self->eth == &eth_instance0) {
+        eth_id = 0;
+    }
+    #endif
+    #if defined(ENET_1_PHY_ADDRESS)
+    if (self->eth == &eth_instance1) {
+        eth_id = 1;
+    }
+    #endif
     mp_printf(print, "<ETH%d status=%u ip=%u.%u.%u.%u>",
-        self->eth == &eth_instance0 ? 0 : 1,
+        eth_id,
         status,
         netif->ip_addr.addr & 0xff,
         netif->ip_addr.addr >> 8 & 0xff,
@@ -77,8 +92,18 @@ static void network_lan_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 
 static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_phy_type, ARG_phy_addr, ARG_ref_clk_mode};
+
+    // Default to port 0 if ENET available, else port 1 if only ENET_1 available
+    #if defined(ENET_PHY_ADDRESS)
+    #define DEFAULT_ETH_ID 0
+    #elif defined(ENET_1_PHY_ADDRESS)
+    #define DEFAULT_ETH_ID 1
+    #else
+    #error "No Ethernet PHY configured"
+    #endif
+
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_id, MP_ARG_INT, {.u_int = DEFAULT_ETH_ID} },
         { MP_QSTR_phy_type, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_phy_addr, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_ref_clk_mode, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
@@ -92,18 +117,21 @@ static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, s
     bool phy_clock;
 
     int mac_id = args[ARG_id].u_int;
-    // set default
+    // set default based on which interface is being used
+    #if defined(ENET_PHY_ADDRESS)
     if (mac_id == 0) {
         phy_ops = &ENET_PHY_OPS;
         phy_addr = ENET_PHY_ADDRESS;
         phy_clock = ENET_TX_CLK_OUTPUT;
-    #if defined(ENET_DUAL_PORT)
-    } else {
+    }
+    #endif
+    #if defined(ENET_1_PHY_ADDRESS)
+    if (mac_id == 1) {
         phy_ops = &ENET_1_PHY_OPS;
         phy_addr = ENET_1_PHY_ADDRESS;
         phy_clock = ENET_1_TX_CLK_OUTPUT;
-    #endif
     }
+    #endif
 
     // Select PHY driver
     int phy_type = args[ARG_phy_type].u_int;
@@ -132,17 +160,21 @@ static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, s
         phy_clock = args[ARG_ref_clk_mode].u_int;
     }
 
-    // Prepare for two ETH interfaces.
-    const network_lan_obj_t *self;
+    // Initialize the appropriate ETH interface
+    const network_lan_obj_t *self = NULL;
+    #if defined(ENET_PHY_ADDRESS)
     if (mac_id == 0) {
         self = &network_lan_eth0;
         eth_init_0(self->eth, MP_HAL_MAC_ETH0, phy_ops, phy_addr, phy_clock);
-    #if defined(ENET_DUAL_PORT)
-    } else if (mac_id == 1) {
+    }
+    #endif
+    #if defined(ENET_1_PHY_ADDRESS)
+    if (mac_id == 1) {
         self = &network_lan_eth1;
         eth_init_1(self->eth, MP_HAL_MAC_ETH1, phy_ops, phy_addr, phy_clock);
+    }
     #endif
-    } else {
+    if (self == NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Invalid LAN interface %d"), mac_id);
     }
 
@@ -275,4 +307,4 @@ MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 
-#endif // defined(IOMUX_TABLE_ENET)
+#endif // defined(ENET_PHY_ADDRESS) || defined(ENET_1_PHY_ADDRESS)

--- a/ports/mimxrt/network_lan.c
+++ b/ports/mimxrt/network_lan.c
@@ -35,6 +35,7 @@
 #include "hal/phy/device/phyksz8081/fsl_phyksz8081.h"
 #include "hal/phy/device/phydp83825/fsl_phydp83825.h"
 #include "hal/phy/device/phydp83848/fsl_phydp83848.h"
+#include "hal/phy/device/phydp83867/fsl_phydp83867.h"
 #include "hal/phy/device/phylan8720/fsl_phylan8720.h"
 #include "hal/phy/device/phyrtl8211f/fsl_phyrtl8211f.h"
 
@@ -113,6 +114,8 @@ static mp_obj_t network_lan_make_new(const mp_obj_type_t *type, size_t n_args, s
             phy_ops = &phydp83825_ops;
         } else if (phy_type == PHY_DP83848) {
             phy_ops = &phydp83848_ops;
+        } else if (phy_type == PHY_DP83867) {
+            phy_ops = &phydp83867_ops;
         } else if (phy_type == PHY_LAN8720) {
             phy_ops = &phylan8720_ops;
         } else if (phy_type == PHY_RTL8211F) {
@@ -254,6 +257,7 @@ static const mp_rom_map_elem_t network_lan_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PHY_KSZ8081), MP_ROM_INT(PHY_KSZ8081) },
     { MP_ROM_QSTR(MP_QSTR_PHY_DP83825), MP_ROM_INT(PHY_DP83825) },
     { MP_ROM_QSTR(MP_QSTR_PHY_DP83848), MP_ROM_INT(PHY_DP83848) },
+    { MP_ROM_QSTR(MP_QSTR_PHY_DP83867), MP_ROM_INT(PHY_DP83867) },
     { MP_ROM_QSTR(MP_QSTR_PHY_LAN8720), MP_ROM_INT(PHY_LAN8720) },
     { MP_ROM_QSTR(MP_QSTR_PHY_RTL8211F), MP_ROM_INT(PHY_RTL8211F) },
     { MP_ROM_QSTR(MP_QSTR_IN), MP_ROM_INT(PHY_TX_CLK_IN) },


### PR DESCRIPTION
This PR adds support for the Texas Instruments DP83867 Gigabit Ethernet PHY to the mimxrt port.

## Changes

**New driver implementation:**
- Add `fsl_phydp83867.c` and `fsl_phydp83867.h` implementing the DP83867 PHY driver
- Supports 10/100/1000 Mbps Ethernet with auto-negotiation
- Implements standard PHY operations interface (init, read/write, link status detection, speed/duplex configuration, loopback mode)
- Uses DP83867-specific PHYSTS register (0x11) for link status monitoring
- PHY ID verification: 0x2000A231

**Integration:**
- Add driver to mimxrt Makefile build system
- Include DP83867 header in `eth.c` and `network_lan.c`

**Bug fix:**
- Fix incorrect conditional check in `eth.c:426` - changed from `pin_ENET_1_INT` to `pin_ENET_1_RESET` to properly initialize reset pin
- Update `network_lan.c` conditional compilation to check `ENET_PHY_ADDRESS || ENET_DUAL_PORT` instead of `IOMUX_TABLE_ENET`

This driver enables Gigabit Ethernet support on boards using the DP83867 PHY, such as the phyCORE-i.MX RT1170's secondary Ethernet port (1G RGMII interface).