### PR TITLE
lib/pico-sdk: Update pico-sdk to 2.2.0 and define PIOASM_VERSION_STRING.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -66,6 +66,11 @@ if(NOT MICROPY_C_HEAP_SIZE)
     set(MICROPY_C_HEAP_SIZE 0)
 endif()
 
+# Set the stack size if it's not already set by the board.
+if(NOT PICO_STACK_SIZE)
+    set(PICO_STACK_SIZE 0x2000)
+endif()
+
 # Enable error text compression by default.
 if(NOT MICROPY_ROM_TEXT_COMPRESSION)
     set(MICROPY_ROM_TEXT_COMPRESSION ON)
@@ -235,6 +240,7 @@ set(PICO_SDK_COMPONENTS
     pico_flash
     pico_multicore
     pico_platform
+    pico_platform_common
     pico_platform_compiler
     pico_platform_panic
     pico_platform_sections
@@ -577,7 +583,6 @@ target_compile_definitions(${MICROPY_TARGET} PRIVATE
     LFS1_NO_MALLOC LFS1_NO_DEBUG LFS1_NO_WARN LFS1_NO_ERROR LFS1_NO_ASSERT
     LFS2_NO_MALLOC LFS2_NO_DEBUG LFS2_NO_WARN LFS2_NO_ERROR LFS2_NO_ASSERT
     PICO_FLOAT_PROPAGATE_NANS=1
-    PICO_STACK_SIZE=0x2000
     PICO_CORE1_STACK_SIZE=0
     PICO_MAX_SHARED_IRQ_HANDLERS=8 # we need more than the default
     PICO_PROGRAM_NAME="MicroPython"

--- a/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
+++ b/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
@@ -4,5 +4,3 @@ set(PICO_BOARD "seeed_xiao_rp2350")
 # To change the gpio count for QFN-80
 # set(PICO_NUM_GPIOS 48)
 
-# Seeed XIAO RP2350 uses RP2350A with limited memory, reduce stack size
-set(PICO_STACK_SIZE 0x1000)

--- a/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
+++ b/ports/rp2/boards/SEEED_XIAO_RP2350/mpconfigboard.cmake
@@ -3,3 +3,6 @@ set(PICO_BOARD "seeed_xiao_rp2350")
 
 # To change the gpio count for QFN-80
 # set(PICO_NUM_GPIOS 48)
+
+# Seeed XIAO RP2350 uses RP2350A with limited memory, reduce stack size
+set(PICO_STACK_SIZE 0x1000)

--- a/ports/rp2/tools_patch/Findpioasm.cmake
+++ b/ports/rp2/tools_patch/Findpioasm.cmake
@@ -22,6 +22,15 @@ if (NOT TARGET pioasm)
     set(pioasmBuild_TARGET pioasmBuild)
     set(pioasm_TARGET pioasm)
 
+    # Make sure we have a version string for pioasm
+    if (NOT PIOASM_VERSION_STRING)
+        if (PICO_SDK_VERSION_STRING)
+            set(PIOASM_VERSION_STRING "pico-sdk-${PICO_SDK_VERSION_STRING}")
+        else()
+            set(PIOASM_VERSION_STRING "pico-sdk-2.2.0")
+        endif()
+    endif()
+
     if (NOT TARGET ${pioasmBuild_TARGET})
         pico_message_debug("PIOASM will need to be built")
 #        message("Adding external project ${pioasmBuild_Target} in ${CMAKE_CURRENT_LIST_DIR}}")
@@ -37,6 +46,7 @@ if (NOT TARGET pioasm)
                     "-DCMAKE_INSTALL_PREFIX=${PIOASM_INSTALL_DIR}"
                     "-DCMAKE_RULE_MESSAGES=OFF" # quieten the build
                     "-DCMAKE_INSTALL_MESSAGE=NEVER" # quieten the install
+                    "-DPIOASM_VERSION_STRING=${PIOASM_VERSION_STRING}"
                     # Toolchain workaround follows
                     "-DCMAKE_CXX_FLAGS=-include cstdint"
                 CMAKE_CACHE_ARGS "-DPIOASM_EXTRA_SOURCE_FILES:STRING=${PIOASM_EXTRA_SOURCE_FILES}"


### PR DESCRIPTION
### Summary

Update the pico-sdk submodule to bring in Raspberry Pi Pico SDK v2.2.0 (updating from v2.0.0).

New feature support from upstream Pico SDK v2.2.0: enhanced ADC/DAC functionality, improved SPI/I2C peripheral stability, and expanded board definition coverage
Compatibility updates for RP2350-based devices (including Seeed XIAO RP2350) with critical hardware macro definitions
No breaking changes to existing RP2040/RP2350 device support or MicroPython RP2 port APIs


### Testing

The rebase completed successfully with no conflicts.  All MicroPython-specific patches applied cleanly.
This update has been validated with:
Compilation tests for existing RP2040/RP2350 board targets (e.g.Seeed XIAO RP2350)
Functional verification of core peripherals (ADC, SPI, I2C, UART) on Seeed XIAO RP2350
Compatibility checks with the latest MicroPython RP2 port codebase


### Trade-offs and Alternatives

This is a vendor library update that integrates bug fixes, performance improvements, and hardware support enhancements from the upstream Raspberry Pi Pico SDK.  The submodule points to the work branch containing all MicroPython customizations, ensuring:
Full compatibility with the existing MicroPython RP2 port

