### PR TITLE
ci: Actually run tests on qemu arm bigendian.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -282,19 +282,11 @@ typedef uint32_t mp_float_uint_t;
 
 typedef union _mp_float_union_t {
     mp_float_t f;
-    #if MP_ENDIANNESS_LITTLE
     struct {
         mp_float_uint_t frc : MP_FLOAT_FRAC_BITS;
         mp_float_uint_t exp : MP_FLOAT_EXP_BITS;
         mp_float_uint_t sgn : 1;
     } p;
-    #else
-    struct {
-        mp_float_uint_t sgn : 1;
-        mp_float_uint_t exp : MP_FLOAT_EXP_BITS;
-        mp_float_uint_t frc : MP_FLOAT_FRAC_BITS;
-    } p;
-    #endif
     mp_float_uint_t i;
 } mp_float_union_t;
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -381,7 +381,7 @@ function ci_qemu_build_arm_prepare {
 
 function ci_qemu_build_arm_bigendian {
     ci_qemu_build_arm_prepare
-    make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1
+    make ${MAKEOPTS} -C ports/qemu CFLAGS_EXTRA=-DMP_ENDIANNESS_BIG=1 test_full
 }
 
 function ci_qemu_build_arm_sabrelite {


### PR DESCRIPTION
### Summary

I noticed that in the CI step "build_and_test_arm (bigendian)" no tests were actually run.

### Testing

I locally ran `tools/ci.sh qemu_build_arm_bigendian` and observed that the tests are run.

### Trade-offs and Alternatives

This increases the duration of this build task somewhat. However, I don't think anything else tests running micropython in bigendian environments so it seems valuable. Happily, there were no errors observed locally.