### PR TITLE
ci: Put embedding build rules in ci.sh.

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -20,6 +20,4 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Build
-      run: make -C examples/embedding -f micropython_embed.mk && make -C examples/embedding
-    - name: Run
-      run: ./examples/embedding/embed | grep "hello world"
+      run: tools/ci.sh embedding_build

--- a/examples/embedding/.gitignore
+++ b/examples/embedding/.gitignore
@@ -1,0 +1,4 @@
+# Files created by ci.sh embed_build
+embed
+main.o
+micropython_embed

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -195,6 +195,15 @@ function ci_cc3200_build {
 }
 
 ########################################################################################
+# ports/embed
+
+function ci_embedding_build {
+    make ${MAKEOPTS} -C examples/embedding -f micropython_embed.mk
+    make ${MAKEOPTS} -C examples/embedding
+    ./examples/embedding/embed | grep "hello world"
+}
+
+########################################################################################
 # ports/esp32
 
 # GitHub tag of ESP-IDF to use for CI, extracted from the esp32 dependency lockfile


### PR DESCRIPTION
### Summary

I noticed this was not runnable locally by `ci.sh`.

### Testing

I ran it locally.

### Trade-offs and Alternatives

I also added some .gitignore lines for files created by running these commands. This has been mildly controversial in the past.