### PR TITLE
tests/ports/esp32/check_err_str.py: Preallocate global variable.

### DIFF
--- a/tests/ports/esp32/check_err_str.py
+++ b/tests/ports/esp32/check_err_str.py
@@ -1,3 +1,5 @@
+# This tests checks the behaviour of the `check_esp_err`/`check_esp_err_` C function.
+
 try:
     from esp32 import Partition as p
     import micropython
@@ -23,6 +25,7 @@ except OSError as e:
 
 # same but with out of memory condition by locking the heap
 exc = "FAILED TO RAISE"
+e = None  # preallocate entry in globals dict
 micropython.heap_lock()
 try:
     fun(part)
@@ -34,6 +37,7 @@ print("exc:", exc)  # exc empty due to no memory
 # same again but having an emergency buffer
 micropython.alloc_emergency_exception_buf(256)
 exc = "FAILED TO RAISE"
+e = None  # preallocate entry in globals dict
 micropython.heap_lock()
 try:
     fun(part)


### PR DESCRIPTION
### Summary

This test fails on all esp32 boards without this fix, because the try/except that runs with the heap locked attempts to increase the size of the globals dict when assigning to the exception variable `e`.

Fix that by preallocating the global variable `e`.

### Testing

Tested on ESP32_GENERIC_S3 and ESP32_GENERIC_C3, running as bytecode, via .mpy and native code.  It now passes in all cases.

### Trade-offs and Alternatives

Could put all this code in a function (so that `e` is a local variable), but that's a bigger change and not necessarily better.