### PR TITLE
unix: Add IP ADD and DROP MEMBERSHIP in usocket.

### DIFF
--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -709,6 +709,9 @@ static const mp_rom_map_elem_t mp_module_socket_globals_table[] = {
     C(SO_KEEPALIVE),
     C(SO_LINGER),
     C(SO_REUSEADDR),
+
+    C(IP_ADD_MEMBERSHIP),
+    C(IP_DROP_MEMBERSHIP),
 #undef C
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

Add the `IP_ADD_MEMBERSHIP` and `IP_DROP_MEMBERSHIP` to `modsocket` in the Unix port so that the directives take on the values defined in the system headers. This was needed because the values of these directives are different for MacOS vs other Unix systems. 

With this change, `IP_ADD_MEMBERSHIP` and `IP_DROP_MEMBERSHIP` are now available in the built-in socket module without needing to install the micropython-lib package. Another PR on the micropython-lib repository needs to be created to remove the directives being redefined there.

Fixes: https://github.com/micropython/micropython/issues/8456
Is depended on by: https://github.com/micropython/micropython-lib/pull/1067
### Testing

Tested on MacOS Tahoe:
```
MicroPython a6864109db-dirty on 2025-11-21; darwin [Clang 17.0.0] version
Type "help()" for more information.
>>> import socket
>>> socket.IP_ADD_MEMBERSHIP
12
>>> socket.IP_DROP_MEMBERSHIP
13
>>> 
```

Tested on Fedora Linux 43:
```
MicroPython v1.27.0-preview.440.ga6864109db.dirty on 2025-11-21; linux [GCC 15.2.1] version
Type "help()" for more information.
>>> import socket
>>> socket.IP_ADD_MEMBERSHIP
35
>>> socket.IP_DROP_MEMBERSHIP
36 
```

### Trade-offs and Alternatives
Have micropython-lib detect the platform and adjust the values accordingly.