### PR TITLE
py: Cast prior to bitwise invert when the type is widened.

### DIFF
--- a/py/asmbase.c
+++ b/py/asmbase.c
@@ -102,7 +102,7 @@ void mp_asm_base_label_assign(mp_asm_base_t *as, size_t label) {
 
 // align must be a multiple of 2
 void mp_asm_base_align(mp_asm_base_t *as, unsigned int align) {
-    as->code_offset = (as->code_offset + align - 1) & (~(align - 1));
+    as->code_offset = (as->code_offset + align - 1) & (~(size_t)(align - 1));
 }
 
 // this function assumes a little endian machine

--- a/py/emitinlinerv32.c
+++ b/py/emitinlinerv32.c
@@ -390,9 +390,9 @@ static const opcode_t OPCODES[] = {
 
 // These two checks assume the bitmasks are contiguous.
 
-static bool is_in_signed_mask(mp_uint_t mask, mp_uint_t value) {
-    mp_uint_t leading_zeroes = mp_clz(mask);
-    if (leading_zeroes == 0 || leading_zeroes > 32) {
+static bool is_in_signed_mask(uint32_t mask, mp_uint_t value) {
+    uint32_t leading_zeroes = mp_clz(mask);
+    if (leading_zeroes == 0) {
         return true;
     }
     mp_uint_t positive_mask = ~(mask & ~(1U << (31 - leading_zeroes)));


### PR DESCRIPTION
### Summary

Add two casts to fix build error of mpy-cross on Windows CI.

Prior to this fix, the failures were:
```
       "D:\a\micropython\micropython\mpy-cross\mpy-cross.vcxproj" (default target) (1) ->
       (ClCompile target) -> 
         D:\a\micropython\micropython\py\asmbase.c(105,56): warning C4319: '~': zero extending 'unsigned int' to 'size_t' of greater size [D:\a\micropython\micropython\mpy-cross\mpy-cross.vcxproj]
         D:\a\micropython\micropython\py\emitinlinerv32.c(398,40): warning C4319: '~': zero extending 'unsigned int' to 'mp_uint_t' of greater size [D:\a\micropython\micropython\mpy-cross\mpy-cross.vcxproj]
```

### Testing

To be tested by CI.