### PR TITLE
esp32: register user C modules with IDF component manager and handle relative usermod paths

### DIFF
--- a/docs/develop/cmodules.rst
+++ b/docs/develop/cmodules.rst
@@ -216,11 +216,13 @@ Then build with:
 .. code-block:: bash
 
     cd my_project/micropython/ports/esp32
-    make USER_C_MODULES=../../../../modules/micropython.cmake
+    make USER_C_MODULES=../../../modules/micropython.cmake
 
-Note that the esp32 port needs the extra ``..`` for relative paths due to the
-location of its main ``CMakeLists.txt`` file.   You can also specify absolute
-paths to ``USER_C_MODULES``.
+Previously, the esp32 port required an extra ``..`` in relative paths (e.g.,
+``../../../../modules/micropython.cmake``) due to path resolution happening from
+the ``main`` subdirectory. This has been fixed and paths are now resolved
+consistently from the port directory (``ports/esp32``), matching other ports.
+You can also specify absolute paths to ``USER_C_MODULES``.
 
 All modules specified by the ``USER_C_MODULES`` variable (either found in this
 directory when using Make, or added via ``include`` when using CMake) will be

--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -58,6 +58,26 @@ endforeach()
 configure_file(${CMAKE_BINARY_DIR}/sdkconfig.combined.in ${CMAKE_BINARY_DIR}/sdkconfig.combined COPYONLY)
 set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 
+# Register user module directories with IDF component manager so it can find idf_component.yml files
+# This must happen before the project() call so dependencies can be resolved
+if(USER_C_MODULES)
+    set(USER_C_MODULES_ABS "")
+    foreach(USER_C_MODULE_PATH ${USER_C_MODULES})
+        # Convert to absolute path and extract directory
+        get_filename_component(USER_C_MODULE_PATH_ABS "${USER_C_MODULE_PATH}" ABSOLUTE)
+        list(APPEND USER_C_MODULES_ABS "${USER_C_MODULE_PATH_ABS}")
+        get_filename_component(USER_C_MODULE_DIR "${USER_C_MODULE_PATH_ABS}" DIRECTORY)
+        
+        # Only register directories containing idf_component.yml and CMakeLists.txt
+        if(EXISTS "${USER_C_MODULE_DIR}/idf_component.yml" AND EXISTS "${USER_C_MODULE_DIR}/CMakeLists.txt")
+            list(APPEND EXTRA_COMPONENT_DIRS "${USER_C_MODULE_DIR}")
+        endif()
+    endforeach()
+    
+    # Override USER_C_MODULES with absolute paths for later cmake stages
+    set(USER_C_MODULES ${USER_C_MODULES_ABS})
+endif()
+
 # Include main IDF cmake file.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -229,7 +229,7 @@ function ci_esp32_build_cmod_spiram_s2 {
     ci_esp32_build_common
 
     make ${MAKEOPTS} -C ports/esp32 \
-        USER_C_MODULES=../../../examples/usercmodule/micropython.cmake \
+        USER_C_MODULES=../../examples/usercmodule/micropython.cmake \
         FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest_test.py
 
     # Test building native .mpy with xtensawin architecture.


### PR DESCRIPTION
### Summary

This change adds the possibility to define usermod specific IDF manifests and improves how user-provided C modules with relative paths are handled when building the ESP32 port:

- Register user module directories with the ESP-IDF Component Manager when the user module directory contains both idf_component.yml and CMakeLists.txt and append those directories to EXTRA_COMPONENT_DIRS so the IDF can locate them correctly.
- Convert configured USER_C_MODULES entries to absolute paths and replace the original variable with those absolute paths for later CMake stages. This makes relative module paths safe and reliable across the build.



### Testing

Built MicroPython locally for BOARD=ESP32_GENERIC_S3 and BOARD_VARIANT=SPIRAM_OCT with a user module passed as absolute and relative path. The build contained the needed files.
The build completed successfully.


### Trade-offs and Alternatives

The code size of the main `CMakeLists.txt` is 20 lines longer. On the other hand, you don't need to touch the micropython code to build with custom user modules with ESP components integrated.
Also, providing relative paths to the build changes behavior. This should be documented. On the other hand, this will prevent such issues like https://github.com/micropython/micropython/issues/14352.

(Maintainer edit: Closes #14352 )