### PR TITLE
ports: Fix main.c some machine_*_deinit_all() have no #if macro.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -187,7 +187,9 @@ soft_reset_exit:
 
     // Deinit uart before timers, as esp32 uart
     // depends on a timer instance
+    #if MICROPY_PY_MACHINE_UART
     machine_uart_deinit_all();
+    #endif
     machine_timer_deinit_all();
 
     #if MICROPY_PY_ESP32_PCNT
@@ -210,7 +212,9 @@ soft_reset_exit:
     mp_hal_stdout_tx_str("MPY: soft reboot\r\n");
 
     // deinitialise peripherals
+    #if MICROPY_PY_MACHINE_PWM
     machine_pwm_deinit_all();
+    #endif
     // TODO: machine_rmt_deinit_all();
     machine_pins_deinit();
     #if MICROPY_PY_MACHINE_I2C_TARGET

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -170,8 +170,12 @@ int main(void) {
         #if MICROPY_PY_NETWORK
         mod_network_deinit();
         #endif
+        #if MICROPY_PY_MACHINE_UART
         machine_uart_deinit_all();
+        #endif
+        #if MICROPY_PY_MACHINE_PWM
         machine_pwm_deinit_all();
+        #endif
         soft_timer_deinit();
         gc_sweep_all();
         mp_deinit();

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -249,15 +249,21 @@ int main(int argc, char **argv) {
         #if MICROPY_PY_NETWORK
         mod_network_deinit();
         #endif
+        #if MICROPY_PY_MACHINE_I2S
         machine_i2s_deinit_all();
+        #endif
         rp2_dma_deinit();
         rp2_pio_deinit();
         #if MICROPY_PY_BLUETOOTH
         mp_bluetooth_deinit();
         #endif
+        #if MICROPY_PY_MACHINE_PWM
         machine_pwm_deinit_all();
+        #endif
         machine_pin_deinit();
+        #if MICROPY_PY_MACHINE_UART
         machine_uart_deinit_all();
+        #endif
         #if MICROPY_PY_MACHINE_I2C_TARGET
         mp_machine_i2c_target_deinit_all();
         #endif


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

When some feature (pwm, uart) disabled , deinit function doesn't exist.
So we need to use `#if` for `main.c` before calling the deinit function.
### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

