### PR TITLE
py: Add support for nested f-strings within f-strings

### DIFF
--- a/py/lexer.h
+++ b/py/lexer.h
@@ -164,9 +164,6 @@ typedef struct _mp_lexer_t {
 
     uint32_t chr0;              // first cached byte from source (32-bits for efficient access)
     uint8_t chr1, chr2;         // subsequent cached bytes from source
-    #if MICROPY_PY_FSTRINGS
-    uint8_t chr0_saved, chr1_saved, chr2_saved; // current cached bytes from alt source
-    #endif
 
     size_t line;                // current source line
     size_t column;              // current source column
@@ -183,8 +180,9 @@ typedef struct _mp_lexer_t {
     mp_token_kind_t tok_kind;   // token kind
     vstr_t vstr;                // token data
     #if MICROPY_PY_FSTRINGS
+    vstr_t inject_chrs;         // characters currently being injected into the stream
+    size_t inject_chrs_idx;     // current index into inject_chrs
     vstr_t fstring_args;        // extracted arguments to pass to .format()
-    size_t fstring_args_idx;    // how many bytes of fstring_args have been read
     #endif
 } mp_lexer_t;
 

--- a/py/lexer.h
+++ b/py/lexer.h
@@ -162,9 +162,10 @@ typedef struct _mp_lexer_t {
     qstr source_name;           // name of source
     mp_reader_t reader;         // stream source
 
-    unichar chr0, chr1, chr2;   // current cached characters from source
+    uint32_t chr0;              // first cached byte from source (32-bits for efficient access)
+    uint8_t chr1, chr2;         // subsequent cached bytes from source
     #if MICROPY_PY_FSTRINGS
-    unichar chr0_saved, chr1_saved, chr2_saved; // current cached characters from alt source
+    uint8_t chr0_saved, chr1_saved, chr2_saved; // current cached bytes from alt source
     #endif
 
     size_t line;                // current source line

--- a/py/misc.h
+++ b/py/misc.h
@@ -26,6 +26,7 @@
 #ifndef MICROPY_INCLUDED_PY_MISC_H
 #define MICROPY_INCLUDED_PY_MISC_H
 
+#include <string.h>
 #include "py/mpconfig.h"
 
 // a mini library of useful types and functions
@@ -243,6 +244,10 @@ static inline void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr) {
     // TODO UNICODE
     char *s = vstr_ins_blank_bytes(vstr, char_pos, 1);
     *s = chr;
+}
+static inline void vstr_ins_strn(vstr_t *vstr, size_t byte_pos, const char *str, size_t len) {
+    char *s = vstr_ins_blank_bytes(vstr, byte_pos, len);
+    memcpy(s, str, len);
 }
 void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_tail_bytes(vstr_t *vstr, size_t bytes_to_cut);

--- a/py/misc.h
+++ b/py/misc.h
@@ -234,8 +234,16 @@ void vstr_add_byte(vstr_t *vstr, byte v);
 void vstr_add_char(vstr_t *vstr, unichar chr);
 void vstr_add_str(vstr_t *vstr, const char *str);
 void vstr_add_strn(vstr_t *vstr, const char *str, size_t len);
-void vstr_ins_byte(vstr_t *vstr, size_t byte_pos, byte b);
-void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr);
+char *vstr_ins_blank_bytes(vstr_t *vstr, size_t byte_pos, size_t byte_len);
+static inline void vstr_ins_byte(vstr_t *vstr, size_t byte_pos, byte b) {
+    char *s = vstr_ins_blank_bytes(vstr, byte_pos, 1);
+    *s = b;
+}
+static inline void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr) {
+    // TODO UNICODE
+    char *s = vstr_ins_blank_bytes(vstr, char_pos, 1);
+    *s = chr;
+}
 void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_tail_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_out_bytes(vstr_t *vstr, size_t byte_pos, size_t bytes_to_cut);

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -183,7 +183,7 @@ void vstr_add_strn(vstr_t *vstr, const char *str, size_t len) {
     vstr->len += len;
 }
 
