### PR TITLE
ports/rp2: Add guard around machine_i2s_init0().

### DIFF
--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -192,7 +192,9 @@ int main(int argc, char **argv) {
         machine_pin_init();
         rp2_pio_init();
         rp2_dma_init();
+        #if MICROPY_PY_MACHINE_I2S
         machine_i2s_init0();
+        #endif
 
         #if MICROPY_PY_BLUETOOTH
         mp_bluetooth_hci_init();


### PR DESCRIPTION
### Summary

Add a `#if MICROPY_PY_MACHINE_I2S` guard around the call to `machine_i2s_init0()` in `ports/rp2/main.c`. This matches the existing guard around `machine_i2s_deinit_all()` in the same function.


### Testing

Only compile-tested so far. I was trying to disable I2S on a build and got linker errors without this.

