### PR TITLE
docs: Fix typos under I2CTarget irq method description.

### DIFF
--- a/docs/library/machine.I2CTarget.rst
+++ b/docs/library/machine.I2CTarget.rst
@@ -126,7 +126,7 @@ General Methods
 
       - ``IRQ_ADDR_MATCH_READ`` indicates that the target was addressed by a
         controller for a read transaction.
-      - ``IRQ_ADDR_MATCH_READ`` indicates that the target was addressed by a
+      - ``IRQ_ADDR_MATCH_WRITE`` indicates that the target was addressed by a
         controller for a write transaction.
       - ``IRQ_READ_REQ`` indicates that the controller is requesting data, and this
         request must be satisfied by calling `I2CTarget.write` with the data to be
@@ -141,7 +141,7 @@ General Methods
 
    Note the following restrictions:
 
-      - ``IRQ_ADDR_MATCH_READ``, ``IRQ_ADDR_MATCH_READ``, ``IRQ_READ_REQ`` and
+      - ``IRQ_ADDR_MATCH_READ``, ``IRQ_ADDR_MATCH_WRITE``, ``IRQ_READ_REQ`` and
         ``IRQ_WRITE_REQ`` must be handled by a hard IRQ callback (with the *hard* argument
         set to ``True``).  This is because these events have very strict timing requirements
         and must usually be satisfied synchronously with the hardware event.


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

There were a few typos in the documentation for the `I2CTarget.irq` method description where `IRQ_ADDR_MATCH_READ` was used, however `IRQ_ADDR_MATCH_WRITE` should have been used. This small patch makes fixes those typos.

Fixes: #18470
### Testing

Built the documentation.