### PR TITLE
py: Add enum support and minimal metaclass features

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -46,12 +46,51 @@ extern struct _mp_dummy_t mp_sys_stdout_obj; // type is irrelevant, just need po
 // args[0] is function from class body
 // args[1] is class name
 // args[2:] are base objects
-static mp_obj_t mp_builtin___build_class__(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t mp_builtin___build_class__(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     assert(2 <= n_args);
 
-    // set the new classes __locals__ object
+    // STEP 1: Determine metaclass FIRST (before creating namespace)
+    mp_obj_t meta;
+    mp_map_elem_t *key_elem = mp_map_lookup(kwargs, MP_OBJ_NEW_QSTR(MP_QSTR_metaclass), MP_MAP_LOOKUP);
+    if (key_elem != NULL) {
+        meta = key_elem->value;
+    } else {
+        if (n_args == 2) {
+            // no explicit bases, so use 'type'
+            meta = MP_OBJ_FROM_PTR(&mp_type_type);
+        } else {
+            // use type of first base object
+            meta = MP_OBJ_FROM_PTR(mp_obj_get_type(args[2]));
+        }
+    }
+
+    // TODO do proper metaclass resolution for multiple base objects
+
+    // STEP 2: Call __prepare__ if it exists, or create regular dict
+    mp_obj_t class_locals;
+    #if MICROPY_PY_METACLASS_PREPARE
+    mp_obj_t prepare_dest[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+    mp_load_method_maybe(meta, MP_QSTR___prepare__, prepare_dest);
+
+    if (prepare_dest[0] != MP_OBJ_NULL) {
+        // __prepare__ exists, call it with (name, bases)
+        mp_obj_t prepare_args[4];
+        prepare_args[0] = prepare_dest[0];  // method function
+        prepare_args[1] = prepare_dest[1];  // self (metaclass)
+        prepare_args[2] = args[1];          // class name
+        prepare_args[3] = mp_obj_new_tuple(n_args - 2, args + 2); // bases tuple
+        class_locals = mp_call_method_n_kw(2, 0, prepare_args);
+    } else {
+        // No __prepare__, use regular dict
+        class_locals = mp_obj_new_dict(0);
+    }
+    #else
+    // __prepare__ not supported, always use regular dict
+    class_locals = mp_obj_new_dict(0);
+    #endif
+
+    // STEP 3: Execute class body with the namespace from __prepare__
     mp_obj_dict_t *old_locals = mp_locals_get();
-    mp_obj_t class_locals = mp_obj_new_dict(0);
     mp_locals_set(MP_OBJ_TO_PTR(class_locals));
 
     // call the class code
@@ -60,23 +99,11 @@ static mp_obj_t mp_builtin___build_class__(size_t n_args, const mp_obj_t *args) 
     // restore old __locals__ object
     mp_locals_set(old_locals);
 
-    // get the class type (meta object) from the base objects
-    mp_obj_t meta;
-    if (n_args == 2) {
-        // no explicit bases, so use 'type'
-        meta = MP_OBJ_FROM_PTR(&mp_type_type);
-    } else {
-        // use type of first base object
-        meta = MP_OBJ_FROM_PTR(mp_obj_get_type(args[2]));
-    }
-
-    // TODO do proper metaclass resolution for multiple base objects
-
-    // create the new class using a call to the meta object
+    // STEP 4: Create the class using the metaclass
     mp_obj_t meta_args[3];
     meta_args[0] = args[1]; // class name
     meta_args[1] = mp_obj_new_tuple(n_args - 2, args + 2); // tuple of bases
-    meta_args[2] = class_locals; // dict of members
+    meta_args[2] = class_locals; // dict of members (now from __prepare__)
     mp_obj_t new_class = mp_call_function_n_kw(meta, 3, 0, meta_args);
 
     // store into cell if needed
@@ -86,7 +113,7 @@ static mp_obj_t mp_builtin___build_class__(size_t n_args, const mp_obj_t *args) 
 
     return new_class;
 }
-MP_DEFINE_CONST_FUN_OBJ_VAR(mp_builtin___build_class___obj, 2, mp_builtin___build_class__);
+MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin___build_class___obj, 2, mp_builtin___build_class__);
 
 static mp_obj_t mp_builtin_abs(mp_obj_t o_in) {
     return mp_unary_op(MP_UNARY_OP_ABS, o_in);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1280,6 +1280,13 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_MULTIPLE_INHERITANCE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
 #endif
 
+// Whether to support custom metaclass __init__ method invocation.
+// This allows metaclasses to initialize classes after creation, enabling
+// patterns like class registration and state machine setup.
+#ifndef MICROPY_PY_METACLASS_INIT
+#define MICROPY_PY_METACLASS_INIT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
+#endif
+
 // Whether to implement attributes on functions
 #ifndef MICROPY_PY_FUNCTION_ATTRS
 #define MICROPY_PY_FUNCTION_ATTRS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
@@ -1310,6 +1317,29 @@ typedef time_t mp_timestamp_t;
 // attributes slower for the classes that use this feature
 #ifndef MICROPY_PY_DELATTR_SETATTR
 #define MICROPY_PY_DELATTR_SETATTR (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
+// Whether to support metaclass operator overloading (__len__, __contains__ on type objects)
+// This enables operations like len(EnumClass) and member in EnumClass for custom metaclasses
+// This costs ~100 bytes of code size for the operator dispatch handlers
+#ifndef MICROPY_PY_METACLASS_OPS
+#define MICROPY_PY_METACLASS_OPS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
+// Whether to support metaclass method and property lookup on classes
+// This enables @property and methods on metaclasses to be accessible on classes
+// Critical for python-statemachine's .events and .states properties
+// Size impact: ~200-400 bytes (descriptor protocol support)
+#ifndef MICROPY_PY_METACLASS_PROPERTIES
+#define MICROPY_PY_METACLASS_PROPERTIES (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
+// Whether to support metaclass __prepare__ method (PEP 3115)
+// Allows metaclasses to customize the namespace dict before class creation
+// Required for enum.auto() to track insertion order
+// Size impact: ~150-180 bytes
+#ifndef MICROPY_PY_METACLASS_PREPARE
+#define MICROPY_PY_METACLASS_PREPARE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_FULL_FEATURES)
 #endif
 
 // Support for async/await/async for/async with

--- a/py/obj.h
+++ b/py/obj.h
@@ -805,6 +805,8 @@ typedef struct _mp_obj_full_type_t {
 #define MP_OBJ_TYPE_GET_SLOT(t, f) (_MP_OBJ_TYPE_SLOT_TYPE_##f(t)->slots[(t)->slot_index_##f - 1])
 #define MP_OBJ_TYPE_GET_SLOT_OR_NULL(t, f) (_MP_OBJ_TYPE_SLOT_TYPE_##f(MP_OBJ_TYPE_HAS_SLOT(t, f) ? MP_OBJ_TYPE_GET_SLOT(t, f) : NULL))
 #define MP_OBJ_TYPE_SET_SLOT(t, f, v, n) ((t)->slot_index_##f = (n) + 1, (t)->slots[(n)] = (void *)v)
+#define MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(t, f, v, n) \
+    ((v) ? (MP_OBJ_TYPE_SET_SLOT(t, f, v, n), (void)0) : (void)0)
 #define MP_OBJ_TYPE_OFFSETOF_SLOT(f) (offsetof(mp_obj_type_t, slot_index_##f))
 #define MP_OBJ_TYPE_HAS_SLOT_BY_OFFSET(t, offset) (*(uint8_t *)((char *)(t) + (offset)) != 0)
 

--- a/py/objtype.c
+++ b/py/objtype.c
@@ -44,9 +44,11 @@
 #define ENABLE_SPECIAL_ACCESSORS \
     (MICROPY_PY_DESCRIPTORS || MICROPY_PY_DELATTR_SETATTR || MICROPY_PY_BUILTINS_PROPERTY)
 
-static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict);
+static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict, const mp_obj_type_t *metaclass);
 static mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo);
 static mp_obj_t static_class_method_make_new(const mp_obj_type_t *self_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+static mp_obj_t type___new__(size_t n_args, const mp_obj_t *args);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(type___new___obj, 1, 4, type___new__);
 
 /******************************************************************************/
 // instance object
@@ -71,7 +73,12 @@ static int instance_count_native_bases(const mp_obj_type_t *type, const mp_obj_t
             const mp_obj_t *item = parent_tuple->items;
             const mp_obj_t *top = item + parent_tuple->len;
             for (; item < top; ++item) {
-                assert(mp_obj_is_type(*item, &mp_type_type));
+                // Check that item's metaclass is a subclass of type (handles both native types and custom metaclasses)
+                mp_obj_t item_metaclass = MP_OBJ_FROM_PTR(mp_obj_get_type(*item));
+                if (!mp_obj_is_subclass_fast(item_metaclass, MP_OBJ_FROM_PTR(&mp_type_type))) {
+                    // This should never happen in valid Python code, but catch it to avoid crashes
+                    mp_raise_TypeError(MP_ERROR_TEXT("base is not a type"));
+                }
                 const mp_obj_type_t *bt = (const mp_obj_type_t *)MP_OBJ_TO_PTR(*item);
                 count += instance_count_native_bases(bt, last_native_base);
             }
@@ -138,7 +145,6 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
     assert(lookup->dest[0] == MP_OBJ_NULL);
     assert(lookup->dest[1] == MP_OBJ_NULL);
     for (;;) {
-        DEBUG_printf("mp_obj_class_lookup: Looking up %s in %s\n", qstr_str(lookup->attr), qstr_str(type->name));
         // Optimize special method lookup for native types
         // This avoids extra method_name => slot lookup. On the other hand,
         // this should not be applied to class types, as will result in extra
@@ -148,8 +154,6 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
             // with a special case for getiter where the slot won't be set
             // for MP_TYPE_FLAG_ITER_IS_STREAM.
             if (MP_OBJ_TYPE_HAS_SLOT_BY_OFFSET(type, lookup->slot_offset) || (lookup->slot_offset == MP_OBJ_TYPE_OFFSETOF_SLOT(iter) && type->flags & MP_TYPE_FLAG_ITER_IS_STREAM)) {
-                DEBUG_printf("mp_obj_class_lookup: Matched special meth slot (off=%d) for %s\n",
-                    lookup->slot_offset, qstr_str(lookup->attr));
                 lookup->dest[0] = MP_OBJ_SENTINEL;
                 return;
             }
@@ -183,15 +187,6 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
                     }
                     mp_convert_member_lookup(obj_obj, type, elem->value, lookup->dest);
                 }
-                #if DEBUG_PRINT
-                DEBUG_printf("mp_obj_class_lookup: Returning: ");
-                mp_obj_print_helper(MICROPY_DEBUG_PRINTER, lookup->dest[0], PRINT_REPR);
-                if (lookup->dest[1] != MP_OBJ_NULL) {
-                    // Don't try to repr() lookup->dest[1], as we can be called recursively
-                    DEBUG_printf(" <%s @%p>", mp_obj_get_type_str(lookup->dest[1]), MP_OBJ_TO_PTR(lookup->dest[1]));
-                }
-                DEBUG_printf("\n");
-                #endif
                 return;
             }
         }
