### PR TITLE
stm32: Add support for all variants of STM32F412xx.

### DIFF
--- a/ports/stm32/adc.c
+++ b/ports/stm32/adc.c
@@ -134,7 +134,9 @@
     defined(STM32F407xx) || defined(STM32F417xx) || \
     defined(STM32F401xC) || defined(STM32F401xE)
 #define VBAT_DIV (2)
-#elif defined(STM32F411xE) || defined(STM32F412Zx) || \
+#elif defined(STM32F411xE) || \
+    defined(STM32F412Cx) || defined(STM32F412Rx) || \
+    defined(STM32F412Vx) || defined(STM32F412Zx) || \
     defined(STM32F413xx) || defined(STM32F427xx) || \
     defined(STM32F429xx) || defined(STM32F437xx) || \
     defined(STM32F439xx) || defined(STM32F446xx) || \

--- a/ports/stm32/boards/NUCLEO_F412ZG/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_F412ZG/mpconfigboard.mk
@@ -1,7 +1,7 @@
 MCU_SERIES = f4
 CMSIS_MCU = STM32F412Zx
 AF_FILE = boards/stm32f412_af.csv
-LD_FILES = boards/stm32f412zx.ld boards/common_ifs.ld
+LD_FILES = boards/stm32f412xg.ld boards/common_ifs.ld
 TEXT0_ADDR = 0x08000000
 TEXT1_ADDR = 0x08020000
 

--- a/ports/stm32/boards/plli2svalues.py
+++ b/ports/stm32/boards/plli2svalues.py
@@ -24,6 +24,9 @@ mcu_support_plli2s = [
     "stm32f401xe",
     "stm32f407xx",
     "stm32f411xe",
+    "stm32f412cx",
+    "stm32f412rx",
+    "stm32f412vx",
     "stm32f412zx",
     "stm32f413xx",
     "stm32f427xx",
@@ -163,7 +166,7 @@ def main():
 
     if mcu_series in mcu_support_plli2s:
         if len(argv) not in (1, 2):
-            print("usage: pllvalues.py [-c] [-m <mcu_series>] <hse in MHz> <pllm in MHz>")
+            print("usage: plli2svalues.py [-c] [-m <mcu_series>] <hse in MHz> <pllm in MHz>")
             sys.exit(1)
 
         if argv[0].startswith("hse:"):

--- a/ports/stm32/boards/stm32f412xe.ld
+++ b/ports/stm32/boards/stm32f412xe.ld
@@ -1,14 +1,14 @@
 /*
-    GNU linker script for STM32F412zx (1MB flash, 256kB RAM)
+    GNU linker script for STM32F412xe (512kB flash, 256kB RAM)
 */
 
 /* Specify the memory areas */
 MEMORY
 {
-    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 512K /* entire flash */
     FLASH_START (rx): ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
     FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 64K /* sectors 1,2,3,4: 16k+16k+16k+16k(of 64k)=64k */
-    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K /* sectors 5,6,7,8,9,10,11 are 128K */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 384K /* sectors 5,6,7 are 128K */
     RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 240K
     FS_CACHE (xrw)  : ORIGIN = 0x2003c000, LENGTH = 16K
 }

--- a/ports/stm32/boards/stm32f412xg.ld
+++ b/ports/stm32/boards/stm32f412xg.ld
@@ -1,0 +1,35 @@
+/*
+    GNU linker script for STM32F412xg (1MB flash, 256kB RAM)
+*/
+
+/* Specify the memory areas */
+MEMORY
+{
+    FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 1024K /* entire flash */
+    FLASH_START (rx): ORIGIN = 0x08000000, LENGTH = 16K /* sector 0 */
+    FLASH_FS (rx)   : ORIGIN = 0x08004000, LENGTH = 64K /* sectors 1,2,3,4: 16k+16k+16k+16k(of 64k)=64k */
+    FLASH_TEXT (rx) : ORIGIN = 0x08020000, LENGTH = 896K /* sectors 5,6,7,8,9,10,11 are 128K */
+    RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 240K
+    FS_CACHE (xrw)  : ORIGIN = 0x2003c000, LENGTH = 16K
+}
+
+/* produce a link error if there is not this amount of RAM for these sections */
+_minimum_stack_size = 2K;
+_minimum_heap_size = 16K;
+
+/* Define the stack.  The stack is full descending so begins just above last byte
+   of RAM.  Note that EABI requires the stack to be 8-byte aligned for a call. */
+_estack = ORIGIN(RAM) + LENGTH(RAM) - _estack_reserve;
+_sstack = _estack - 16K; /* tunable */
+
+/* RAM extents for the garbage collector */
+_ram_start = ORIGIN(RAM);
+_ram_end = ORIGIN(RAM) + LENGTH(RAM);
+_heap_start = _ebss; /* heap starts just after statically allocated memory */
+_heap_end = _sstack;
+
+/* Filesystem cache in RAM, and storage in flash */
+_micropy_hw_internal_flash_storage_ram_cache_start = ORIGIN(FS_CACHE);
+_micropy_hw_internal_flash_storage_ram_cache_end = ORIGIN(FS_CACHE) + LENGTH(FS_CACHE);
+_micropy_hw_internal_flash_storage_start = ORIGIN(FLASH_FS);
+_micropy_hw_internal_flash_storage_end = ORIGIN(FLASH_FS) + LENGTH(FLASH_FS);

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -889,7 +889,7 @@ static const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
     #endif
 
     #if defined(TIM6)
-    #if defined(STM32F412Zx) || defined(STM32L1)
+    #if defined(STM32F412Cx) || defined(STM32F412Rx) || defined(STM32F412Vx) || defined(STM32F412Zx) || defined(STM32L1)
     TIM_ENTRY(6, TIM6_IRQn),
     #elif defined(STM32G0)
     TIM_ENTRY(6, TIM6_DAC_LPTIM1_IRQn),


### PR DESCRIPTION
### Summary

MicroPython already supports the NUCLEO_F412ZG board with a `F412ZG`. But there are other variants named `F412[CVRZ][EG]` with different pin numbers / flash sizes. MicroPython does not yet work for other variants than F412ZG.

### Testing

With this PR I am able to use MicroPython in two products with custom boards: one with a F412RG and the other with a F412CG.

I also tested that the NUCLEO_F412ZG still works with this PR. I tested its 3 LEDs, its USER switch, ADC(0) on pin A0, the REPL on the ST-Link UART and on the second USB port, as well as storage including USB MSC access.