### PR TITLE
tools/ci.sh: Add zsh and fish shell completion support.

### DIFF
--- a/docs/develop/gettingstarted.rst
+++ b/docs/develop/gettingstarted.rst
@@ -338,7 +338,15 @@ If you use the bash shell, you can add a ``ci`` command with tab completion:
 
 .. code-block:: bash
 
-   $ eval `tools/ci.sh --bash-completion`
+   $ eval $(tools/ci.sh --bash-completion)
+
+For the zsh shell, replace ``--bash-completion`` with ``--zsh-completion``.
+For the fish shell, replace ``--bash-completion`` with ``--fish-completion``.
+
+Then, typing:
+
+.. code-block:: bash
+
    $ ci unix_cov<tab>
 
 This will complete the ci step name to ``unix_coverage_``.

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1049,6 +1049,14 @@ function _ci_bash_completion {
     echo "alias ci=\"$(readlink -f "$0")\"; complete -W '$(grep '^function ci_' $0 | awk '{print $2}' | sed 's/^ci_//')' ci"
 }
 
+function _ci_zsh_completion {
+    echo "alias ci=\"$(readlink -f "$0"\"); _complete_mpy_ci_zsh() { compadd $(grep '^function ci_' $0 | awk '{sub(/^ci_/,"",$2); print $2}' | tr '\n' ' ') }; autoload -Uz compinit; compinit; compdef _complete_mpy_ci_zsh $(readlink -f "$0")"
+}
+
+function _ci_fish_completion {
+    echo "alias ci=\"$(readlink -f "$0"\"); complete -c ci -p $(readlink -f "$0") -f -a '$(grep '^function ci_' $(readlink -f "$0") | awk '{sub(/^ci_/,"",$2); print $2}' | tr '\n' ' ')'"
+}
+
 function _ci_main {
     case "$1" in
         (-h|-?|--help)
@@ -1056,6 +1064,12 @@ function _ci_main {
         ;;
         (--bash-completion)
             _ci_bash_completion
+        ;;
+        (--zsh-completion)
+            _ci_zsh_completion
+        ;;
+        (--fish-completion)
+            _ci_fish_completion
         ;;
         (-*)
             echo "Unknown option: $1" 1>&2


### PR DESCRIPTION
### Summary

This commit adds custom command completion functions for both the zsh and fish shell.

The behaviour for those new completions follow the existing completion for the bash shell, including the way to generate the completion alias (with appropriately named command line switches).  The documentation was updated to use `$(..)` instead of backticks to pass the text output to `eval`; that was done just to have a single command line compatible with all three shells (fish doesn't like backticks).

As both a zsh and fish user, I'd like to replace my own custom completions with something standardised and coming directly from `tools/ci.sh`.  Since there's already bash completion support, maybe it wouldn't hurt to add support for those two shells in the script.

### Testing

This was tested on Linux using zsh 5.9 and fish 4.2.1, behaving the same as bash.