### PR TITLE
i2c_target: Add attribute that exposes the number of bytes transferred.

### DIFF
--- a/docs/library/machine.I2CTarget.rst
+++ b/docs/library/machine.I2CTarget.rst
@@ -40,8 +40,10 @@ For example to be notified when the memory is read/written::
         flags = i2c_target.irq().flags()
         if flags & I2CTarget.IRQ_END_READ:
             print("controller read target at addr", i2c_target.memaddr)
+            print("controller read", i2c_target.numbytes, "bytes from target")
         if flags & I2CTarget.IRQ_END_WRITE:
             print("controller wrote target at addr", i2c_target.memaddr)
+            print("controller wrote", i2c_target.numbytes, "bytes to target")
 
     # Create the I2C target and register to receive default events.
     mem = bytearray(8)
@@ -160,6 +162,12 @@ General Methods
 
    The integer value of the most recent memory address that was selected by the I2C
    controller (only valid if ``mem`` was specified in the constructor).
+
+.. attribute:: I2CTarget.numbytes
+
+   The number of bytes read or written in the most recent transaction.  This is
+   updated after each read or write operation.  (only valid if ``mem`` was specified in
+   the constructor).
 
 Constants
 ---------

--- a/tests/extmod_hardware/machine_i2c_target.py
+++ b/tests/extmod_hardware/machine_i2c_target.py
@@ -81,47 +81,62 @@ class TestMemory(unittest.TestCase):
         self.mem[:] = b"01234567"
         self.i2c.writeto_mem(ADDR, 0, b"test")
         self.assertEqual(self.mem, bytearray(b"test4567"))
+        self.assertEqual(self.i2c_target.numbytes, 4)
         self.i2c.writeto_mem(ADDR, 4, b"TEST")
         self.assertEqual(self.mem, bytearray(b"testTEST"))
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     def test_write_wrap(self):
         self.mem[:] = b"01234567"
         self.i2c.writeto_mem(ADDR, 6, b"test")
         self.assertEqual(self.mem, bytearray(b"st2345te"))
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     @unittest.skipIf(sys.platform == "esp32", "write lengths larger than buffer unsupported")
     def test_write_wrap_large(self):
         self.mem[:] = b"01234567"
         self.i2c.writeto_mem(ADDR, 0, b"testTESTmore")
         self.assertEqual(self.mem, bytearray(b"moreTEST"))
+        self.assertEqual(self.i2c_target.numbytes, 12)
 
     def test_read(self):
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 0, 4), b"0123")
+        self.assertEqual(self.i2c_target.numbytes, 4)
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 4, 4), b"4567")
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     def test_read_wrap(self):
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 0, 4), b"0123")
+        self.assertEqual(self.i2c_target.numbytes, 4)
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 2, 4), b"2345")
+        self.assertEqual(self.i2c_target.numbytes, 4)
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 6, 4), b"6701")
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     @unittest.skipIf(sys.platform == "esp32", "read lengths larger than buffer unsupported")
     def test_read_wrap_large(self):
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 0, 12), b"012345670123")
+        self.assertEqual(self.i2c_target.numbytes, 12)
 
     def test_write_read(self):
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.writeto(ADDR, b"\x02"), 1)
+        self.assertEqual(self.i2c_target.numbytes, 1)
         self.assertEqual(self.i2c.readfrom(ADDR, 4), b"2345")
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     @unittest.skipIf(sys.platform == "esp32", "read after read unsupported")
     def test_write_read_read(self):
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.writeto(ADDR, b"\x02"), 1)
+        self.assertEqual(self.i2c_target.numbytes, 1)
         self.assertEqual(self.i2c.readfrom(ADDR, 4), b"2345")
+        self.assertEqual(self.i2c_target.numbytes, 4)
         self.assertEqual(self.i2c.readfrom(ADDR, 4), b"7012")
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
 
 @unittest.skipUnless(hasattr(I2CTarget, "IRQ_END_READ"), "IRQ unsupported")
@@ -159,12 +174,14 @@ class TestMemoryIRQ(unittest.TestCase):
         self.i2c.writeto_mem(ADDR, 2, b"test")
         self.assertEqual(self.mem, bytearray(b"01test67"))
         self.assertEqual(self.events[: self.num_events], [I2CTarget.IRQ_END_WRITE, 2])
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
     def test_read(self):
         TestMemoryIRQ.num_events = 0
         self.mem[:] = b"01234567"
         self.assertEqual(self.i2c.readfrom_mem(ADDR, 2, 4), b"2345")
         self.assertEqual(self.events[: self.num_events], [I2CTarget.IRQ_END_READ, 2])
+        self.assertEqual(self.i2c_target.numbytes, 4)
 
 
 @unittest.skipUnless(hasattr(I2CTarget, "IRQ_WRITE_REQ"), "IRQ unsupported")

--- a/tests/multi_extmod/machine_i2c_target_irq.py
+++ b/tests/multi_extmod/machine_i2c_target_irq.py
@@ -59,6 +59,7 @@ class I2CTargetMemory:
         self.buf1 = bytearray(1)
         self.mem = mem
         self.memaddr = 0
+        self.numbytes = 0
         self.state = 0
         i2c_target.irq(
             self.irq,
@@ -76,9 +77,11 @@ class I2CTargetMemory:
         if flags & I2CTarget.IRQ_READ_REQ:
             self.buf1[0] = self.mem[self.memaddr]
             self.memaddr += 1
+            self.numbytes += len(self.buf1)
             i2c_target.write(self.buf1)
         if flags & I2CTarget.IRQ_WRITE_REQ:
             i2c_target.readinto(self.buf1)
+            self.numbytes += len(self.buf1)
             if self.state == 0:
                 self.state = 1
                 self.memaddr = self.buf1[0]

--- a/tests/multi_extmod/machine_i2c_target_memory.py
+++ b/tests/multi_extmod/machine_i2c_target_memory.py
@@ -42,9 +42,9 @@ else:
 def simple_irq(i2c_target):
     flags = i2c_target.irq().flags()
     if flags & I2CTarget.IRQ_END_READ:
-        print("IRQ_END_READ", i2c_target.memaddr)
+        print("IRQ_END_READ", i2c_target.memaddr, "bytes read:", i2c_target.numbytes)
     if flags & I2CTarget.IRQ_END_WRITE:
-        print("IRQ_END_WRITE", i2c_target.memaddr)
+        print("IRQ_END_WRITE", i2c_target.memaddr, "bytes written:", i2c_target.numbytes)
 
 
 # I2C controller


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

As mentioned in the issue, the `I2CTarget` class exposes the `memaddr` attribute which is first memory address read/written by the controller, but there is no way of knowing how many attributes were read or written. This patch series adds the implementation, documentation, and tests for the `numbytes` attribute to expose how many bytes were read/written in the last transaction.

It is supported only when the I2C target device is configured as a memory device, otherwise the `numbytes` attribute remains at 0.

Fixes: #17996
### Testing

`Esp32 WROOM` as the controller.
`RPI PICO 2W (RP2350)` as the target.

Tested for cases when the target was configured as a memory device and as an arbitrary I2C device.

### Trade-offs and Alternatives

Alternatively, `numbytes` can be split into 2 separate attributes, one for the number of bytes read and one for the number of bytes written after each transaction.

Another alternative is to configure the I2C target device as an arbitrary I2C device and keep track of the count of a read/write request event until its end event has occurred. However, this method comes with more python code and some potential overhead of clock stretching.