### PR TITLE
restore disabled modules on g474re, for consistency…

### DIFF
--- a/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
@@ -9,16 +9,6 @@
 #define MICROPY_HW_HAS_SWITCH       (1)
 #define MICROPY_HW_HAS_FLASH        (0) // QSPI extflash not mounted
 
-#define MICROPY_PY_ASYNCIO          (0)
-#define MICROPY_PY_DEFLATE          (0)
-#define MICROPY_PY_BINASCII         (0)
-#define MICROPY_PY_HASHLIB          (0)
-#define MICROPY_PY_JSON             (0)
-#define MICROPY_PY_RE               (0)
-#define MICROPY_PY_FRAMEBUF         (0)
-#define MICROPY_PY_SOCKET           (0)
-#define MICROPY_PY_NETWORK          (0)
-
 // The board has an 24MHz HSE, the following gives 170MHz CPU speed
 #define MICROPY_HW_CLK_PLLM         (6)
 #define MICROPY_HW_CLK_PLLN         (85)


### PR DESCRIPTION
… with other 512k boards, i.e. f411re

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

Follow up to https://github.com/micropython/micropython/issues/18524 & https://github.com/orgs/micropython/discussions/18482.

I recently discovered that the `framebuf` module is missing on `NUCEO_G474RE`.  This board seems to disable a lot of modules; other `*E`  boards with the same flash configuration, i.e. `NUCLEO_F411RE`  don't seem to disable any modules in this way.

So I removed all of the lines disabling modules from g474re to make is consistent with the older f411re. 

### Testing

So far, I flashed it to a board and tested `help('modules')`.  Since this is a minor configuration change copied directly from a board with similar hardware, it should be straightforward.

Since this change is isolated to `NUCLEO_G474RE/mpconfigboard.h` I only tested on that board.

These are the `.bin` files I build; `master-build` is from master with no changes, `all-build` is from this PR.

```
>ls -l *-build/firmware.bin
-rwxrwxr-x 1 steve steve 319260 Dec  6 16:57 all-build/firmware.bin
-rwxrwxr-x 1 steve steve 299792 Dec  6 16:31 master-build/firmware.bin
```
### Trade-offs and Alternatives

This will add some size, but I think it's worth it for consistency.  As far as I can tell, the `G474RE` is essentially a newer, slightly improved update to the `F411RE` with the same flash size, but a lightly faster CPU.   So it is surprising that using a newer, higher-spec part would give less functionality than the older part.



