### PR TITLE
Continuous ADC driver for esp32

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -120,6 +120,7 @@ list(APPEND MICROPY_SOURCE_PORT
     fatfs_port.c
     help.c
     machine_bitstream.c
+    machine_cont_adc.c
     machine_timer.c
     machine_pin.c
     machine_touchpad.c

--- a/ports/esp32/machine_cont_adc.c
+++ b/ports/esp32/machine_cont_adc.c
@@ -1,0 +1,947 @@
+// machine_cont_adc.c : ESP32-C3 continuous ADC -> UDP for MicroPython v1.28 / ESP-IDF v5.5.1
+//
+// Packet format, little-endian, mono only, 8-byte header:
+//   uint16 seq             = packet sequence number, wraps at 65535
+//   uint8  codec           = 0: PCM16, 1: IMA-style ADPCM4
+//   uint8  step_index      = initial ADPCM step index; 0 for PCM16
+//   uint16 sample_rate_hz  = sender sample rate, max 65535 Hz
+//   int16  predictor       = first PCM sample for ADPCM; reserved for PCM16
+//   uint8 payload[]
+//
+// Decoded sample count is derived from UDP datagram length:
+//   PCM16:  payload_bytes / 2
+//   ADPCM4: 1 + payload_bytes * 2
+//
+// To make ADPCM4 self-delimiting without a sample_count field, every ADPCM
+// packet carries an odd number of decoded samples. If a partial ADPCM packet
+// would otherwise be even length, the last sample is duplicated once.
+//
+// MicroPython API as a standalone module:
+//   import cont_adc
+//   cont_adc.config_adc_udp_stream(channel[, atten[, iir_coeff[, unit]]])
+//     iir_coeff: 0/None/omitted = disabled; otherwise one of 2, 4, 8, 16, 32, 64.
+//     unit: omitted/None = ADC_UNIT_1; ADC_UNIT_2 is allowed if valid for the selected channel/target.
+//   cont_adc.start_adc_udp_stream(sample_rate_hz, dest_ip, dest_port[, codec])
+//   cont_adc.stop_adc_udp_stream()
+//   cont_adc.stats_adc_udp_stream()
+//
+// Short aliases are also provided: config(), start(), stop(), stats().
+// If you prefer exposing the functions under machine.*, add the *_obj symbols
+// to ports/esp32/modmachine.c and disable/ignore MP_REGISTER_MODULE below.
+
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/time.h>
+
+#include "py/runtime.h"
+#include "py/obj.h"
+#include "py/objmodule.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+
+#include "esp_log.h"
+#include "esp_err.h"
+#include "esp_heap_caps.h"
+
+#include "esp_adc/adc_continuous.h"
+#include "esp_adc/adc_filter.h"
+#include "soc/adc_channel.h"
+#include "soc/soc_caps.h"
+
+#include "lwip/sockets.h"
+#include "lwip/inet.h"
+
+#define TAG "ADC_UDP_STREAM"
+
+#ifndef SOC_ADC_DIGI_RESULT_BYTES
+#define SOC_ADC_DIGI_RESULT_BYTES SOC_ADC_DIGI_DATA_BYTES_PER_CONV
+#endif
+
+/* ESP-IDF v5.5.x does not provide adc_continuous_parse_data()/adc_continuous_data_t
+ * on ESP32-C3. adc_continuous_read() returns raw conversion results; the v5.5.1
+ * official continuous_read example casts each SOC_ADC_DIGI_RESULT_BYTES entry to
+ * adc_digi_output_data_t and uses type2 on targets other than ESP32/ESP32-S2.
+ */
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+#define CONT_ADC_OUTPUT_TYPE         ADC_DIGI_OUTPUT_FORMAT_TYPE1
+#define CONT_ADC_GET_CHANNEL(p_data) ((p_data)->type1.channel)
+#define CONT_ADC_GET_DATA(p_data)    ((p_data)->type1.data)
+#else
+#define CONT_ADC_OUTPUT_TYPE         ADC_DIGI_OUTPUT_FORMAT_TYPE2
+#define CONT_ADC_GET_CHANNEL(p_data) ((p_data)->type2.channel)
+#define CONT_ADC_GET_DATA(p_data)    ((p_data)->type2.data)
+#endif
+
+/* ---------------- User-tunable compile-time parameters ---------------- */
+
+#ifndef CONT_ADC_SAMPLES_PER_PACKET
+#define CONT_ADC_SAMPLES_PER_PACKET 320u
+#endif
+
+#ifndef CONT_ADC_CONV_FRAME_SIZE
+#define CONT_ADC_CONV_FRAME_SIZE 512u
+#endif
+
+#ifndef CONT_ADC_STORE_FRAMES
+#define CONT_ADC_STORE_FRAMES 8u
+#endif
+
+#ifndef CONT_ADC_SEND_TIMEOUT_MS
+#define CONT_ADC_SEND_TIMEOUT_MS 20u
+#endif
+
+#ifndef CONT_ADC_TASK_STACK_BYTES
+#define CONT_ADC_TASK_STACK_BYTES 4096u
+#endif
+
+#if (CONT_ADC_CONV_FRAME_SIZE % SOC_ADC_DIGI_RESULT_BYTES) != 0
+#error "CONT_ADC_CONV_FRAME_SIZE must be a multiple of SOC_ADC_DIGI_RESULT_BYTES"
+#endif
+
+#if CONT_ADC_SAMPLES_PER_PACKET < 2
+#error "CONT_ADC_SAMPLES_PER_PACKET must be at least 2"
+#endif
+
+/* ---------------- Packet constants ---------------- */
+
+#define AUDIO_CODEC_PCM16           0u
+#define AUDIO_CODEC_ADPCM4          1u
+#define AUDIO_PACKET_HEADER_BYTES   8u
+#define AUDIO_SAMPLE_RATE_MAX       65535u
+#define AUDIO_PACKET_MAX_BYTES      (AUDIO_PACKET_HEADER_BYTES + CONT_ADC_SAMPLES_PER_PACKET * 2u)
+
+/* Return codes from start/stop, keeping the original integer style. */
+#define CADC_RET_OK                 0
+#define CADC_RET_ALREADY_RUNNING    1
+#define CADC_RET_NOT_RUNNING        1
+#define CADC_RET_BAD_ARG           -2
+#define CADC_RET_UDP_FAIL          -3
+#define CADC_RET_ADC_FAIL          -4
+#define CADC_RET_TASK_FAIL         -5
+#define CADC_RET_BAD_CODEC         -6
+#define CADC_RET_STOP_TIMEOUT      -7
+
+/* ---------------- Runtime state ---------------- */
+
+static adc_channel_t s_adc_channel = ADC_CHANNEL_0;
+static adc_atten_t s_adc_atten = ADC_ATTEN_DB_0;
+static adc_unit_t s_adc_unit = ADC_UNIT_1;
+
+static adc_continuous_handle_t s_adc_handle = NULL;
+static adc_iir_filter_handle_t s_iir_filter = NULL;
+static volatile bool s_adc_started = false;
+static int s_udp_sock = -1;
+static struct sockaddr_in s_dest_addr;
+
+static TaskHandle_t s_stream_task_handle = NULL;
+static SemaphoreHandle_t s_task_started_sem = NULL;
+static SemaphoreHandle_t s_task_done_sem = NULL;
+static volatile bool s_running = false;
+
+static uint8_t *s_adc_buf = NULL;
+static uint8_t *s_packet_buf = NULL;
+
+static uint8_t s_codec_mode = AUDIO_CODEC_PCM16;
+static uint16_t s_sample_rate_hz = 0;
+static uint16_t s_packet_seq = 0;
+static uint8_t s_adpcm_step_index = 20;
+static esp_err_t s_task_start_error = ESP_OK;
+static bool s_iir_filter_enabled = false;
+static adc_digi_iir_filter_coeff_t s_iir_filter_coeff = ADC_DIGI_IIR_FILTER_COEFF_64;
+
+static uint32_t s_packets_sent = 0;
+static uint32_t s_send_errors = 0;
+static uint32_t s_adc_overflows = 0;
+static uint32_t s_adc_read_errors = 0;
+static uint32_t s_bad_adc_samples = 0;
+static esp_err_t s_last_error = ESP_OK;
+
+/* ---------------- Little-endian helpers ---------------- */
+
+static inline void put_u16le(uint8_t *p, uint16_t v) {
+    p[0] = (uint8_t)(v & 0xffu);
+    p[1] = (uint8_t)((v >> 8) & 0xffu);
+}
+
+static inline void put_s16le(uint8_t *p, int16_t v) {
+    put_u16le(p, (uint16_t)v);
+}
+
+static inline void write_audio_header(uint8_t *p,
+                                      uint16_t seq,
+                                      uint8_t codec,
+                                      uint8_t step_index,
+                                      uint16_t sample_rate_hz,
+                                      int16_t predictor) {
+    put_u16le(p + 0, seq);
+    p[2] = codec;
+    p[3] = step_index;
+    put_u16le(p + 4, sample_rate_hz);
+    put_s16le(p + 6, predictor);
+}
+
+static inline int16_t clip_i16(int32_t x) {
+    if (x < -32768) {
+        return -32768;
+    }
+    if (x > 32767) {
+        return 32767;
+    }
+    return (int16_t)x;
+}
+
+/* Convert unsigned 12-bit ADC value to signed 16-bit PCM.
+ * Assumes the analog front-end is biased near ADC midscale.
+ */
+static inline int16_t adc12_to_pcm16(uint32_t raw) {
+    return clip_i16((((int32_t)(raw & 0x0fffu)) - 2048) << 4);
+}
+
+/* ---------------- IMA-style ADPCM encoder ---------------- */
+
+static const int16_t ima_step_table[89] = {
+      7,     8,     9,    10,    11,    12,    13,    14,
+     16,    17,    19,    21,    23,    25,    28,    31,
+     34,    37,    41,    45,    50,    55,    60,    66,
+     73,    80,    88,    97,   107,   118,   130,   143,
+    157,   173,   190,   209,   230,   253,   279,   307,
+    337,   371,   408,   449,   494,   544,   598,   658,
+    724,   796,   876,   963,  1060,  1166,  1282,  1411,
+   1552,  1707,  1878,  2066,  2272,  2499,  2749,  3024,
+   3327,  3660,  4026,  4428,  4871,  5358,  5894,  6484,
+   7132,  7845,  8630,  9493, 10442, 11487, 12635, 13899,
+  15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
+  32767
+};
+
+static const int8_t ima_index_table[16] = {
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8
+};
+
+static inline uint8_t ima_adpcm_encode_nibble(int16_t sample,
+                                              int16_t *predictor,
+                                              uint8_t *step_index) {
+    int step = ima_step_table[*step_index];
+    int diff = (int)sample - (int)(*predictor);
+    uint8_t code = 0;
+
+    if (diff < 0) {
+        code = 8;
+        diff = -diff;
+    }
+
+    int delta = step >> 3;
+    if (diff >= step) {
+        code |= 4;
+        diff -= step;
+        delta += step;
+    }
+    if (diff >= (step >> 1)) {
+        code |= 2;
+        diff -= (step >> 1);
+        delta += (step >> 1);
+    }
+    if (diff >= (step >> 2)) {
+        code |= 1;
+        delta += (step >> 2);
+    }
+
+    if (code & 8) {
+        *predictor = clip_i16((int32_t)(*predictor) - delta);
+    } else {
+        *predictor = clip_i16((int32_t)(*predictor) + delta);
+    }
+
+    int new_index = (int)(*step_index) + ima_index_table[code & 0x0f];
+    if (new_index < 0) {
+        new_index = 0;
+    } else if (new_index > 88) {
+        new_index = 88;
+    }
+    *step_index = (uint8_t)new_index;
+
+    return code & 0x0f;
+}
+
+/* ---------------- Packet builder ---------------- */
+
+typedef struct {
+    uint8_t *buf;
+    uint8_t codec;
+    uint16_t sample_count;
+    int16_t header_predictor;
+    int16_t adpcm_predictor;
+    int16_t last_pcm;
+    uint8_t header_step_index;
+} packet_builder_t;
+
+static inline void packet_begin(packet_builder_t *pb, uint8_t *buf, uint8_t codec) {
+    pb->buf = buf;
+    pb->codec = codec;
+    pb->sample_count = 0;
+    pb->header_predictor = 0;
+    pb->adpcm_predictor = 0;
+    pb->last_pcm = 0;
+    pb->header_step_index = s_adpcm_step_index;
+}
+
+static inline void packet_add_sample(packet_builder_t *pb, int16_t pcm) {
+    uint16_t n = pb->sample_count;
+
+    if (pb->codec == AUDIO_CODEC_ADPCM4) {
+        if (n == 0) {
+            pb->header_predictor = pcm;
+            pb->adpcm_predictor = pcm;
+            pb->last_pcm = pcm;
+            pb->header_step_index = s_adpcm_step_index;
+            pb->sample_count = 1;
+            return;
+        }
+
+        uint8_t code = ima_adpcm_encode_nibble(pcm, &pb->adpcm_predictor, &s_adpcm_step_index);
+        uint16_t code_index = (uint16_t)(n - 1u);
+        uint8_t *dst = pb->buf + AUDIO_PACKET_HEADER_BYTES + (code_index >> 1);
+        if ((code_index & 1u) == 0) {
+            *dst = code;
+        } else {
+            *dst |= (uint8_t)(code << 4);
+        }
+    } else {
+        if (n == 0) {
+            pb->header_predictor = pcm;
+        }
+        put_s16le(pb->buf + AUDIO_PACKET_HEADER_BYTES + ((size_t)n * 2u), pcm);
+    }
+
+    pb->last_pcm = pcm;
+    pb->sample_count = (uint16_t)(n + 1u);
+}
+
+static inline size_t packet_payload_len(const packet_builder_t *pb) {
+    if (pb->codec == AUDIO_CODEC_ADPCM4) {
+        // ADPCM packets are forced to odd decoded sample counts, so payload_bytes = (samples - 1) / 2.
+        return (size_t)(pb->sample_count / 2u);
+    }
+    return (size_t)pb->sample_count * 2u;
+}
+
+static inline uint16_t packet_target_samples(uint8_t codec) {
+    if (codec == AUDIO_CODEC_ADPCM4 && (CONT_ADC_SAMPLES_PER_PACKET & 1u) == 0) {
+        // One extra ADPCM sample still uses much less space than a PCM packet and keeps length self-delimiting.
+        return (uint16_t)(CONT_ADC_SAMPLES_PER_PACKET + 1u);
+    }
+    return (uint16_t)CONT_ADC_SAMPLES_PER_PACKET;
+}
+
+static inline void packet_make_length_decodable(packet_builder_t *pb) {
+    if (pb->codec == AUDIO_CODEC_ADPCM4 && pb->sample_count != 0 && (pb->sample_count & 1u) == 0) {
+        // Without sample_count in the header, ADPCM nibble length is ambiguous for even sample counts.
+        // Duplicate the final sample once so receiver can derive samples = 1 + payload_bytes * 2.
+        packet_add_sample(pb, pb->last_pcm);
+    }
+}
+
+static void udp_send_buf(const uint8_t *buf, size_t len) {
+    if (s_udp_sock < 0) {
+        s_send_errors++;
+        return;
+    }
+
+    ssize_t sent = sendto(s_udp_sock,
+                          buf,
+                          len,
+                          0,
+                          (const struct sockaddr *)&s_dest_addr,
+                          sizeof(s_dest_addr));
+    if (sent == (ssize_t)len) {
+        s_packets_sent++;
+    } else {
+        s_send_errors++;
+        if (sent < 0) {
+            ESP_LOGW(TAG, "sendto failed: errno %d", errno);
+        } else {
+            ESP_LOGW(TAG, "sendto short write: %d/%u", (int)sent, (unsigned)len);
+        }
+    }
+}
+
+static inline void packet_finish_and_send(packet_builder_t *pb) {
+    if (pb->sample_count == 0) {
+        return;
+    }
+
+    packet_make_length_decodable(pb);
+    size_t payload_len = packet_payload_len(pb);
+    write_audio_header(pb->buf,
+                       s_packet_seq,
+                       pb->codec,
+                       (pb->codec == AUDIO_CODEC_ADPCM4) ? pb->header_step_index : 0,
+                       s_sample_rate_hz,
+                       pb->header_predictor);
+    udp_send_buf(pb->buf, AUDIO_PACKET_HEADER_BYTES + payload_len);
+    s_packet_seq++;
+
+    packet_begin(pb, pb->buf, pb->codec);
+}
+
+/* ---------------- ADC and UDP setup ---------------- */
+
+static bool is_valid_atten(int atten) {
+    return atten == ADC_ATTEN_DB_0
+        || atten == ADC_ATTEN_DB_2_5
+        || atten == ADC_ATTEN_DB_6
+        || atten == ADC_ATTEN_DB_12;
+}
+
+static bool is_valid_adc_unit_int(int unit) {
+    return unit == ADC_UNIT_1 || unit == ADC_UNIT_2;
+}
+
+static bool is_valid_adc_channel_for_unit(adc_unit_t unit, int channel) {
+    if (channel < 0) {
+        return false;
+    }
+    int io_num = -1;
+    return adc_continuous_channel_to_io(unit, (adc_channel_t)channel, &io_num) == ESP_OK;
+}
+
+
+static bool iir_coeff_from_int(int coeff, adc_digi_iir_filter_coeff_t *out_coeff) {
+    switch (coeff) {
+        case 2:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_2;
+            return true;
+        case 4:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_4;
+            return true;
+        case 8:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_8;
+            return true;
+        case 16:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_16;
+            return true;
+        case 32:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_32;
+            return true;
+        case 64:
+            *out_coeff = ADC_DIGI_IIR_FILTER_COEFF_64;
+            return true;
+        default:
+            return false;
+    }
+}
+
+static int iir_coeff_to_int(adc_digi_iir_filter_coeff_t coeff) {
+    switch (coeff) {
+        case ADC_DIGI_IIR_FILTER_COEFF_2:
+            return 2;
+        case ADC_DIGI_IIR_FILTER_COEFF_4:
+            return 4;
+        case ADC_DIGI_IIR_FILTER_COEFF_8:
+            return 8;
+        case ADC_DIGI_IIR_FILTER_COEFF_16:
+            return 16;
+        case ADC_DIGI_IIR_FILTER_COEFF_32:
+            return 32;
+        case ADC_DIGI_IIR_FILTER_COEFF_64:
+            return 64;
+        default:
+            return 0;
+    }
+}
+
+static void cleanup_iir_filter(void) {
+    if (s_iir_filter != NULL) {
+        (void)adc_continuous_iir_filter_disable(s_iir_filter);
+        (void)adc_del_continuous_iir_filter(s_iir_filter);
+        s_iir_filter = NULL;
+    }
+}
+
+static esp_err_t init_udp_socket(const char *ip, uint16_t port) {
+    s_udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+    if (s_udp_sock < 0) {
+        ESP_LOGE(TAG, "Unable to create UDP socket: errno %d", errno);
+        return ESP_FAIL;
+    }
+
+    struct timeval tv = {
+        .tv_sec = (time_t)(CONT_ADC_SEND_TIMEOUT_MS / 1000u),
+        .tv_usec = (suseconds_t)((CONT_ADC_SEND_TIMEOUT_MS % 1000u) * 1000u),
+    };
+    (void)setsockopt(s_udp_sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    memset(&s_dest_addr, 0, sizeof(s_dest_addr));
+    s_dest_addr.sin_family = AF_INET;
+    s_dest_addr.sin_port = htons(port);
+    if (inet_pton(AF_INET, ip, &s_dest_addr.sin_addr) != 1) {
+        ESP_LOGE(TAG, "Invalid IPv4 address: %s", ip ? ip : "<null>");
+        close(s_udp_sock);
+        s_udp_sock = -1;
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    ESP_LOGI(TAG, "UDP socket ready, dest=%s:%u", ip, (unsigned)port);
+    return ESP_OK;
+}
+
+static esp_err_t init_adc_config(uint32_t sample_rate_hz) {
+#if defined(SOC_ADC_SAMPLE_FREQ_THRES_LOW) && defined(SOC_ADC_SAMPLE_FREQ_THRES_HIGH)
+    if (sample_rate_hz < SOC_ADC_SAMPLE_FREQ_THRES_LOW || sample_rate_hz > SOC_ADC_SAMPLE_FREQ_THRES_HIGH) {
+        ESP_LOGE(TAG, "sample_rate_hz out of range: %u", (unsigned)sample_rate_hz);
+        return ESP_ERR_INVALID_ARG;
+    }
+#endif
+
+    adc_continuous_handle_cfg_t handle_cfg = {
+        .max_store_buf_size = CONT_ADC_CONV_FRAME_SIZE * CONT_ADC_STORE_FRAMES,
+        .conv_frame_size = CONT_ADC_CONV_FRAME_SIZE,
+        .flags.flush_pool = 1,
+    };
+
+    esp_err_t ret = adc_continuous_new_handle(&handle_cfg, &s_adc_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "adc_continuous_new_handle failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    adc_digi_pattern_config_t pattern = {
+        .atten = s_adc_atten,
+        .channel = s_adc_channel,
+        .unit = s_adc_unit,
+        .bit_width = ADC_BITWIDTH_12,
+    };
+
+    adc_continuous_config_t dig_cfg = {
+        .pattern_num = 1,
+        .adc_pattern = &pattern,
+        .sample_freq_hz = sample_rate_hz,
+        .conv_mode = (s_adc_unit == ADC_UNIT_2) ? ADC_CONV_SINGLE_UNIT_2 : ADC_CONV_SINGLE_UNIT_1,
+        .format = CONT_ADC_OUTPUT_TYPE,
+    };
+
+    ret = adc_continuous_config(s_adc_handle, &dig_cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "adc_continuous_config failed: %s", esp_err_to_name(ret));
+        adc_continuous_deinit(s_adc_handle);
+        s_adc_handle = NULL;
+        return ret;
+    }
+
+    if (s_iir_filter_enabled) {
+        adc_continuous_iir_filter_config_t filter_cfg = {
+            .unit = s_adc_unit,
+            .channel = s_adc_channel,
+            .coeff = s_iir_filter_coeff,
+        };
+
+        ret = adc_new_continuous_iir_filter(s_adc_handle, &filter_cfg, &s_iir_filter);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "adc_new_continuous_iir_filter failed: %s", esp_err_to_name(ret));
+            adc_continuous_deinit(s_adc_handle);
+            s_adc_handle = NULL;
+            return ret;
+        }
+
+        ret = adc_continuous_iir_filter_enable(s_iir_filter);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "adc_continuous_iir_filter_enable failed: %s", esp_err_to_name(ret));
+            cleanup_iir_filter();
+            adc_continuous_deinit(s_adc_handle);
+            s_adc_handle = NULL;
+            return ret;
+        }
+    }
+
+    return ESP_OK;
+}
+
+static void send_stop_hint(void) {
+    if (s_udp_sock >= 0) {
+        (void)sendto(s_udp_sock,
+                     "",
+                     0,
+                     0,
+                     (const struct sockaddr *)&s_dest_addr,
+                     sizeof(s_dest_addr));
+    }
+}
+
+static void free_stream_buffers(void) {
+    if (s_adc_buf != NULL) {
+        heap_caps_free(s_adc_buf);
+        s_adc_buf = NULL;
+    }
+    if (s_packet_buf != NULL) {
+        heap_caps_free(s_packet_buf);
+        s_packet_buf = NULL;
+    }
+}
+
+static esp_err_t alloc_stream_buffers(void) {
+    free_stream_buffers();
+
+    // Keep sizeable buffers off the FreeRTOS task stack. heap_caps_malloc() returns memory
+    // suitably aligned for ordinary objects, including the 4-byte ADC result entries.
+    s_adc_buf = (uint8_t *)heap_caps_malloc(CONT_ADC_CONV_FRAME_SIZE, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    s_packet_buf = (uint8_t *)heap_caps_malloc(AUDIO_PACKET_MAX_BYTES, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (s_adc_buf == NULL || s_packet_buf == NULL) {
+        ESP_LOGE(TAG, "failed to allocate stream buffers: adc=%u packet=%u bytes",
+                 (unsigned)CONT_ADC_CONV_FRAME_SIZE,
+                 (unsigned)AUDIO_PACKET_MAX_BYTES);
+        free_stream_buffers();
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+static void cleanup_stream_resources(void) {
+    if (s_adc_handle != NULL) {
+        if (s_adc_started) {
+            (void)adc_continuous_stop(s_adc_handle);
+            s_adc_started = false;
+        }
+        cleanup_iir_filter();
+        (void)adc_continuous_deinit(s_adc_handle);
+        s_adc_handle = NULL;
+    }
+
+    if (s_udp_sock >= 0) {
+        close(s_udp_sock);
+        s_udp_sock = -1;
+    }
+
+    free_stream_buffers();
+
+    if (s_task_started_sem != NULL) {
+        vSemaphoreDelete(s_task_started_sem);
+        s_task_started_sem = NULL;
+    }
+
+    if (s_task_done_sem != NULL) {
+        vSemaphoreDelete(s_task_done_sem);
+        s_task_done_sem = NULL;
+    }
+}
+
+/* ---------------- Streaming task ---------------- */
+
+static inline bool adc_output_to_pcm(const adc_digi_output_data_t *d, int16_t *pcm) {
+    /* ESP-IDF v5.5.1 raw conversion result parsing.
+     *
+     * Do not use adc_continuous_parse_data() here: that helper exists in newer
+     * ESP-IDF docs/releases, but not in the v5.5.1 headers used by MicroPython
+     * v1.28.0 at the time of this module.
+     *
+     * Also do not require d->type2.unit to match s_adc_unit. Espressif's v5.5.1
+     * continuous_read example only validates the channel for the configured
+     * single-unit conversion mode. Some targets/IDF combinations encode the
+     * unit field differently, while channel+single-unit mode is sufficient here.
+     */
+    const uint32_t chan_num = CONT_ADC_GET_CHANNEL(d);
+    uint32_t max_channels = SOC_ADC_CHANNEL_NUM(0);
+    if (s_adc_unit == ADC_UNIT_2) {
+        max_channels = SOC_ADC_CHANNEL_NUM(1);
+    }
+    if (chan_num >= max_channels || (adc_channel_t)chan_num != s_adc_channel) {
+        return false;
+    }
+
+    *pcm = adc12_to_pcm16(CONT_ADC_GET_DATA(d));
+    return true;
+}
+
+static void adc_udp_stream_task(void *arg) {
+    (void)arg;
+
+    packet_builder_t pb;
+    uint32_t adc_bytes = 0;
+    const uint8_t codec = s_codec_mode;
+    const uint16_t target_samples = packet_target_samples(codec);
+    uint8_t *adc_buf = s_adc_buf;
+    uint8_t *packet_buf = s_packet_buf;
+
+    if (adc_buf == NULL || packet_buf == NULL) {
+        s_task_start_error = ESP_ERR_NO_MEM;
+        s_last_error = ESP_ERR_NO_MEM;
+        s_running = false;
+        if (s_task_started_sem != NULL) {
+            xSemaphoreGive(s_task_started_sem);
+        }
+        goto task_exit;
+    }
+
+    esp_err_t ret = adc_continuous_start(s_adc_handle);
+    s_task_start_error = ret;
+    if (ret != ESP_OK) {
+        s_last_error = ret;
+        ESP_LOGE(TAG, "adc_continuous_start failed: %s", esp_err_to_name(ret));
+        s_running = false;
+        if (s_task_started_sem != NULL) {
+            xSemaphoreGive(s_task_started_sem);
+        }
+        goto task_exit;
+    }
+    s_adc_started = true;
+    if (s_task_started_sem != NULL) {
+        xSemaphoreGive(s_task_started_sem);
+    }
+
+    packet_begin(&pb, packet_buf, codec);
+
+    while (s_running) {
+        ret = adc_continuous_read(s_adc_handle,
+                                  adc_buf,
+                                  CONT_ADC_CONV_FRAME_SIZE,
+                                  &adc_bytes,
+                                  50);
+        if (ret == ESP_ERR_TIMEOUT) {
+            continue;
+        }
+        if (ret == ESP_ERR_INVALID_STATE) {
+            // Usually means producer outran consumer. With flush_pool enabled, continue with the newest data.
+            s_adc_overflows++;
+            continue;
+        }
+        if (ret != ESP_OK) {
+            s_adc_read_errors++;
+            s_last_error = ret;
+            ESP_LOGW(TAG, "adc_continuous_read failed: %s", esp_err_to_name(ret));
+            s_running = false;
+            break;
+        }
+
+        for (uint32_t pos = 0;
+             pos + SOC_ADC_DIGI_RESULT_BYTES <= adc_bytes && s_running;
+             pos += SOC_ADC_DIGI_RESULT_BYTES) {
+
+            const adc_digi_output_data_t *d = (const adc_digi_output_data_t *)(const void *)&adc_buf[pos];
+            int16_t pcm;
+            if (!adc_output_to_pcm(d, &pcm)) {
+                s_bad_adc_samples++;
+                continue;
+            }
+
+            packet_add_sample(&pb, pcm);
+            if (pb.sample_count >= target_samples) {
+                packet_finish_and_send(&pb);
+            }
+        }
+    }
+
+    // Flush a partial packet before notifying the desktop receiver to stop.
+    packet_finish_and_send(&pb);
+    send_stop_hint();
+
+    if (s_adc_started) {
+        (void)adc_continuous_stop(s_adc_handle);
+        s_adc_started = false;
+    }
+
+task_exit:
+    ESP_LOGI(TAG,
+             "stream task exit: sent=%u send_errors=%u overflows=%u read_errors=%u bad_samples=%u",
+             (unsigned)s_packets_sent,
+             (unsigned)s_send_errors,
+             (unsigned)s_adc_overflows,
+             (unsigned)s_adc_read_errors,
+             (unsigned)s_bad_adc_samples);
+
+    s_stream_task_handle = NULL;
+    if (s_task_done_sem != NULL) {
+        xSemaphoreGive(s_task_done_sem);
+    }
+    vTaskDelete(NULL);
+}
+
+/* ---------------- Public MicroPython API ---------------- */
+
+static mp_obj_t config_adc_udp_stream(size_t n_args, const mp_obj_t *args) {
+    // args: channel[, atten[, iir_coeff[, unit]]]
+    // iir_coeff: 0/None/omitted disables IIR; 2, 4, 8, 16, 32, or 64 enables it.
+    // unit: None/omitted selects ADC_UNIT_1; ADC_UNIT_2 is permitted when the
+    // selected target/channel supports it.
+    if (s_running || s_stream_task_handle != NULL) {
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("ADC UDP stream is running"));
+    }
+
+    int atten = (int)s_adc_atten;
+    if (n_args >= 2 && args[1] != mp_const_none) {
+        atten = mp_obj_get_int(args[1]);
+        if (!is_valid_atten(atten)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid ADC attenuation"));
+        }
+    }
+
+    bool iir_enabled = false;
+    adc_digi_iir_filter_coeff_t iir_coeff = ADC_DIGI_IIR_FILTER_COEFF_64;
+    if (n_args >= 3 && args[2] != mp_const_none) {
+        int coeff_arg = mp_obj_get_int(args[2]);
+        if (coeff_arg != 0) {
+            if (!iir_coeff_from_int(coeff_arg, &iir_coeff)) {
+                mp_raise_ValueError(MP_ERROR_TEXT("invalid IIR coefficient; use 0, 2, 4, 8, 16, 32, or 64"));
+            }
+            iir_enabled = true;
+        }
+    }
+
+    int unit_arg = ADC_UNIT_1;
+    if (n_args >= 4 && args[3] != mp_const_none) {
+        unit_arg = mp_obj_get_int(args[3]);
+        if (!is_valid_adc_unit_int(unit_arg)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid ADC unit"));
+        }
+    }
+
+    int channel = mp_obj_get_int(args[0]);
+    adc_unit_t unit = (adc_unit_t)unit_arg;
+    if (!is_valid_adc_channel_for_unit(unit, channel)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid ADC channel for selected unit"));
+    }
+
+    s_adc_channel = (adc_channel_t)channel;
+    s_adc_atten = (adc_atten_t)atten;
+    s_adc_unit = unit;
+    s_iir_filter_enabled = iir_enabled;
+    s_iir_filter_coeff = iir_coeff;
+    return mp_const_none;
+}
+
+static mp_obj_t start_adc_udp_stream(size_t n_args, const mp_obj_t *args) {
+    // args: sample_rate_hz, dest_ip, dest_port[, codec]
+    if (s_running || s_stream_task_handle != NULL) {
+        ESP_LOGW(TAG, "stream already running");
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_ALREADY_RUNNING);
+    }
+
+    mp_int_t sample_rate_arg = mp_obj_get_int(args[0]);
+    const char *dest_ip = mp_obj_str_get_str(args[1]);
+    int dest_port = mp_obj_get_int(args[2]);
+    int codec_arg = (n_args >= 4) ? mp_obj_get_int(args[3]) : AUDIO_CODEC_PCM16;
+
+    if (sample_rate_arg <= 0 || sample_rate_arg > AUDIO_SAMPLE_RATE_MAX || dest_ip == NULL || dest_port <= 0 || dest_port > 65535) {
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_BAD_ARG);
+    }
+    if (codec_arg != AUDIO_CODEC_PCM16 && codec_arg != AUDIO_CODEC_ADPCM4) {
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_BAD_CODEC);
+    }
+
+    s_last_error = ESP_OK;
+    s_packet_seq = 0;
+    s_sample_rate_hz = (uint16_t)sample_rate_arg;
+    s_adpcm_step_index = 20;
+    s_packets_sent = 0;
+    s_send_errors = 0;
+    s_adc_overflows = 0;
+    s_adc_read_errors = 0;
+    s_bad_adc_samples = 0;
+    s_codec_mode = (uint8_t)codec_arg;
+
+    s_task_started_sem = xSemaphoreCreateBinary();
+    s_task_done_sem = xSemaphoreCreateBinary();
+    if (s_task_started_sem == NULL || s_task_done_sem == NULL) {
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_TASK_FAIL);
+    }
+
+    esp_err_t ret = alloc_stream_buffers();
+    if (ret != ESP_OK) {
+        s_last_error = ret;
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_TASK_FAIL);
+    }
+
+    ret = init_udp_socket(dest_ip, (uint16_t)dest_port);
+    if (ret != ESP_OK) {
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_UDP_FAIL);
+    }
+
+    ret = init_adc_config((uint32_t)sample_rate_arg);
+    if (ret != ESP_OK) {
+        s_last_error = ret;
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_ADC_FAIL);
+    }
+
+    s_task_start_error = ESP_OK;
+    s_running = true;
+
+    BaseType_t task_ok = xTaskCreate(adc_udp_stream_task,
+                                     "adc_udp_stream",
+                                     CONT_ADC_TASK_STACK_BYTES,
+                                     NULL,
+                                     uxTaskPriorityGet(NULL),
+                                     &s_stream_task_handle);
+    if (task_ok != pdPASS) {
+        ESP_LOGE(TAG, "failed to create stream task");
+        s_running = false;
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_TASK_FAIL);
+    }
+
+    if (xSemaphoreTake(s_task_started_sem, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        ESP_LOGE(TAG, "stream task did not report ADC start in time");
+        s_running = false;
+        if (s_task_done_sem != NULL) {
+            (void)xSemaphoreTake(s_task_done_sem, pdMS_TO_TICKS(1000));
+        }
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_TASK_FAIL);
+    }
+
+    if (s_task_start_error != ESP_OK) {
+        cleanup_stream_resources();
+        return MP_OBJ_NEW_SMALL_INT(s_task_start_error == ESP_ERR_NO_MEM ? CADC_RET_TASK_FAIL : CADC_RET_ADC_FAIL);
+    }
+
+    ESP_LOGI(TAG,
+             "ADC->UDP started: rate=%u codec=%s unit=%d channel=%u atten=%d iir=%s coeff=%d samples/packet=%u",
+             (unsigned)sample_rate_arg,
+             codec_arg == AUDIO_CODEC_ADPCM4 ? "ADPCM4" : "PCM16",
+             (int)s_adc_unit,
+             (unsigned)s_adc_channel,
+             (int)s_adc_atten,
+             s_iir_filter_enabled ? "on" : "off",
+             s_iir_filter_enabled ? iir_coeff_to_int(s_iir_filter_coeff) : 0,
+             (unsigned)packet_target_samples((uint8_t)codec_arg));
+
+    return MP_OBJ_NEW_SMALL_INT(CADC_RET_OK);
+}
+
+static mp_obj_t stop_adc_udp_stream(void) {
+    bool had_resources = s_running || s_stream_task_handle != NULL || s_adc_handle != NULL || s_udp_sock >= 0;
+    if (!had_resources) {
+        return MP_OBJ_NEW_SMALL_INT(CADC_RET_NOT_RUNNING);
+    }
+
+    ESP_LOGI(TAG, "stopping ADC->UDP stream");
+    s_running = false;
+
+    // Unblock adc_continuous_read() promptly. The stream task also stops ADC on self-exit/fatal-error paths.
+    if (s_adc_handle != NULL && s_adc_started) {
+        (void)adc_continuous_stop(s_adc_handle);
+        s_adc_started = false;
+    }
+
+    if (s_stream_task_handle != NULL && s_task_done_sem != NULL) {
+        if (xSemaphoreTake(s_task_done_sem, pdMS_TO_TICKS(1000)) != pdTRUE) {
+            ESP_LOGE(TAG, "stream task did not exit in time; resources left allocated");
+            return MP_OBJ_NEW_SMALL_INT(CADC_RET_STOP_TIMEOUT);
+        }
+    }
+
+    cleanup_stream_resources();
+    ESP_LOGI(TAG, "ADC->UDP stopped");
+    return MP_OBJ_NEW_SMALL_INT(CADC_RET_OK);
+}
+
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(config_adc_udp_stream_obj, 1, 4, config_adc_udp_stream);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(start_adc_udp_stream_obj, 3, 4, start_adc_udp_stream);
+MP_DEFINE_CONST_FUN_OBJ_0(stop_adc_udp_stream_obj, stop_adc_udp_stream);