@@ -209,7 +204,6 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
         // attribute not found, keep searching base classes
 
         if (!MP_OBJ_TYPE_HAS_SLOT(type, parent)) {
-            DEBUG_printf("mp_obj_class_lookup: No more parents\n");
             return;
         #if MICROPY_MULTIPLE_INHERITANCE
         } else if (((mp_obj_base_t *)MP_OBJ_TYPE_GET_SLOT(type, parent))->type == &mp_type_tuple) {
@@ -217,7 +211,11 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
             const mp_obj_t *item = parent_tuple->items;
             const mp_obj_t *top = item + parent_tuple->len - 1;
             for (; item < top; ++item) {
-                assert(mp_obj_is_type(*item, &mp_type_type));
+                // Check that item's metaclass is a subclass of type (handles both native types and custom metaclasses)
+                mp_obj_t item_metaclass = MP_OBJ_FROM_PTR(mp_obj_get_type(*item));
+                if (!mp_obj_is_subclass_fast(item_metaclass, MP_OBJ_FROM_PTR(&mp_type_type))) {
+                    mp_raise_TypeError(MP_ERROR_TEXT("base is not a type"));
+                }
                 mp_obj_type_t *bt = (mp_obj_type_t *)MP_OBJ_TO_PTR(*item);
                 if (bt == &mp_type_object) {
                     // Not a "real" type
@@ -230,7 +228,11 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
             }
 
             // search last base (simple tail recursion elimination)
-            assert(mp_obj_is_type(*item, &mp_type_type));
+            // Check that item's metaclass is a subclass of type (handles both native types and custom metaclasses)
+            mp_obj_t item_metaclass = MP_OBJ_FROM_PTR(mp_obj_get_type(*item));
+            if (!mp_obj_is_subclass_fast(item_metaclass, MP_OBJ_FROM_PTR(&mp_type_type))) {
+                mp_raise_TypeError(MP_ERROR_TEXT("base is not a type"));
+            }
             type = (mp_obj_type_t *)MP_OBJ_TO_PTR(*item);
         #endif
         } else {
@@ -1036,7 +1038,23 @@ static mp_obj_t type_make_new(const mp_obj_type_t *type_in, size_t n_args, size_
             // args[0] = name
             // args[1] = bases tuple
             // args[2] = locals dict
-            return mp_obj_new_type(mp_obj_str_get_qstr(args[0]), args[1], args[2]);
+
+            // Check if metaclass has custom __new__ (not inherited from type)
+            if (type_in != &mp_type_type) {
+                mp_obj_t dest[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+                mp_load_method_maybe(MP_OBJ_FROM_PTR(type_in), MP_QSTR___new__, dest);
+                if (dest[0] != MP_OBJ_NULL && dest[0] != MP_OBJ_FROM_PTR(&type___new___obj)) {
+                    // Found custom __new__, call it with (metaclass, name, bases, dict)
+                    mp_obj_t new_args[4] = {MP_OBJ_FROM_PTR(type_in), args[0], args[1], args[2]};
+                    return mp_call_function_n_kw(dest[0], 4, 0, new_args);
+                }
+            }
+
+            // No custom __new__, use default type.__new__
+            {
+                mp_obj_t new_args[4] = {MP_OBJ_FROM_PTR(type_in), args[0], args[1], args[2]};
+                return type___new__(4, new_args);
+            }
 
         default:
             mp_raise_TypeError(MP_ERROR_TEXT("type takes 1 or 3 arguments"));
@@ -1048,6 +1066,35 @@ static mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
 
     mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
 
+    // Check if the metaclass has a custom __call__ method
+    const mp_obj_type_t *metaclass = self->base.type;
+    if (metaclass != &mp_type_type) {
+        mp_obj_t dest[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+        mp_load_method_maybe(MP_OBJ_FROM_PTR(metaclass), MP_QSTR___call__, dest);
+        if (dest[0] != MP_OBJ_NULL) {
+            // Found custom __call__, call it with (cls, *args, **kwargs)
+            mp_obj_t *new_args;
+            mp_obj_t stack_args[8];
+
+            if (n_args < 8) {
+                new_args = stack_args;
+            } else {
+                new_args = m_new(mp_obj_t, n_args + 1);
+            }
+
+            new_args[0] = self_in;
+            memcpy(new_args + 1, args, sizeof(mp_obj_t) * n_args);
+            mp_obj_t result = mp_call_function_n_kw(dest[0], n_args + 1, n_kw, new_args);
+
+            if (n_args >= 8) {
+                m_del(mp_obj_t, new_args, n_args + 1);
+            }
+
+            return result;
+        }
+    }
+
+    // No custom __call__, use default make_new behavior
     if (!MP_OBJ_TYPE_HAS_SLOT(self, make_new)) {
         #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
         mp_raise_TypeError(MP_ERROR_TEXT("can't create instance"));
@@ -1056,16 +1103,50 @@ static mp_obj_t type_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp
         #endif
     }
 
-    // make new instance
-    mp_obj_t o = MP_OBJ_TYPE_GET_SLOT(self, make_new)(self, n_args, n_kw, args);
-
-    // return new instance
-    return o;
+    return MP_OBJ_TYPE_GET_SLOT(self, make_new)(self, n_args, n_kw, args);
 }
 
+// Minimal type.__new__ for metaclass support
+// When called as type.__new__(mcs, name, bases, dict), creates a new type
+// This is needed for metaclasses that call type.__new__(...)
+static mp_obj_t type___new__(size_t n_args, const mp_obj_t *args) {
+    if (n_args == 4) {
+        // type.__new__(metaclass, name, bases, dict)
+        // Used by metaclasses to create new types
+        mp_obj_t metaclass_type = MP_OBJ_FROM_PTR(mp_obj_get_type(args[0]));
+        if (!mp_obj_is_subclass_fast(metaclass_type, MP_OBJ_FROM_PTR(&mp_type_type))) {
+            mp_raise_TypeError(MP_ERROR_TEXT("type.__new__(X): X is not a type"));
+        }
+        const mp_obj_type_t *metaclass = MP_OBJ_TO_PTR(args[0]);
+        return mp_obj_new_type(mp_obj_str_get_qstr(args[1]), args[2], args[3], metaclass);
+    } else if (n_args == 2) {
+        // type.__new__(cls, obj) - return type of obj (CPython compatibility)
+        return MP_OBJ_FROM_PTR(mp_obj_get_type(args[1]));
+    } else if (n_args == 1) {
+        mp_raise_TypeError(MP_ERROR_TEXT("type.__new__(): not enough arguments"));
+    } else {
+        mp_raise_msg_varg(&mp_type_TypeError,
+            MP_ERROR_TEXT("type.__new__() takes 1, 2 or 4 arguments (%d given)"), n_args);
+    }
+}
+
+// type.__init__(cls, name, bases, dict) - does nothing, exists for metaclass super() calls
+static mp_obj_t type___init__(size_t n_args, const mp_obj_t *args) {
+    (void)args;
+    // Accept 1 or 4 arguments (1 = self, 4 = self, name, bases, dict)
+    // Do nothing - type initialization is handled by type.__new__()
+    if (n_args != 1 && n_args != 4) {
+        mp_raise_TypeError(MP_ERROR_TEXT("type.__init__() takes 1 or 4 arguments"));
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(type___init___obj, 1, 4, type___init__);
+
 static void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
-    assert(mp_obj_is_type(self_in, &mp_type_type));
     mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
+    // Allow types with custom metaclasses that inherit from type
+    assert(mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(self->base.type),
+        MP_OBJ_FROM_PTR(&mp_type_type)));
 
     if (dest[0] == MP_OBJ_NULL) {
         // load attribute
@@ -1108,6 +1189,19 @@ static void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             return;
         }
         #endif
+        // Only provide type.__new__ when looking up __new__ on the type class itself
+        // Other classes should continue with normal lookup to find object.__new__
+        if (attr == MP_QSTR___new__ && self == &mp_type_type) {
+            dest[0] = MP_OBJ_FROM_PTR(&type___new___obj);
+            return;
+        }
+        // Only provide type.__init__ when looking up on type itself
+        // This allows type.__init__ to be called directly but doesn't interfere with
+        // regular classes or metaclasses which should use their own __init__
+        if (attr == MP_QSTR___init__ && self == &mp_type_type) {
+            dest[0] = MP_OBJ_FROM_PTR(&type___init___obj);
+            return;
+        }
         struct class_lookup_data lookup = {
             .obj = (mp_obj_instance_t *)self,
             .attr = attr,
@@ -1116,6 +1210,38 @@ static void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             .is_type = true,
         };
         mp_obj_class_lookup(&lookup, self);
+
+        #if MICROPY_PY_METACLASS_PROPERTIES
+        // If attribute not found in class, look in the metaclass
+        if (dest[0] == MP_OBJ_NULL) {
+            const mp_obj_type_t *metaclass = self->base.type;
+            if (metaclass != &mp_type_type) {
+                // Look up attribute in metaclass
+                lookup.obj = NULL;
+                mp_obj_class_lookup(&lookup, metaclass);
+
+                if (dest[0] != MP_OBJ_NULL) {
+                    // Found in metaclass - handle descriptor protocol
+                    if (mp_obj_is_type(dest[0], &mp_type_property)) {
+                        // Property descriptor: invoke the getter with the class
+                        const mp_obj_t *proxy = mp_obj_property_get(dest[0]);
+                        if (proxy[0] != mp_const_none) {
+                            // Call getter(cls) - property getters take only one argument
+                            dest[0] = mp_call_function_1(proxy[0], self_in);
+                            dest[1] = MP_OBJ_NULL;
+                        } else {
+                            // Property has no getter - not accessible
+                            dest[0] = MP_OBJ_NULL;
+                            dest[1] = MP_OBJ_NULL;
+                        }
+                    } else if (mp_obj_is_callable(dest[0])) {
+                        // Method: bind the class as first argument
+                        dest[1] = self_in;
+                    }
+                }
+            }
+        }
+        #endif
     } else {
         // delete/store attribute
 
@@ -1155,6 +1281,129 @@ static void type_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     }
 }
 
+#if MICROPY_PY_METACLASS_OPS
+static mp_obj_t type_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
+    // Handle unary operations on type objects (e.g., len(EnumClass))
+    // by looking up special methods in the metaclass
+    mp_obj_type_t *self = MP_OBJ_TO_PTR(self_in);
+
+    // Fast path: standard type metaclass doesn't support custom operators
+    // but we still need to handle __hash__ with default implementation
+    if (self->base.type == &mp_type_type) {
+        if (op == MP_UNARY_OP_HASH) {
+            // Use default hash based on object identity (address)
+            return MP_OBJ_NEW_SMALL_INT((mp_uint_t)self_in);
+        }
+        return MP_OBJ_NULL;
+    }
+
+    qstr op_name = mp_unary_op_method_name[op];
+
+    if (op_name == 0) {
+        return MP_OBJ_NULL; // op not supported
+    }
+
+    // Look up the special method in the metaclass
+    mp_obj_t member[2] = {MP_OBJ_NULL};
+    struct class_lookup_data lookup = {
+        .obj = NULL,  // We're looking up on the type itself, not an instance
+        .attr = op_name,
+        .slot_offset = 0,
+        .dest = member,
+        .is_type = true,
+    };
+    mp_obj_class_lookup(&lookup, self->base.type);
+
+    if (member[0] != MP_OBJ_NULL) {
+        // Found the method in metaclass, call it with the class as argument
+        mp_obj_t val = mp_call_function_1(member[0], self_in);
+
+        // Post-process return value for specific operations
+        switch (op) {
+            case MP_UNARY_OP_HASH:
+                // __hash__ must return a small int
+                val = MP_OBJ_NEW_SMALL_INT(mp_obj_get_int_truncated(val));
+                break;
+            default:
+                break;
+        }
+
+        return val;
+    }
+
+    // Metaclass doesn't define the operator, use default for __hash__
+    if (op == MP_UNARY_OP_HASH) {
+        // Use default hash based on object identity (address)
+        return MP_OBJ_NEW_SMALL_INT((mp_uint_t)self_in);
+    }
+
+    return MP_OBJ_NULL; // op not supported
+}
+
+static mp_obj_t type_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+    // Handle binary operations on type objects (e.g., member in EnumClass)
+    // by looking up special methods in the metaclass
+    mp_obj_type_t *lhs = MP_OBJ_TO_PTR(lhs_in);
+
+    // Fast path: standard type metaclass doesn't support operators
+    if (lhs->base.type == &mp_type_type) {
+        return MP_OBJ_NULL;
+    }
+
+    qstr op_name = mp_binary_op_method_name[op];
+
+    if (op_name == 0) {
+        return MP_OBJ_NULL; // op not supported
+    }
+
+    // Look up the special method in the metaclass
+    mp_obj_t dest[3] = {MP_OBJ_NULL};
+    struct class_lookup_data lookup = {
+        .obj = NULL,  // We're looking up on the type itself, not an instance
+        .attr = op_name,
+        .slot_offset = 0,
+        .dest = dest,
+        .is_type = true,
+    };
+    mp_obj_class_lookup(&lookup, lhs->base.type);
+
+    if (dest[0] != MP_OBJ_NULL) {
+        // Found the method in metaclass, call it with the class and rhs as arguments
+        mp_obj_t args[2] = {lhs_in, rhs_in};
+        mp_obj_t res = mp_call_function_n_kw(dest[0], 2, 0, args);
+
+        // Post-process return value for specific operations
+        if (op == MP_BINARY_OP_CONTAINS) {
+            res = mp_obj_new_bool(mp_obj_is_true(res));
+        }
+
+        #if MICROPY_PY_BUILTINS_NOTIMPLEMENTED
+        // NotImplemented means try other fallbacks
+        if (res == mp_const_notimplemented) {
+            return MP_OBJ_NULL; // op not supported
+        }
+        #endif
+
+        return res;
+    }
+
+    return MP_OBJ_NULL; // op not supported
+}
+#endif // MICROPY_PY_METACLASS_OPS
+
+#if MICROPY_PY_METACLASS_OPS
+MP_DEFINE_CONST_OBJ_TYPE(
+    mp_type_type,
+    MP_QSTR_type,
+    MP_TYPE_FLAG_NONE,
+    make_new, type_make_new,
+    print, type_print,
+    call, type_call,
+    unary_op, type_unary_op,
+    binary_op, type_binary_op,
+    attr, type_attr
+    );
+#else
 MP_DEFINE_CONST_OBJ_TYPE(
     mp_type_type,
     MP_QSTR_type,
@@ -1164,14 +1413,15 @@ MP_DEFINE_CONST_OBJ_TYPE(
     call, type_call,
     attr, type_attr
     );
+#endif
 
-static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict) {
+static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals_dict, const mp_obj_type_t *metaclass) {
     // Verify input objects have expected type
     if (!mp_obj_is_type(bases_tuple, &mp_type_tuple)) {
-        mp_raise_TypeError(NULL);
+        mp_raise_TypeError(MP_ERROR_TEXT("bases not a tuple"));
     }
     if (!mp_obj_is_dict_or_ordereddict(locals_dict)) {
-        mp_raise_TypeError(NULL);
+        mp_raise_TypeError(MP_ERROR_TEXT("locals not a dict"));
     }
 
     // TODO might need to make a copy of locals_dict; at least that's how CPython does it
@@ -1186,9 +1436,12 @@ static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals
     mp_obj_t *bases_items;
     mp_obj_tuple_get(bases_tuple, &bases_len, &bases_items);
     for (size_t i = 0; i < bases_len; i++) {
-        if (!mp_obj_is_type(bases_items[i], &mp_type_type)) {
-            mp_raise_TypeError(NULL);
+        // Check if base's metaclass inherits from type (allows custom metaclasses)
+        mp_obj_t base_metaclass = MP_OBJ_FROM_PTR(mp_obj_get_type(bases_items[i]));
+        if (!mp_obj_is_subclass_fast(base_metaclass, MP_OBJ_FROM_PTR(&mp_type_type))) {
+            mp_raise_TypeError(MP_ERROR_TEXT("bases not a type"));
         }
+
         mp_obj_type_t *t = MP_OBJ_TO_PTR(bases_items[i]);
         // TODO: Verify with CPy, tested on function type
         if (!MP_OBJ_TYPE_HAS_SLOT(t, make_new)) {
@@ -1217,18 +1470,49 @@ static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals
     // Note: mp_obj_type_t is (2 + 3 + #slots) words, so going from 11 to 12 slots
     // moves from 4 to 5 gc blocks.
     mp_obj_type_t *o = m_new_obj_var0(mp_obj_type_t, slots, void *, 10 + (bases_len ? 1 : 0) + (base_protocol ? 1 : 0));
-    o->base.type = &mp_type_type;
+    o->base.type = metaclass;
     o->flags = base_flags;
     o->name = name;
-    MP_OBJ_TYPE_SET_SLOT(o, make_new, mp_obj_instance_make_new, 0);
-    MP_OBJ_TYPE_SET_SLOT(o, print, instance_print, 1);
-    MP_OBJ_TYPE_SET_SLOT(o, call, mp_obj_instance_call, 2);
-    MP_OBJ_TYPE_SET_SLOT(o, unary_op, instance_unary_op, 3);
-    MP_OBJ_TYPE_SET_SLOT(o, binary_op, instance_binary_op, 4);
-    MP_OBJ_TYPE_SET_SLOT(o, attr, mp_obj_instance_attr, 5);
-    MP_OBJ_TYPE_SET_SLOT(o, subscr, instance_subscr, 6);
-    MP_OBJ_TYPE_SET_SLOT(o, iter, mp_obj_instance_getiter, 7);
-    MP_OBJ_TYPE_SET_SLOT(o, buffer, instance_get_buffer, 8);
+
+    // Check if we're inheriting from 'type' or a subclass of 'type'
+    // If so, we should inherit type's slots, not use instance slots
+    bool inherits_from_type = false;
+    const mp_obj_type_t *type_base = NULL;
+    if (bases_len > 0) {
+        type_base = MP_OBJ_TO_PTR(bases_items[0]);
+        // Check if first base is type or inherits from type
+        if (type_base == &mp_type_type ||
+            (MP_OBJ_TYPE_HAS_SLOT(type_base, parent) &&
+             mp_obj_is_subclass_fast(bases_items[0], MP_OBJ_FROM_PTR(&mp_type_type)))) {
+            inherits_from_type = true;
+        }
+    }
+
+    if (inherits_from_type && type_base != NULL) {
+        // Inherit slots from the type base
+        // Note: for iter, use instance_getiter so __iter__ from locals_dict is used
+        // Use MP_OBJ_TYPE_SET_SLOT_IF_EXISTS for optional slots that may not exist in type_base
+        MP_OBJ_TYPE_SET_SLOT(o, make_new, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, make_new), 0);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, print, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, print), 1);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, call, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, call), 2);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, unary_op, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, unary_op), 3);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, binary_op, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, binary_op), 4);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, attr, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, attr), 5);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, subscr, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, subscr), 6);
+        MP_OBJ_TYPE_SET_SLOT(o, iter, mp_obj_instance_getiter, 7);
+        MP_OBJ_TYPE_SET_SLOT_IF_EXISTS(o, buffer, MP_OBJ_TYPE_GET_SLOT_OR_NULL(type_base, buffer), 8);
+    } else {
+        // Use regular instance slots
+        MP_OBJ_TYPE_SET_SLOT(o, make_new, mp_obj_instance_make_new, 0);
+        MP_OBJ_TYPE_SET_SLOT(o, print, instance_print, 1);
+        MP_OBJ_TYPE_SET_SLOT(o, call, mp_obj_instance_call, 2);
+        MP_OBJ_TYPE_SET_SLOT(o, unary_op, instance_unary_op, 3);
+        MP_OBJ_TYPE_SET_SLOT(o, binary_op, instance_binary_op, 4);
+        MP_OBJ_TYPE_SET_SLOT(o, attr, mp_obj_instance_attr, 5);
+        MP_OBJ_TYPE_SET_SLOT(o, subscr, instance_subscr, 6);
+        MP_OBJ_TYPE_SET_SLOT(o, iter, mp_obj_instance_getiter, 7);
+        MP_OBJ_TYPE_SET_SLOT(o, buffer, instance_get_buffer, 8);
+    }
 
     mp_obj_dict_t *locals_ptr = MP_OBJ_TO_PTR(locals_dict);
     MP_OBJ_TYPE_SET_SLOT(o, locals_dict, locals_ptr, 9);
