### PR TITLE
Update the submodule pico-sdk to version 2.2.0 and make it compatible

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -235,6 +235,7 @@ set(PICO_SDK_COMPONENTS
     pico_flash
     pico_multicore
     pico_platform
+    pico_platform_common
     pico_platform_compiler
     pico_platform_panic
     pico_platform_sections

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -66,6 +66,11 @@ if(NOT MICROPY_C_HEAP_SIZE)
     set(MICROPY_C_HEAP_SIZE 0)
 endif()
 
+# Set the stack size if it's not already set by the board.
+if(NOT PICO_STACK_SIZE)
+    set(PICO_STACK_SIZE 0x2000)
+endif()
+
 # Enable error text compression by default.
 if(NOT MICROPY_ROM_TEXT_COMPRESSION)
     set(MICROPY_ROM_TEXT_COMPRESSION ON)
@@ -98,6 +103,8 @@ project(${MICROPY_TARGET})
 pico_sdk_init()
 
 include(${MICROPY_DIR}/py/usermod.cmake)
+
+set(PIOASM_VERSION_STRING "pico-sdk-${PICO_SDK_VERSION_STRING}")
 
 add_executable(${MICROPY_TARGET})
 
@@ -578,7 +585,6 @@ target_compile_definitions(${MICROPY_TARGET} PRIVATE
     LFS1_NO_MALLOC LFS1_NO_DEBUG LFS1_NO_WARN LFS1_NO_ERROR LFS1_NO_ASSERT
     LFS2_NO_MALLOC LFS2_NO_DEBUG LFS2_NO_WARN LFS2_NO_ERROR LFS2_NO_ASSERT
     PICO_FLOAT_PROPAGATE_NANS=1
-    PICO_STACK_SIZE=0x2000
     PICO_CORE1_STACK_SIZE=0
     PICO_MAX_SHARED_IRQ_HANDLERS=8 # we need more than the default
     PICO_PROGRAM_NAME="MicroPython"

--- a/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
+++ b/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
@@ -3,3 +3,6 @@ set(PICO_BOARD "seeed_xiao_rp2350")
 
 # To change the gpio count for QFN-80
 # set(PICO_NUM_GPIOS 48)
+
+# Seeed XIAO RP2350 uses RP2350A with limited memory, reduce stack size
+set(PICO_STACK_SIZE 0x1000)


### PR DESCRIPTION
### Summary
#### A bug in the previous version of pico-sdk prevents the Seeed XIAO RP2350 from utilizing the ADC functionality.
#### Compatibility adjustments after updating the pico-sdk：
##### 1、 PICO-SDK 2.2.0 reorganized the file structure.

&#x20;The pico/platform/common.h file is from:&#x20;

*   src/rp2040/pico\_platform/include/pico/platform/common.h
*   src/rp2350/pico\_platform/include/pico/platform/common.h&#x20;

Moved to a unified location :

*   src/rp2\_common/pico\_platform\_common/include/pico/platform/common.h

##### 2、Memory overflow

Seeed XIAO RP2350 uses the RP2350A chip. The SCRATCH\_Y area is only 4KB, reducing the stack from 8KB to 4KB and avoiding linker overflow.


### Testing
After adjusting to use the pico-sdk version 2.2.0, the adc function can be used
Test development board: SEEED XIAO RP2350

```python
import machine

adc = machine.ADC(26) 
value = adc.read_u16()
print(f"ADC read value: {value}")

>>> %Run -c $EDITOR_CONTENT
ADC read value: 10290
```

issue:https://github.com/micropython/micropython/issues/18076


### Trade-offs and Alternatives