### PR TITLE
esp32/boards/ESP32_GENERIC_S3: Reinstate old FLASH_4M variant for download only.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_S3/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_S3/board.json
@@ -22,5 +22,8 @@
     "vendor": "Espressif",
     "variants": {
         "SPIRAM_OCT": "Support for Octal-SPIRAM"
+    },
+    "old_variants": {
+        "FLASH_4M": ["4MiB flash", "Use the standard variant instead."]
     }
 }


### PR DESCRIPTION
### Summary

Commit 6201e77999b3614518abc4b21773e735d9b0b0ee removed the ESP32_GENERIC_S3 FLASH_4M variant from `board.json`.  But the firmware still exists on the download server, and it makes sense to still keep those old versions available for download, just like all other older versions are still available.

This introduce a new scheme for `board.json` whereby old variants that are no longer built can be moved to the `"old_variants"` section.  This keeps them available on the download page, allowing a way for us to deprecate individual board variants without removing them entirely.

### Testing

I updated the download server to understand this new "old_variants" entry.  You can see it working at https://micropython.org/download/ESP32_GENERIC_S3/, at the bottom the old FLASH_4M is back!

### Trade-offs and Alternatives

IMO it's quite an abrupt change to remove a variant entirely, including all its historical downloads.  Hence this change, which I tried to make as simple as possible.

The name "old_variants" could possibly be something better, maybe "previous_variants"?
