### PR TITLE
tests/serial_test.py: add a serial echo test

### DIFF
--- a/tests/serial_test.py
+++ b/tests/serial_test.py
@@ -86,6 +86,8 @@ def drain_input(ser):
 
 
 def send_script(ser, script):
+    ser.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
+    drain_input(ser)
     chunk_size = 32
     for i in range(0, len(script), chunk_size):
         ser.write(script[i : i + chunk_size])
@@ -109,8 +111,6 @@ def read_test(ser_repl, ser_data, bufsize, nbuf):
     READ_TIMEOUT_S = 2
 
     # Load and run the read_test_script.
-    ser_repl.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
-    drain_input(ser_repl)
     script = bytes(read_test_script % (bufsize, nbuf), "ascii")
     send_script(ser_repl, script)
 
@@ -166,8 +166,6 @@ def write_test(ser_repl, ser_data, bufsize, nbuf, verified):
     global test_passed
 
     # Load and run the write_test_script.
-    ser_repl.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
-    drain_input(ser_repl)
     if verified:
         script = write_test_script_verified
     else:


### PR DESCRIPTION
### Summary

The existing `serial_test.py` script tests data in/out throughput and reliability.  But it only tests data sizes that are a power of two.  It's also important to test reliability of data in/out that is not a power of two.

This PR adds a new echo sub-test to the `serial_test.py` script.  It sends out data to the board and gets the board to echo it back, and then compares the result (the echo'd data should be equal to the sent data).  It does this for data packets between 1 and 520 (inclusive) bytes.  That covers USB FS and HS packet sizes (64 and 512 respectively).

It uses random data for the test, but seeded by a constant seed so that it's deterministic.  If there's an error then it prints out all the sent and echo'd data to make it easier to see where it went wrong (eg if the previous packet was repeated).

### Testing

Tested on PYBV11 with the stm32 and TinyUSB stacks:
- using Linux as the host the new tests pass
- using macOS as the host, the stm32 USB stack passes the test, but TinyUSB fails!

Testing ESP32-S3 (uses TinyUSB), again it passes on Linux but fails on macOS.

So, this is an important test, it found a bug.

### Trade-offs and Alternatives

It takes around 10 seconds to run on a board with UART REPL, but I'm not sure how to make that faster without decreasing the coverage of the test.
