### PR TITLE
ports/esp8266: Dead code.

### DIFF
--- a/ports/esp8266/main.c
+++ b/ports/esp8266/main.c
@@ -123,8 +123,6 @@ static void mp_reset(void) {
     // Activate UART(0) on dupterm slot 1 for the REPL
     {
         mp_obj_t args[2];
-        args[0] = MP_OBJ_NEW_SMALL_INT(0);
-        args[1] = MP_OBJ_NEW_SMALL_INT(115200);
         args[0] = MP_OBJ_TYPE_GET_SLOT(&machine_uart_type, make_new)(&machine_uart_type, 2, 0, args);
         args[1] = MP_OBJ_NEW_SMALL_INT(1);
         mp_os_dupterm_obj.fun.var(2, args);


### PR DESCRIPTION
### Summary

This change removes two lines of obviously-dead code.

### Testing

Does not seem to be necessary.
