### PR TITLE
stm32: Default to --connect-under-reset if flashing via deploy-stlink.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -72,7 +72,7 @@ PYDFU ?= $(TOP)/tools/pydfu.py
 DFU_UTIL ?= dfu-util
 BOOTLOADER_DFU_USB_VID ?= 0x0483
 BOOTLOADER_DFU_USB_PID ?= 0xDF11
-STFLASH ?= st-flash
+STFLASH ?= st-flash --connect-under-reset
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
 

--- a/ports/stm32/boards/NUCLEO_H723ZG/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_H723ZG/mpconfigboard.mk
@@ -26,5 +26,4 @@ MICROPY_HW_ENABLE_ISR_UART_FLASH_FUNCS_IN_RAM = 1
 FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py
 
 # Flash tool configuration
-STFLASH = st-flash --connect-under-reset
 OPENOCD_CONFIG = boards/openocd_stm32h7_dual_bank.cfg

--- a/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.mk
+++ b/ports/stm32/boards/NUCLEO_H743ZI/mpconfigboard.mk
@@ -26,5 +26,4 @@ MICROPY_HW_ENABLE_ISR_UART_FLASH_FUNCS_IN_RAM = 1
 FROZEN_MANIFEST ?= $(BOARD_DIR)/manifest.py
 
 # Flash tool configuration
-STFLASH = st-flash --connect-under-reset
 OPENOCD_CONFIG = boards/openocd_stm32h7_dual_bank.cfg

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -54,7 +54,7 @@ DFU=$(TOP)/tools/dfu.py
 PYDFU ?= $(TOP)/tools/pydfu.py
 BOOTLOADER_DFU_USB_VID ?= 0x0483
 BOOTLOADER_DFU_USB_PID ?= 0xDF11
-STFLASH ?= st-flash
+STFLASH ?= st-flash --connect-under-reset
 OPENOCD ?= openocd
 OPENOCD_CONFIG ?= boards/openocd_stm32f4.cfg
 


### PR DESCRIPTION
### Summary

(Can be overridden by setting `STFLASH` variable.)

This is necessary on at least some STM32 boards (NUCLEO_H723ZG for one), if they're currently running MicroPython as the SWD port is no longer enabled (I think due to pin function changes).

As we're resetting the target to flash it anyway, it shouldn't hurt to put every target into reset before trying to connect.

*This work was funded through GitHub Sponsors.*

### Testing

I ran `make deploy-stlink` for all the STM32 boards with integrated ST-Links that I have on hand: NUCLEO_H723ZG, NUCLEO_G474RE, NUCLEO_G0B1RE, NUCLEO_WL55, NUCLEO_WB55, NUCLEO_L476RG, B_L072Z_LRWAN1.

All but one can flash alright with `--connect-under-reset`. The NUCLEO_G0B1RE board fails to flash regardless of this option, it seems to be an issue with st-flash (at least v1.8.0) and not related to the new argument (board flashes OK from `pyocd`).

### Trade-offs and Alternatives

* For a long time I would remember to override `STFLASH` on the command line, which works - but changing the default seems to have no downside.
* Originally implemented this as a new `STFLASH_ARGS` variable that defaults to `--connect-under-reset`, but this actually harder to undo because you can't do `make deploy-stlink BOARD=... STFLASH_ARGS=` but you can do `make deploy-stlink BOARD=... STFLASH=st-flash`. It's not clear anyone would have a need to undo this change, though.
