### PR TITLE
stm32: Define TinyUSB MCU type for N6.

### DIFF
--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -542,6 +542,9 @@
 #define MICROPY_HW_MAX_UART (10)
 #define MICROPY_HW_MAX_LPUART (1)
 
+#define CFG_TUSB_MCU OPT_MCU_STM32N6
+#define CFG_TUSB_RHPORT0_MODE (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+
 // Configuration for STM32U5 series
 #elif defined(STM32U5)
 


### PR DESCRIPTION

### Summary

Enable using TinyUSB stack on N6.

### Testing

Tested this stack on N6, works fine just needs a few extra config options.