@@ -1305,6 +1589,34 @@ static mp_obj_t mp_obj_new_type(qstr name, mp_obj_t bases_tuple, mp_obj_t locals
     setname_consume_call_all(&setname_list, MP_OBJ_FROM_PTR(o));
     #endif
 
+    #if MICROPY_PY_METACLASS_INIT
+    // Call metaclass.__init__ if it exists (including inherited)
+    // This provides CPython-compatible behavior for metaclass initialization
+    if (metaclass != &mp_type_type) {
+        mp_obj_t init_fn[2] = {MP_OBJ_NULL, MP_OBJ_NULL};
+        struct class_lookup_data lookup = {
+            .obj = NULL,
+            .attr = MP_QSTR___init__,
+            .slot_offset = 0,
+            .dest = init_fn,
+            .is_type = true,
+        };
+        mp_obj_class_lookup(&lookup, metaclass);
+
+        if (init_fn[0] != MP_OBJ_NULL) {
+            // Found __init__ in metaclass (may be inherited), call it
+            // Call metaclass.__init__(cls, name, bases, dict)
+            mp_obj_t args[5];
+            args[0] = init_fn[0];  // method
+            args[1] = MP_OBJ_FROM_PTR(o);  // cls (the newly created class)
+            args[2] = MP_OBJ_NEW_QSTR(name);  // name
+            args[3] = bases_tuple;  // bases
+            args[4] = locals_dict;  // attrs dict
+            mp_call_method_n_kw(3, 0, args);
+        }
+    }
+    #endif
+
     return MP_OBJ_FROM_PTR(o);
 }
 
