### PR TITLE
lib/tinyusb: Update to version 0.19.0-24.

### DIFF
--- a/ports/nrf/drivers/usb/tusb_config.h
+++ b/ports/nrf/drivers/usb/tusb_config.h
@@ -31,4 +31,11 @@
 // Device configuration
 #define CFG_TUSB_MCU                OPT_MCU_NRF5X
 
+// TinyUSB uses newer style errata functions, but we currently don't have the
+// latest nrfx component.  So provide macros mapping the new name to the old.
+#include "nrfx_usbd_errata.h"
+#define nrf52_errata_166 nrfx_usbd_errata_166
+#define nrf52_errata_171 nrfx_usbd_errata_171
+#define nrf52_errata_187 nrfx_usbd_errata_187
+
 #endif // MICROPY_INCLUDED_NRF_TUSB_CONFIG_H

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -61,19 +61,12 @@
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
     #if MICROPY_HW_USB_CDC
-    tud_cdc_configure_fifo_t cfg = { .rx_persistent = 0,
-                                     .tx_persistent = 1,
-
-                                     // This config flag is unreleased in TinyUSB >v0.18.0
-                                     // but included in Espressif's TinyUSB component since v0.18.0~3
-                                     //
-                                     // Versioning issue reported as
-                                     // https://github.com/espressif/esp-usb/issues/236
-                                     #if TUSB_VERSION_NUMBER > 1800 || defined(ESP_PLATFORM)
-                                     .tx_overwritabe_if_not_connected = 1,
-                                     #endif
+    tud_cdc_configure_t cfg = {
+        .rx_persistent = 0,
+        .tx_persistent = 1,
+        .tx_overwritabe_if_not_connected = 1,
     };
-    tud_cdc_configure_fifo(&cfg);
+    tud_cdc_configure(&cfg);
     #endif
 }
 


### PR DESCRIPTION
### Summary

This PR updates TinyUSB to 0.19.0-24.  That's 0.19.0 plus the following changes:
- remove obsolete dcd_esp32sx
- fix for HID stylus descriptor and HID example
- typos, docs and generator scripts
- MTP fix
- DWC2 enumeration when EP0 size=8
- DWC2 fix for EP0 IN
- stm32 FSDEV IRQ remapping fix
- DWC2 ZLP fix

The reason we need the extra 24 commits is due to a bug with TinyUSB's handling of zero-length-packets in the DWC2 (Synopsis) backend, which affects the stm32 port.  That's fixed by https://github.com/hathach/tinyusb/pull/3293

(The same DWC2 bug affects ESP32-Sx, but needs to be fixed separately because we are using the IDF component manager to get TinyUSB for the esp32 port.)

### Testing

Tested on Linux and macOS using the test from #18402, with the following boards:
- rp2 Pico: ok
- rp2 Pico 2 RISCV: ok
- mimxrt TEENSY40: ok (although fails DATA IN for largest packet, but that's also on current TinyUSB)
- samd ADAFRUIT_ITSYBITSY_M0_EXPRESS: ok (but fails DATA OUT verified for 16k packets, but that's also on current TinyUSB)
- stm32 PYBV10: ok
- stm32 OPENMV_N6: ok (but known issue with soft reset)
- nrf ARDUINO_NANO_33_BLE_SENSE: ok

### Trade-offs and Alternatives

Not much alternative here, we anyway need to update TinyUSB to keep up with the latest version, and get STM32N6 support.
