### PR TITLE
ports: Reduce pin structures footprint.

### DIFF
--- a/ports/cc3200/mods/pybpin.h
+++ b/ports/cc3200/mods/pybpin.h
@@ -88,7 +88,7 @@ enum {
 };
 
 typedef struct {
-  qstr name;
+  qstr_short_t name;
   int8_t  idx;
   uint8_t fn;
   uint8_t unit;

--- a/ports/mimxrt/pin.h
+++ b/ports/mimxrt/pin.h
@@ -106,7 +106,7 @@ enum {
 
 typedef struct {
     mp_obj_base_t base;
-    qstr name;  // port name
+    qstr_short_t name;  // port name
     uint8_t af_mode;  // alternate function
     uint8_t input_daisy;
     void *instance;  // pointer to peripheral instance for alternate function
@@ -121,15 +121,15 @@ typedef struct {
 
 typedef struct {
     mp_obj_base_t base;
-    qstr name;  // pad name
     GPIO_Type *gpio;  // gpio instance for pin
     uint32_t pin;  // pin number
     uint32_t muxRegister;
     uint32_t configRegister;
-    uint8_t af_list_len;  // length of available alternate functions list
-    uint8_t adc_list_len; // length of available ADC options list
     const machine_pin_af_obj_t *af_list;  // pointer to list with alternate functions
     const machine_pin_adc_obj_t *adc_list; // pointer to list with ADC options
+    qstr_short_t name;  // pad name
+    uint8_t af_list_len;  // length of available alternate functions list
+    uint8_t adc_list_len; // length of available ADC options list
 } machine_pin_obj_t;
 
 typedef struct _machine_pin_irq_obj_t {

--- a/ports/nrf/modules/machine/pin.h
+++ b/ports/nrf/modules/machine/pin.h
@@ -56,7 +56,6 @@ typedef struct {
     uint32_t adc_channel : 5; // Some ARM processors use 32 bits/PORT
     uint32_t adc_num  : 3;  // 1 bit per ADC
     const pin_af_obj_t *af;
-    uint32_t pull;
 } pin_obj_t;
 
 extern const mp_obj_type_t pin_type;

--- a/ports/renesas-ra/pin.h
+++ b/ports/renesas-ra/pin.h
@@ -41,9 +41,9 @@ typedef struct {
 
 typedef struct {
     mp_obj_base_t base;
-    qstr name;
-    uint8_t pin;
     const machine_pin_adc_obj_t *ad;
+    qstr_short_t name;
+    uint8_t pin;
 } machine_pin_obj_t;
 
 // Include all of the individual pin objects

--- a/ports/rp2/machine_pin.h
+++ b/ports/rp2/machine_pin.h
@@ -40,7 +40,7 @@ enum {
 
 typedef struct _machine_pin_af_obj_t {
     mp_obj_base_t base;
-    qstr name;
+    qstr_short_t name;
     uint8_t idx     : 4;
     uint8_t fn      : 4;
     uint8_t unit    : 8;
@@ -48,7 +48,7 @@ typedef struct _machine_pin_af_obj_t {
 
 typedef struct _machine_pin_obj_t {
     mp_obj_base_t base;
-    qstr name;
+    qstr_short_t name;
     uint8_t id                  : 6;
     #if MICROPY_HW_PIN_EXT_COUNT
     uint8_t is_ext              : 1;

--- a/ports/samd/boards/pins_prefix.c
+++ b/ports/samd/boards/pins_prefix.c
@@ -11,11 +11,11 @@
 #if defined(MCU_SAMD21)
 
 #define PIN(p_name, p_eic, p_adc0, p_sercom1, p_sercom2, p_tcc1, p_tcc2) \
-    {{&machine_pin_type}, PIN_##p_name, MP_QSTR_##p_name, p_eic, p_adc0, p_sercom1, p_sercom2, p_tcc1, p_tcc2 }
+    {{&machine_pin_type}, MP_QSTR_##p_name, PIN_##p_name, p_eic, p_adc0, p_sercom1, p_sercom2, p_tcc1, p_tcc2 }
 
 #elif defined(MCU_SAMD51)
 
 #define PIN(p_name, p_eic, p_adc0, p_adc1, p_sercom1, p_sercom2, p_tc, p_tcc1, p_tcc2) \
-    {{&machine_pin_type}, PIN_##p_name, MP_QSTR_##p_name, p_eic, p_adc0, p_adc1, p_sercom1, p_sercom2, p_tc, p_tcc1, p_tcc2 }
+    {{&machine_pin_type}, MP_QSTR_##p_name, PIN_##p_name, p_eic, p_adc0, p_adc1, p_sercom1, p_sercom2, p_tc, p_tcc1, p_tcc2 }
 
 #endif

--- a/ports/samd/pin_af.h
+++ b/ports/samd/pin_af.h
@@ -32,8 +32,8 @@
 
 typedef struct _machine_pin_obj_t {
     mp_obj_base_t base;
+    qstr_short_t name;
     uint8_t pin_id;
-    qstr name;
     uint8_t eic;
     uint8_t adc0;
     uint8_t sercom1;
@@ -50,8 +50,8 @@ typedef struct _machine_pin_obj_t {
 
 typedef struct _machine_pin_obj_t {
     mp_obj_base_t base;
+    qstr_short_t name;
     uint8_t pin_id;
-    qstr name;
     uint8_t eic;
     uint8_t adc0;
     uint8_t adc1;


### PR DESCRIPTION
### Summary

This PR modifies the existing structure definitions for pin objects across selected ports, in order to reduce the overall footprint of each single pin instance.

There are two changes in this commit:

* Some ports pin structure's usage of "qstr" (32 bits) has been changed to "qstr_short_t" (16 bits) which encodes the same string index in half the space, and given that pin names are precomputed and immutable this alone should help saving a few bytes without any noticeable slowdown
* Structures affected by the earlier change have been reorganised to be more tightly packed, reducing the amount of padding bytes introduced by the compiler to keep structure elements aligned.

These changes should provide functionally equivalent binaries but with some minor size savings.  The generated code for accessing a 16-bits quantity instead of a 32-bits one may or may not be much different from what was generated before, and there is a chance of either a very tiny speedup or a very tiny slowdown.

In any case, that would be probably detected in code that keeps creating pin instances that are looked up via name in a tight loop. That's very uncommon to see in production code anyway.

Results are promising, here's what I found:

Notes:

* Arm ports were built using GCC 13.3.0 from Ubuntu 24.04 repos, RV32 ports were built using GCC 14.1.0 from Embecosm's Core-V 20240530 toolchain
* Results are for the default board for the port except for RP2 and SAMD ports, with the boards being built being reported
* "Before" refers to the current master (27544a2d81da5b0d804a932d98d680f121a22b8f).

|Port|Before|After|Delta|
|----|------|-----|-----|
|CC3200|185328|185256|-72|
|MIMXRT|332876|331284|-1592|
|NRF|187040|186920|-120|
|RENESAS-RA|256616|256160|-456|
|RP2/RPI_PICO|316088|314984|-1104|
|RP2/RPI_PICO2|308852|307748|-1104|
|RP2/RPI_PICO2(RV32)|390996|389944|-1052|
|SAMD/ADAFRUIT_ITSYBITSY_M0_EXPRESS|235280|235128|-152|
|SAMD/ADAFRUIT_ITSYBITSY_M4_EXPRESS|268000|267852|-148|

Size savings come from both the qstr type being narrow and in certain cases from structure repacking.  In most cases structures contain mostly word-sized elements and there isn't much that can be done to maintain intra-structure member alignment.

Unless there are default GCC flags to let the compiler assume that all structures are packed, then repacking structures that will show up in .rodata could be an interesting source of size savings.

### Testing

I've currently tested this on the two SAMD boards mentioned in the table, as the PR also touches the port's pins prefix file (see Octoprobe run 366 - the M0 failures are also present in the master branch, checked in Octoprobe run 367).

I plan to launch Octoprobe runs for each of the ports involved but I'll schedule them over time to not hog the server with a full 4hrs+ test run.  The Reneses port has to be tested by somebody else as I have no means to test that in any reasonable way.

### Trade-offs and Alternatives

The ports being affected still need more in-depth testing, although unless there's a compiler problem or non-standard structure member accesses happen when dealing with pin structures on MicroPython's side, these changes should be harmless.