### PR TITLE
extmod/modjson: Add default argument for json.dump(s).

### DIFF
--- a/docs/library/json.rst
+++ b/docs/library/json.rst
@@ -12,7 +12,7 @@ data format.
 Functions
 ---------
 
-.. function:: dump(obj, stream, separators=None)
+.. function:: dump(obj, stream, separators=None, default=None)
 
    Serialise *obj* to a JSON string, writing it to the given *stream*.
 
@@ -20,7 +20,11 @@ Functions
    tuple. The default is ``(', ', ': ')``. To get the most compact JSON
    representation, you should specify ``(',', ':')`` to eliminate whitespace.
 
-.. function:: dumps(obj, separators=None)
+   If specified, default should be an ``(obj) -> serializable_obj`` callable
+   for objects that can't otherwise be serialized. It should return a JSON encodable
+   version of the object or raise a ``TypeError``.
+
+.. function:: dumps(obj, separators=None, default=None)
 
    Return *obj* represented as a JSON string.
 

--- a/extmod/modjson.c
+++ b/extmod/modjson.c
@@ -42,9 +42,10 @@ enum {
 };
 
 static mp_obj_t mod_json_dump_helper(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, unsigned int mode) {
-    enum { ARG_separators };
+    enum { ARG_separators, ARG_default };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_separators, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
+        { MP_QSTR_default, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -60,6 +61,16 @@ static mp_obj_t mod_json_dump_helper(size_t n_args, const mp_obj_t *pos_args, mp
         mp_obj_get_array_fixed_n(args[ARG_separators].u_obj, 2, &items);
         print_ext.item_separator = mp_obj_str_get_str(items[0]);
         print_ext.key_separator = mp_obj_str_get_str(items[1]);
+    }
+
+    if (args[ARG_default].u_obj != mp_const_none) {
+        if (!mp_obj_is_callable(args[ARG_default].u_obj)) {
+            const mp_obj_type_t *type = mp_obj_get_type(args[ARG_default].u_obj);
+            mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("'%q' object is not callable"), type->name);
+        }
+        print_ext.default_cb = (void *)(uintptr_t)args[ARG_default].u_obj;
+    } else {
+        print_ext.default_cb = NULL;
     }
 
     if (mode == DUMP_MODE_TO_STRING) {

--- a/py/mpprint.h
+++ b/py/mpprint.h
@@ -56,6 +56,7 @@ typedef struct _mp_print_ext_t {
     mp_print_t base;
     const char *item_separator;
     const char *key_separator;
+    void *default_cb;
 } mp_print_ext_t;
 
 #define MP_PRINT_GET_EXT(print) ((mp_print_ext_t *)print)

--- a/tests/extmod/json_dump_default.py
+++ b/tests/extmod/json_dump_default.py
@@ -1,0 +1,61 @@
+try:
+    from io import StringIO
+    import json
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class Node:
+    def __init__(self, value, left=None, right=None):
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def node_default(obj):
+    if isinstance(obj, Node):
+        d = {
+            "left": obj.left,
+            "right": obj.right,
+            "value": obj.value,
+        }
+        return {k: d[k] for k in sorted(d.keys())}
+    raise TypeError("Object of type %s is not JSON serializable" % type(obj).__name__)
+
+
+tree = Node(1, Node(2), Node(3, Node(4), None))
+node_list = [Node(i) for i in range(5, 8)]
+
+s = StringIO()
+json.dump(tree, s, default=node_default)
+print(s.getvalue())
+
+s1 = StringIO()
+json.dump({"nodes": node_list}, s1, default=node_default)
+print(s1.getvalue())
+
+# Invalid serializing of an object without a default function
+try:
+    json.dump(Node(10), s, default=None)
+except TypeError:
+    print("Exception")
+
+
+class Square:
+    def __init__(self, side):
+        self.side = side
+
+
+# Invalid serializing of an object without a proper default function
+try:
+    json.dump(Square(5), s, default=node_default)
+except TypeError:
+    print("Exception")
+
+
+# Invalid default function type
+try:
+    json.dump(Node(10), s, default=123)
+except TypeError:
+    print("Exception")

--- a/tests/extmod/json_dump_default.py.exp
+++ b/tests/extmod/json_dump_default.py.exp
@@ -1,0 +1,5 @@
+{"right": {"right": null, "left": {"right": null, "left": null, "value": 4}, "value": 3}, "left": {"right": null, "left": null, "value": 2}, "value": 1}
+{"nodes": [{"right": null, "left": null, "value": 5}, {"right": null, "left": null, "value": 6}, {"right": null, "left": null, "value": 7}]}
+Exception
+Exception
+Exception

--- a/tests/extmod/json_dumps_default.py
+++ b/tests/extmod/json_dumps_default.py
@@ -1,0 +1,55 @@
+try:
+    import json
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class Node:
+    def __init__(self, value, left=None, right=None):
+        self.value = value
+        self.left = left
+        self.right = right
+
+
+def node_default(obj):
+    if isinstance(obj, Node):
+        d = {
+            "left": obj.left,
+            "right": obj.right,
+            "value": obj.value,
+        }
+        return {k: d[k] for k in sorted(d.keys())}
+    raise TypeError("Object of type %s is not JSON serializable" % type(obj).__name__)
+
+
+tree = Node(1, Node(2), Node(3, Node(4), None))
+node_list = [Node(i) for i in range(5, 8)]
+
+print(json.dumps(tree, default=node_default))
+print(json.dumps({"nodes": node_list}, default=node_default))
+
+# Invalid serializing of an object without a default function
+try:
+    print(json.dumps(Node(10)))
+except TypeError:
+    print("Exception")
+
+
+class Square:
+    def __init__(self, side):
+        self.side = side
+
+
+# Invalid serializing of an object without a proper default function
+try:
+    print(json.dumps(Square(5), default=node_default))
+except TypeError:
+    print("Exception")
+
+
+# Invalid default function type
+try:
+    print(json.dumps(Node(10), default=123))
+except TypeError:
+    print("Exception")

--- a/tests/extmod/json_dumps_default.py.exp
+++ b/tests/extmod/json_dumps_default.py.exp
@@ -1,0 +1,5 @@
+{"right": {"right": null, "left": {"right": null, "left": null, "value": 4}, "value": 3}, "left": {"right": null, "left": null, "value": 2}, "value": 1}
+{"nodes": [{"right": null, "left": null, "value": 5}, {"right": null, "left": null, "value": 6}, {"right": null, "left": null, "value": 7}]}
+Exception
+Exception
+Exception


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

As mentioned in the issue, the CPython api for `json.dump` and `json.dumps` allows for the named argument `default` to be provided. It is a callable type that specifies a way for non-serializable objects to be serialized. This patch series adds support for this argument in Micropython along with the documentation update and extending tests to cover the new argument.

CPython reference: https://docs.python.org/3/library/json.html

default ([callable](https://docs.python.org/3/glossary.html#term-callable) | None) – A function that is called for objects that can’t otherwise be serialized. It should return a JSON encodable version of the object or raise a [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError). If None (the default), TypeError is raised.

Fixes: #16963
### Testing

Tested on the Unix port.
