### PR TITLE
py/objdict: Implement bool and len unary ops for dict views.

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -521,7 +521,8 @@ static mp_obj_t dict_view_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
     if (op == MP_UNARY_OP_HASH && o->kind == MP_DICT_VIEW_VALUES) {
         return MP_OBJ_NEW_SMALL_INT((mp_uint_t)o_in);
     }
-    return MP_OBJ_NULL;
+    // delegate all other ops to dict unary op handler
+    return dict_unary_op(op, o->dict);
 }
 
 static mp_obj_t dict_view_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {

--- a/tests/basics/dict_views.py
+++ b/tests/basics/dict_views.py
@@ -6,6 +6,11 @@ for m in d.items, d.values, d.keys:
 # print a view with more than one item
 print({1:1, 2:1}.values())
 
+# `bool` and `len` unary ops
+for d in ({}, {1: 2}, {1: 2, 3: 4}):
+    for op in (bool, len):
+        print(op(d.keys()), op(d.values()), op(d.items()))
+
 # unsupported binary op on a dict values view
 try:
     {1:1}.values() + 1


### PR DESCRIPTION
### Summary

Currently, dict views (eg `dict.keys()`, `dict.values()`) do not implement the `bool` or `len` unary operations.  That may seem like a reasonable omission for MicroPython to keep code size down, but it actually leads to silently incorrect bool operations, because by default things are true.

Eg we currently have:
```py
>>> bool(dict().keys())
True
```
which is wrong, it should be `False` because the dict is empty.

This PR implements `bool` and `len` unary operations on dict views by simply delegating to the existing dict unary op function.

Fixes issue #12385.

### Testing

Tested locally on the unix port.  Will be tested more thoroughly by CI.

### Trade-offs and Alternatives

It adds a tiny bit of code size.  The alternative would be to do nothing, but that leaves silent errors when using `bool` on empty dict views.  Catching that case and raising a `NotImplementedError` would probably cost more than just making it work.
