### PR TITLE
py/misc: Add byte-swapping macros.

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -553,4 +553,30 @@ static inline bool mp_sub_ll_overflow(long long int lhs, long long int rhs, long
 #define MP_SANITIZER_BUILD (MP_UBSAN || MP_ASAN)
 #endif
 
+// halfword/word/longword swapping macros
+
+#if __has_builtin(__builtin_bswap16)
+#define MP_BSWAP16(x) __builtin_bswap16(x)
+#else
+#define MP_BSWAP16(x) ((uint16_t)((((x) & 0xFF) << 8) | (((x) >> 8) & 0xFF)))
+#endif
+
+#if __has_builtin(__builtin_bswap32)
+#define MP_BSWAP32(x) __builtin_bswap32(x)
+#else
+#define MP_BSWAP32(x) \
+    ((uint32_t)((((x) & 0xFF) << 24) | (((x) & 0xFF00) << 8) | \
+    (((x) >> 8) & 0xFF00) | (((x) >> 24) & 0xFF)))
+#endif
+
+#if __has_builtin(__builtin_bswap64)
+#define MP_BSWAP64(x) __builtin_bswap64(x)
+#else
+#define MP_BSWAP64(x) \
+    ((uint64_t)((((x) & 0xFF) << 56) | (((x) & 0xFF00) << 40) | \
+    (((x) & 0xFF0000) << 24) | (((x) & 0xFF000000) << 8) | \
+    (((x) >> 8) & 0xFF000000) | (((x) >> 24) & 0xFF0000) | \
+    (((x) >> 40) & 0xFF00) | (((x) >> 56) & 0xFF)))
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MISC_H

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -2394,7 +2394,7 @@ typedef time_t mp_timestamp_t;
 
 #ifndef MP_HTOBE16
 #if MP_ENDIANNESS_LITTLE
-#define MP_HTOBE16(x) ((uint16_t)((((x) & 0xff) << 8) | (((x) >> 8) & 0xff)))
+#define MP_HTOBE16(x) MP_BSWAP16(x)
 #define MP_BE16TOH(x) MP_HTOBE16(x)
 #else
 #define MP_HTOBE16(x) (x)
@@ -2404,7 +2404,7 @@ typedef time_t mp_timestamp_t;
 
 #ifndef MP_HTOBE32
 #if MP_ENDIANNESS_LITTLE
-#define MP_HTOBE32(x) ((uint32_t)((((x) & 0xff) << 24) | (((x) & 0xff00) << 8) | (((x) >> 8) & 0xff00) | (((x) >> 24) & 0xff)))
+#define MP_HTOBE32(x) MP_BSWAP32(x)
 #define MP_BE32TOH(x) MP_HTOBE32(x)
 #else
 #define MP_HTOBE32(x) (x)


### PR DESCRIPTION
### Summary

This PR adds byte-swapping macros for 16-, 32-, and 64-bit values.

Modern compilers are usually able to detect manual byte/endian swaps and will generate optimised code sequences if they know how to do that. However, in certain situations it may be helpful to let the compiler generate an optimised sequence if it doesn't recognise the pattern.

Most compilers provide built-in byte swap operations for 16, 32, and 64 bit values, accessed via "__builtin_bswap<size>", but if those are not available a fallback implementation is provided.

This happens to shrink the ESP8266 port by a few bytes and speed AES-ECB operations up on that port by a tiny bit.

### Testing

Besides the usual CI tests round, on an ESP8266EX the full test suite passes with the same number of errors as regular 1.27.0 master (PR to fix those coming up soon).