### PR TITLE
rp2/mpconfigport: Enable MD5, SHA1 and cryptolib on all boards.

### DIFF
--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -151,6 +151,9 @@
 #define MICROPY_PY_OS_URANDOM                   (1)
 #define MICROPY_PY_RE_MATCH_GROUPS              (1)
 #define MICROPY_PY_RE_MATCH_SPAN_START_END      (1)
+#define MICROPY_PY_HASHLIB_MD5                  (1)
+#define MICROPY_PY_HASHLIB_SHA1                 (1)
+#define MICROPY_PY_CRYPTOLIB                    (1)
 #define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME (1)
 #define MICROPY_PY_TIME_TIME_TIME_NS            (1)
 #define MICROPY_PY_TIME_INCLUDEFILE             "ports/rp2/modtime.c"


### PR DESCRIPTION
### Summary

This fixes a regression introduced by b5fcb33eaa682bb666c839cd4fb301175cc3564f / #17926 which accidentally disabled `hashlib.sha1` and the `cryptolib` module on rp2 boards that don't have networking enabled, eg `RPI_PICO`.

`hashlib.md5` is enabled to keep the configuration the same as boards that do have networking enabled.

### Testing

Built `RPI_PICO`, it now contains the missing parts (and code size goes up by about +20k).