### PR TITLE
stress_schedule: Fix for !GIL + emit=native.

### DIFF
--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -132,7 +132,8 @@ Functions
      handler (an IRQ).
    - Inside native code functions, scheduled functions are not called unless
      the native code calls a function that specifically does so.
-   - ``time.sleep`` and ``time.sleep_ms``, including zero-duration sleeps,
+   - Certain functions including ``poll.poll``, ``poll.ipoll``,
+     ``time.sleep``, ``time.sleep_ms``, including zero-duration sleeps,
      will call scheduled functions.
 
    A use for this function is to schedule a callback from a preempting IRQ.

--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -130,6 +130,10 @@ Functions
      a critical region but they will not be executed until that region
      is exited.  An example of a critical region is a preempting interrupt
      handler (an IRQ).
+   - Inside native code functions, scheduled functions are not called unless
+     the native code calls a function that specifically does so.
+   - ``time.sleep`` and ``time.sleep_ms``, including zero-duration sleeps,
+     will call scheduled functions.
 
    A use for this function is to schedule a callback from a preempting IRQ.
    Such an IRQ puts restrictions on the code that runs in the IRQ (for example

--- a/docs/library/select.rst
+++ b/docs/library/select.rst
@@ -81,6 +81,9 @@ Methods
 
       Tuples returned may contain more than 2 elements as described above.
 
+   Calling ``poll.poll`` is guaranteed to call pending callback
+   functions before entering the polling loop.
+
 .. method:: poll.ipoll(timeout=-1, flags=0, /)
 
    Like :meth:`poll.poll`, but instead returns an iterator which yields a
@@ -97,3 +100,6 @@ Methods
       :class: attention
 
       This function is a MicroPython extension.
+
+   Calling ``poll.ipoll`` is guaranteed to call pending callback
+   functions before entering the polling loop.

--- a/docs/library/time.rst
+++ b/docs/library/time.rst
@@ -71,6 +71,9 @@ Functions
    other boards may not accept a floating-point argument, for compatibility with
    them use `sleep_ms()` and `sleep_us()` functions.
 
+   Calling ``sleep``, including ``sleep(0)`` is guaranteed to call pending callback
+   functions.
+
 .. function:: sleep_ms(ms)
 
    Delay for given number of milliseconds, should be positive or 0.
@@ -79,6 +82,9 @@ Functions
    may take longer than that if other processing must take place, for example
    interrupt handlers or other threads.  Passing in 0 for *ms* will still allow
    this other processing to occur.  Use `sleep_us()` for more precise delays.
+
+   Calling ``sleep_ms``, including ``sleep_ms(0)`` is guaranteed to call
+   pending callback functions.
 
 .. function:: sleep_us(us)
 

--- a/extmod/modselect.c
+++ b/extmod/modselect.c
@@ -342,6 +342,8 @@ static mp_uint_t poll_set_poll_until_ready_or_timeout(poll_set_t *poll_set, size
     mp_uint_t start_ticks = mp_hal_ticks_ms();
     bool has_timeout = timeout != (mp_uint_t)-1;
 
+    mp_handle_pending(true);
+
     #if MICROPY_PY_SELECT_POSIX_OPTIMISATIONS
 
     for (;;) {

--- a/ports/qemu/mphalport.c
+++ b/ports/qemu/mphalport.c
@@ -25,6 +25,7 @@
  */
 
 #include "py/mphal.h"
+#include "py/runtime.h"
 #include "py/stream.h"
 #include "shared/runtime/semihosting_arm.h"
 #include "uart.h"
@@ -82,8 +83,12 @@ mp_uint_t mp_hal_ticks_us(void) {
 }
 
 void mp_hal_delay_ms(mp_uint_t ms) {
-    mp_uint_t start = mp_hal_ticks_ms();
-    while (mp_hal_ticks_ms() - start < ms) {
+    if (ms) {
+        mp_uint_t start = mp_hal_ticks_ms();
+        while (mp_hal_ticks_ms() - start < ms) {
+        }
+    } else {
+        mp_handle_pending(true);
     }
 }
 

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -95,6 +95,7 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     tv.tv_sec = (suseconds_t)ipart;
     int res;
     while (1) {
+        mp_handle_pending(true);
         MP_THREAD_GIL_EXIT();
         res = sleep_select(0, NULL, NULL, NULL, &tv);
         MP_THREAD_GIL_ENTER();
@@ -104,7 +105,6 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
         if (res != -1 || errno != EINTR) {
             break;
         }
-        mp_handle_pending(true);
         // printf("select: EINTR: %ld:%ld\n", tv.tv_sec, tv.tv_usec);
         #else
         break;
@@ -114,13 +114,13 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #else
     int seconds = mp_obj_get_int(arg);
     for (;;) {
+        mp_handle_pending(true);
         MP_THREAD_GIL_EXIT();
         seconds = sleep(seconds);
         MP_THREAD_GIL_ENTER();
         if (seconds == 0) {
             break;
         }
-        mp_handle_pending(true);
     }
     #endif
     return mp_const_none;

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -242,9 +242,13 @@ uint64_t mp_hal_time_ns(void) {
 
 #ifndef mp_hal_delay_ms
 void mp_hal_delay_ms(mp_uint_t ms) {
-    mp_uint_t start = mp_hal_ticks_ms();
-    while (mp_hal_ticks_ms() - start < ms) {
-        mp_event_wait_ms(1);
+    if (ms) {
+        mp_uint_t start = mp_hal_ticks_ms();
+        while (mp_hal_ticks_ms() - start < ms) {
+            mp_event_wait_ms(1);
+        }
+    } else {
+        mp_handle_pending(true);
     }
 }
 #endif

--- a/tests/micropython/schedule_sleep.py
+++ b/tests/micropython/schedule_sleep.py
@@ -1,14 +1,17 @@
 # test micropython.schedule() function
-# this test should be manually kept in synch with
-# tests/micrpython/schedule_sleep.py.
+# this is the same as tests/micropython/schedule.py but the busy loops are
+# replaced with sleep/sleep_ms which allows the test to succeed when run under
+# the native emitter.
 
 try:
     import micropython
+    import time
 
     micropython.schedule
 except (ImportError, AttributeError):
     print("SKIP")
     raise SystemExit
+
 
 # Basic test of scheduling a function.
 
@@ -22,7 +25,7 @@ def callback(arg):
 done = False
 micropython.schedule(callback, 1)
 while not done:
-    pass
+    time.sleep(0)
 
 # Test that callbacks can be scheduled from within a callback, but
 # that they don't execute until the outer callback is finished.
@@ -47,7 +50,7 @@ def callback_outer(arg):
 done = 0
 micropython.schedule(callback_outer, 0)
 while done != 2:
-    pass
+    time.sleep(0)
 
 # Test that scheduling too many callbacks leads to an exception.  To do this we
 # must schedule from within a callback to guarantee that the scheduler is locked.
@@ -66,4 +69,4 @@ def callback(arg):
 done = False
 micropython.schedule(callback, None)
 while not done:
-    pass
+    time.sleep_ms(0)

--- a/tests/micropython/schedule_sleep.py.exp
+++ b/tests/micropython/schedule_sleep.py.exp
@@ -1,0 +1,4 @@
+1
+outer
+inner
+RuntimeError

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -985,8 +985,6 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
     # Some tests shouldn't be run on GitHub Actions
     if os.getenv("GITHUB_ACTIONS") == "true":
-        skip_tests.add("thread/stress_schedule.py")  # has reliability issues
-
         if os.getenv("RUNNER_OS") == "Windows" and os.getenv("CI_BUILD_CONFIGURATION") == "Debug":
             # fails with stack overflow on Debug builds
             skip_tests.add("misc/sys_settrace_features.py")

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -164,7 +164,7 @@ emitter_tests_to_skip = {
         "basics/exception_chain.py",
         # These require stack-allocated slice optimisation.
         "micropython/heapalloc_slice.py",
-        # These require running the scheduler.
+        # These require implicitly running the scheduler between bytecodes.
         "micropython/schedule.py",
         "extmod/asyncio_event_queue.py",
         "extmod/asyncio_iterator_event.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -166,8 +166,6 @@ emitter_tests_to_skip = {
         "micropython/heapalloc_slice.py",
         # These require implicitly running the scheduler between bytecodes.
         "micropython/schedule.py",
-        "extmod/asyncio_event_queue.py",
-        "extmod/asyncio_iterator_event.py",
         # These require sys.exc_info().
         "misc/sys_exc_info.py",
         # These require sys.settrace().

--- a/tests/thread/stress_schedule.py
+++ b/tests/thread/stress_schedule.py
@@ -35,7 +35,7 @@ def thread():
             micropython.schedule(task, None)
         except RuntimeError:
             # Queue full, back off.
-            time.sleep_ms(10)
+            time.sleep_ms(1)
 
 
 for i in range(8):

--- a/tests/thread/stress_schedule.py
+++ b/tests/thread/stress_schedule.py
@@ -27,8 +27,6 @@ def task(x):
     n += 1
 
 
-# This function must always use the bytecode emitter so it bounces the GIL when running.
-@micropython.bytecode
 def thread():
     while thread_run:
         try:


### PR DESCRIPTION
### Summary

Ensure that zero-duration sleeps run scheduled callbacks.

Reduce a wait making the test run 8x faster locally, which hopefully also makes it reliable on ci.

Restore the test during ci as well as some asyncio tests.

Closes: #18415 

ping @projectgus 

### Testing

I ran the script manually locally.

### Trade-offs and Alternatives

We could delete stress_schedule, it's been unused in CI since 2020.