### PR TITLE
esp32: Fix board images for ESP32_GENERIC_[C2|C5|P4].

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_C2/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_C2/board.json
@@ -12,7 +12,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32c2_devkitmini.jpg"
+        "esp8684_devkitc.jpg"
     ],
     "mcu": "esp32c2",
     "product": "ESP32-C2",

--- a/ports/esp32/boards/ESP32_GENERIC_C5/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_C5/board.json
@@ -12,7 +12,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32c5_devkitmini.jpg"
+        "esp32c5_devkitc.jpg"
     ],
     "mcu": "esp32c5",
     "product": "ESP32-C5",

--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.json
@@ -11,7 +11,7 @@
         "WiFi"
     ],
     "images": [
-        "esp32p4_devkitmini.jpg"
+        "esp32_p4_function_ev_board.jpg"
     ],
     "mcu": "esp32p4",
     "product": "ESP32-P4",


### PR DESCRIPTION
### Summary

These recently added boards had copy-paste image names, change them to match the images pending addition to micropython-media. See PR https://github.com/micropython/micropython-media/pull/106

*This work was funded through GitHub Sponsors.*
