### PR TITLE
docs/mimxrt/pinout: Use Dxx pin identifiers for Teensy boards in the Pinout section.

### DIFF
--- a/docs/mimxrt/pinout.rst
+++ b/docs/mimxrt/pinout.rst
@@ -5,7 +5,10 @@ Pinout for the i.MXRT machine modules
 
 .. _mimxrt_uart_pinout:
 
-|
+The Teensy 4.0 and 4.1 board show pin numbers **nn** at the board's silkscreen.
+These are denoted in the tables below as **Dnn**. E.g. a silkscreen number **1** is
+shown as **D1**. Whenever a Pin has to be specified in a script, **Dnn** must
+be used, not **nn**.
 
 UART pin assignment
 -------------------
@@ -17,8 +20,8 @@ tables below:
 =================  ===========  ===========  ===========  ===========
 Board / Pin           UART0        UART1        UART2        UART3
 =================  ===========  ===========  ===========  ===========
-Teensy 4.0             -            0/1          7/8         14/15
-Teensy 4.1             -            0/1          7/8         14/15
+Teensy 4.0             -          D0/D1        D7/D8       D14/D15
+Teensy 4.1             -          D0/D1        D7/D8       D14/D15
 MIMXRT1010-EVK     Debug USB      D0/D1        D7/D6           -
 MIMXRT1015-EVK     Debug USB      D0/D1        D7/A1           -
 MIMXRT1020-EVK     Debug USB      D0/D1        D9/D6       D10/D13
@@ -35,11 +38,11 @@ Makerdiary RT1011     -           D9/D10      D13/A0       D11/D12
 
 |
 
-=================  ===========  ===========  =======  =======  =====
-Board / Pin            UART4        UART5      UART6   UART7   UART8
-=================  ===========  ===========  =======  =======  =====
-Teensy 4.0             16/17        21/20     25/24    28/29      -
-Teensy 4.1             16/17        21/20     25/24    28/29   34/35
+=================  ===========  ===========  =======  =======  =======
+Board / Pin            UART4        UART5      UART6   UART7    UART8
+=================  ===========  ===========  =======  =======  =======
+Teensy 4.0           D16/D17      D21/D20    D25/D24  D28/D29      -
+Teensy 4.1           D16/D17      D21/D20    D25/D24  D28/D29  D34/D35
 MIMXRT1010-EVK          -            -         -        -        -
 MIMXRT1015-EVK          -            -         -        -        -
 MIMXRT1020-EVK       D15/D14       A1/A0       -        -        -
@@ -51,7 +54,7 @@ MIMXRT1170-EVK       D15/D14      D25/D26    D33/D34  D35/D36    -
 Olimex RT1010Py         -            -         -        -        -
 Seeed ARCH MIX     J4_10/J4_11  J5_08/J5_12    -        -        -
 Makerdiary RT1011     A1/A2          -         -        -        -
-=================  ===========  ===========  =======  =======  =====
+=================  ===========  ===========  =======  =======  =======
 
 .. _mimxrt_pwm_pinout:
 
@@ -102,46 +105,46 @@ Pins denoted with (*) are by default not wired at the board.
 ====   ==========  ====   ==========
 Pin    Teensy 4.0  Pin    Teensy 4.1
 ====   ==========  ====   ==========
-0      F1/1/X      0      F1/1/X
-1      F1/0/X      1      F1/0/X
-2      F4/2/A      2      F4/2/A
-3      F4/2/B      3      F4/2/B
-4      F2/0/A      4      F2/0/A
-5      F2/1/A      5      F2/1/A
-6      F2/2/A      6      F2/2/A
-7      F1/3/B      7      F1/3/B
-8      F1/3/A      8      F1/3/A
-9      F2/2/B      9      F2/2/B
-10     Q1/0        10     Q1/0
-11     Q1/2        11     Q1/2
-12     Q1/1        12     Q1/1
-13     Q2/0        13     Q2/0
-14     Q3/2        14     Q3/2
-15     Q3/3        15     Q3/3
-18     Q3/1        18     Q3/1
-19     Q3/0        19     Q3/0
-22     F4/0/A      22     F4/0/A
-23     F4/1/A      23     F4/1/A
-24     F1/2/X      24     F1/2/X
-25     F1/3/X      25     F1/3/X
-28     F3/1/B      28     F3/1/B
-29     F3/1/A      29     F3/1/A
-33     F2/0/B      33     F2/0/B
--      -           36     F2/3/A
--      -           37     F2/3/B
-DAT1   F1/1/B      42     F1/1/B
-DAT0   F1/1/A      43     F1/1/A
-CLK    F1/0/B      44     F1/0/B
-CMD    F1/0/A      45     F1/0/A
-DAT2   F1/2/A      46     F1/2/A
-DAT3   F1/2/B      47     F1/2/B
--      -           48     F1/0/B
--      -           49     F1/2/A
--      -           50     F1/2/B
--      -           51     F3/3/B
--      -           52     F1/1/B
--      -           53     F1/1/A
--      -           54     F3/0/A
+D0     F1/1/X      D0     F1/1/X
+D1     F1/0/X      D1     F1/0/X
+D2     F4/2/A      D2     F4/2/A
+D3     F4/2/B      D3     F4/2/B
+D4     F2/0/A      D4     F2/0/A
+D5     F2/1/A      D5     F2/1/A
+D6     F2/2/A      D6     F2/2/A
+D7     F1/3/B      D7     F1/3/B
+D8     F1/3/A      D8     F1/3/A
+D9     F2/2/B      D9     F2/2/B
+D10    Q1/0        D10    Q1/0
+D11    Q1/2        D11    Q1/2
+D12    Q1/1        D12    Q1/1
+D13    Q2/0        D13    Q2/0
+D14    Q3/2        D14    Q3/2
+D15    Q3/3        D15    Q3/3
+D18    Q3/1        D18    Q3/1
+D19    Q3/0        D19    Q3/0
+D22    F4/0/A      D22    F4/0/A
+D23    F4/1/A      D23    F4/1/A
+D24    F1/2/X      D24    F1/2/X
+D25    F1/3/X      D25    F1/3/X
+D28    F3/1/B      D28    F3/1/B
+D29    F3/1/A      D29    F3/1/A
+D33    F2/0/B      D33    F2/0/B
+-      -           D36    F2/3/A
+-      -           D37    F2/3/B
+DAT1   F1/1/B      D42    F1/1/B
+DAT0   F1/1/A      D43    F1/1/A
+CLK    F1/0/B      D44    F1/0/B
+CMD    F1/0/A      D45    F1/0/A
+DAT2   F1/2/A      D46    F1/2/A
+DAT3   F1/2/B      D47    F1/2/B
+-      -           D48    F1/0/B
+-      -           D49    F1/2/A
+-      -           D50    F1/2/B
+-      -           D51    F3/3/B
+-      -           D52    F1/1/B
+-      -           D53    F1/1/A
+-      -           D54    F3/0/A
 ====   ==========  ====   ==========
 
 |
