### PR TITLE
tools/autobuild: Make firmware destination directory configurable.

### DIFF
--- a/tools/autobuild/autobuild.sh
+++ b/tools/autobuild/autobuild.sh
@@ -7,6 +7,9 @@
 # - IDF_PATH_V50 must be set
 # - MICROPY_AUTOBUILD_MICROPYTHON_REPO must be set to location of micropython repository
 # - MICROPY_AUTOBUILD_MAKE must be set to the make command to use, eg "make -j2"
+# - MICROPY_AUTOBUILD_DEST must be set to a directory name to place the output firmware
+#   (this directory will be created, and removed at the end if firmware is copied to a
+#   remote machine using MICROPY_AUTOBUILD_REMOTE_MACHINE and MICROPY_AUTOBUILD_REMOTE_DIR)
 #
 # Optional settings:
 # - MICROPY_AUTOBUILD_REMOTE_MACHINE can be set to a remote ssh machine to copy files to
@@ -27,6 +30,11 @@ if [ -z "$MICROPY_AUTOBUILD_MAKE" ]; then
     exit 1
 fi
 
+if [ -z "$MICROPY_AUTOBUILD_DEST" ]; then
+    echo "must set MICROPY_AUTOBUILD_DEST"
+    exit 1
+fi
+
 ########################################
 # Initialisation
 
@@ -37,7 +45,7 @@ AUTODIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${AUTODIR}/build-boards.sh
 
 # make local directory to put firmware
-LOCAL_FIRMWARE=/tmp/autobuild-firmware-$$
+LOCAL_FIRMWARE=${MICROPY_AUTOBUILD_DEST}
 mkdir -p ${LOCAL_FIRMWARE}
 
 # get latest MicroPython


### PR DESCRIPTION
### Summary

The destination directory for the firmware built by `autobuild.sh` is currently hard-coded to `/tmp/autobuild-firmware-$$`.  Now that there are many boards built by this script, the `/tmp` partition can run out of space.

This commit makes the destination directory configurable via the `MICROPY_AUTOBUILD_DEST` environment variable.

### Testing

Tested on the autobuild server.  It seems to work as expected.