### PR TITLE
py/builtinhelp: Fix segfault when calling `help` on objects with deleted attributes.

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -152,9 +152,8 @@ static void mp_help_print_obj(const mp_obj_t obj) {
     }
     if (map != NULL) {
         for (uint i = 0; i < map->alloc; i++) {
-            mp_obj_t key = map->table[i].key;
-            if (key != MP_OBJ_NULL) {
-                mp_help_print_info_about_object(key, map->table[i].value);
+            if (mp_map_slot_is_filled(map, i)) {
+                mp_help_print_info_about_object(map->table[i].key, map->table[i].value);
             }
         }
     }

--- a/tests/basics/builtin_help.py
+++ b/tests/basics/builtin_help.py
@@ -14,4 +14,10 @@ import micropython
 help(micropython) # help for a module
 help('modules') # list available modules
 
+class A:
+    x = 1
+    y = 2
+    del x
+help(A)
+
 print('done') # so last bit of output is predictable


### PR DESCRIPTION
### Summary
The builtin `help` function does not correctly iterate over the members of the object passed through it; it mistakes `MP_OBJ_SENTINEL` keys for extant entries, resulting in a segmentation fault or similar access error when attempting to access help on a module or object with deleted entries in its table. This PR adds a test case for this issue and resolves it by using the proper `mp_map_slot_is_filled` method rather than directly checking the key against `MP_OBJ_NULL`.

This was the root cause of #18061 and #18481, but is actually an issue present on _every_ port; it's just coincidence that the particular layout of esp32's machine module meant that that module would also trigger this bug.

Thanks to @agatti for providing the [stack trace](https://github.com/micropython/micropython/issues/18481#issuecomment-3592408485) that allowed me to diagnose this issue.

### Testing
I've tested this on hardware with the Unix and RP2 ports, and can confirm that this fix resolves the problem. I've also tested the test changes for sensitivity and can confirm that the updated test detects this bug.
I lack a working ESP32 toolchain at the moment, but @dpgeorge has reported that this also resolves the specific case of `help(machine)`.
