### PR TITLE
docs/os: Clarify ilistdir tuples size element.

### DIFF
--- a/docs/library/os.rst
+++ b/docs/library/os.rst
@@ -55,10 +55,9 @@ Filesystem access
       directories and 0x8000 for regular files;
     - *inode* is an integer corresponding to the inode of the file, and may be 0
       for filesystems that don't have such a notion.
-    - Some platforms may return a 4-tuple that includes the entry's *size*.  For
-      file entries, *size* is an integer representing the size of the file
-      or -1 if unknown.  Its meaning is currently undefined for directory
-      entries.
+    - *size* is an integer that may be included depending on the filesystem type.
+      For file entries, *size* represents the size of the file or -1 if unknown.
+      Its meaning is currently undefined for directory entries.
 
 .. function:: listdir([dir])
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

The currently documentation for `ilistdir` tuples says that the `size` element is included based on the platform. However, this is not the case as it is included based on the filesystem type. This PR makes the according adjustment. 

Fixes: #17516


### Testing

The documentation was built and verified.

