### PR TITLE
tests: Test fstring nested replacement fields.

### DIFF
--- a/tests/basics/string_fstring.py
+++ b/tests/basics/string_fstring.py
@@ -79,3 +79,14 @@ print(
 # Raw f-strings.
 print(rf"\r\a\w {'f'} \s\t\r\i\n\g")
 print(fr"\r{x}")
+
+# Format specifiers with nested replacement fields
+space = 5
+prec = 2
+print(f"{3.14:{space}.{prec}}")
+
+space_prec = "5.2"
+print(f"{3.14:{space_prec}}")
+
+radix = "x"
+print(f"{314:{radix}}")


### PR DESCRIPTION
### Summary

I was not able to find an explicit test for "fstring nested replacement fields", like `f"{x:{space}.{prec}}"`. So I added several cases to the existing test `string_fstring.py`.

### Testing

I locally ran `make test//fstring` in the unix port.

### Trade-offs and Alternatives

Are there more cases that should be tested?

Should the test be in its own file?

This does not actually cover any additional _lines_ but unless I overlooked an existing test it does cover new functionality not previously covered.