### PR TITLE
misc: Remove unused mp_check()

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -411,11 +411,6 @@ static inline uint32_t mp_ctz(uint32_t x) {
     return _BitScanForward(&tz, x) ? tz : 0;
 }
 
-// Workaround for 'warning C4127: conditional expression is constant'.
-static inline bool mp_check(bool value) {
-    return value;
-}
-
 static inline uint32_t mp_popcount(uint32_t x) {
     return __popcnt(x);
 }
@@ -424,7 +419,6 @@ static inline uint32_t mp_popcount(uint32_t x) {
 #define mp_clzl(x) __builtin_clzl(x)
 #define mp_clzll(x) __builtin_clzll(x)
 #define mp_ctz(x) __builtin_ctz(x)
-#define mp_check(x) (x)
 #if __has_builtin(__builtin_popcount)
 #define mp_popcount(x) __builtin_popcount(x)
 #else


### PR DESCRIPTION
### Summary

This is unused since 007f127a61ea058ca010b85883072bdefe0234c0 "all: Simplify mp_int_t/mp_uint_t definition".

### Testing

I checked locally with grep.