### PR TITLE
pyproject.toml: Update Ruff configuration to allign to micropython-lib.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,17 @@ ACKNOWLEDGEMENTS,\
 
 [tool.ruff]
 # Exclude third-party code from linting and formatting
-extend-exclude = ["lib"]
+extend-exclude = [
+  "lib",
+  "esp-idf",
+  "pico-sdk",
+  "emsdk",
+  "tests/cpydiff/syntax_assign_expr.py" # intentionally incorrect CPython code
+]
 # Include Python source files that don't end with .py
 extend-include = ["tools/cc1"]
 line-length = 99
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.lint]
 exclude = [  # Ruff finds Python SyntaxError in these files
@@ -44,7 +50,7 @@ exclude = [  # Ruff finds Python SyntaxError in these files
   "tests/micropython/viper_args.py",
 ]
 extend-select = ["C9", "PLC"]
-ignore = [
+extend-ignore = [
   "E401",
   "E402",
   "E722",
@@ -54,6 +60,7 @@ ignore = [
   "F403",
   "F405",
   "PLC0206",
+  "PLC0415", # conditional imports are common in MicroPython
 ]
 mccabe.max-complexity = 40
 
@@ -64,6 +71,8 @@ mccabe.max-complexity = 40
 # manifest.py files are evaluated with some global names pre-defined
 "**/manifest.py" = ["F821"]
 "ports/**/boards/**/manifest_*.py" = ["F821"]
+# Uses assignment expressions.
+"tests/cpydiff/syntax_assign_expr.py" = ["F821"]
 
 [tool.ruff.format]
 # Exclude third-party code, and exclude the following tests:


### PR DESCRIPTION
### Summary

- Update to python 3.8 syntax.
- Ignore import not at top of module warnings.
- Exclude common SDK folders.
- Exclude cpydiff test with intentional error.

Also see: https://github.com/micropython/micropython-lib/pull/1059

### Testing

ran:
- ruff format
- ruff check 
- python tools/codeformat.py -p 

each resulting in no errors and no changes.

