### PR TITLE
tools/mpremote: Add streaming hash verification to file transfers

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -155,7 +155,9 @@ def do_filesystem_cp(state, src, dest, multiple, check_hash=False):
     # Download the contents of source.
     try:
         if src.startswith(":"):
-            data = state.transport.fs_readfile(src[1:], progress_callback=show_progress_bar)
+            data = state.transport.fs_readfile(
+                src[1:], progress_callback=show_progress_bar, verify_hash=check_hash
+            )
             filename = _remote_path_basename(src[1:])
         else:
             with open(src, "rb") as f:
@@ -183,8 +185,10 @@ def do_filesystem_cp(state, src, dest, multiple, check_hash=False):
             except OSError:
                 pass
 
-        # Write to remote.
-        state.transport.fs_writefile(dest[1:], data, progress_callback=show_progress_bar)
+        # Write to remote with hash verification if check_hash is enabled.
+        state.transport.fs_writefile(
+            dest[1:], data, progress_callback=show_progress_bar, verify_hash=check_hash
+        )
     else:
         # If the destination path is just the directory, then add the source filename.
         if dest_isdir:


### PR DESCRIPTION
### Summary

Addresses #18420 by adding streaming SHA256 verification to file transfers. Computes hash incrementally during transfer to detect transmission corruption on unreliable serial connections, without requiring flash re-read.

### Testing

Tested on ESP32 via CH340 USB-UART with files from 62B to 25KB. Overhead is ~180ms absolute per file (2-3% for large files, 20-28% for small files). Verified bidirectional transfers and `--force` bypass.

### Trade-offs and Alternatives

Hash computed on device during transfer using data already in RAM. More efficient than post-transfer flash re-read. Small files have higher relative overhead but minimal absolute penalty. Acceptable trade-off for corruption detection on marginal connections.