### PR TITLE
py/runtime: Multi-Level Init/Deinit System for Embedded Ports (RFC/PoC).

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -316,6 +316,7 @@ SRC_C += \
 	sdio.c \
 	subghz.c \
 	xspi.c \
+	mpinit_register.c \
 	$(wildcard $(BOARD_DIR)/*.c)
 
 SRC_O += \
@@ -630,7 +631,7 @@ TEXT0_ADDR ?= 0x08000000
 ifeq ($(TEXT1_ADDR),)
 # No TEXT1_ADDR given so put all firmware at TEXT0_ADDR location
 
-TEXT0_SECTIONS ?= .isr_vector .isr_extratext .text .gc.blocks.table .data .ARM
+TEXT0_SECTIONS ?= .isr_vector .isr_extratext .text .gc.blocks.table .mp_init_early .mp_init_core .mp_init_driver .mp_init_service .mp_deinit_early .mp_deinit_core .mp_deinit_driver .mp_deinit_service .data .ARM
 
 deploy-stlink: $(BUILD)/firmware.bin
 	$(call RUN_STLINK,$^,$(TEXT0_ADDR))

--- a/ports/stm32/boards/common_init.ld
+++ b/ports/stm32/boards/common_init.ld
@@ -1,0 +1,75 @@
+/* This linker script fragment is intended to be included in SECTIONS. */
+
+/* Multi-level init/deinit sections - 4 levels */
+
+.mp_init_early :
+{
+    . = ALIGN(4);
+    __mp_init_early_start = .;
+    KEEP(*(SORT(.mp_init_early.*)));
+    __mp_init_early_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_init_core :
+{
+    . = ALIGN(4);
+    __mp_init_core_start = .;
+    KEEP(*(SORT(.mp_init_core.*)));
+    __mp_init_core_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_init_driver :
+{
+    . = ALIGN(4);
+    __mp_init_driver_start = .;
+    KEEP(*(SORT(.mp_init_driver.*)));
+    __mp_init_driver_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_init_service :
+{
+    . = ALIGN(4);
+    __mp_init_service_start = .;
+    KEEP(*(SORT(.mp_init_service.*)));
+    __mp_init_service_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_deinit_early :
+{
+    . = ALIGN(4);
+    __mp_deinit_early_start = .;
+    KEEP(*(SORT(.mp_deinit_early.*)));
+    __mp_deinit_early_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_deinit_core :
+{
+    . = ALIGN(4);
+    __mp_deinit_core_start = .;
+    KEEP(*(SORT(.mp_deinit_core.*)));
+    __mp_deinit_core_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_deinit_driver :
+{
+    . = ALIGN(4);
+    __mp_deinit_driver_start = .;
+    KEEP(*(SORT(.mp_deinit_driver.*)));
+    __mp_deinit_driver_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT
+
+.mp_deinit_service :
+{
+    . = ALIGN(4);
+    __mp_deinit_service_start = .;
+    KEEP(*(SORT(.mp_deinit_service.*)));
+    __mp_deinit_service_end = .;
+    . = ALIGN(4);
+} >FLASH_TEXT

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1769,3 +1769,64 @@ MP_NORETURN void mp_raise_recursion_depth(void) {
     mp_raise_type_arg(&mp_type_RuntimeError, MP_OBJ_NEW_QSTR(MP_QSTR_maximum_space_recursion_space_depth_space_exceeded));
 }
 #endif
+
+#if MICROPY_ENABLE_INIT_LEVELS
+
+// Multi-level initialization implementation
+
+// External linker symbols for each level
+extern mp_init_func_t __mp_init_early_start[], __mp_init_early_end[];
+extern mp_init_func_t __mp_init_core_start[], __mp_init_core_end[];
+extern mp_init_func_t __mp_init_driver_start[], __mp_init_driver_end[];
+extern mp_init_func_t __mp_init_service_start[], __mp_init_service_end[];
+
+extern mp_init_func_t __mp_deinit_early_start[], __mp_deinit_early_end[];
+extern mp_init_func_t __mp_deinit_core_start[], __mp_deinit_core_end[];
+extern mp_init_func_t __mp_deinit_driver_start[], __mp_deinit_driver_end[];
+extern mp_init_func_t __mp_deinit_service_start[], __mp_deinit_service_end[];
+
+// Tables of start/end pointers
+static const struct {
+    mp_init_func_t *start;
+    mp_init_func_t *end;
+} mp_init_table[] = {
+    { __mp_init_early_start, __mp_init_early_end },
+    { __mp_init_core_start, __mp_init_core_end },
+    { __mp_init_driver_start, __mp_init_driver_end },
+    { __mp_init_service_start, __mp_init_service_end },
+};
+
+static const struct {
+    mp_init_func_t *start;
+    mp_init_func_t *end;
+} mp_deinit_table[] = {
+    { __mp_deinit_early_start, __mp_deinit_early_end },
+    { __mp_deinit_core_start, __mp_deinit_core_end },
+    { __mp_deinit_driver_start, __mp_deinit_driver_end },
+    { __mp_deinit_service_start, __mp_deinit_service_end },
+};
+
+void mp_init_run_level(mp_init_level_t level) {
+    if (level >= MP_INIT_NUM_LEVELS) {
+        return;
+    }
+    for (mp_init_func_t *f = mp_init_table[level].start;
+         f < mp_init_table[level].end;
+         f++) {
+        (*f)();
+    }
+}
+
+void mp_deinit_run_level(mp_init_level_t level) {
+    if (level >= MP_INIT_NUM_LEVELS) {
+        return;
+    }
+    // Iterate BACKWARDS
+    for (mp_init_func_t *f = mp_deinit_table[level].end - 1;
+         f >= mp_deinit_table[level].start;
+         f--) {
+        (*f)();
+    }
+}
+
+#endif // MICROPY_ENABLE_INIT_LEVELS

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -321,4 +321,38 @@ void mp_warning(const char *category, const char *msg, ...);
 #define mp_warning(...)
 #endif
 
+// Multi-level initialization system
+typedef enum {
+    MP_INIT_EARLY = 0,   // Critical early init (future use)
+    MP_INIT_CORE,        // Core subsystems (future use)
+    MP_INIT_DRIVER,      // Low-level drivers
+    MP_INIT_SERVICE,     // High-level services
+    MP_INIT_NUM_LEVELS
+} mp_init_level_t;
+
+typedef void (*mp_init_func_t)(void);
+
+#if MICROPY_ENABLE_INIT_LEVELS
+
+// Registration macros - embeds function name in section for debugging
+#define MP_INIT_REGISTER(level, priority, func) \
+    static const mp_init_func_t __mp_init_##level##_##priority##_##func \
+    __attribute__((section(".mp_init_" #level "." #priority "." #func), used)) = func
+
+#define MP_DEINIT_REGISTER(level, priority, func) \
+    static const mp_init_func_t __mp_deinit_##level##_##priority##_##func \
+    __attribute__((section(".mp_deinit_" #level "." #priority "." #func), used)) = func
+
+// Runner functions
+void mp_init_run_level(mp_init_level_t level);
+void mp_deinit_run_level(mp_init_level_t level);
+
+#else
+
+// Empty macros when feature is disabled
+#define MP_INIT_REGISTER(level, priority, func)
+#define MP_DEINIT_REGISTER(level, priority, func)
+
+#endif // MICROPY_ENABLE_INIT_LEVELS
+
 #endif // MICROPY_INCLUDED_PY_RUNTIME_H


### PR DESCRIPTION
### Summary

This PR introduces a multi-level initialization and deinitialization system for embedded MicroPython ports. The system uses GNU linker sections to automatically collect and order init/deinit function pointers, eliminating the need to manually maintain initialization sequences in `main.c`.

Example usage:
```C
MP_INIT_REGISTER(driver, 00, timer_init0);
MP_DEINIT_REGISTER(driver, 00, timer_deinit);

...
// Calls all your init functions
mp_init_run_level(MP_INIT_DRIVER);
```

#### Key Benefits
* Makes init order dependencies (or lack thereof) explicit and consistent across ports.
* Optional via config: Ports can keep their old init/deinit behavior.
* Allows ordering init/deinit functions within a level, so can easily replicate exact current behavior.
* Modules/drivers can register their init/deinit. Alternatively, we could extern & register all init/deinit functions in a port-specific file (e.g., `stm32/mpinit_register.c`), allowing ports even more flexibility and customization, but this kinda defeats the consistency point.
* Improves readability: replace 100s of duplicate lines with a few calls.
* New ports get correct initialization automatically.
* New driver/service/etc.. won't require updating `main.c` in every port that uses it.

### Testing

Didn't do any actual testing, since this is just an RFC/PoC, but here's what one section looks like:
```bash
grep "\.mp_init_driver\." build-*/firmware.map

 *(SORT_BY_NAME(.mp_init_driver.*))
 .mp_init_driver.00.readline_init0
 .mp_init_driver.01.pin_init0
 .mp_init_driver.02.extint_init0
 .mp_init_driver.03.timer_init0
 .mp_init_driver.05.pyb_usb_init0
 .mp_init_driver.09.servo_init
```

### Challenges and risks

* There's no common linker script between boards, let alone ports, so to enable this in stm32 port, for example, we'd have to go through every board and make sure its linker script includes the common script.
* Very few init functions accept args, we could either make their state/arg extern/global, add wrappers or just call them manually.
* This is a big change that may break things, however, not every port needs to enable it. So we could start small, then migrate more and more ports.