### PR TITLE
extmod/modlwip: Keep any existing incoming TCP data upon remote TCP RST

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -371,11 +371,7 @@ static struct tcp_pcb *volatile *lwip_socket_incoming_array(lwip_socket_obj_t *s
 }
 
 static void lwip_socket_free_incoming(lwip_socket_obj_t *socket) {
-    bool socket_is_listener =
-        socket->type == MOD_NETWORK_SOCK_STREAM
-        && socket->pcb.tcp->state == LISTEN;
-
-    if (!socket_is_listener) {
+    if (socket->state != STATE_LISTENING) {
         if (socket->type == MOD_NETWORK_SOCK_STREAM) {
             if (socket->incoming.tcp.pbuf != NULL) {
                 pbuf_free(socket->incoming.tcp.pbuf);
@@ -1648,7 +1644,7 @@ static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
                 tcp_err(socket->pcb.tcp, NULL);
                 tcp_recv(socket->pcb.tcp, NULL);
 
-                if (socket->pcb.tcp->state != LISTEN) {
+                if (socket->state != STATE_LISTENING) {
                     // Schedule a callback to abort the connection if it's not cleanly closed after
                     // the given timeout.  The callback must be set before calling tcp_close since
                     // the latter may free the pcb; if it doesn't then the callback will be active.

--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -213,7 +213,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
 // TODO: We just know that change happened somewhere between 1.4.0 and 1.4.1,
 // investigate in more detail.
 #if LWIP_VERSION_MACRO < 0x01040100
-static const int error_lookup_table[] = {
+static const int8_t error_lookup_table[] = {
     0,                /* ERR_OK          0      No error, everything OK. */
     MP_ENOMEM,        /* ERR_MEM        -1      Out of memory error.     */
     MP_ENOBUFS,       /* ERR_BUF        -2      Buffer error.            */
@@ -234,7 +234,7 @@ static const int error_lookup_table[] = {
     MP_EBADF,         /* _ERR_BADF      -16     Closed socket (null pcb) */
 };
 #elif LWIP_VERSION_MACRO < 0x02000000
-static const int error_lookup_table[] = {
+static const int8_t error_lookup_table[] = {
     0,                /* ERR_OK          0      No error, everything OK. */
     MP_ENOMEM,        /* ERR_MEM        -1      Out of memory error.     */
     MP_ENOBUFS,       /* ERR_BUF        -2      Buffer error.            */
@@ -258,7 +258,7 @@ static const int error_lookup_table[] = {
 // Matches lwIP 2.0.3
 #undef _ERR_BADF
 #define _ERR_BADF -17
-static const int error_lookup_table[] = {
+static const int8_t error_lookup_table[] = {
     0,                /* ERR_OK          0      No error, everything OK  */
     MP_ENOMEM,        /* ERR_MEM        -1      Out of memory error      */
     MP_ENOBUFS,       /* ERR_BUF        -2      Buffer error             */

--- a/tests/multi_net/tcp_client_rst.py
+++ b/tests/multi_net/tcp_client_rst.py
@@ -2,6 +2,12 @@
 
 import struct, time, socket, select
 
+try:
+    import errno
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 
@@ -18,27 +24,49 @@ def instance0():
     s.bind(socket.getaddrinfo("0.0.0.0", PORT)[0][-1])
     s.listen(1)
     multitest.next()
-    s2, _ = s.accept()
-    s2.setblocking(False)
-    poll = select.poll()
-    poll.register(s2, select.POLLIN)
-    time.sleep(0.4)
-    print(convert_poll_list(poll.poll(1000)))
-    # TODO: the following recv don't work with lwip, it abandons data upon TCP RST
-    try:
-        print(s2.recv(10))
+
+    for iteration in range(2):
+        print("server iteration", iteration)
+
+        # Accept a connection from the client.
+        s2, _ = s.accept()
+        s2.setblocking(False)
+
+        # Create a poller for the connected socket.
+        poll = select.poll()
+        poll.register(s2, select.POLLIN)
+
+        # Wait for the client to send data and issue a TCP RST.
+        for _ in range(10):
+            if select.POLLIN | select.POLLERR | select.POLLHUP in convert_poll_list(
+                poll.poll(1000)
+            ):
+                break
+            time.sleep(0.1)
         print(convert_poll_list(poll.poll(1000)))
-        print(s2.recv(10))
+
+        # On the second test, drain the incoming data.
+        if iteration == 1:
+            for _ in range(5):
+                try:
+                    print(s2.recv(10))
+                except OSError as er:
+                    # This error should only happen on the 3rd recv.
+                    print("ECONNRESET:", er.errno == errno.ECONNRESET)
+                print(convert_poll_list(poll.poll(1000)))
+
+        # Close the connection to the client.
+        s2.close()
         print(convert_poll_list(poll.poll(1000)))
-        print(s2.recv(10))
+
+        # Try to read more data from the closed socket, to make sure the error code is correct.
+        try:
+            print(s2.recv(10))
+        except OSError as er:
+            print("EBADF:", er.errno == errno.EBADF)
         print(convert_poll_list(poll.poll(1000)))
-    except OSError as er:
-        print(er.errno)
-    print(convert_poll_list(poll.poll(1000)))
-    # TODO lwip raises here but apparently it shouldn't
-    print(s2.recv(10))
-    print(convert_poll_list(poll.poll(1000)))
-    s2.close()
+
+    # Close the listening socket.
     s.close()
 
 
@@ -47,11 +75,13 @@ def instance1():
     if not hasattr(socket, "SO_LINGER"):
         multitest.skip()
     multitest.next()
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-    s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
-    lgr_onoff = 1
-    lgr_linger = 0
-    s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", lgr_onoff, lgr_linger))
-    s.send(b"GET / HTTP/1.0\r\n\r\n")
-    time.sleep(0.2)
-    s.close()  # This issues a TCP RST since we've set the linger option
+    for iteration in range(2):
+        print("client iteration", iteration)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        s.connect(socket.getaddrinfo(IP, PORT)[0][-1])
+        lgr_onoff = 1
+        lgr_linger = 0
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", lgr_onoff, lgr_linger))
+        s.send(b"GET / HTTP/1.0\r\n\r\n")
+        time.sleep(0.2)
+        s.close()  # This issues a TCP RST since we've set the linger option


### PR DESCRIPTION
### Summary

This PR fixes a long standing bug/deficiency in the lwIP socket code, whereby it would abandon all incoming TCP data if the remote sent a TCP RST.

This behaviour it tested by the existing `multi_net/tcp_client_rst.py` and `multi_net/asyncio_tcp_client_rst.py` tests, and they both fail on boards like PYBD_SFx and RPI_PICO_W due to the deficiency.

With the fix here, both of those tests now pass, along with all existing socket tests.

The `multi_net/tcp_client_rst.py` test is also improved in this PR to make it test other behaviour related to TCP RST.

### Testing

Tested on the unix port and PYBD_SF2, running the `multi_net` tests.

### Trade-offs and Alternatives

I tried to make this change as minimal as possible.  It includes a few related fixes to `modlwip.c` as well, done in separate commits here.