-static char *vstr_ins_blank_bytes(vstr_t *vstr, size_t byte_pos, size_t byte_len) {
+char *vstr_ins_blank_bytes(vstr_t *vstr, size_t byte_pos, size_t byte_len) {
     size_t l = vstr->len;
     if (byte_pos > l) {
         byte_pos = l;
@@ -197,17 +197,6 @@ static char *vstr_ins_blank_bytes(vstr_t *vstr, size_t byte_pos, size_t byte_len
         vstr->len += byte_len;
     }
     return vstr->buf + byte_pos;
-}
-
-void vstr_ins_byte(vstr_t *vstr, size_t byte_pos, byte b) {
-    char *s = vstr_ins_blank_bytes(vstr, byte_pos, 1);
-    *s = b;
-}
-
-void vstr_ins_char(vstr_t *vstr, size_t char_pos, unichar chr) {
-    // TODO UNICODE
-    char *s = vstr_ins_blank_bytes(vstr, char_pos, 1);
-    *s = chr;
 }
 
 void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut) {

--- a/py/vstr.c
+++ b/py/vstr.c
@@ -188,14 +188,13 @@ char *vstr_ins_blank_bytes(vstr_t *vstr, size_t byte_pos, size_t byte_len) {
     if (byte_pos > l) {
         byte_pos = l;
     }
-    if (byte_len > 0) {
-        // ensure room for the new bytes
-        vstr_ensure_extra(vstr, byte_len);
-        // copy up the string to make room for the new bytes
-        memmove(vstr->buf + byte_pos + byte_len, vstr->buf + byte_pos, l - byte_pos);
-        // increase the length
-        vstr->len += byte_len;
-    }
+    // ensure room for the new bytes
+    vstr_ensure_extra(vstr, byte_len);
+    // copy up the string to make room for the new bytes
+    memmove(vstr->buf + byte_pos + byte_len, vstr->buf + byte_pos, l - byte_pos);
+    // increase the length
+    vstr->len += byte_len;
+    // return a pointer to the location to insert new bytes at
     return vstr->buf + byte_pos;
 }
 

--- a/tests/basics/lexer.py
+++ b/tests/basics/lexer.py
@@ -91,3 +91,11 @@ try:
     eval("01")
 except SyntaxError:
     print("SyntaxError")
+
+# Bytes 0-8 inclusive are not allowed in input stream.
+# Earlier CPython (eg 3.10.12) raises ValueError, later CPython (eg 3.11.14) raises SyntaxError.
+for invalid_byte_value in range(0, 10):
+    try:
+        print(eval(b"123" + bytes([invalid_byte_value])))
+    except (ValueError, SyntaxError):
+        print("byte {}: SyntaxError".format(invalid_byte_value))

--- a/tests/basics/string_fstring_nested.py
+++ b/tests/basics/string_fstring_nested.py
@@ -1,0 +1,9 @@
+# Test nesting of f-strings within f-strings.
+
+x = 1
+
+# 2-level nesting, with padding.
+print(f"a{f'b{x:2}c':>5}d")
+
+# 4-level nesting using the different styles of quotes.
+print(f"""a{f'''b{f"c{f'd{x}e'}f"}g'''}h""")

--- a/tests/basics/string_fstring_nested_py312.py
+++ b/tests/basics/string_fstring_nested_py312.py
@@ -1,0 +1,7 @@
+# Test nesting of f-strings within f-strings.
+# These test rely on Python 3.12+ to use the same quote style for nesting.
+
+x = 1
+
+# 8-level nesting using the same quote style.
+print(f"a{f"b{f"c{f"d{f"e{f"f{f"g{f"h{x}i"}j"}k"}l"}m"}n"}o"}p")

--- a/tests/basics/string_fstring_nested_py312.py.exp
+++ b/tests/basics/string_fstring_nested_py312.py.exp
@@ -1,0 +1,1 @@
+abcdefgh1ijklmnop


### PR DESCRIPTION
### Summary

During the discussion about t-string support #17557, I thought that it might not be much effort to support nested f-strings with the current f-string parser.  And it turned out relatively simple.

The way the MicroPython f-string parser works is:
1. it extracts the f-string arguments (things in curly braces) into a temporary buffer (a vstr)
2. once the f-string ends (reaches its closing quote) the lexer switches to tokenizing the temporary buffer
3. once the buffer is empty it switches back to the stream.

The temporary buffer can easily hold f-strings itself (ie nested f-strings) and they can be re-parsed by the lexer using the same algorithm.  The only thing stopping that from working is that the temporary buffer can't be reused for the nested f-string because it's currently being parsed.

This PR fixes that by adding a second temporary buffer, which is the "injection" buffer.  That allows arbitrary number of nestings with a simple modification to the original algorithm:
1. when an f-string is encountered the string is parsed and its arguments are extracted into `fstring_args`
2. when the f-string finishes, `fstring_args` is inserted into the current position in `inject_chrs` (which is the start of that buffer if no injection is ongoing)
3. `fstring_args` is now cleared and ready for any further f-strings (nested or not)
4. the lexer switches to `inject_chrs` if it's not already reading from it
5. if an f-string appeared inside the f-string then it is in `inject_chrs` and can be processed as before, extracting its arguments into `fstring_args`, which can then be inserted again into `inject_chrs`
6. once `inject_chrs` is exhausted (meaning that all levels of f-strings have been fully processed) the lexer switched back to tokenizing the stream

Amazingly, this scheme supports arbitrary numbers of nestings of f-strings using the same quote style.

### Testing

A new test is added which will run under CI.

### Trade-offs and Alternatives

This adds some code size and a bit more memory usage for the lexer.  In particular for a single (non-nested) f-string it now makes an extra copy of the `fstring_args` data, when copying it across to `inject_chrs`.  That could possibly be optimized to reuse the same buffer (`inject_chrs` would steal the memory from `fstring_args`).

Otherwise, memory use only goes up with the complexity of nested f-strings.