### PR TITLE
esp32/boards/ESP32_GENERIC_P4: Add variants to board.json and .md files.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.json
@@ -17,5 +17,9 @@
     "product": "ESP32-P4",
     "thumbnail": "",
     "url": "https://www.espressif.com/en/products/modules",
+    "variants": {
+        "C5_WIFI": "Support for external C5 WiFi/BLE",
+        "C6_WIFI": "Support for external C6 WiFi/BLE"
+    },
     "vendor": "Espressif"
 }

--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.md
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.md
@@ -1,2 +1,11 @@
 The following firmware is applicable to most development boards based on ESP32-P4, and
 the development boards must be equipped with at least 16 MiB external SPI Flash.
+
+This board has multiple variants available:
+
+* If your board has a standalone ESP32-P4 processor (or the board has a coprocessor but
+  you do not want to use it) then choose the generic variant (first heading below).
+* If your board has an external ESP32-C5 coprocessor for WiFi and BLE then choose the
+  "C5 WiFi/BLE" variant.
+* If your board has an external ESP32-C6 coprocessor for WiFi and BLE then choose the
+  "C6 WiFi/BLE" variant.


### PR DESCRIPTION
### Summary

Add variants to the new `ESP32_GENERIC_P4` board, so they appear on the download page.

### Testing

Not tested.  Change follows other boards with variants.