### PR TITLE
mimxrt: Add LPADC A/B side channel support for MIMXRT117x.

### DIFF
--- a/ports/mimxrt/boards/mimxrt_prefix.c
+++ b/ports/mimxrt/boards/mimxrt_prefix.c
@@ -16,10 +16,11 @@
         .pad_config = (uint32_t)(_pad_config), \
     } \
 
-#define PIN_ADC(_instance, _channel) \
+#define PIN_ADC(_instance, _channel, _side) \
     { \
         .instance = (_instance), \
-        .channel = (_channel) \
+        .channel = (_channel), \
+        .side = (_side) \
     } \
 
 #define PIN(_name, _gpio, _pin, _af_list, _adc_list_len, _adc_list) \

--- a/ports/mimxrt/pin.h
+++ b/ports/mimxrt/pin.h
@@ -117,6 +117,7 @@ typedef struct {
 typedef struct {
     ADC_Type *instance;
     uint8_t channel;
+    uint8_t side;  // 0 = side A, 1 = side B (for LPADC)
 } machine_pin_adc_obj_t;
 
 typedef struct {


### PR DESCRIPTION
The i.MX RT1170 uses the LPADC peripheral which supports both A-side and B-side channel inputs (e.g. ADC1_CH1A, ADC1_CH1B). The existing code only supported side A, causing side B channels to return incorrect values.

This extends the pin parser to capture the optional A/B suffix and sets the sampleChannelMode appropriately when reading. Chips like RT1050/RT1060 use the traditional ADC peripheral without A/B sides and are unaffected.

Also initializes all available ADC instances (LPADC1/LPADC2) rather than just LPADC1.

### Summary

The LPADC on RT1170 supports both A-side and B-side channel inputs (e.g. `ADC1_CH1A`, `ADC1_CH1B`), but the existing code always used side A regardless of the pin definition. This caused side B channels to return incorrect readings.

This extends the pin parser to capture the optional A/B suffix and sets `sampleChannelMode` appropriately when reading. Also initializes both LPADC1 and LPADC2 instances. Older chips like RT1050/RT1060 use the ADC peripheral without A/B sides and are unaffected.

### Testing

Tested on a custom MIMXRT1170 board, verified both side A and side B ADC channels now return correct values. Haven't tested on RT1050/RT1060 boards but the changes should be backwards compatible since the side field defaults to 0 (side A).

