### PR TITLE
tools/mpy_ld.py: Write architecture flags to output natmod if needed.

### DIFF
--- a/docs/develop/natmod.rst
+++ b/docs/develop/natmod.rst
@@ -43,9 +43,14 @@ options for the ``ARCH`` variable, see below):
 * ``rv32imc`` (RISC-V 32 bits with compressed instructions, eg ESP32C3, ESP32C6)
 * ``rv64imc`` (RISC-V 64 bits with compressed instructions)
 
+If the chosen platform supports explicit architecture flags and you want to let
+the output .mpy file carry those flags' value, you must pass them to the
+``ARCH_FLAGS`` flags variable when building the .mpy file.
+
 When compiling and linking the native .mpy file the architecture must be chosen
-and the corresponding file can only be imported on that architecture.  For more
-details about .mpy files see :ref:`mpy_files`.
+and the corresponding file can only be imported on that architecture (and if
+architecture flags are present, only if they match the target's capabilities).
+For more details about .mpy files see :ref:`mpy_files`.
 
 Native code must be compiled as position independent code (PIC) and use a global
 offset table (GOT), although the details of this varies from architecture to
@@ -124,7 +129,8 @@ The filesystem layout consists of two main parts, the source files and the Makef
   location of the MicroPython repository (to find header files, the relevant Makefile
   fragment, and the ``mpy_ld.py`` tool), ``MOD`` as the name of the module, ``SRC``
   as the list of source files, optionally specify the machine architecture via ``ARCH``,
-  and then include ``py/dynruntime.mk``.
+  along with optional machine architecture flags specified via ``ARCH_FLAGS``, and
+  then include ``py/dynruntime.mk``.
 
 Minimal example
 ---------------
@@ -216,6 +222,10 @@ Then build with::
 Without modifying the Makefile you can specify the target architecture via::
 
     $ make ARCH=armv7m
+
+Same applies for optional architecture flags via::
+
+    $ make ARCH=rv32imc ARCH_FLAGS=zba
 
 Module usage in MicroPython
 ---------------------------

--- a/docs/reference/mpyfiles.rst
+++ b/docs/reference/mpyfiles.rst
@@ -193,7 +193,8 @@ MPY files is used to indicate that no specific extensions are needed, and saves
 one byte in the final output binary.
 
 See also the ``-march-flags`` command-line option in both ``mpy-tool.py`` and
-``mpy-cross`` to set this value when creating MPY files.
+``mpy-cross``, and the ``--arch-flags`` command-line option in ``mpy_ld.py`` to
+set this value when creating MPY files.
 
 The global qstr and constant tables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -194,6 +194,9 @@ endif
 ifneq ($(MPY_EXTERN_SYM_FILE),)
 MPY_LD_FLAGS += --externs "$(realpath $(MPY_EXTERN_SYM_FILE))"
 endif
+ifneq ($(ARCH_FLAGS),)
+MPY_LD_FLAGS += --arch-flags "$(ARCH_FLAGS)"
+endif
 
 CFLAGS += $(CFLAGS_EXTRA)
 


### PR DESCRIPTION
### Summary

This PR lets "tools/mpy_ld.py" store architecture flags in generated MPY files if explicitly requested, like "mpy-cross" does.

To achieve this, a new command-line option ("--arch-flags") was added to receive the architecture flags value, accepting the same arguments' format as "mpy-cross", and performing the same input validation.

The rest of the MPY toolchain was also modified to let the user pass the arch flags to standard native module makefiles.  Given that there's already a well-established "ARCH" argument, "ARCH_FLAGS" was chosen to pass the optional flags to "mpy_ld.py".

Finally, documentation was updated to mention the new variable.

This is probably the last bit needed in the MPY toolchain to fully support architecture flags.  There's no rush in merging this as without these changes native modules will contain no architecture by default, maintaining compatibility.

### Testing

Input validation tests were made to make sure errors were raised if architecture flags are passed for any architecture that's not "rv32imc".

Example natmods were built using different combinations of compatible values for the `ARCH_FLAGS` variable ("zba", 0, 1, 0x01, etc), then `mpy-tool.py -d` was used to check whether the `arch_flags` value in its output matches expectations, and then finally the QEMU/RV32 natmod tests were run using those files.

After that, the same thing was done but to check unsupported `ARCH_FLAGS` values to see whether they were rejected by `mpy_ld.py` or if they were successfully written to the output MPY file if passed as raw integers.  QEMU/RV32 natmod tests were run for those files, checking whether loading would fail with `ValueError: incompatible .mpy file`.

### Trade-offs and Alternatives

The RV32 extensions lookup dict is duplicated at least twice for python code with this.  It'd be nice if validation/lookup/etc could be refactored into a separate file and then referenced by tools when needed.  Ideally this file should be generated from the extensions enum in `py/asmrv32.h` (or from an appropriately formatted comment block).

I haven't gone as far as adding that in this PR as it'd be out of scope, but it's something I'll probably explore soon.  Maybe there are better alternatives to solve this problem than the one mentioned, but that's something better left for later.