### PR TITLE
esp32: Don't disable component manager when updating submodules.

### DIFF
--- a/ports/esp32/Makefile
+++ b/ports/esp32/Makefile
@@ -112,4 +112,4 @@ size-files:
 # This is done in a dedicated build directory as some CMake cache values are not
 # set correctly if not all submodules are loaded yet.
 submodules:
-	$(Q)IDF_COMPONENT_MANAGER=0 idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D UPDATE_SUBMODULES=1 reconfigure
+	$(Q)idf.py $(IDFPY_FLAGS) -B $(BUILD)/submodules -D UPDATE_SUBMODULES=1 reconfigure


### PR DESCRIPTION
### Summary

- Reverts the change from ec527a1 - since later change cccac2cc we no longer exit CMake early to get the submodule list, so it's OK to run component manager during this phase.

- Fixes #18497 - specifically that `make submodules BOARD=ESP32_GENERIC_S3` (or any other board that depends on USB) fails due to missing component(s).

See also #16441, #16530

### Testing

Verified I got the reported failure when running `make submodules BOARD=ESP32_GENERIC_S3` without this fix (although plain `make submodules` would pass). Verified it no longer fails with the fix.

*This work was funded through GitHub Sponsors.*