### PR TITLE
docs/mimxrt: Add docs for mimxrt.Flash.

### DIFF
--- a/docs/library/index.rst
+++ b/docs/library/index.rst
@@ -172,6 +172,16 @@ The following libraries are specific to the ESP8266 and ESP32.
   espnow.rst
 
 
+Libraries specific to NXP i.MXRT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following libraries are specific to the NXP i.MXRT family of microcontrollers.
+
+.. toctree::
+  :maxdepth: 2
+
+  mimxrt.rst
+
 Libraries specific to the RP2040
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/library/mimxrt.Flash.rst
+++ b/docs/library/mimxrt.Flash.rst
@@ -1,0 +1,39 @@
+.. currentmodule:: mimxrt
+.. _mimxrt.Flash:
+
+class Flash -- access to built-in flash storage
+===============================================
+
+This class gives access to the SPI flash memory.
+
+In most cases, to store persistent data on the device, you'll want to use a
+higher-level abstraction, for example the filesystem via Python's standard file
+API, but this interface is useful to :ref:`customise the filesystem
+configuration <filesystem>` or implement a low-level storage system for your
+application.
+
+
+Constructors
+------------
+
+.. class:: Flash()
+
+   Gets the singleton object for accessing the SPI flash memory.
+
+
+Methods
+-------
+
+.. method:: Flash.readblocks(block_num, buf)
+            Flash.readblocks(block_num, buf, offset)
+.. method:: Flash.writeblocks(block_num, buf)
+            Flash.writeblocks(block_num, buf, offset)
+.. method:: Flash.ioctl(cmd, arg)
+
+    These methods implement the simple and extended
+    :ref:`block protocol <block-device-interface>` defined by
+    :class:`vfs.AbstractBlockDev`.
+
+    The block size can be queried by calling ``ioctl(5, 0)``. Block numbers
+    are relative to the start of the user flash storage area, not the physical
+    start of flash memory.

--- a/docs/library/mimxrt.rst
+++ b/docs/library/mimxrt.rst
@@ -1,0 +1,19 @@
+.. currentmodule:: mimxrt
+
+:mod:`mimxrt` --- functionality specific to NXP i.MXRT
+======================================================
+
+.. module:: mimxrt
+    :synopsis: functionality specific to NXP i.MXRT
+
+The ``mimxrt`` module contains functions and classes specific to the NXP i.MXRT
+family of microcontrollers.
+
+
+Classes
+-------
+
+.. toctree::
+    :maxdepth: 1
+
+    mimxrt.Flash.rst


### PR DESCRIPTION
### Summary

This adds the docs for `mimxrt.Flash`, the impl for which was first added in: https://github.com/micropython/micropython/commit/dfd4324eb1b758e37cfc77da8467e7f5d72f519c

The docs are pretty simple, following the conventions used for similar classes in rp2 / stm32

I actually noticed this missing thanks for @Josverl 's micropython-stubber; I'd generated stubs for my board after which mypy was complaining about things like:
```
src/boot.py:25: error: Argument 1 to "mkfs" of "VfsLfs2" has incompatible type "Flash"; expected "AbstractBlockDev"  [arg-type]
src/boot.py:35: error: Argument 1 to "VfsLfs2" has incompatible type "Flash"; expected "AbstractBlockDev"  [arg-type]
```

The types of classes like mimxrt.Flash are parsed from the docs; without which it's declared as a basic class rather than correctly as 
a subclass of `AbstractBlockDev`.

### Testing

docs only; however they are correctly parsed by [micropython-stubber](https://github.com/Josverl/micropython-stubber)

