### PR TITLE
tools: Add board image check script, update 3x ESP32 board image URLs

### DIFF
--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -20,3 +20,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Build ports download metadata
       run: mkdir boards && ./tools/autobuild/build-downloads.py . ./boards
+    - name: Check board image links
+      # Note: this only checks board.json files that have changed in this PR, and prints the
+      # usage message otherwise.
+      run: tools/board_image_check.py $(git diff --name-only HEAD^1 HEAD | grep board.json)

--- a/ports/esp32/boards/ESP32_GENERIC_C2/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_C2/board.json
@@ -12,7 +12,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32c2_devkitmini.jpg"
+        "esp8684_devkitc.jpg"
     ],
     "mcu": "esp32c2",
     "product": "ESP32-C2",

--- a/ports/esp32/boards/ESP32_GENERIC_C5/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_C5/board.json
@@ -12,7 +12,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32c5_devkitmini.jpg"
+        "esp32c5_devkitc.jpg"
     ],
     "mcu": "esp32c5",
     "product": "ESP32-C5",

--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.json
@@ -11,7 +11,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32p4_devkitmini.jpg"
+        "esp32_p4_function_ev_board.jpg"
     ],
     "mcu": "esp32p4",
     "product": "ESP32-P4",

--- a/tools/board_image_check.py
+++ b/tools/board_image_check.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+import glob
+import json
+import os.path
+import sys
+import urllib.request
+from urllib.error import HTTPError
+
+# Check that board image files are present in the media repo
+# (if not, they need to be merged to https://github.com/micropython/micropython-media/)
+
+# This URL on GitHub corresponds to https://micropython.org/resources/micropython-media/boards once published
+BASE_URL = "https://raw.githubusercontent.com/micropython/micropython-media/refs/heads/main/boards"
+
+
+def check_board(board_json_path):
+    # Board name is the name of the directory containing the board.json file
+    board_name = os.path.basename(os.path.dirname(os.path.realpath(board_json_path)))
+
+    try:
+        with open(board_json_path, "r") as f:
+            contents = json.load(f)
+    except json.JSONDecodeError:
+        print(f"ERROR: Board file {board_json_path} is not valid JSON")
+        return False
+
+    images = contents.get("images", [])
+    if not images:
+        print(f"WARNING: Board {board_name} has no images.")
+
+    for image in images:
+        url = f"{BASE_URL}/{board_name}/{image}"
+        print(f"Testing {url}")
+        req = urllib.request.Request(url, method="HEAD")
+        try:
+            with urllib.request.urlopen(req) as response:
+                for k, v in response.getheaders():
+                    if k.lower() == "content-type":
+                        if "image" not in v:
+                            print(f"... ERROR: Unexpected Content-Type: {v}")
+                            return False
+                        break
+                print("... OK")
+                return True
+        except HTTPError as e:
+            print(f"... ERROR: {e}")
+            return False
+
+
+def main(paths_to_test):
+    missing = [a for a in paths_to_test if not os.path.exists(a)]
+    if any(missing):
+        raise SystemExit(f"File(s) not found: {missing}")
+
+    failed = [b for b in paths_to_test if not check_board(b)]
+    print("***")
+    if not failed:
+        print("All board files found in micropython-media repository")
+    else:
+        print(
+            f"{len(failed)}/{len(paths_to_test)} boards have images missing from micropython-media repository:"
+        )
+        for f in failed:
+            print(f"  - {f}")
+        print(
+            "To correct, please raise a PR in https://github.com/micropython/micropython-media adding the images under boards/"
+        )
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1 or sys.argv[1] in ("-h", "--help"):
+        print("Usage: tools.board_image_check.py [--all|BOARD_JSON_FILES]")
+    elif "--all" in sys.argv:
+        print("Scanning all board.json files under current directory...")
+        main(glob.glob("**/board.json", recursive=True))
+    else:
+        main(sys.argv[1:])


### PR DESCRIPTION
### Summary

[@eMUQI pointed out in this comment](https://github.com/micropython/micropython/pull/17951#issuecomment-3600354717) that some newly added ESP32 board definitions don't yet have images on the download site.

* This PR adds a script to check for missing board images automatically (if run with the `--all` option it currently shows five missing images).
* Second commit in this PR updates the board.json files with names of images added in a pending micropython-media PR (the names in the original PRs were copy-pasta).

### Testing

* [ ] The new CI check is expected to fail due to the updated board.json files pointing to missing images.
* [ ] After micropython-media PR https://github.com/micropython/micropython-media/pull/106 is merged, the check should pass on retry
* [ ] After the second micropython-media PR https://github.com/micropython/micropython-media/pull/107 is merged then the check should also pass when run manually as `./tools/board_image_check.py --all`.

### Trade-offs and Alternatives

Could continue checking manually, but this should be more reliable and encourages PR submitters to also submit the PR to micropython-media themselves.