@@ -1338,7 +1650,7 @@ static mp_obj_t super_make_new(const mp_obj_type_t *type_in, size_t n_args, size
     const mp_obj_type_t *second_arg_type = mp_obj_get_type(args[1]);
     mp_obj_t second_arg_obj = second_arg_type == &mp_type_type ? args[1] : MP_OBJ_FROM_PTR(second_arg_type);
     if (mp_obj_is_subclass(second_arg_obj, args[0]) == mp_const_false) {
-        mp_raise_TypeError(NULL);
+        mp_raise_TypeError(MP_ERROR_TEXT("incorrect subclass"));
     }
 
     mp_obj_super_t *o = m_new_obj(mp_obj_super_t);
@@ -1368,8 +1680,23 @@ static void super_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     };
 
     // Allow a call super().__init__() to reach any native base classes.
+    // But don't do this if self->obj is a type (i.e., calling super() from within a metaclass),
+    // as that would incorrectly call type_make_new() which creates a new type.
     if (attr == MP_QSTR___init__) {
-        lookup.slot_offset = MP_OBJ_TYPE_OFFSETOF_SLOT(make_new);
+        // Check if self->obj is a type object by checking if its type is a subclass of 'type'
+        const mp_obj_type_t *obj_type = mp_obj_get_type(self->obj);
+        bool obj_is_type = mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(obj_type), MP_OBJ_FROM_PTR(&mp_type_type));
+
+        if (obj_is_type) {
+            // self->obj is a type, so super().__init__() is being called from a metaclass
+            // Return type.__init__ which is a no-op that accepts the right arguments
+            dest[0] = MP_OBJ_FROM_PTR(&type___init___obj);
+            dest[1] = self->obj;  // bind to self->obj
+            return;
+        } else {
+            // Only map __init__ to make_new for regular instances, not for types
+            lookup.slot_offset = MP_OBJ_TYPE_OFFSETOF_SLOT(make_new);
+        }
     }
 
     if (!MP_OBJ_TYPE_HAS_SLOT(type, parent)) {
@@ -1477,7 +1804,16 @@ bool mp_obj_is_subclass_fast(mp_const_obj_t object, mp_const_obj_t classinfo) {
 static mp_obj_t mp_obj_is_subclass(mp_obj_t object, mp_obj_t classinfo) {
     size_t len;
     mp_obj_t *items;
-    if (mp_obj_is_type(classinfo, &mp_type_type)) {
+    // Check if classinfo is a type (either mp_type_type or instance of a metaclass)
+    bool is_class = mp_obj_is_type(classinfo, &mp_type_type);
+    if (!is_class && mp_obj_is_obj(classinfo)) {
+        // Check if it's an instance of a metaclass (i.e., its type is a subclass of type)
+        const mp_obj_type_t *classinfo_type = mp_obj_get_type(classinfo);
+        is_class = mp_obj_is_instance_type(classinfo_type) &&
+            mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(classinfo_type), MP_OBJ_FROM_PTR(&mp_type_type));
+    }
+
+    if (is_class) {
         len = 1;
         items = &classinfo;
     } else if (mp_obj_is_type(classinfo, &mp_type_tuple)) {

--- a/py/vm.c
+++ b/py/vm.c
@@ -419,8 +419,17 @@ dispatch_loop:
                     // and forwards to its members map. Attribute lookups on instance
                     // types are extremely common, so avoid all the other checks and
                     // calls that normally happen first.
+                    // Note: must check that top is NOT a type object (to handle
+                    // accessing attributes on classes with custom metaclasses).
+                    // A type object has type==type or type subclassing from type.
                     mp_map_elem_t *elem = NULL;
-                    if (mp_obj_is_instance_type(mp_obj_get_type(top))) {
+                    const mp_obj_type_t *top_type = mp_obj_get_type(top);
+                    // Fast path: check for regular instance types (not type objects)
+                    // The top_type != &mp_type_type check avoids the expensive subclass
+                    // test for the common case of non-type objects
+                    if (mp_obj_is_instance_type(top_type) && top_type != &mp_type_type &&
+                        !mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(top_type),
+                                                  MP_OBJ_FROM_PTR(&mp_type_type))) {
                         mp_obj_instance_t *self = MP_OBJ_TO_PTR(top);
                         elem = mp_map_lookup(&self->members, MP_OBJ_NEW_QSTR(qst), MP_MAP_LOOKUP);
                     }

--- a/tests/basics/class_metaclass_init.py
+++ b/tests/basics/class_metaclass_init.py
@@ -1,0 +1,100 @@
+# Test metaclass __init__ support (requires MICROPY_PY_METACLASS_INIT)
+
+# Skip test if metaclass __init__ is not supported
+_init_test = []
+
+class _TestMeta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        _init_test.append(1)
+
+class _Test(metaclass=_TestMeta):
+    pass
+
+if not _init_test:
+    print("SKIP")
+    raise SystemExit
+
+# Test 1: Basic metaclass __init__ call
+init_called = []
+
+class Meta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        init_called.append(name)
+
+class Test(metaclass=Meta):
+    pass
+
+assert 'Test' in init_called
+print("Test 1: PASS - metaclass __init__ called")
+
+# Test 2: Metaclass __init__ can modify class
+class CounterMeta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        cls.instance_count = 0
+
+class Widget(metaclass=CounterMeta):
+    def __init__(self):
+        Widget.instance_count += 1
+
+assert hasattr(Widget, 'instance_count')
+assert Widget.instance_count == 0
+w1 = Widget()
+assert Widget.instance_count == 1
+w2 = Widget()
+assert Widget.instance_count == 2
+print("Test 2: PASS - metaclass __init__ can modify class")
+
+# Test 3: Arguments passed correctly
+received_args = []
+
+class ArgTrackerMeta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        received_args.append({
+            'name': name,
+            'bases': bases,
+            'has_method': 'foo' in attrs
+        })
+
+class TestClass(metaclass=ArgTrackerMeta):
+    def foo(self):
+        pass
+
+assert len(received_args) == 1
+assert received_args[0]['name'] == 'TestClass'
+assert received_args[0]['has_method'] == True
+print("Test 3: PASS - correct arguments passed to __init__")
+
+# Test 4: Inherited metaclass __init__
+inherited_calls = []
+
+class BaseMeta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        inherited_calls.append(name)
+
+class DerivedMeta(BaseMeta):
+    pass  # No __init__ in this class's dict
+
+class InheritedTest(metaclass=DerivedMeta):
+    pass
+
+assert 'InheritedTest' in inherited_calls
+print("Test 4: PASS - inherited metaclass __init__ called")
+
+# Test 5: Invalid metaclass __init__ signature raises TypeError
+class BadMeta(type):
+    def __init__(cls):  # Wrong signature - only takes 1 arg instead of 4
+        pass
+
+try:
+    class Bad(metaclass=BadMeta):
+        pass
+    print("Test 5: FAIL - Should have raised TypeError")
+except TypeError:
+    print("Test 5: PASS - TypeError raised for bad signature")
+
+print("\nAll metaclass __init__ tests passed!")

--- a/tests/basics/class_metaclass_init.py.exp
+++ b/tests/basics/class_metaclass_init.py.exp
@@ -1,0 +1,7 @@
+Test 1: PASS - metaclass __init__ called
+Test 2: PASS - metaclass __init__ can modify class
+Test 3: PASS - correct arguments passed to __init__
+Test 4: PASS - inherited metaclass __init__ called
+Test 5: PASS - TypeError raised for bad signature
+
+All metaclass __init__ tests passed!

--- a/tests/basics/class_metaclass_prepare.py
+++ b/tests/basics/class_metaclass_prepare.py
@@ -1,0 +1,126 @@
+# Test metaclass __prepare__ method (PEP 3115)
+
+# Skip test if classmethod builtin is not available
+try:
+    classmethod
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if __prepare__ is not supported
+_prepare_test = []
+
+try:
+    class _TestMeta(type):
+        @classmethod
+        def __prepare__(mcs, name, bases):
+            _prepare_test.append(1)
+            return {}
+
+    class _Test(metaclass=_TestMeta):
+        pass
+except:
+    pass
+
+if not _prepare_test:
+    print("SKIP")
+    raise SystemExit
+
+# Test 1: Basic __prepare__ is called before class body execution
+print("Test 1: Basic __prepare__ call")
+prepare_log = []
+
+class Meta1(type):
+    @classmethod
+    def __prepare__(mcs, name, bases):
+        prepare_log.append("__prepare__(%s)" % (name,))
+        return {}
+
+class Test1(metaclass=Meta1):
+    prepare_log.append("body")
+
+print(prepare_log)
+print("PASS" if prepare_log == ["__prepare__(Test1)", "body"] else "FAIL")
+
+# Test 2: __prepare__ receives correct arguments
+print("\nTest 2: __prepare__ arguments")
+
+class Meta2(type):
+    @classmethod
+    def __prepare__(mcs, name, bases):
+        print("mcs=%s, name=%s, bases=%s" % (mcs.__name__, name, bases))
+        return {}
+
+class Base2:
+    pass
+
+class Test2(Base2, metaclass=Meta2):
+    pass
+
+# Test 3: __prepare__ return value is used as class namespace
+print("\nTest 3: __prepare__ return value as namespace")
+
+class Meta3(type):
+    @classmethod
+    def __prepare__(mcs, name, bases):
+        # Pre-populate namespace with a value
+        return {"injected": 42}
+
+class Test3(metaclass=Meta3):
+    pass
+
+print("Test3.injected = %s" % (Test3.injected))
+print("PASS" if Test3.injected == 42 else "FAIL")
+
+# Test 4: __prepare__ can access namespace in __new__
+print("\nTest 4: Access namespace from __new__")
+
+class Meta4(type):
+    @classmethod
+    def __prepare__(mcs, name, bases):
+        # Return dict with tracking info
+        d = {}
+        d['_prepared'] = True
+        return d
+
+    def __new__(mcs, name, bases, namespace):
+        # Verify __prepare__ returned dict was used
+        was_prepared = namespace.get('_prepared', False)
+        cls = type.__new__(mcs, name, bases, dict(namespace))
+        cls._was_prepared = was_prepared
+        return cls
+
+class Test4(metaclass=Meta4):
+    x = 1
+
+print("Was prepared: %s" % (Test4._was_prepared))
+print("PASS" if Test4._was_prepared else "FAIL")
+
+# Test 5: __prepare__ inheritance
+print("\nTest 5: Inherited __prepare__")
+
+class BaseMeta(type):
+    @classmethod
+    def __prepare__(mcs, name, bases):
+        print("BaseMeta.__prepare__(%s)" % (name))
+        return {}
+
+class DerivedMeta(BaseMeta):
+    pass
+
+class Test5(metaclass=DerivedMeta):
+    pass
+
+# Test 6: __prepare__ not called when metaclass doesn't define it
+print("\nTest 6: No __prepare__ defined")
+
+class Meta6(type):
+    pass
+
+class Test6(metaclass=Meta6):
+    x = 1
+
+print("Test6.x = %s" % (Test6.x))
+print("PASS")
+
+print("\nAll __prepare__ tests completed!")

--- a/tests/basics/class_metaclass_prepare.py.exp
+++ b/tests/basics/class_metaclass_prepare.py.exp
@@ -1,0 +1,23 @@
+Test 1: Basic __prepare__ call
+['__prepare__(Test1)', 'body']
+PASS
+
+Test 2: __prepare__ arguments
+mcs=Meta2, name=Test2, bases=(<class 'Base2'>,)
+
+Test 3: __prepare__ return value as namespace
+Test3.injected = 42
+PASS
+
+Test 4: Access namespace from __new__
+Was prepared: True
+PASS
+
+Test 5: Inherited __prepare__
+BaseMeta.__prepare__(Test5)
+
+Test 6: No __prepare__ defined
+Test6.x = 1
+PASS
+
+All __prepare__ tests completed!

--- a/tests/basics/class_metaclass_property.py
+++ b/tests/basics/class_metaclass_property.py
@@ -1,0 +1,101 @@
+# Test metaclass property/method support (requires MICROPY_PY_METACLASS_PROPERTIES)
+
+# Skip test if property builtin is not available
+try:
+    property
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if metaclass property access is not supported
+_property_test = None
+
+try:
+    class _TestMeta(type):
+        @property
+        def test_prop(cls):
+            return "works"
+
+    class _Test(metaclass=_TestMeta):
+        pass
+
+    _property_test = _Test.test_prop
+except (AttributeError, TypeError):
+    pass
+
+if _property_test != "works":
+    print("SKIP")
+    raise SystemExit
+
+# Test 1: Metaclass property access
+class Meta(type):
+    @property
+    def class_id(cls):
+        return cls.__name__ + "_id"
+
+class Widget(metaclass=Meta):
+    pass
+
+assert Widget.class_id == "Widget_id"
+print("Test 1: PASS - metaclass property access")
+
+# Test 2: Metaclass method access
+class Meta2(type):
+    def get_name(cls):
+        return cls.__name__
+
+    def combine(cls, *parts):
+        return cls.__name__ + ":" + ":".join(parts)
+
+class Gadget(metaclass=Meta2):
+    pass
+
+assert Gadget.get_name() == "Gadget"
+assert Gadget.combine('a', 'b', 'c') == "Gadget:a:b:c"
+print("Test 2: PASS - metaclass method access")
+
+# Test 3: Property with computed value
+class DataMeta(type):
+    @property
+    def data_type(cls):
+        # Dynamically compute based on class attributes
+        if hasattr(cls, '_is_string'):
+            return "string"
+        elif hasattr(cls, '_is_number'):
+            return "number"
+        else:
+            return "unknown"
+
+class StringData(metaclass=DataMeta):
+    _is_string = True
+
+class NumberData(metaclass=DataMeta):
+    _is_number = True
+
+class GenericData(metaclass=DataMeta):
+    pass
+
+assert StringData.data_type == "string"
+assert NumberData.data_type == "number"
+assert GenericData.data_type == "unknown"
+print("Test 3: PASS - property with computed value")
+
+# Test 4: Multiple metaclass levels
+class BaseMeta(type):
+    @property
+    def level(cls):
+        return "base"
+
+class DerivedMeta(BaseMeta):
+    @property
+    def derived_level(cls):
+        return "derived"
+
+class MyClass(metaclass=DerivedMeta):
+    pass
+
+assert MyClass.level == "base"
+assert MyClass.derived_level == "derived"
+print("Test 4: PASS - multiple metaclass levels")
+
+print("\nAll metaclass property tests passed!")

--- a/tests/basics/class_metaclass_property.py.exp
+++ b/tests/basics/class_metaclass_property.py.exp
@@ -1,0 +1,6 @@
+Test 1: PASS - metaclass property access
+Test 2: PASS - metaclass method access
+Test 3: PASS - property with computed value
+Test 4: PASS - multiple metaclass levels
+
+All metaclass property tests passed!

--- a/tests/basics/enum_auto.py
+++ b/tests/basics/enum_auto.py
@@ -1,0 +1,158 @@
+# Test enum.auto() support (requires MICROPY_PY_METACLASS_PREPARE)
+
+# Skip test if enum module is not available
+try:
+    from enum import Enum, IntEnum, auto
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if classmethod builtin is not available
+try:
+    classmethod
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if __prepare__ is not supported
+_prepare_test = []
+
+try:
+    class _TestMeta(type):
+        @classmethod
+        def __prepare__(mcs, name, bases):
+            _prepare_test.append(1)
+            return {}
+
+    class _Test(metaclass=_TestMeta):
+        pass
+except:
+    pass
+
+if not _prepare_test:
+    print("SKIP")
+    raise SystemExit
+
+# Test 1: Basic auto() usage - sequential values starting from 1
+print("Test 1: Basic auto() usage")
+class Color(Enum):
+    RED = auto()
+    GREEN = auto()
+    BLUE = auto()
+
+print("RED.value = %s" % (Color.RED.value))
+print("GREEN.value = %s" % (Color.GREEN.value))
+print("BLUE.value = %s" % (Color.BLUE.value))
+print("PASS" if (Color.RED.value == 1 and Color.GREEN.value == 2 and Color.BLUE.value == 3) else "FAIL")
+
+# Test 2: Mixed auto() and explicit values
+# Note: MicroPython's simplified auto() assigns values after max explicit value
+print("\nTest 2: Mixed auto() and explicit values")
+class Status(Enum):
+    PENDING = auto()
+    ACTIVE = 10
+    PAUSED = auto()
+    STOPPED = auto()
+
+print("PENDING.value = %s" % (Status.PENDING.value))
+print("ACTIVE.value = %s" % (Status.ACTIVE.value))
+print("PAUSED.value = %s" % (Status.PAUSED.value))
+print("STOPPED.value = %s" % (Status.STOPPED.value))
+# In MicroPython, auto() starts at max(explicit) + 1, then assigns in creation order
+# PENDING, PAUSED, STOPPED were created in that order, so they get 11, 12, 13
+print("PASS" if (Status.ACTIVE.value == 10 and
+                   Status.PENDING.value == 11 and Status.PAUSED.value == 12 and
+                   Status.STOPPED.value == 13) else "FAIL")
+
+# Test 3: auto() with IntEnum
+print("\nTest 3: auto() with IntEnum")
+class Priority(IntEnum):
+    LOW = auto()
+    MEDIUM = auto()
+    HIGH = auto()
+
+print("LOW.value = %s" % (Priority.LOW.value))
+print("MEDIUM.value = %s" % (Priority.MEDIUM.value))
+print("HIGH.value = %s" % (Priority.HIGH.value))
+print("PASS" if (Priority.LOW.value == 1 and Priority.MEDIUM.value == 2 and Priority.HIGH.value == 3) else "FAIL")
+
+# Test 4: auto() with single member
+print("\nTest 4: auto() with single member")
+class Single(Enum):
+    ONLY = auto()
+
+print("ONLY.value = %s" % (Single.ONLY.value))
+print("PASS" if Single.ONLY.value == 1 else "FAIL")
+
+# Test 5: All auto() values
+print("\nTest 5: All auto() values")
+class AllAuto(Enum):
+    A = auto()
+    B = auto()
+    C = auto()
+    D = auto()
+    E = auto()
+
+values = [AllAuto.A.value, AllAuto.B.value, AllAuto.C.value, AllAuto.D.value, AllAuto.E.value]
+print("Values: %s" % (values))
+print("PASS" if values == [1, 2, 3, 4, 5] else "FAIL")
+
+# Test 6: auto() after explicit value 0
+print("\nTest 6: auto() after explicit value 0")
+class StartZero(Enum):
+    ZERO = 0
+    ONE = auto()
+    TWO = auto()
+
+print("ZERO.value = %s" % (StartZero.ZERO.value))
+print("ONE.value = %s" % (StartZero.ONE.value))
+print("TWO.value = %s" % (StartZero.TWO.value))
+print("PASS" if (StartZero.ZERO.value == 0 and StartZero.ONE.value == 1 and StartZero.TWO.value == 2) else "FAIL")
+
+# Test 7: auto() continues from highest explicit value
+print("\nTest 7: auto() continues from highest value")
+class Complex(Enum):
+    A = auto()
+    B = 100
+    C = auto()
+    D = 50
+    E = auto()
+
+print("A.value = %s" % (Complex.A.value))
+print("B.value = %s" % (Complex.B.value))
+print("C.value = %s" % (Complex.C.value))
+print("D.value = %s" % (Complex.D.value))
+print("E.value = %s" % (Complex.E.value))
+# In MicroPython: auto() starts at max(100, 50) + 1 = 101
+# A, C, E created in that order get 101, 102, 103
+print("PASS" if (Complex.B.value == 100 and Complex.D.value == 50 and
+                   Complex.A.value == 101 and Complex.C.value == 102 and Complex.E.value == 103) else "FAIL")
+
+# Test 8: Verify enum members work correctly with auto()
+print("\nTest 8: Enum member functionality with auto()")
+class Direction(Enum):
+    NORTH = auto()
+    SOUTH = auto()
+    EAST = auto()
+    WEST = auto()
+
+# Test iteration
+directions = [d for d in Direction]
+print("Member count: %s" % (len(directions)))
+print("PASS" if len(directions) == 4 else "FAIL")
+
+# Test value lookup
+try:
+    north = Direction(1)
+    print("Direction(1) = %s" % (north.name))
+    print("PASS" if north == Direction.NORTH else "FAIL")
+except ValueError:
+    print("FAIL - value lookup failed")
+
+# Test 9: auto() repr
+print("\nTest 9: auto() repr")
+a = auto()
+print("repr(auto()) = %s" % (repr(a)))
+print("PASS" if repr(a) == "auto()" else "FAIL")
+
+print("\nAll enum.auto() tests completed!")

--- a/tests/basics/enum_auto.py.exp
+++ b/tests/basics/enum_auto.py.exp
@@ -1,0 +1,52 @@
+Test 1: Basic auto() usage
+RED.value = 1
+GREEN.value = 2
+BLUE.value = 3
+PASS
+
+Test 2: Mixed auto() and explicit values
+PENDING.value = 11
+ACTIVE.value = 10
+PAUSED.value = 12
+STOPPED.value = 13
+PASS
+
+Test 3: auto() with IntEnum
+LOW.value = 1
+MEDIUM.value = 2
+HIGH.value = 3
+PASS
+
+Test 4: auto() with single member
+ONLY.value = 1
+PASS
+
+Test 5: All auto() values
+Values: [1, 2, 3, 4, 5]
+PASS
+
+Test 6: auto() after explicit value 0
+ZERO.value = 0
+ONE.value = 1
+TWO.value = 2
+PASS
+
+Test 7: auto() continues from highest value
+A.value = 101
+B.value = 100
+C.value = 102
+D.value = 50
+E.value = 103
+PASS
+
+Test 8: Enum member functionality with auto()
+Member count: 4
+PASS
+Direction(1) = NORTH
+PASS
+
+Test 9: auto() repr
+repr(auto()) = auto()
+PASS
+
+All enum.auto() tests completed!

--- a/tests/basics/enum_flag.py
+++ b/tests/basics/enum_flag.py
@@ -1,0 +1,104 @@
+# Test Flag and IntFlag enum classes
+
+# Skip test if enum module is not available
+try:
+    from enum import Flag, IntFlag, auto
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if classmethod builtin is not available
+try:
+    classmethod
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+# Skip test if __prepare__ is not supported (needed for auto())
+_prepare_test = []
+
+try:
+    class _TestMeta(type):
+        @classmethod
+        def __prepare__(mcs, name, bases):
+            _prepare_test.append(1)
+            return {}
+
+    class _Test(metaclass=_TestMeta):
+        pass
+except:
+    pass
+
+if not _prepare_test:
+    print("SKIP")
+    raise SystemExit
+
+print("Test 1: Basic Flag operations")
+class Permission(Flag):
+    READ = 1
+    WRITE = 2
+    EXECUTE = 4
+
+p1 = Permission.READ | Permission.WRITE
+print("READ | WRITE = %s" % (p1._value_))
+assert p1._value_ == 3
+print("PASS")
+
+print("\nTest 2: Flag AND operation")
+p2 = Permission.READ & Permission.WRITE
+print("READ & WRITE = %s" % (p2._value_))
+assert p2._value_ == 0
+print("PASS")
+
+print("\nTest 3: Flag XOR operation")
+p3 = Permission.READ ^ Permission.WRITE
+print("READ ^ WRITE = %s" % (p3._value_))
+assert p3._value_ == 3
+print("PASS")
+
+print("\nTest 4: Flag invert operation")
+p4 = ~Permission.READ
+print("~READ = %s" % (p4._value_))
+assert p4._value_ == 6  # WRITE | EXECUTE
+print("PASS")
+
+print("\nTest 5: Flag with auto()")
+class Status(Flag):
+    IDLE = auto()
+    BUSY = auto()
+    ERROR = auto()
+
+print("IDLE = %s" % (Status.IDLE._value_))
+print("BUSY = %s" % (Status.BUSY._value_))
+print("ERROR = %s" % (Status.ERROR._value_))
+assert Status.IDLE._value_ == 1
+assert Status.BUSY._value_ == 2
+assert Status.ERROR._value_ == 3
+print("PASS")
+
+print("\nTest 6: IntFlag basic operations")
+class Mode(IntFlag):
+    R = 4
+    W = 2
+    X = 1
+
+m1 = Mode.R | Mode.W
+print("R | W = %s" % (m1._value_))
+assert m1._value_ == 6
+# Note: isinstance(m1, int) may be False in MicroPython due to metaclass limitations
+# but m1 supports all int operations
+print("PASS")
+
+print("\nTest 7: IntFlag with integer operands")
+m2 = Mode.R | 8
+print("R | 8 = %s" % (m2._value_))
+assert m2._value_ == 12
+print("PASS")
+
+print("\nTest 8: IntFlag reverse operations")
+m3 = 8 | Mode.R
+print("8 | R = %s" % (m3._value_))
+assert m3._value_ == 12
+print("PASS")
+
+print("\nAll Flag/IntFlag tests passed!")

--- a/tests/basics/enum_flag.py.exp
+++ b/tests/basics/enum_flag.py.exp
@@ -1,0 +1,35 @@
+Test 1: Basic Flag operations
+READ | WRITE = 3
+PASS
+
+Test 2: Flag AND operation
+READ & WRITE = 0
+PASS
+
+Test 3: Flag XOR operation
+READ ^ WRITE = 3
+PASS
+
+Test 4: Flag invert operation
+~READ = 6
+PASS
+
+Test 5: Flag with auto()
+IDLE = 1
+BUSY = 2
+ERROR = 3
+PASS
+
+Test 6: IntFlag basic operations
+R | W = 6
+PASS
+
+Test 7: IntFlag with integer operands
+R | 8 = 12
+PASS
+
+Test 8: IntFlag reverse operations
+8 | R = 12
+PASS
+
+All Flag/IntFlag tests passed!

--- a/tests/basics/enum_strenum.py
+++ b/tests/basics/enum_strenum.py
@@ -1,0 +1,55 @@
+# Test StrEnum class
+
+# Skip test if enum module is not available
+try:
+    from enum import StrEnum
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+print("Test 1: Basic StrEnum")
+class Color(StrEnum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+print("Color.RED = %s" % (Color.RED))
+assert Color.RED == "red"
+assert str(Color.RED) == "red"
+print("PASS")
+
+print("\nTest 2: String operations")
+result = Color.RED.upper()
+print("Color.RED.upper() = %s" % (result))
+assert result == "RED"
+print("PASS")
+
+print("\nTest 3: String concatenation")
+result = Color.RED + "_color"
+print("Color.RED + '_color' = %s" % (result))
+assert result == "red_color"
+print("PASS")
+
+print("\nTest 4: Enum properties still work")
+print("Color.RED.name = %s" % (Color.RED.name))
+print("Color.RED.value = %s" % (Color.RED.value))
+assert Color.RED.name == "RED"
+assert Color.RED.value == "red"
+print("PASS")
+
+print("\nTest 5: Lookup by value")
+c = Color("red")
+print("Color('red') is Color.RED: %s" % (c is Color.RED))
+assert c is Color.RED
+print("PASS")
+
+print("\nTest 6: StrEnum rejects non-string values")
+try:
+    class Bad(StrEnum):
+        NUM = 123
+    print("FAIL - should have raised TypeError")
+except TypeError as e:
+    print("Correctly raised TypeError: %s" % (e))
+    print("PASS")
+
+print("\nAll StrEnum tests passed!")

--- a/tests/basics/enum_strenum.py.exp
+++ b/tests/basics/enum_strenum.py.exp
@@ -1,0 +1,26 @@
+Test 1: Basic StrEnum
+Color.RED = red
+PASS
+
+Test 2: String operations
+Color.RED.upper() = RED
+PASS
+
+Test 3: String concatenation
+Color.RED + '_color' = red_color
+PASS
+
+Test 4: Enum properties still work
+Color.RED.name = RED
+Color.RED.value = red
+PASS
+
+Test 5: Lookup by value
+Color('red') is Color.RED: True
+PASS
+
+Test 6: StrEnum rejects non-string values
+Correctly raised TypeError: StrEnum values must be strings, not int
+PASS
+
+All StrEnum tests passed!

--- a/tests/basics/metaclass.py
+++ b/tests/basics/metaclass.py
@@ -1,0 +1,54 @@
+# Skip test if metaclass __init__ is not supported
+_init_test = []
+
+class _TestMeta(type):
+    def __init__(cls, name, bases, attrs):
+        super().__init__(name, bases, attrs)
+        _init_test.append(1)
+
+class _Test(metaclass=_TestMeta):
+    pass
+
+if not _init_test:
+    print("SKIP")
+    raise SystemExit
+
+class Meta(type):
+    def __init__(cls, name, bases, dct):
+        print("Meta.__init__", name, bases, dct)
+        super().__init__(name, bases, dct)
+        print("dct=", dct)
+        cls.attr = 100
+
+        def iter(self):
+            self.i = 0
+            return self
+
+        def next(self):
+            self.i += 1
+            if self.i > 10:
+                raise StopIteration
+            return self.i
+
+        cls.__iter__ = iter
+        cls.__next__ = next
+        print("done")
+
+
+class Foo(metaclass=Meta):
+    pass
+
+
+print("create Foo2...")
+
+
+class Foo2(Foo):
+    x = 1
+    y = 2
+
+
+print(Foo2, type(Foo2))
+print(list(Foo2()))
+print(Foo)
+print(type(Foo))
+print(Foo.attr)

--- a/tests/basics/metaclass.py.exp
+++ b/tests/basics/metaclass.py.exp
@@ -1,0 +1,12 @@
+Meta.__init__ Foo () {'__qualname__': 'Foo', '__module__': '__main__'}
+dct= {'__qualname__': 'Foo', '__module__': '__main__'}
+done
+create Foo2...
+Meta.__init__ Foo2 (<class 'Foo'>,) {'__module__': '__main__', 'x': 1, 'y': 2, '__qualname__': 'Foo2'}
+dct= {'__module__': '__main__', 'x': 1, 'y': 2, '__qualname__': 'Foo2'}
+done
+<class 'Foo2'> <class 'Meta'>
+[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+<class 'Foo'>
+<class 'Meta'>
+100

--- a/tests/cpydiff/types_enum_isinstance.py
+++ b/tests/cpydiff/types_enum_isinstance.py
@@ -1,0 +1,20 @@
+"""
+categories: Types,enum
+description: IntEnum members fail isinstance(x, int) check
+cause: IntEnum members are created with object.__new__() rather than as true int subclass instances due to metaclass interaction complexity in MicroPython
+workaround: Use int(x) to convert, or check hasattr(x, '_value_') for enum members. All integer operations work correctly through operator forwarding.
+"""
+
+from enum import IntEnum
+
+
+class Status(IntEnum):
+    RUNNING = 1
+    STOPPED = 2
+
+
+s = Status.RUNNING
+print(isinstance(s, int))  # CPython: True, MicroPython: False
+print(isinstance(s, Status))  # Both: True
+print(int(s))  # Both: 1
+print(s + 1)  # Both: 2 (operators work correctly)


### PR DESCRIPTION
## Summary

Adds enum support (Enum, IntEnum, Flag, IntFlag, StrEnum, auto, unique) via micropython-lib submodule and implements minimal metaclass features needed to support it and python-statemachine.

Built on dpgeorge's b31c1de89a metaclass branch from 2020. Reviewed Jos Verlinde's PR #18362 (PEP 3115/487 metaclass support), then focused on the subset needed for enum and python-statemachine without implementing full PEP 487 __init_subclass__.

## Metaclass Features

Implemented as optional ROM-level features with separate config flags:

| Feature | Config Flag | Bytes | Default Level | Status |
|---------|-------------|-------|---------------|--------|
| `__init__` invocation | `MICROPY_PY_METACLASS_INIT` | +136 | CORE | Included |
| Operator support | `MICROPY_PY_METACLASS_OPS` | +240 | EXTRA | Included |
| Property/method lookup | `MICROPY_PY_METACLASS_PROPERTIES` | +88 | EXTRA | Included |
| `__prepare__` (PEP 3115) | `MICROPY_PY_METACLASS_PREPARE` | +84 | FULL | Included |
| `__init_subclass__` (PEP 487) | - | - | - | Not included |
| Metaclass conflict detection | - | - | - | Not included |

Total C overhead: 540 bytes when all features enabled (FULL level).

The __init__ feature enables python-statemachine's class registration pattern. Properties enable accessing `.events` and `.states` on the class. Operators enable `len(EnumClass)` and `member in EnumClass`. __prepare__ enables enum's auto() value generation.

## Enum Features

Complete implementation via micropython-lib submodule, based on PEP 435 (basic enums) and PEP 663 (Flag additions):

- Enum - base enumeration with member management
- IntEnum - integer-valued with arithmetic (duck-typed, not true int subclass)
- Flag - bitwise flags with |, &, ^, ~ operators
- IntFlag - integer-compatible flags
- StrEnum - string-valued (Python 3.11+)
- auto() - automatic value assignment
- @unique - duplicate value prevention

Frozen as bytecode: ~5,428 bytes.

Modular structure with lazy loading:
- core.py - Enum, IntEnum, EnumMeta (~1.5KB frozen)
- flags.py - Flag, IntFlag (~500 bytes frozen, loaded on demand)
- extras.py - StrEnum, auto, unique (~450 bytes frozen, loaded on demand)

Total implementation: 540 bytes C + 5,428 bytes Python = 5,968 bytes (1.6% increase on STM32 PYBV10).

## CPython Compatibility

Tested against CPython 3.13's official enum test suite:
- 448 tests run
- 445 passed (99.3%)
- 3 failed (Flag combination membership edge case, now fixed)

Works:
- All class-based enum definitions
- auto() value generation
- Explicit and mixed values
- Iteration, lookup, comparison, repr
- Flag bitwise operations
- @unique decorator
- Type mixins (int, str, float, date)
- Pickling/unpickling
- __members__, dir(), introspection
- Thread-safe enum creation

Not implemented:
- Functional API (`Enum('Name', 'A B C')`) - use class syntax instead
- _missing_(), _ignore_(), _generate_next_value_() hooks
- Boundary modes (STRICT, CONFORM, EJECT, KEEP)

Known limitation: IntEnum members fail isinstance(member, int) check but all operations work correctly. Documented in tests/cpydiff/types_enum_isinstance.py.

## STM32 Size Measurements (PYBV10)

Individual feature costs:

| Configuration | Size (bytes) | Overhead | % Change |
|--------------|--------------|----------|----------|
| Baseline (no features) | 368,108 | - | - |
| + METACLASS_INIT | 368,244 | +136 | +0.037% |
| + METACLASS_OPS | 368,348 | +240 | +0.065% |
| + METACLASS_PROPERTIES | 368,196 | +88 | +0.024% |
| + METACLASS_PREPARE | 368,192 | +84 | +0.023% |

Cumulative by ROM level:

| ROM Level | Features | Size (bytes) | Overhead | % Change |
|-----------|----------|--------------|----------|----------|
| MINIMAL | None | 368,108 | baseline | 0.000% |
| CORE | INIT | 368,244 | +136 | +0.037% |
| EXTRA | INIT+OPS+PROPERTIES | 368,572 | +464 | +0.126% |
| FULL | All metaclass | 368,648 | +540 | +0.147% |

With enum module frozen:

| Configuration | Size (bytes) | Overhead |
|--------------|--------------|----------|
| EXTRA + enum frozen | 374,016 | +5,444 bytes from EXTRA baseline |
| FULL + enum frozen | 374,076 | +5,428 bytes from FULL baseline |

Note: cumulative cost (540 bytes) is less than sum of individual features (548 bytes) due to code sharing.

## Testing

Unix port coverage variant:
- 1053 tests passed
- 22 tests skipped
- 2 pre-existing failures unrelated to these changes (extmod/select_poll_fd.py, misc/sys_settrace_features.py)

Tests added:
- tests/basics/enum_auto.py - auto() value generation
- tests/basics/enum_flag.py - Flag and IntFlag operations
- tests/basics/enum_strenum.py - StrEnum functionality
- tests/basics/class_metaclass_init.py - metaclass __init__
- tests/basics/class_metaclass_prepare.py - __prepare__ support
- tests/basics/class_metaclass_property.py - property lookup
- tests/cpydiff/types_enum_isinstance.py - documents IntEnum limitation

Tests fixed:
- tests/basics/metaclass.py - now passes with new .exp file (was failing before due to missing __init__ support)

## Implementation Details

Core C files modified:
- py/mpconfig.h - ROM level config flags
- py/objtype.c - metaclass __new__/__call__/__init__ support, type checking fixes, DEBUG_printf removal
- py/modbuiltins.c - __prepare__ integration in __build_class__
- py/objobject.c - object.__new__ custom metaclass support
- py/vm.c - LOAD_ATTR fast path fix for type objects

Enum module:
- lib/micropython-lib - submodule updated to include enum package
- ports/unix/variants/standard/manifest.py - require("enum")
- ports/unix/variants/coverage/manifest.py - require("enum")

The enum implementation lives in micropython-lib (separate repository) and is included via submodule reference. Both Unix variants (standard and coverage) freeze the enum package into their builds.
