### PR TITLE
unix: enable optional system MbedTLS UNIX port

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -193,6 +193,20 @@ CFLAGS += $(LIBFFI_CFLAGS) -DMICROPY_PY_FFI=1
 LDFLAGS += $(LIBFFI_LDFLAGS)
 endif
 
+# ---------------------------------------------------------------------
+# Optional: use system-provided MbedTLS instead of the bundled one
+# ---------------------------------------------------------------------
+ifeq ($(MICROPY_USE_SYSTEM_MBEDTLS),1)
+    MBEDTLS_CFLAGS := $(shell pkg-config --cflags mbedtls)
+    MBEDTLS_LDFLAGS := $(shell pkg-config --libs mbedtls)
+    CFLAGS += $(MBEDTLS_CFLAGS) -DMICROPY_USE_SYSTEM_MBEDTLS=1
+    LDFLAGS += $(MBEDTLS_LDFLAGS)
+else
+    MBEDTLS_DIR = $(TOP)/lib/mbedtls
+    include $(MBEDTLS_DIR)/Makefile
+endif
+
+
 ifeq ($(MICROPY_PY_JNI),1)
 # Path for 64-bit OpenJDK, should be adjusted for other JDKs
 CFLAGS += -I/usr/lib/jvm/java-7-openjdk-amd64/include -DMICROPY_PY_JNI=1


### PR DESCRIPTION
 Added optional support for mbedTLS that can be taken by passing arguments
Fixes issue: https://github.com/micropython/micropython/issues/18319

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
* MicroPython’s UNIX port by default uses a bundled lib/mbedtls submodule.

* This causes issues if the submodule is missing or you prefer the system-installed MbedTLS.
* MICROPY_USE_SYSTEM_MBEDTLS=1 tells the Makefile to use the system-installed MbedTLS
 ### Benefits:

> No need for lib/mbedtls submodule.

> Uses system-managed MbedTLS version.

> Optional: can revert to bundled submodule by not setting the flag.

> Portable: works on different Linux systems if pkg-config is available.


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
<img width="1314" height="736" alt="image" src="https://github.com/user-attachments/assets/2836f1ac-393a-48a3-ab0a-4ab05afdfc03" />
It is successfully building after the change using MBED TLS.

Need to export the value before :
<img width="1314" height="736" alt="image" src="https://github.com/user-attachments/assets/be6d0730-eb42-4c68-8d3b-6af168778e93" />

Signals to the ports/unix/Makefile that you want to link against the system-installed MbedTLS rather than the bundled lib/mbedtls submodule.

It’s a clean way to make the build optional — you can turn it off just by not exporting it.

Why it’s needed:

* MicroPython’s UNIX port by default expects the bundled lib/mbedtls.

* If you want to avoid downloading or maintaining the submodule, this variable instructs the Makefile to skip it.


### Trade-offs and Alternatives
* You could also hardcode the use of system MbedTLS in the Makefile by directly editing it, but that makes the build less flexible for others who might want the bundled version.

Note:
Ensure you have the necessary packages:
<img width="1314" height="736" alt="image" src="https://github.com/user-attachments/assets/856d5727-5874-470a-afde-900694ba5028" />


<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

