### PR TITLE
esp32/modesp32: Allow wake_on_ext1/gpio to accept a single Pin.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -37,17 +37,17 @@ Functions
 
 .. function:: wake_on_ext1(pins, level)
 
-    Configure how EXT1 wakes the device from sleep.  *pins* can be ``None``
-    or a tuple/list of valid Pin objects.  *level* should be ``esp32.WAKEUP_ALL_LOW``
-    or ``esp32.WAKEUP_ANY_HIGH``.
+    Configure how EXT1 wakes the device from sleep.  *pins* can be ``None``,
+    a single Pin object, or a tuple/list of valid Pin objects.  *level* should be
+    ``esp32.WAKEUP_ALL_LOW`` or ``esp32.WAKEUP_ANY_HIGH``.
 
     .. note:: This is only available for boards that have ext1 support.
 
 .. function:: wake_on_gpio(pins, level)
 
-    Configure how GPIO wakes the device from sleep.  *pins* can be ``None``
-    or a tuple/list of valid Pin objects.  *level* should be ``esp32.WAKEUP_ALL_LOW``
-    or ``esp32.WAKEUP_ANY_HIGH``.
+    Configure how GPIO wakes the device from sleep.  *pins* can be ``None``,
+    a single Pin object, or a tuple/list of valid Pin objects.  *level* should be
+    ``esp32.WAKEUP_ALL_LOW`` or ``esp32.WAKEUP_ANY_HIGH``.
 
     .. note:: Some boards don't support waking on GPIO from deep sleep,
        on those boards, the pins set here can only be used to wake from light sleep.

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -47,6 +47,7 @@
 #include "../multi_heap_platform.h"
 #include "../heap_private.h"
 #include "driver/rtc_io.h"
+#include "extmod/modmachine.h"
 
 #if SOC_TOUCH_SENSOR_SUPPORTED
 static mp_obj_t esp32_wake_on_touch(const mp_obj_t wake) {
@@ -116,11 +117,21 @@ static mp_obj_t esp32_wake_on_ext1(size_t n_args, const mp_obj_t *pos_args, mp_m
     if (args[ARG_pins].u_obj != mp_const_none) {
         size_t len = 0;
         mp_obj_t *elem;
-        mp_obj_get_array(args[ARG_pins].u_obj, &len, &elem);
+        mp_obj_t pins_obj = args[ARG_pins].u_obj;
+
+        // Support both a single Pin object and a tuple/list of Pins
+        if (mp_obj_is_type(pins_obj, &machine_pin_type)) {
+            // Single Pin object - treat as a single-element array
+            elem = &pins_obj;
+            len = 1;
+        } else {
+            // Tuple or list of Pins
+            mp_obj_get_array(pins_obj, &len, &elem);
+        }
+
         ext1_pins = 0;
 
         for (int i = 0; i < len; i++) {
-
             gpio_num_t pin_id = machine_pin_get_id(elem[i]);
             if (!RTC_IS_VALID_EXT_PIN(pin_id)) {
                 mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
@@ -177,7 +188,18 @@ static mp_obj_t esp32_wake_on_gpio(size_t n_args, const mp_obj_t *pos_args, mp_m
     if (args[ARG_pins].u_obj != mp_const_none) {
         size_t len = 0;
         mp_obj_t *elem;
-        mp_obj_get_array(args[ARG_pins].u_obj, &len, &elem);
+        mp_obj_t pins_obj = args[ARG_pins].u_obj;
+
+        // Support both a single Pin object and a tuple/list of Pins
+        if (mp_obj_is_type(pins_obj, &machine_pin_type)) {
+            // Single Pin object - treat as a single-element array
+            elem = &pins_obj;
+            len = 1;
+        } else {
+            // Tuple or list of Pins
+            mp_obj_get_array(pins_obj, &len, &elem);
+        }
+
         gpio_pins = 0;
 
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
  Both esp32.wake_on_ext1() and esp32.wake_on_gpio() now accept
  either
  a single Pin object or a tuple/list of Pin objects, making the
  common
  single-pin use case more ergonomic while maintaining backward
  compatibility.

  Documentation updated accordingly.

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
As seen [here](https://github.com/micropython/micropython/pull/17518#issuecomment-3525081511) it is useful to be able to set the board wake with a single pin, and not a tuple when not necessary.


### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I checkout on my esp32 that it works


