### PR TITLE
esp32/machine_sdcard: Fix SDMMC slot assignment for non-default slots

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -166,6 +166,8 @@ static esp_err_t sdcard_ensure_card_init(sdcard_card_obj_t *self, bool force) {
 
         esp_err_t err = sdmmc_card_init(&(self->host), &(self->card));
         if (err == ESP_OK) {
+            // Ensure card's host structure has the correct slot after init
+            self->card.host.slot = self->host.slot;
             self->flags |= SDCARD_CARD_FLAGS_CARD_INIT_DONE;
         } else {
             self->flags &= ~SDCARD_CARD_FLAGS_CARD_INIT_DONE;
@@ -307,6 +309,7 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     else {
         sdmmc_host_t _temp_host = SDMMC_HOST_DEFAULT();
         _temp_host.max_freq_khz = freq / 1000;
+        _temp_host.slot = slot_num;
         self->host = _temp_host;
     }
     #endif


### PR DESCRIPTION
## Summary

Fixes SDMMC slot assignment bug where `slot` parameter was not being applied to the host configuration, causing initialization failures on ESP32-P4 when using slot 0.

## Problem

The `SDMMC_HOST_DEFAULT()` macro in ESP-IDF hardcodes `.slot = SDMMC_HOST_SLOT_1`, but MicroPython's `machine.SDCard` constructor was not overriding this when the user specified a different slot number (e.g., `slot=0`).

This resulted in the SDMMC peripheral being initialized for the wrong physical slot, causing communication failures and timeouts when attempting to access SD cards on non-default slots.

## Solution

Added `_temp_host.slot = slot_num;` to ensure the user-specified slot number is properly assigned to the `sdmmc_host_t` structure.

## Testing

- Tested on ESP32-P4 (dual SDMMC host controller) with SD card connected to slot 0
- Verified SD card initialization, mounting, read/write operations work correctly
- Matches the pattern already used in the SPI mode path (line 303)

## Technical Details

ESP32-P4 has two SDMMC host controllers (slot 0 and slot 1), and the default ESP-IDF configuration assumes slot 1. This fix ensures MicroPython respects the user's slot selection, particularly important for boards that wire SD cards to slot 0.

Closes: N/A (new bug discovered during ESP32-P4 testing)