@@ -330,11 +333,11 @@ The SPI signals have fixed assignments to GPIO pins.
 It depends on the board design, which SPI's signals are exposed to the user, as
 detailed in the table below.  The signal order in the table is: CS0, CS1, MOSI, MISO, CLK.
 
-=================  =========================  =======================  ===============
+=================  =========================  =======================  =================
 Board / Pin        SPI0                       SPI1                     SPI2
-=================  =========================  =======================  ===============
-Teensy 4.0         10/-/11/12/13              0/-/26/1/27                    -
-Teensy 4.1         10/37/11/12/13             0/-/26/1/27              -/29/50/54/49
+=================  =========================  =======================  =================
+Teensy 4.0         D10/-/D11/D12/D13          D0/-/D26/D1/D27                -
+Teensy 4.1         D10/D37/D11/D12/D13        D0/-/D26/D1/D27          -/D29/D50/D54/D49
 MIXMXRT1010-EVK    D10/D7/D11/D12/D13                -                       -
 MIXMXRT1015-EVK    D10/-/D11/D12/D13                 -                       -
 MIXMXRT1020-EVK    D10/-/D11/D12/D13          A3/D0/A5/A4/A0                 -
@@ -347,7 +350,7 @@ Adafruit Metro M7  -/-/MOSI/MISO/SCK                -                        -
 Olimex RT1010Py             -                 CS0/-/SDO/SDI/SCK        SDCARD with CS1
 Seeed ARCH MIX     J4_12/-/J4_14/J4_13/J4_15  J3_09/J3_05/J3_08_J3_11
 Makerdiary RT1011  A5/A2/A4/A3/A6             A11/A1/A10/A9/CLK
-=================  =========================  =======================  ===============
+=================  =========================  =======================  =================
 
 Pins denoted with (*) are by default not wired at the board. The CS0 and CS1 signals
 are enabled with the keyword option cs=0 or cs=1 of the SPI object constructor.
@@ -367,8 +370,8 @@ detailed in the table below.  The signal order in the table is: SDA, SCL.
 =================  ===========  ===========  ===========  =======  =======
 Board / Pin        I2C 0        I2C 1        I2C 2        I2C 3    I2C 4
 =================  ===========  ===========  ===========  =======  =======
-Teensy 4.0         18/19        17/16        25/24         -        -
-Teensy 4.1         18/19        17/16        25/24         -        -
+Teensy 4.0         D18/D19      D17/D16      D25/D24       -        -
+Teensy 4.1         D18/D19      D17/D16      D25/D24       -        -
 MIXMXRT1010-EVK    D14/D15      D0/D1         -            -        -
 MIXMXRT1015-EVK    D14/D15       -            -            -        -
 MIXMXRT1020-EVK    D14/D15      A4/A5        D0/D1         -        -
@@ -396,10 +399,10 @@ Pin assignments for a few MIMXRT boards:
 =================  ==  =====  ======== ======= ======= ======== ======= =======
 Board              ID  MCK    SCK_TX   WS_TX   SD_TX   SCK_RX   WS_RX   SD_RX
 =================  ==  =====  ======== ======= ======= ======== ======= =======
-Teensy 4.0         1   23     26       27      7       21       20      8
-Teensy 4.0         2   33     4        3       2       -        -       5
-Teensy 4.1         1   23     26       27      7       21       20      8
-Teensy 4.1         2   33     4        3       2       -        -       5
+Teensy 4.0         1   D23    D26      D27     D7      D21      D20     D8
+Teensy 4.0         2   D33    D4       D3      D2      -        -       D5
+Teensy 4.1         1   D23    D26      D27     D7      D21      D20     D8
+Teensy 4.1         2   D33    D4       D3      D2      -        -       D5
 Seeed Arch MIX     1   J4_09  J4_14    J4_15   J14_13  J4_11    J4_10   J4_10
 Adafruit Metro M7  1   D8     D10      D9      D12     D14      D15     D13
 Olimex RT1010Py    1   D8     D6       D7      D4      D1       D2      D3


### PR DESCRIPTION
### Summary

The documentation used integers to specify Teensy board pins, which match the board's silkscreen. But in Python code Dxx had to be used, since integers are not accepted a Pin identifier. This PR changes the Pinout tables accordingly, consistent to the other MIMXRT boards.

### Testing

The documentation was built and verified, that the format is not broken.