--- a/ports/esp32/machine_cont_adc.py
+++ b/ports/esp32/machine_cont_adc.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Receive ESP32-C3 continuous ADC UDP audio packets and save decoded PCM as WAV.
+
+Packet header, little-endian, 8 bytes:
+  <H B B H h
+  seq, codec, step_index, sample_rate_hz, predictor
+
+Codec 0: PCM16 payload, little-endian signed 16-bit samples.
+Codec 1: IMA-style ADPCM4 payload; predictor is sample 0, nibbles are low-first.
+
+Decoded sample count is derived from the UDP datagram length:
+  PCM16  -> payload_bytes / 2
+  ADPCM4 -> 1 + payload_bytes * 2
+
+The sender pads ADPCM4 packets to odd decoded sample counts when necessary, so
+ADPCM4 packet length is self-delimiting without a sample_count header field.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import struct
+import sys
+import time
+import wave
+from dataclasses import dataclass
+from typing import Iterable
+
+CODEC_PCM16 = 0
+CODEC_ADPCM4 = 1
+HEADER = struct.Struct("<HBBHh")  # seq, codec, step_index, sample_rate_hz, predictor
+DEFAULT_SAMPLES_PER_PACKET = 320
+
+IMA_STEP_TABLE = [
+    7, 8, 9, 10, 11, 12, 13, 14,
+    16, 17, 19, 21, 23, 25, 28, 31,
+    34, 37, 41, 45, 50, 55, 60, 66,
+    73, 80, 88, 97, 107, 118, 130, 143,
+    157, 173, 190, 209, 230, 253, 279, 307,
+    337, 371, 408, 449, 494, 544, 598, 658,
+    724, 796, 876, 963, 1060, 1166, 1282, 1411,
+    1552, 1707, 1878, 2066, 2272, 2499, 2749, 3024,
+    3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484,
+    7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+    15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
+    32767,
+]
+
+IMA_INDEX_TABLE = [
+    -1, -1, -1, -1, 2, 4, 6, 8,
+    -1, -1, -1, -1, 2, 4, 6, 8,
+]
+
+
+def clip_i16(x: int) -> int:
+    return max(-32768, min(32767, x))
+
+
+def decode_ima_nibble(code: int, predictor: int, step_index: int) -> tuple[int, int]:
+    step = IMA_STEP_TABLE[step_index]
+    diffq = step >> 3
+    if code & 4:
+        diffq += step
+    if code & 2:
+        diffq += step >> 1
+    if code & 1:
+        diffq += step >> 2
+
+    predictor = predictor - diffq if (code & 8) else predictor + diffq
+    predictor = clip_i16(predictor)
+
+    step_index += IMA_INDEX_TABLE[code & 0x0F]
+    step_index = max(0, min(88, step_index))
+    return predictor, step_index
+
+
+def sample_count_from_payload_len(codec: int, payload_len: int) -> int:
+    if codec == CODEC_PCM16:
+        if payload_len & 1:
+            raise ValueError(f"PCM16 payload has odd byte length: {payload_len}")
+        return payload_len // 2
+    if codec == CODEC_ADPCM4:
+        return 1 + payload_len * 2
+    raise ValueError(f"unknown codec {codec}")
+
+
+def decode_adpcm4_into(
+    payload: memoryview,
+    predictor: int,
+    step_index: int,
+    out: bytearray,
+) -> memoryview:
+    if not 0 <= step_index <= 88:
+        raise ValueError(f"bad ADPCM step index {step_index}")
+
+    sample_count = sample_count_from_payload_len(CODEC_ADPCM4, len(payload))
+    needed_out = sample_count * 2
+    if len(out) < needed_out:
+        raise ValueError("internal ADPCM output buffer too small")
+
+    struct.pack_into("<h", out, 0, predictor)
+    out_pos = 2
+    for i in range(sample_count - 1):
+        b = payload[i >> 1]
+        code = (b & 0x0F) if (i & 1) == 0 else ((b >> 4) & 0x0F)
+        predictor, step_index = decode_ima_nibble(code, predictor, step_index)
+        struct.pack_into("<h", out, out_pos, predictor)
+        out_pos += 2
+
+    return memoryview(out)[:needed_out]
+
+
+def decode_pcm16(payload: memoryview) -> memoryview:
+    sample_count_from_payload_len(CODEC_PCM16, len(payload))
+    return payload
+
+
+@dataclass
+class Stats:
+    packets: int = 0
+    lost_packets: int = 0
+    reordered_or_old_packets: int = 0
+    bad_packets: int = 0
+    samples: int = 0
+    first_codec: int | None = None
+    sample_rate: int | None = None
+    sample_rate_mismatches: int = 0
+
+
+def seq_distance(expected: int, got: int) -> int:
+    return (got - expected) & 0xFFFF
+
+
+def codec_name(codec: int) -> str:
+    if codec == CODEC_ADPCM4:
+        return "ADPCM4"
+    if codec == CODEC_PCM16:
+        return "PCM16"
+    return f"unknown({codec})"
+
+
+def write_silence_frames(wf: wave.Wave_write, frames: int, chunk_frames: int = 4096) -> None:
+    zero_chunk = b"\x00\x00" * min(frames, chunk_frames)
+    while frames > 0:
+        n = min(frames, chunk_frames)
+        wf.writeframes(zero_chunk[: n * 2])
+        frames -= n
+
+
+def receive_to_wav(
+    bind: str,
+    port: int,
+    sample_rate_override: int | None,
+    out_path: str,
+    timeout: float,
+    max_seconds: float | None,
+    fill_loss: bool,
+    max_loss_fill_packets: int,
+) -> Stats:
+    if sample_rate_override is not None and sample_rate_override <= 0:
+        raise ValueError("sample-rate override must be positive")
+    if not 0 < port <= 65535:
+        raise ValueError("port must be in 1..65535")
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    if max_seconds is not None and max_seconds <= 0:
+        raise ValueError("max seconds must be positive")
+    if max_loss_fill_packets < 0:
+        raise ValueError("max loss fill packets cannot be negative")
+
+    stats = Stats(sample_rate=sample_rate_override)
+    expected_seq: int | None = None
+    last_samples_per_packet = DEFAULT_SAMPLES_PER_PACKET
+    deadline = None if max_seconds is None else time.monotonic() + max_seconds
+    adpcm_out = bytearray((DEFAULT_SAMPLES_PER_PACKET + 1) * 2)
+    wf: wave.Wave_write | None = None
+    warned_rate_mismatch = False
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.bind((bind, port))
+        sock.settimeout(timeout)
+
+        if sample_rate_override is None:
+            print(f"Listening on {bind}:{port}; WAV sample rate will come from the first valid packet.")
+        else:
+            print(f"Listening on {bind}:{port}; writing {out_path} at override rate {sample_rate_override} Hz.")
+        print("Stop with Ctrl+C, --max-seconds, or a zero-length datagram from the ESP32.")
+
+        while True:
+            if deadline is not None and time.monotonic() >= deadline:
+                print("Reached max seconds; stopping.")
+                break
+
+            try:
+                datagram, addr = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+
+            if not datagram:
+                print("Received zero-length stop datagram.")
+                break
+
+            if len(datagram) < HEADER.size:
+                stats.bad_packets += 1
+                continue
+
+            seq, codec, step_index, header_sample_rate, predictor = HEADER.unpack_from(datagram)
+            payload = memoryview(datagram)[HEADER.size:]
+
+            if codec not in (CODEC_PCM16, CODEC_ADPCM4):
+                stats.bad_packets += 1
+                if stats.first_codec is None:
+                    print(f"Ignoring first packet from {addr}: unknown codec {codec}", file=sys.stderr)
+                continue
+
+            if header_sample_rate <= 0:
+                stats.bad_packets += 1
+                print(f"Bad packet {seq}: invalid header sample rate {header_sample_rate}", file=sys.stderr)
+                continue
+
+            if sample_rate_override is not None:
+                effective_sample_rate = sample_rate_override
+                if header_sample_rate != sample_rate_override:
+                    stats.sample_rate_mismatches += 1
+                    if not warned_rate_mismatch:
+                        warned_rate_mismatch = True
+                        print(
+                            f"Warning: packet sample rate is {header_sample_rate} Hz, "
+                            f"but WAV override is {sample_rate_override} Hz; using override.",
+                            file=sys.stderr,
+                        )
+            else:
+                effective_sample_rate = stats.sample_rate or header_sample_rate
+                if stats.sample_rate is not None and header_sample_rate != stats.sample_rate:
+                    stats.sample_rate_mismatches += 1
+                    if not warned_rate_mismatch:
+                        warned_rate_mismatch = True
+                        print(
+                            f"Warning: packet sample rate changed from {stats.sample_rate} Hz "
+                            f"to {header_sample_rate} Hz; keeping the WAV rate fixed.",
+                            file=sys.stderr,
+                        )
+
+            if wf is None:
+                stats.sample_rate = effective_sample_rate
+                wf = wave.open(out_path, "wb")
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(effective_sample_rate)
+                print(f"Writing {out_path} at {effective_sample_rate} Hz")
+
+            if stats.first_codec is None:
+                stats.first_codec = codec
+                print(f"First valid packet from {addr}, codec={codec_name(codec)}")
+
+            if expected_seq is not None and seq != expected_seq:
+                gap = seq_distance(expected_seq, seq)
+                if 0 < gap < 32768:
+                    stats.lost_packets += gap
+                    print(f"Packet gap: expected {expected_seq}, got {seq}; missing {gap}")
+                    if fill_loss:
+                        fill_packets = min(gap, max_loss_fill_packets)
+                        silence_frames = fill_packets * last_samples_per_packet
+                        write_silence_frames(wf, silence_frames)
+                        stats.samples += silence_frames
+                        if fill_packets < gap:
+                            print(
+                                f"Skipped silence fill for {gap - fill_packets} packets "
+                                f"to avoid a huge WAV allocation."
+                            )
+                else:
+                    stats.reordered_or_old_packets += 1
+                    print(f"Ignoring old/reordered packet: expected {expected_seq}, got {seq}")
+                    continue
+
+            try:
+                sample_count = sample_count_from_payload_len(codec, len(payload))
+                if codec == CODEC_PCM16:
+                    pcm = decode_pcm16(payload)
+                else:
+                    needed = sample_count * 2
+                    if len(adpcm_out) < needed:
+                        adpcm_out = bytearray(needed)
+                    pcm = decode_adpcm4_into(payload, predictor, step_index, adpcm_out)
+            except (ValueError, struct.error) as exc:
+                stats.bad_packets += 1
+                print(f"Bad packet {seq}: {exc}", file=sys.stderr)
+                continue
+
+            wf.writeframes(pcm)
+            stats.packets += 1
+            stats.samples += sample_count
+            if sample_count:
+                last_samples_per_packet = sample_count
+            expected_seq = (seq + 1) & 0xFFFF
+
+    except KeyboardInterrupt:
+        print("Interrupted.")
+    finally:
+        if wf is not None:
+            wf.close()
+        sock.close()
+
+    return stats
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Receive ESP32-C3 continuous ADC UDP audio and save WAV.")
+    parser.add_argument("--bind", default="0.0.0.0", help="local address to bind, default: 0.0.0.0")
+    parser.add_argument("--port", type=int, default=5000, help="UDP port, default: 5000")
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=None,
+        help="optional WAV sample-rate override; by default the receiver uses the packet header sample rate",
+    )
+    parser.add_argument("--out", default="capture.wav", help="output WAV file, default: capture.wav")
+    parser.add_argument("--timeout", type=float, default=1.0, help="socket timeout in seconds, default: 1.0")
+    parser.add_argument("--max-seconds", type=float, default=None, help="optional recording duration limit")
+    parser.add_argument("--no-fill-loss", action="store_true", help="do not insert silence for missing UDP packets")
+    parser.add_argument(
+        "--max-loss-fill-packets",
+        type=int,
+        default=200,
+        help="maximum missing packets to fill with silence per gap, default: 200",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        stats = receive_to_wav(
+            bind=args.bind,
+            port=args.port,
+            sample_rate_override=args.sample_rate,
+            out_path=args.out,
+            timeout=args.timeout,
+            max_seconds=args.max_seconds,
+            fill_loss=not args.no_fill_loss,
+            max_loss_fill_packets=args.max_loss_fill_packets,
+        )
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    duration = stats.samples / stats.sample_rate if stats.sample_rate else 0.0
+    print(
+        f"Done. packets={stats.packets}, lost={stats.lost_packets}, "
+        f"old/reordered={stats.reordered_or_old_packets}, bad={stats.bad_packets}, "
+        f"rate={stats.sample_rate or 'unknown'} Hz, rate_mismatches={stats.sample_rate_mismatches}, "
+        f"samples={stats.samples}, duration={duration:.2f}s"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ports/esp32/machine_cont_adc.py
+++ b/ports/esp32/machine_cont_adc.py
@@ -2,6 +2,16 @@
 """
 Receive ESP32-C3 continuous ADC UDP audio packets and save decoded PCM as WAV.
 
+It can also read an existing WAV file with --input-wav/--in-wav, convert it
+to mono PCM16, optionally apply the same receiver-side IIR filtering, and
+write a new WAV file without using UDP.
+
+Recommended offline denoise chain for ESP32-C3 ADC speech recordings:
+  --denoise-noise FILE   Use a separate noise-only WAV file as the noise profile.
+                         The script removes the noise-file DC/bias offset, applies
+                         STFT spectral noise reduction, then applies a speech
+                         band-pass filter. This mode is for --input-wav processing.
+
 Packet header, little-endian, 8 bytes:
   <H B B H h
   seq, codec, step_index, sample_rate_hz, predictor
@@ -15,18 +25,45 @@ Decoded sample count is derived from the UDP datagram length:
 
 The sender pads ADPCM4 packets to odd decoded sample counts when necessary, so
 ADPCM4 packet length is self-delimiting without a sample_count header field.
+
+Optional receiver-side IIR filtering:
+  --iir-noise FILE       Generate an IIR notch-bank filter from a noise-only WAV file.
+  --iir-coeffs FILE      Load IIR coefficients directly from JSON or text.
+  --iir-coeff-count N    Number of notches/coefficients to generate from noise, default: 64.
+  --iir-coeff-out FILE   Save generated coefficients for reuse.
+
+Coefficient file formats accepted by --iir-coeffs:
+  1) JSON direct-form IIR:
+       {"b": [b0, b1, ...], "a": [1, a1, ...]}
+
+  2) JSON biquad cascade:
+       {"sections": [{"b": [b0,b1,b2], "a": [1,a1,a2]}, ...]}
+       or {"sections": [[b0,b1,b2,a1,a2], ...]}
+
+  3) Plain text, one biquad per line:
+       b0 b1 b2 a1 a2
+       b0 b1 b2 a0 a1 a2
+
+  4) Plain text or JSON flat numeric list:
+       64 64 64
+     This is interpreted as a cascade of ESP-style first-order smoothers:
+       y += (x - y) / coeff
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import math
+import os
+import re
 import socket
 import struct
 import sys
 import time
 import wave
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Sequence
 
 CODEC_PCM16 = 0
 CODEC_ADPCM4 = 1
@@ -54,8 +91,8 @@ IMA_INDEX_TABLE = [
 ]
 
 
-def clip_i16(x: int) -> int:
-    return max(-32768, min(32767, x))
+def clip_i16(x: int | float) -> int:
+    return max(-32768, min(32767, int(round(x))))
 
 
 def decode_ima_nibble(code: int, predictor: int, step_index: int) -> tuple[int, int]:
@@ -129,6 +166,846 @@ class Stats:
     sample_rate_mismatches: int = 0
 
 
+@dataclass
+class IIRBuildOptions:
+    coeff_file: str | None = None
+    noise_file: str | None = None
+    coeff_out_file: str | None = None
+    coeff_count: int = 64
+    notch_radius: float = 0.995
+    min_frequency_hz: float = 20.0
+    max_frequency_hz: float | None = None
+
+
+@dataclass
+class DenoiseOptions:
+    noise_file: str | None = None
+    strength: float = 1.35
+    floor: float = 0.06
+    frame_size: int = 1024
+    hop_size: int = 256
+    gain_smoothing: float = 0.80
+    remove_dc: bool = True
+    bandpass_low_hz: float = 100.0
+    bandpass_high_hz: float = 3500.0
+    bandpass_sections: int = 2
+
+
+class PCM16IIRFilter:
+    """Base class for streaming int16 little-endian IIR filters."""
+
+    description: str = "IIR filter"
+
+    def process_sample(self, sample: float) -> float:
+        raise NotImplementedError
+
+    def process_pcm16le(self, pcm: bytes | bytearray | memoryview) -> bytes:
+        if len(pcm) & 1:
+            raise ValueError("PCM16 buffer has odd byte length")
+        out = bytearray(len(pcm))
+        out_pos = 0
+        for (sample,) in struct.iter_unpack("<h", pcm):
+            filtered = self.process_sample(float(sample))
+            struct.pack_into("<h", out, out_pos, clip_i16(filtered))
+            out_pos += 2
+        return bytes(out)
+
+
+class DirectFormIIR(PCM16IIRFilter):
+    """Direct-form I IIR with arbitrary-length b/a coefficients."""
+
+    def __init__(self, b: Sequence[float], a: Sequence[float], description: str = "direct-form IIR") -> None:
+        if not b:
+            raise ValueError("IIR numerator coefficient list b cannot be empty")
+        if not a:
+            raise ValueError("IIR denominator coefficient list a cannot be empty")
+        if abs(a[0]) < 1e-30:
+            raise ValueError("IIR denominator a[0] cannot be zero")
+
+        a0 = float(a[0])
+        self.b = [float(v) / a0 for v in b]
+        self.a = [float(v) / a0 for v in a]
+        self.x_hist = [0.0] * max(0, len(self.b) - 1)
+        self.y_hist = [0.0] * max(0, len(self.a) - 1)
+        self.description = description
+
+    def process_sample(self, sample: float) -> float:
+        y = self.b[0] * sample
+        for i, coeff in enumerate(self.b[1:]):
+            y += coeff * self.x_hist[i]
+        for i, coeff in enumerate(self.a[1:]):
+            y -= coeff * self.y_hist[i]
+
+        if self.x_hist:
+            self.x_hist[1:] = self.x_hist[:-1]
+            self.x_hist[0] = sample
+        if self.y_hist:
+            self.y_hist[1:] = self.y_hist[:-1]
+            self.y_hist[0] = y
+        return y
+
+
+class FirstOrderSmootherCascade(PCM16IIRFilter):
+    """Cascade of y += (x - y) / coeff sections."""
+
+    def __init__(self, coeffs: Sequence[float]) -> None:
+        if not coeffs:
+            raise ValueError("smoother coefficient list cannot be empty")
+        self.coeffs = [float(c) for c in coeffs]
+        for c in self.coeffs:
+            if c < 1.0:
+                raise ValueError("smoother coefficients must be >= 1")
+        self.state = [0.0] * len(self.coeffs)
+        self.initialized = [False] * len(self.coeffs)
+        self.description = f"{len(self.coeffs)} first-order smoother section(s)"
+
+    def process_sample(self, sample: float) -> float:
+        y = sample
+        for i, coeff in enumerate(self.coeffs):
+            if not self.initialized[i]:
+                self.state[i] = y
+                self.initialized[i] = True
+            else:
+                self.state[i] += (y - self.state[i]) / coeff
+            y = self.state[i]
+        return y
+
+
+class BiquadCascadeIIR(PCM16IIRFilter):
+    """Cascade of normalized second-order IIR sections using DF-II transposed state."""
+
+    def __init__(self, sections: Sequence[tuple[Sequence[float], Sequence[float]]], description: str = "biquad IIR cascade") -> None:
+        if not sections:
+            raise ValueError("biquad section list cannot be empty")
+
+        normalized: list[tuple[list[float], list[float]]] = []
+        for idx, (b, a) in enumerate(sections):
+            if len(b) != 3 or len(a) != 3:
+                raise ValueError(f"biquad section {idx} must have 3 b and 3 a coefficients")
+            if abs(a[0]) < 1e-30:
+                raise ValueError(f"biquad section {idx} has zero a[0]")
+            a0 = float(a[0])
+            normalized.append(([float(v) / a0 for v in b], [float(v) / a0 for v in a]))
+
+        self.sections = normalized
+        self.z1 = [0.0] * len(normalized)
+        self.z2 = [0.0] * len(normalized)
+        self.description = description
+
+    def process_sample(self, sample: float) -> float:
+        y = sample
+        for i, (b, a) in enumerate(self.sections):
+            x = y
+            y = b[0] * x + self.z1[i]
+            self.z1[i] = b[1] * x - a[1] * y + self.z2[i]
+            self.z2[i] = b[2] * x - a[2] * y
+        return y
+
+
+_NUMBER_RE = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+
+
+def parse_number_list(text: str) -> list[float]:
+    return [float(m.group(0)) for m in _NUMBER_RE.finditer(text)]
+
+
+def normalize_biquad_from_numbers(values: Sequence[float]) -> tuple[list[float], list[float]]:
+    if len(values) == 5:
+        b0, b1, b2, a1, a2 = values
+        return [b0, b1, b2], [1.0, a1, a2]
+    if len(values) == 6:
+        b0, b1, b2, a0, a1, a2 = values
+        return [b0, b1, b2], [a0, a1, a2]
+    raise ValueError("a biquad must contain 5 values (b0 b1 b2 a1 a2) or 6 values (b0 b1 b2 a0 a1 a2)")
+
+
+def is_number_list(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(x, (int, float)) for x in value)
+
+
+def json_section_to_biquad(section: object) -> tuple[list[float], list[float]]:
+    if isinstance(section, dict):
+        if "b" in section and "a" in section:
+            b = [float(v) for v in section["b"]]
+            a = [float(v) for v in section["a"]]
+            if len(b) != 3 or len(a) != 3:
+                raise ValueError("JSON biquad section b/a arrays must each contain 3 coefficients")
+            return b, a
+        if "coeffs" in section:
+            return normalize_biquad_from_numbers([float(v) for v in section["coeffs"]])
+        raise ValueError("JSON biquad section must contain b/a arrays or coeffs")
+    if is_number_list(section):
+        return normalize_biquad_from_numbers([float(v) for v in section])
+    raise ValueError("invalid JSON biquad section")
+
+
+def notch_biquad(frequency_hz: float, sample_rate_hz: int, radius: float) -> tuple[list[float], list[float]]:
+    if not 0.0 < frequency_hz < sample_rate_hz / 2.0:
+        raise ValueError(f"notch frequency {frequency_hz} Hz is outside 0..Nyquist")
+    if not 0.0 < radius < 1.0:
+        raise ValueError("notch radius must be between 0 and 1")
+
+    w0 = 2.0 * math.pi * frequency_hz / sample_rate_hz
+    c = math.cos(w0)
+    b = [1.0, -2.0 * c, 1.0]
+    a = [1.0, -2.0 * radius * c, radius * radius]
+
+    # Normalize each section to unity DC gain so a large cascade does not
+    # unintentionally attenuate the whole recording outside the notches.
+    sum_b = b[0] + b[1] + b[2]
+    sum_a = a[0] + a[1] + a[2]
+    if abs(sum_b) > 1e-30:
+        gain = sum_a / sum_b
+        b = [v * gain for v in b]
+    return b, a
+
+
+def load_iir_filter_from_json(data: object, target_sample_rate: int, source_name: str) -> PCM16IIRFilter:
+    if isinstance(data, dict):
+        source_rate = data.get("sample_rate")
+        if source_rate is not None:
+            try:
+                source_rate_int = int(source_rate)
+                if source_rate_int != target_sample_rate:
+                    print(
+                        f"Warning: coefficient file sample_rate={source_rate_int} Hz, "
+                        f"recording rate={target_sample_rate} Hz.",
+                        file=sys.stderr,
+                    )
+            except (TypeError, ValueError):
+                print(f"Warning: ignoring non-integer coefficient sample_rate={source_rate!r}", file=sys.stderr)
+
+        if "sections" in data:
+            sections_raw = data["sections"]
+            if not isinstance(sections_raw, list):
+                raise ValueError("JSON sections must be a list")
+
+            # If the file came from this script and stores notch frequencies,
+            # re-design the biquads for the current target sample rate.
+            can_redesign = all(
+                isinstance(s, dict) and "frequency_hz" in s and "r" in s for s in sections_raw
+            )
+            if can_redesign:
+                sections = [
+                    notch_biquad(float(s["frequency_hz"]), target_sample_rate, float(s["r"]))
+                    for s in sections_raw
+                    if 0.0 < float(s["frequency_hz"]) < target_sample_rate / 2.0
+                ]
+                return BiquadCascadeIIR(
+                    sections,
+                    description=f"{len(sections)} generated notch biquad section(s) from {source_name}",
+                )
+
+            sections = [json_section_to_biquad(section) for section in sections_raw]
+            return BiquadCascadeIIR(sections, description=f"{len(sections)} loaded biquad section(s) from {source_name}")
+
+        if "b" in data and "a" in data:
+            b = [float(v) for v in data["b"]]
+            a = [float(v) for v in data["a"]]
+            return DirectFormIIR(b, a, description=f"direct-form IIR from {source_name}: len(b)={len(b)}, len(a)={len(a)}")
+
+        if "smoothing" in data:
+            coeffs = [float(v) for v in data["smoothing"]]
+            return FirstOrderSmootherCascade(coeffs)
+
+        raise ValueError("JSON coefficient file must contain sections, b/a, or smoothing")
+
+    if is_number_list(data):
+        values = [float(v) for v in data]
+        if len(values) in (5, 6):
+            return BiquadCascadeIIR([normalize_biquad_from_numbers(values)], description=f"1 loaded biquad section from {source_name}")
+        return FirstOrderSmootherCascade(values)
+
+    if isinstance(data, list):
+        sections = [json_section_to_biquad(section) for section in data]
+        return BiquadCascadeIIR(sections, description=f"{len(sections)} loaded biquad section(s) from {source_name}")
+
+    raise ValueError("unsupported JSON coefficient file format")
+
+
+def load_iir_filter_from_text(text: str, target_sample_rate: int, source_name: str) -> PCM16IIRFilter:
+    lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].split(";", 1)[0].strip()
+        if line:
+            lines.append(line)
+
+    if not lines:
+        raise ValueError("coefficient file is empty")
+
+    b_values: list[float] | None = None
+    a_values: list[float] | None = None
+    unlabeled_lines: list[str] = []
+
+    for line in lines:
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip().lower()
+            numbers = parse_number_list(value)
+            if key in ("b", "num", "numerator", "feedforward"):
+                b_values = numbers
+            elif key in ("a", "den", "denominator", "feedback"):
+                a_values = numbers
+            else:
+                raise ValueError(f"unknown coefficient line label {key!r}")
+        else:
+            unlabeled_lines.append(line)
+
+    if b_values is not None or a_values is not None:
+        if b_values is None or a_values is None:
+            raise ValueError("labeled text coefficient file needs both b: and a: lines")
+        return DirectFormIIR(
+            b_values,
+            a_values,
+            description=f"direct-form IIR from {source_name}: len(b)={len(b_values)}, len(a)={len(a_values)}",
+        )
+
+    per_line = [parse_number_list(line) for line in unlabeled_lines]
+    if per_line and all(len(values) in (5, 6) for values in per_line):
+        sections = [normalize_biquad_from_numbers(values) for values in per_line]
+        return BiquadCascadeIIR(sections, description=f"{len(sections)} loaded biquad section(s) from {source_name}")
+
+    flat_values = parse_number_list("\n".join(unlabeled_lines))
+    if not flat_values:
+        raise ValueError("coefficient file does not contain numeric coefficients")
+    return FirstOrderSmootherCascade(flat_values)
+
+
+def load_iir_filter_from_file(path: str, target_sample_rate: int) -> PCM16IIRFilter:
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    stripped = text.lstrip()
+    if stripped.startswith("{") or stripped.startswith("["):
+        data = json.loads(text)
+        return load_iir_filter_from_json(data, target_sample_rate, os.path.basename(path))
+    return load_iir_filter_from_text(text, target_sample_rate, os.path.basename(path))
+
+
+def read_wav_mono_samples(path: str) -> tuple[int, list[float]]:
+    with wave.open(path, "rb") as wf:
+        channels = wf.getnchannels()
+        sampwidth = wf.getsampwidth()
+        sample_rate = wf.getframerate()
+        frame_count = wf.getnframes()
+        raw = wf.readframes(frame_count)
+
+    if channels <= 0:
+        raise ValueError("WAV file has no channels")
+    if frame_count <= 0:
+        raise ValueError("WAV file has no samples")
+
+    samples: list[float] = []
+
+    if sampwidth == 1:
+        # WAV 8-bit PCM is unsigned.
+        vals = [float(b - 128) * 256.0 for b in raw]
+    elif sampwidth == 2:
+        vals = [float(v[0]) for v in struct.iter_unpack("<h", raw)]
+    elif sampwidth == 3:
+        vals = []
+        for i in range(0, len(raw), 3):
+            b0, b1, b2 = raw[i], raw[i + 1], raw[i + 2]
+            value = b0 | (b1 << 8) | (b2 << 16)
+            if value & 0x800000:
+                value -= 0x1000000
+            vals.append(float(value) / 256.0)
+    elif sampwidth == 4:
+        vals = [float(v[0]) / 65536.0 for v in struct.iter_unpack("<i", raw)]
+    else:
+        raise ValueError(f"unsupported WAV sample width: {sampwidth} bytes")
+
+    if len(vals) % channels != 0:
+        raise ValueError("WAV data length is not divisible by channel count")
+
+    for i in range(0, len(vals), channels):
+        samples.append(sum(vals[i : i + channels]) / channels)
+
+    return sample_rate, samples
+
+
+def power_of_two_at_most(value: int) -> int:
+    if value < 1:
+        return 0
+    return 1 << (value.bit_length() - 1)
+
+
+def fft_inplace(values: list[complex]) -> None:
+    n = len(values)
+    if n == 0 or n & (n - 1):
+        raise ValueError("FFT length must be a power of two")
+
+    j = 0
+    for i in range(1, n):
+        bit = n >> 1
+        while j & bit:
+            j ^= bit
+            bit >>= 1
+        j ^= bit
+        if i < j:
+            values[i], values[j] = values[j], values[i]
+
+    size = 2
+    while size <= n:
+        half = size >> 1
+        theta = -2.0 * math.pi / size
+        w_m = complex(math.cos(theta), math.sin(theta))
+        for start in range(0, n, size):
+            w = 1.0 + 0.0j
+            for k in range(start, start + half):
+                t = w * values[k + half]
+                u = values[k]
+                values[k] = u + t
+                values[k + half] = u - t
+                w *= w_m
+        size <<= 1
+
+
+def find_noise_peak_frequencies(
+    samples: Sequence[float],
+    sample_rate: int,
+    count: int,
+    min_frequency_hz: float,
+    max_frequency_hz: float | None,
+) -> list[tuple[float, float]]:
+    if count <= 0:
+        raise ValueError("IIR coefficient count must be positive")
+    if sample_rate <= 0:
+        raise ValueError("noise sample rate must be positive")
+    if len(samples) < 512:
+        raise ValueError("noise sample file is too short; need at least 512 samples")
+
+    max_fft_size = 65536
+    nfft = power_of_two_at_most(min(len(samples), max_fft_size))
+    if nfft < 512:
+        raise ValueError("noise sample file is too short after FFT sizing")
+
+    # Use a centered block to avoid startup transients in the noise sample.
+    offset = max(0, (len(samples) - nfft) // 2)
+    block = [float(x) for x in samples[offset : offset + nfft]]
+    mean = sum(block) / len(block)
+
+    # Hann window; power normalization is unnecessary because we only rank peaks.
+    spectrum = []
+    for n, x in enumerate(block):
+        w = 0.5 - 0.5 * math.cos(2.0 * math.pi * n / (nfft - 1))
+        spectrum.append(complex((x - mean) * w, 0.0))
+
+    fft_inplace(spectrum)
+    bin_hz = sample_rate / nfft
+    nyquist = sample_rate / 2.0
+    max_hz = max_frequency_hz if max_frequency_hz is not None else nyquist * 0.95
+    max_hz = min(max_hz, nyquist * 0.999)
+    min_bin = max(1, int(math.ceil(min_frequency_hz / bin_hz)))
+    max_bin = min((nfft // 2) - 1, int(math.floor(max_hz / bin_hz)))
+    if min_bin >= max_bin:
+        raise ValueError("invalid frequency range for noise-derived filter")
+
+    powers = [0.0] * (max_bin + 1)
+    for i in range(min_bin, max_bin + 1):
+        v = spectrum[i]
+        powers[i] = (v.real * v.real) + (v.imag * v.imag)
+
+    candidates: list[tuple[float, int]] = []
+    for i in range(min_bin + 1, max_bin):
+        if powers[i] > powers[i - 1] and powers[i] >= powers[i + 1]:
+            candidates.append((powers[i], i))
+
+    if not candidates:
+        # Broadband noise may not have sharp local maxima. Fall back to the
+        # strongest bins so the user still gets a deterministic filter.
+        candidates = [(powers[i], i) for i in range(min_bin, max_bin + 1)]
+
+    candidates.sort(reverse=True)
+    min_spacing_bins = max(1, int(round(5.0 / bin_hz)))
+    selected: list[tuple[float, float]] = []
+    selected_bins: list[int] = []
+    for power, bin_index in candidates:
+        if len(selected) >= count:
+            break
+        if any(abs(bin_index - prev) < min_spacing_bins for prev in selected_bins):
+            continue
+        selected_bins.append(bin_index)
+        selected.append((bin_index * bin_hz, power))
+
+    selected.sort(key=lambda item: item[0])
+    return selected
+
+
+def save_generated_iir_coefficients(
+    path: str,
+    target_sample_rate: int,
+    source_noise_file: str,
+    radius: float,
+    peaks: Sequence[tuple[float, float]],
+) -> None:
+    sections = []
+    for frequency_hz, power in peaks:
+        b, a = notch_biquad(frequency_hz, target_sample_rate, radius)
+        sections.append(
+            {
+                "frequency_hz": frequency_hz,
+                "power": power,
+                "r": radius,
+                "b": b,
+                "a": a,
+            }
+        )
+
+    payload = {
+        "type": "biquad_cascade",
+        "sample_rate": target_sample_rate,
+        "source_noise_file": source_noise_file,
+        "sections": sections,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def build_iir_filter_from_noise(
+    path: str,
+    target_sample_rate: int,
+    coeff_count: int,
+    radius: float,
+    min_frequency_hz: float,
+    max_frequency_hz: float | None,
+    coeff_out_file: str | None,
+) -> PCM16IIRFilter:
+    noise_rate, noise_samples = read_wav_mono_samples(path)
+    peak_count = coeff_count
+    target_max_hz = (target_sample_rate / 2.0) * 0.95
+    noise_max_hz = max_frequency_hz if max_frequency_hz is not None else target_max_hz
+    noise_max_hz = min(noise_max_hz, (noise_rate / 2.0) * 0.95, target_max_hz)
+
+    peaks = find_noise_peak_frequencies(
+        noise_samples,
+        noise_rate,
+        peak_count,
+        min_frequency_hz=min_frequency_hz,
+        max_frequency_hz=noise_max_hz,
+    )
+    if not peaks:
+        raise ValueError("could not find noise peaks to build IIR filter")
+
+    sections = [notch_biquad(freq_hz, target_sample_rate, radius) for freq_hz, _ in peaks]
+
+    if coeff_out_file is not None:
+        save_generated_iir_coefficients(coeff_out_file, target_sample_rate, path, radius, peaks)
+        print(f"Saved generated IIR coefficients to {coeff_out_file}")
+
+    first_freq = peaks[0][0]
+    last_freq = peaks[-1][0]
+    return BiquadCascadeIIR(
+        sections,
+        description=(
+            f"{len(sections)} noise-derived notch biquad section(s) "
+            f"from {os.path.basename(path)} ({first_freq:.1f}..{last_freq:.1f} Hz)"
+        ),
+    )
+
+
+def build_iir_filter(options: IIRBuildOptions | None, target_sample_rate: int) -> PCM16IIRFilter | None:
+    if options is None:
+        return None
+    if options.coeff_file and options.noise_file:
+        raise ValueError("use either --iir-coeffs or --iir-noise, not both")
+    if options.coeff_count <= 0:
+        raise ValueError("--iir-coeff-count must be positive")
+    if not 0.0 < options.notch_radius < 1.0:
+        raise ValueError("--iir-notch-radius must be between 0 and 1")
+    if options.min_frequency_hz < 0:
+        raise ValueError("--iir-min-frequency must be non-negative")
+    if options.max_frequency_hz is not None and options.max_frequency_hz <= options.min_frequency_hz:
+        raise ValueError("--iir-max-frequency must be greater than --iir-min-frequency")
+
+    if options.coeff_file:
+        return load_iir_filter_from_file(options.coeff_file, target_sample_rate)
+    if options.noise_file:
+        return build_iir_filter_from_noise(
+            path=options.noise_file,
+            target_sample_rate=target_sample_rate,
+            coeff_count=options.coeff_count,
+            radius=options.notch_radius,
+            min_frequency_hz=options.min_frequency_hz,
+            max_frequency_hz=options.max_frequency_hz,
+            coeff_out_file=options.coeff_out_file,
+        )
+    if options.coeff_out_file:
+        raise ValueError("--iir-coeff-out only makes sense with --iir-noise")
+    return None
+
+
+def validate_denoise_options(options: DenoiseOptions | None) -> None:
+    if options is None:
+        return
+    if not options.noise_file:
+        raise ValueError("--denoise-noise needs a noise-only WAV file")
+    if options.strength < 0.0:
+        raise ValueError("--denoise-strength cannot be negative")
+    if not 0.0 <= options.floor <= 1.0:
+        raise ValueError("--denoise-floor must be in 0..1")
+    if options.frame_size < 128 or (options.frame_size & (options.frame_size - 1)):
+        raise ValueError("--denoise-frame-size must be a power of two and at least 128")
+    if options.hop_size <= 0 or options.hop_size > options.frame_size:
+        raise ValueError("--denoise-hop-size must be in 1..frame_size")
+    if not 0.0 <= options.gain_smoothing < 1.0:
+        raise ValueError("--denoise-gain-smoothing must be in 0..less-than-1")
+    if options.bandpass_low_hz < 0.0:
+        raise ValueError("--denoise-bandpass-low cannot be negative")
+    if options.bandpass_high_hz < 0.0:
+        raise ValueError("--denoise-bandpass-high cannot be negative")
+    if options.bandpass_sections < 0:
+        raise ValueError("--denoise-bandpass-sections cannot be negative")
+
+
+def mean_value(samples: Sequence[float]) -> float:
+    return sum(float(x) for x in samples) / len(samples) if samples else 0.0
+
+
+def rms_value(samples: Sequence[float]) -> float:
+    if not samples:
+        return 0.0
+    return math.sqrt(sum(float(x) * float(x) for x in samples) / len(samples))
+
+
+def hann_window(length: int) -> list[float]:
+    if length <= 1:
+        return [1.0] * max(0, length)
+    return [0.5 - 0.5 * math.cos(2.0 * math.pi * n / (length - 1)) for n in range(length)]
+
+
+def ifft_inplace(values: list[complex]) -> None:
+    n = len(values)
+    for i, value in enumerate(values):
+        values[i] = value.conjugate()
+    fft_inplace(values)
+    inv_n = 1.0 / n
+    for i, value in enumerate(values):
+        values[i] = value.conjugate() * inv_n
+
+
+def stft_noise_profile(
+    noise_samples: Sequence[float],
+    frame_size: int,
+    hop_size: int,
+    window: Sequence[float],
+) -> list[float]:
+    """Return the mean magnitude spectrum of a noise-only sample."""
+    if not noise_samples:
+        raise ValueError("noise sample file has no samples")
+
+    mag_sum = [0.0] * frame_size
+    frame_count = 0
+    n = len(noise_samples)
+    start = 0
+    while start < n or frame_count == 0:
+        spectrum = [0j] * frame_size
+        for i in range(frame_size):
+            idx = start + i
+            sample = float(noise_samples[idx]) if idx < n else 0.0
+            spectrum[i] = complex(sample * window[i], 0.0)
+        fft_inplace(spectrum)
+        for i, value in enumerate(spectrum):
+            mag_sum[i] += abs(value)
+        frame_count += 1
+        start += hop_size
+
+    inv = 1.0 / frame_count
+    return [v * inv for v in mag_sum]
+
+
+def spectral_noise_reduce(
+    samples: Sequence[float],
+    noise_samples: Sequence[float],
+    frame_size: int,
+    hop_size: int,
+    strength: float,
+    floor: float,
+    gain_smoothing: float,
+) -> list[float]:
+    """Stationary STFT spectral subtraction with Hann overlap-add.
+
+    It preserves phase and reduces bins whose magnitude is close to the
+    noise-only profile. This is intentionally simple and portable; it is best
+    for stationary ADC hiss/whine rather than rapidly changing background noise.
+    """
+    if not samples:
+        return []
+
+    window = hann_window(frame_size)
+    noise_mag = stft_noise_profile(noise_samples, frame_size, hop_size, window)
+
+    original_len = len(samples)
+    # Center the first and last real samples inside several analysis windows.
+    # Without this padding, the tiny edge values of the Hann window can cause
+    # large normalization spikes at the beginning/end of the output.
+    pad = frame_size
+    padded = [0.0] * pad + [float(x) for x in samples] + [0.0] * pad
+    n = len(padded)
+    out = [0.0] * (n + frame_size)
+    norm = [0.0] * (n + frame_size)
+    prev_gain: list[float] | None = None
+    eps = 1e-12
+
+    for start in range(0, n, hop_size):
+        spectrum = [0j] * frame_size
+        for i in range(frame_size):
+            idx = start + i
+            sample = padded[idx] if idx < n else 0.0
+            spectrum[i] = complex(sample * window[i], 0.0)
+
+        fft_inplace(spectrum)
+
+        gains = [1.0] * frame_size
+        for i, value in enumerate(spectrum):
+            mag = abs(value)
+            gain = 1.0 - strength * (noise_mag[i] / (mag + eps))
+            if gain < floor:
+                gain = floor
+            elif gain > 1.0:
+                gain = 1.0
+            if prev_gain is not None:
+                gain = gain_smoothing * prev_gain[i] + (1.0 - gain_smoothing) * gain
+            gains[i] = gain
+            spectrum[i] = value * gain
+        prev_gain = gains
+
+        ifft_inplace(spectrum)
+        for i, value in enumerate(spectrum):
+            idx = start + i
+            win = window[i]
+            out[idx] += value.real * win
+            norm[idx] += win * win
+
+    reconstructed: list[float] = []
+    for i in range(n):
+        if norm[i] > 1e-12:
+            reconstructed.append(out[i] / norm[i])
+        else:
+            reconstructed.append(out[i])
+    return reconstructed[pad : pad + original_len]
+
+
+def rbj_lowpass_biquad(cutoff_hz: float, sample_rate_hz: int, q: float = 0.7071067811865476) -> tuple[list[float], list[float]]:
+    if not 0.0 < cutoff_hz < sample_rate_hz / 2.0:
+        raise ValueError("low-pass cutoff must be between 0 and Nyquist")
+    w0 = 2.0 * math.pi * cutoff_hz / sample_rate_hz
+    c = math.cos(w0)
+    alpha = math.sin(w0) / (2.0 * q)
+    b = [(1.0 - c) * 0.5, 1.0 - c, (1.0 - c) * 0.5]
+    a = [1.0 + alpha, -2.0 * c, 1.0 - alpha]
+    return b, a
+
+
+def rbj_highpass_biquad(cutoff_hz: float, sample_rate_hz: int, q: float = 0.7071067811865476) -> tuple[list[float], list[float]]:
+    if not 0.0 < cutoff_hz < sample_rate_hz / 2.0:
+        raise ValueError("high-pass cutoff must be between 0 and Nyquist")
+    w0 = 2.0 * math.pi * cutoff_hz / sample_rate_hz
+    c = math.cos(w0)
+    alpha = math.sin(w0) / (2.0 * q)
+    b = [(1.0 + c) * 0.5, -(1.0 + c), (1.0 + c) * 0.5]
+    a = [1.0 + alpha, -2.0 * c, 1.0 - alpha]
+    return b, a
+
+
+def apply_speech_bandpass(
+    samples: Sequence[float],
+    sample_rate_hz: int,
+    low_hz: float,
+    high_hz: float,
+    sections_per_edge: int,
+) -> list[float]:
+    """Apply a practical speech band-pass using cascaded biquad HP/LP sections."""
+    if sections_per_edge <= 0:
+        return [float(x) for x in samples]
+    if sample_rate_hz <= 0:
+        raise ValueError("sample rate must be positive")
+
+    nyquist = sample_rate_hz / 2.0
+    sections: list[tuple[list[float], list[float]]] = []
+    if low_hz > 0.0:
+        if low_hz >= nyquist:
+            raise ValueError("denoise band-pass low cutoff is at or above Nyquist")
+        for _ in range(sections_per_edge):
+            sections.append(rbj_highpass_biquad(low_hz, sample_rate_hz))
+    if high_hz > 0.0:
+        if high_hz >= nyquist:
+            high_hz = nyquist * 0.95
+        if low_hz > 0.0 and high_hz <= low_hz:
+            raise ValueError("denoise band-pass high cutoff must be above low cutoff")
+        for _ in range(sections_per_edge):
+            sections.append(rbj_lowpass_biquad(high_hz, sample_rate_hz))
+
+    if not sections:
+        return [float(x) for x in samples]
+
+    filt = BiquadCascadeIIR(sections, description="speech band-pass")
+    return [filt.process_sample(float(sample)) for sample in samples]
+
+
+def apply_recommended_denoise_chain(
+    samples: Sequence[float],
+    sample_rate_hz: int,
+    options: DenoiseOptions,
+) -> list[float]:
+    """ESP32-C3 ADC speech cleanup: DC removal, spectral denoise, speech band-pass."""
+    validate_denoise_options(options)
+    if options.noise_file is None:
+        raise ValueError("--denoise-noise is required")
+
+    noise_rate, noise_samples = read_wav_mono_samples(options.noise_file)
+    if noise_rate != sample_rate_hz:
+        raise ValueError(
+            f"noise WAV sample rate is {noise_rate} Hz, but input WAV is {sample_rate_hz} Hz; "
+            "resample one file first"
+        )
+    if len(noise_samples) < options.frame_size // 2:
+        raise ValueError("noise sample is too short for denoise profile")
+
+    working = [float(x) for x in samples]
+    noise_working = [float(x) for x in noise_samples]
+
+    dc = mean_value(noise_working) if options.remove_dc else 0.0
+    if options.remove_dc:
+        working = [x - dc for x in working]
+        noise_working = [x - dc for x in noise_working]
+
+    before_rms = rms_value(working)
+    noise_rms = rms_value(noise_working)
+    print(
+        f"Applying recommended denoise chain: DC offset={dc:.2f} PCM counts, "
+        f"noise RMS after DC={noise_rms:.2f}, STFT frame={options.frame_size}, hop={options.hop_size}, "
+        f"strength={options.strength}, floor={options.floor}"
+    )
+
+    reduced = spectral_noise_reduce(
+        samples=working,
+        noise_samples=noise_working,
+        frame_size=options.frame_size,
+        hop_size=options.hop_size,
+        strength=options.strength,
+        floor=options.floor,
+        gain_smoothing=options.gain_smoothing,
+    )
+
+    filtered = apply_speech_bandpass(
+        reduced,
+        sample_rate_hz=sample_rate_hz,
+        low_hz=options.bandpass_low_hz,
+        high_hz=options.bandpass_high_hz,
+        sections_per_edge=options.bandpass_sections,
+    )
+    after_rms = rms_value(filtered)
+    if options.bandpass_sections > 0:
+        print(
+            f"Applied speech band-pass: {options.bandpass_low_hz:g}..{options.bandpass_high_hz:g} Hz "
+            f"({options.bandpass_sections} biquad section(s) per edge)."
+        )
+    print(f"Denoise chain RMS: before={before_rms:.2f}, after={after_rms:.2f}")
+    return filtered
+
+
 def seq_distance(expected: int, got: int) -> int:
     return (got - expected) & 0xFFFF
 
@@ -141,12 +1018,87 @@ def codec_name(codec: int) -> str:
     return f"unknown({codec})"
 
 
-def write_silence_frames(wf: wave.Wave_write, frames: int, chunk_frames: int = 4096) -> None:
+def write_silence_frames(
+    wf: wave.Wave_write,
+    frames: int,
+    chunk_frames: int = 4096,
+    iir_filter: PCM16IIRFilter | None = None,
+) -> None:
     zero_chunk = b"\x00\x00" * min(frames, chunk_frames)
     while frames > 0:
         n = min(frames, chunk_frames)
-        wf.writeframes(zero_chunk[: n * 2])
+        chunk = zero_chunk[: n * 2]
+        if iir_filter is not None:
+            chunk = iir_filter.process_pcm16le(chunk)
+        wf.writeframes(chunk)
         frames -= n
+
+
+def process_wav_file_to_wav(
+    in_path: str,
+    sample_rate_override: int | None,
+    out_path: str,
+    iir_options: IIRBuildOptions | None = None,
+    denoise_options: DenoiseOptions | None = None,
+) -> Stats:
+    """Read a WAV file, optionally filter it, and write mono PCM16 WAV output.
+
+    The input WAV is mixed down to mono when needed and converted to signed
+    16-bit PCM samples. If --sample-rate is provided, no resampling is done;
+    the output WAV header is written with the override rate.
+    """
+    if sample_rate_override is not None and sample_rate_override <= 0:
+        raise ValueError("sample-rate override must be positive")
+
+    input_sample_rate, samples = read_wav_mono_samples(in_path)
+    effective_sample_rate = sample_rate_override or input_sample_rate
+
+    if sample_rate_override is None:
+        print(f"Reading {in_path}; writing {out_path} at input rate {effective_sample_rate} Hz.")
+    else:
+        print(
+            f"Reading {in_path}; writing {out_path} at override rate "
+            f"{effective_sample_rate} Hz (input file is {input_sample_rate} Hz)."
+        )
+
+    if denoise_options is not None:
+        # Denoising is offline and file-based. It uses the true input sample
+        # rate because --sample-rate only changes the output WAV header; it
+        # does not resample the audio.
+        samples = apply_recommended_denoise_chain(samples, input_sample_rate, denoise_options)
+
+    iir_filter = build_iir_filter(iir_options, effective_sample_rate)
+    if iir_filter is not None:
+        print(f"Applying receiver-side {iir_filter.description}")
+
+    stats = Stats(
+        packets=0,
+        samples=len(samples),
+        first_codec=CODEC_PCM16,
+        sample_rate=effective_sample_rate,
+        sample_rate_mismatches=int(sample_rate_override is not None and sample_rate_override != input_sample_rate),
+    )
+
+    with wave.open(out_path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(effective_sample_rate)
+
+        chunk_samples = 4096
+        for start in range(0, len(samples), chunk_samples):
+            chunk = samples[start : start + chunk_samples]
+            pcm = bytearray(len(chunk) * 2)
+            out_pos = 0
+            for sample in chunk:
+                struct.pack_into("<h", pcm, out_pos, clip_i16(sample))
+                out_pos += 2
+
+            if iir_filter is not None:
+                wf.writeframes(iir_filter.process_pcm16le(pcm))
+            else:
+                wf.writeframes(pcm)
+
+    return stats
 
 
 def receive_to_wav(
@@ -158,6 +1110,7 @@ def receive_to_wav(
     max_seconds: float | None,
     fill_loss: bool,
     max_loss_fill_packets: int,
+    iir_options: IIRBuildOptions | None = None,
 ) -> Stats:
     if sample_rate_override is not None and sample_rate_override <= 0:
         raise ValueError("sample-rate override must be positive")
@@ -176,6 +1129,7 @@ def receive_to_wav(
     deadline = None if max_seconds is None else time.monotonic() + max_seconds
     adpcm_out = bytearray((DEFAULT_SAMPLES_PER_PACKET + 1) * 2)
     wf: wave.Wave_write | None = None
+    iir_filter: PCM16IIRFilter | None = None
     warned_rate_mismatch = False
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -246,6 +1200,9 @@ def receive_to_wav(
 
             if wf is None:
                 stats.sample_rate = effective_sample_rate
+                iir_filter = build_iir_filter(iir_options, effective_sample_rate)
+                if iir_filter is not None:
+                    print(f"Applying receiver-side {iir_filter.description}")
                 wf = wave.open(out_path, "wb")
                 wf.setnchannels(1)
                 wf.setsampwidth(2)
@@ -264,7 +1221,7 @@ def receive_to_wav(
                     if fill_loss:
                         fill_packets = min(gap, max_loss_fill_packets)
                         silence_frames = fill_packets * last_samples_per_packet
-                        write_silence_frames(wf, silence_frames)
+                        write_silence_frames(wf, silence_frames, iir_filter=iir_filter)
                         stats.samples += silence_frames
                         if fill_packets < gap:
                             print(
@@ -285,12 +1242,17 @@ def receive_to_wav(
                     if len(adpcm_out) < needed:
                         adpcm_out = bytearray(needed)
                     pcm = decode_adpcm4_into(payload, predictor, step_index, adpcm_out)
+                pcm_to_write: bytes | memoryview
+                if iir_filter is not None:
+                    pcm_to_write = iir_filter.process_pcm16le(pcm)
+                else:
+                    pcm_to_write = pcm
             except (ValueError, struct.error) as exc:
                 stats.bad_packets += 1
                 print(f"Bad packet {seq}: {exc}", file=sys.stderr)
                 continue
 
-            wf.writeframes(pcm)
+            wf.writeframes(pcm_to_write)
             stats.packets += 1
             stats.samples += sample_count
             if sample_count:
@@ -308,7 +1270,77 @@ def receive_to_wav(
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Receive ESP32-C3 continuous ADC UDP audio and save WAV.")
+    parser = argparse.ArgumentParser(description="Receive ESP32-C3 continuous ADC UDP audio, or process a WAV file, and save WAV.")
+    parser.add_argument(
+        "--input-wav",
+        "--in-wav",
+        dest="input_wav",
+        default=None,
+        metavar="WAV",
+        help="read audio from this WAV file instead of listening for UDP packets",
+    )
+    parser.add_argument(
+        "--denoise-noise",
+        default=None,
+        metavar="WAV",
+        help=(
+            "noise-only WAV profile for the recommended offline denoise chain; "
+            "used with --input-wav"
+        ),
+    )
+    parser.add_argument(
+        "--denoise-strength",
+        type=float,
+        default=1.35,
+        help="spectral noise-reduction strength, default: 1.35",
+    )
+    parser.add_argument(
+        "--denoise-floor",
+        type=float,
+        default=0.06,
+        help="minimum spectral gain to avoid over-gating, default: 0.06",
+    )
+    parser.add_argument(
+        "--denoise-frame-size",
+        type=int,
+        default=1024,
+        help="STFT frame size, power of two, default: 1024",
+    )
+    parser.add_argument(
+        "--denoise-hop-size",
+        type=int,
+        default=256,
+        help="STFT hop size, default: 256",
+    )
+    parser.add_argument(
+        "--denoise-gain-smoothing",
+        type=float,
+        default=0.80,
+        help="temporal smoothing for spectral gains, default: 0.80",
+    )
+    parser.add_argument(
+        "--denoise-no-dc",
+        action="store_true",
+        help="do not subtract the DC/bias offset measured from the noise WAV",
+    )
+    parser.add_argument(
+        "--denoise-bandpass-low",
+        type=float,
+        default=100.0,
+        help="speech band-pass low cutoff in Hz, default: 100",
+    )
+    parser.add_argument(
+        "--denoise-bandpass-high",
+        type=float,
+        default=3500.0,
+        help="speech band-pass high cutoff in Hz, default: 3500",
+    )
+    parser.add_argument(
+        "--denoise-bandpass-sections",
+        type=int,
+        default=2,
+        help="number of HP and LP biquad sections per band-pass edge; 0 disables band-pass, default: 2",
+    )
     parser.add_argument("--bind", default="0.0.0.0", help="local address to bind, default: 0.0.0.0")
     parser.add_argument("--port", type=int, default=5000, help="UDP port, default: 5000")
     parser.add_argument(
@@ -327,6 +1359,48 @@ def build_parser() -> argparse.ArgumentParser:
         default=200,
         help="maximum missing packets to fill with silence per gap, default: 200",
     )
+    parser.add_argument(
+        "--iir-noise",
+        default=None,
+        metavar="WAV",
+        help="noise-only WAV used to generate a receiver-side IIR notch-bank filter",
+    )
+    parser.add_argument(
+        "--iir-coeffs",
+        default=None,
+        metavar="FILE",
+        help="load receiver-side IIR coefficients from JSON or text instead of generating them from noise",
+    )
+    parser.add_argument(
+        "--iir-coeff-out",
+        default=None,
+        metavar="FILE",
+        help="write generated noise-derived IIR coefficients to this JSON file for reuse",
+    )
+    parser.add_argument(
+        "--iir-coeff-count",
+        type=int,
+        default=64,
+        help="number of noise-derived notch coefficients/sections to generate, default: 64",
+    )
+    parser.add_argument(
+        "--iir-notch-radius",
+        type=float,
+        default=0.995,
+        help="IIR notch pole radius for noise-derived filters; closer to 1 is narrower, default: 0.995",
+    )
+    parser.add_argument(
+        "--iir-min-frequency",
+        type=float,
+        default=20.0,
+        help="lowest frequency considered when generating a noise-derived filter, default: 20 Hz",
+    )
+    parser.add_argument(
+        "--iir-max-frequency",
+        type=float,
+        default=None,
+        help="highest frequency considered when generating a noise-derived filter, default: 95%% of Nyquist",
+    )
     return parser
 
 
@@ -334,18 +1408,58 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    try:
-        stats = receive_to_wav(
-            bind=args.bind,
-            port=args.port,
-            sample_rate_override=args.sample_rate,
-            out_path=args.out,
-            timeout=args.timeout,
-            max_seconds=args.max_seconds,
-            fill_loss=not args.no_fill_loss,
-            max_loss_fill_packets=args.max_loss_fill_packets,
+    iir_options = IIRBuildOptions(
+        coeff_file=args.iir_coeffs,
+        noise_file=args.iir_noise,
+        coeff_out_file=args.iir_coeff_out,
+        coeff_count=args.iir_coeff_count,
+        notch_radius=args.iir_notch_radius,
+        min_frequency_hz=args.iir_min_frequency,
+        max_frequency_hz=args.iir_max_frequency,
+    )
+    if not (iir_options.coeff_file or iir_options.noise_file or iir_options.coeff_out_file):
+        iir_options = None
+
+    denoise_options = None
+    if args.denoise_noise:
+        denoise_options = DenoiseOptions(
+            noise_file=args.denoise_noise,
+            strength=args.denoise_strength,
+            floor=args.denoise_floor,
+            frame_size=args.denoise_frame_size,
+            hop_size=args.denoise_hop_size,
+            gain_smoothing=args.denoise_gain_smoothing,
+            remove_dc=not args.denoise_no_dc,
+            bandpass_low_hz=args.denoise_bandpass_low,
+            bandpass_high_hz=args.denoise_bandpass_high,
+            bandpass_sections=args.denoise_bandpass_sections,
         )
-    except (OSError, ValueError) as exc:
+
+    try:
+        if denoise_options is not None and not args.input_wav:
+            raise ValueError("--denoise-noise is an offline WAV-file mode; use it together with --input-wav")
+
+        if args.input_wav:
+            stats = process_wav_file_to_wav(
+                in_path=args.input_wav,
+                sample_rate_override=args.sample_rate,
+                out_path=args.out,
+                iir_options=iir_options,
+                denoise_options=denoise_options,
+            )
+        else:
+            stats = receive_to_wav(
+                bind=args.bind,
+                port=args.port,
+                sample_rate_override=args.sample_rate,
+                out_path=args.out,
+                timeout=args.timeout,
+                max_seconds=args.max_seconds,
+                fill_loss=not args.no_fill_loss,
+                max_loss_fill_packets=args.max_loss_fill_packets,
+                iir_options=iir_options,
+            )
+    except (OSError, ValueError, json.JSONDecodeError, wave.Error) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
 

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -52,7 +52,7 @@
 #endif
 
 extern mp_obj_fun_builtin_var_t config_adc_udp_stream_obj;
-extern mp_obj_fun_builtin_fixed_t start_adc_udp_stream_obj;
+extern mp_obj_fun_builtin_var_t start_adc_udp_stream_obj;
 extern mp_obj_fun_builtin_fixed_t stop_adc_udp_stream_obj;
 
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \

--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -51,6 +51,10 @@
 #define MICROPY_PY_MACHINE_TOUCH_PAD_ENTRY
 #endif
 
+extern mp_obj_fun_builtin_var_t config_adc_udp_stream_obj;
+extern mp_obj_fun_builtin_fixed_t start_adc_udp_stream_obj;
+extern mp_obj_fun_builtin_fixed_t stop_adc_udp_stream_obj;
+
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
     { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&machine_lightsleep_obj) }, \
     \
@@ -79,6 +83,12 @@
     { MP_ROM_QSTR(MP_QSTR_TIMER_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_TIMER) }, \
     { MP_ROM_QSTR(MP_QSTR_TOUCHPAD_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_TOUCHPAD) }, \
     { MP_ROM_QSTR(MP_QSTR_ULP_WAKE), MP_ROM_INT(ESP_SLEEP_WAKEUP_ULP) }, \
+    \
+    /* Continuous ADC */ \
+    { MP_ROM_QSTR(MP_QSTR_config_adc_udp_stream), MP_ROM_PTR(&config_adc_udp_stream_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_start_adc_udp_stream), MP_ROM_PTR(&start_adc_udp_stream_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_stop_adc_udp_stream), MP_ROM_PTR(&stop_adc_udp_stream_obj) }, \
+
 
 typedef enum {
     MP_PWRON_RESET = 1,


### PR DESCRIPTION
This uses ESP-IDF continuous ADC driver to perform continuous ADC sampling and stream the data to an IP:PORT over UDP

### Summary
Continuous ADC is very useful in practical applications. For example, you can use it to stream PCM audio (voice recording needs only 16kHz) without the need of MP3 codec chip, plot voltage/current waveforms (as an oscilloscope), or view raw signals.


### Example
The following code streams ADC channel (ADC_channel_number) to 1.2.3.4:8888 via UDP for 5 seconds.
```
machine.config_adc_udp_stream(ADC_channel_number, ADC_attenuation, ADC_unit);
machine.start_adc_udp_stream(44100, "1.2.3.4", 8888);
time.sleep(5)
machine.stop_adc_udp_stream();
```