### PR TITLE
py/binary: Reorganize and refactor definitions for typecode letters.

### DIFF
--- a/extmod/modbluetooth.c
+++ b/extmod/modbluetooth.c
@@ -213,7 +213,7 @@ static mp_int_t bluetooth_uuid_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bu
 
     bufinfo->buf = self->data;
     bufinfo->len = self->type;
-    bufinfo->typecode = 'B';
+    bufinfo->typecode = MP_TYPECODE_C(unsigned char);
     return 0;
 }
 
@@ -273,9 +273,9 @@ static mp_obj_t bluetooth_ble_make_new(const mp_obj_type_t *type, size_t n_args,
         o->irq_data_tuple = mp_obj_new_tuple(MICROPY_PY_BLUETOOTH_MAX_EVENT_DATA_TUPLE_LEN, NULL);
 
         // Pre-allocated buffers for address, payload and uuid.
-        mp_obj_memoryview_init(&o->irq_data_addr, 'B', 0, 0, o->irq_data_addr_bytes);
+        mp_obj_memoryview_init(&o->irq_data_addr, MP_TYPECODE_C(unsigned char), 0, 0, o->irq_data_addr_bytes);
         o->irq_data_data_alloc = MICROPY_PY_BLUETOOTH_MAX_EVENT_DATA_BYTES_LEN(MICROPY_PY_BLUETOOTH_RINGBUF_SIZE);
-        mp_obj_memoryview_init(&o->irq_data_data, 'B', 0, 0, m_new(uint8_t, o->irq_data_data_alloc));
+        mp_obj_memoryview_init(&o->irq_data_data, MP_TYPECODE_C(unsigned char), 0, 0, m_new(uint8_t, o->irq_data_data_alloc));
         o->irq_data_uuid.base.type = &mp_type_bluetooth_uuid;
 
         // Allocate the default ringbuf.
@@ -1157,7 +1157,7 @@ static mp_obj_t invoke_irq_handler_run(uint16_t event,
         data_tuple->items[data_tuple->len++] = MP_OBJ_NEW_SMALL_INT(numeric[i]);
     }
     if (addr) {
-        mp_obj_memoryview_init(&mv_addr, 'B', 0, 6, (void *)addr);
+        mp_obj_memoryview_init(&mv_addr, MP_TYPECODE_C(unsigned char), 0, 6, (void *)addr);
         data_tuple->items[data_tuple->len++] = MP_OBJ_FROM_PTR(&mv_addr);
     }
     for (size_t i = 0; i < n_signed; ++i) {
@@ -1198,7 +1198,7 @@ static mp_obj_t invoke_irq_handler_run(uint16_t event,
 
     for (size_t i = 0; i < n_data; ++i) {
         if (data[i]) {
-            mp_obj_memoryview_init(&mv_data[i], 'B', 0, data_len[i], (void *)data[i]);
+            mp_obj_memoryview_init(&mv_data[i], MP_TYPECODE_C(unsigned char), 0, data_len[i], (void *)data[i]);
             data_tuple->items[data_tuple->len++] = MP_OBJ_FROM_PTR(&mv_data[i]);
         } else {
             data_tuple->items[data_tuple->len++] = mp_const_none;

--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -635,7 +635,7 @@ static mp_int_t uctypes_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, 
 
     bufinfo->buf = self->addr;
     bufinfo->len = size;
-    bufinfo->typecode = BYTEARRAY_TYPECODE;
+    bufinfo->typecode = MP_TYPECODE_BYTEARRAY;
     return 0;
 }
 

--- a/extmod/vfs_blockdev.c
+++ b/extmod/vfs_blockdev.c
@@ -49,7 +49,7 @@ void mp_vfs_blockdev_init(mp_vfs_blockdev_t *self, mp_obj_t bdev) {
 // Helper function to minimise code size of read/write functions
 // note the n_args argument is moved to the end for further code size reduction (args keep same position in caller and callee).
 static int mp_vfs_blockdev_call_rw(mp_obj_t *args, size_t block_num, size_t block_off, size_t len, void *buf, size_t n_args) {
-    mp_obj_array_t ar = {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, len, buf};
+    mp_obj_array_t ar = {{&mp_type_bytearray}, MP_TYPECODE_BYTEARRAY, 0, len, buf};
     args[2] = MP_OBJ_NEW_SMALL_INT(block_num);
     args[3] = MP_OBJ_FROM_PTR(&ar);
     args[4] = MP_OBJ_NEW_SMALL_INT(block_off); // ignored for n_args == 2

--- a/extmod/vfs_rom_file.c
+++ b/extmod/vfs_rom_file.c
@@ -29,6 +29,7 @@
 #include "py/reader.h"
 #include "py/runtime.h"
 #include "py/stream.h"
+#include "py/binary.h"
 #include "extmod/vfs_rom.h"
 
 #if MICROPY_VFS_ROM
@@ -85,7 +86,7 @@ static mp_int_t vfs_rom_file_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufi
     if (flags == MP_BUFFER_READ) {
         bufinfo->buf = (void *)self->file_data;
         bufinfo->len = self->file_size;
-        bufinfo->typecode = 'B';
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char);
         return 0;
     } else {
         // Can't write to a ROM file.

--- a/ports/alif/alif_flash.c
+++ b/ports/alif/alif_flash.c
@@ -26,6 +26,7 @@
 
 #include "py/mphal.h"
 #include "py/runtime.h"
+#include "py/binary.h"
 #include "extmod/vfs.h"
 #include "modalif.h"
 #include "ospi_flash.h"
@@ -85,7 +86,7 @@ static mp_int_t alif_flash_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinf
     if (flags == MP_BUFFER_READ) {
         bufinfo->buf = (void *)(ospi_flash_get_xip_base() + self->flash_base_addr);
         bufinfo->len = self->flash_size;
-        bufinfo->typecode = 'B';
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char);
         return 0;
     } else {
         // Can't return a writable buffer.

--- a/ports/esp32/esp32_partition.c
+++ b/ports/esp32/esp32_partition.c
@@ -137,7 +137,7 @@ static mp_int_t esp32_partition_get_buffer(mp_obj_t self_in, mp_buffer_info_t *b
         }
         bufinfo->buf = (void *)esp32_partition_romfs_ptr;
         bufinfo->len = self->part->size;
-        bufinfo->typecode = 'B';
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char);
         return 0;
     } else {
         // Unsupported.

--- a/ports/rp2/rp2_dma.c
+++ b/ports/rp2/rp2_dma.c
@@ -29,6 +29,7 @@
 #include "py/runtime.h"
 #include "py/mperrno.h"
 #include "py/objarray.h"
+#include "py/binary.h"
 #include "shared/runtime/mpirq.h"
 #include "modrp2.h"
 
@@ -185,7 +186,7 @@ static void rp2_dma_attr(mp_obj_t self_in, qstr attr_in, mp_obj_t *dest) {
             dest[0] = mp_obj_new_int_from_uint(self->channel);
         } else if (attr_in == MP_QSTR_registers) {
             mp_obj_array_t *reg_view = m_new_obj(mp_obj_array_t);
-            mp_obj_memoryview_init(reg_view, 'I' | MP_OBJ_ARRAY_TYPECODE_FLAG_RW, 0, 16, dma_channel_hw_addr(self->channel));
+            mp_obj_memoryview_init(reg_view, 'I' | MP_TYPECODE_FLAG_RW, 0, 16, dma_channel_hw_addr(self->channel));
             dest[0] = reg_view;
         } else {
             // Continue attribute search in locals dict.

--- a/ports/rp2/rp2_flash.c
+++ b/ports/rp2/rp2_flash.c
@@ -29,6 +29,7 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 #include "py/mperrno.h"
+#include "py/binary.h"
 #include "extmod/vfs.h"
 #include "modrp2.h"
 #include "hardware/flash.h"
@@ -247,7 +248,7 @@ static mp_int_t rp2_flash_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo
     if (flags == MP_BUFFER_READ) {
         bufinfo->buf = (void *)(XIP_BASE + self->flash_base);
         bufinfo->len = self->flash_size;
-        bufinfo->typecode = 'B';
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char);
         return 0;
     } else {
         // Write unsupported.

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -831,7 +831,7 @@ static mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
     if (n_args > 1) {
         if (args[1] != mp_const_none) {
             mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
-            if (bufinfo.typecode == BYTEARRAY_TYPECODE) {
+            if (bufinfo.typecode == MP_TYPECODE_BYTEARRAY) {
                 bufinfo.typecode = 'b';
             } else {
                 bufinfo.typecode |= 0x20; // make lowercase to support upper and lower
@@ -893,7 +893,7 @@ static mp_obj_t rp2_state_machine_put(size_t n_args, const mp_obj_t *args) {
     const uint8_t *src_top = src + bufinfo.len;
     while (src < src_top) {
         uint32_t value;
-        if (bufinfo.typecode == 'B' || bufinfo.typecode == BYTEARRAY_TYPECODE) {
+        if (bufinfo.typecode == 'B' || bufinfo.typecode == MP_TYPECODE_BYTEARRAY) {
             value = *(uint8_t *)src;
             src += sizeof(uint8_t);
         } else if (bufinfo.typecode == 'H') {

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -832,9 +832,9 @@ static mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
         if (args[1] != mp_const_none) {
             mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_WRITE);
             if (bufinfo.typecode == MP_TYPECODE_BYTEARRAY) {
-                bufinfo.typecode = 'b';
+                bufinfo.typecode = MP_TYPECODE_C(char);
             } else {
-                bufinfo.typecode |= 0x20; // make lowercase to support upper and lower
+                bufinfo.typecode &= ~0x20; // make uppercase to support upper and lower
             }
             if (bufinfo.len == 0) { // edge case: buffer of zero length supplied
                 return args[1];
@@ -855,13 +855,13 @@ static mp_obj_t rp2_state_machine_get(size_t n_args, const mp_obj_t *args) {
         if (dest == NULL) {
             return mp_obj_new_int_from_uint(value);
         }
-        if (bufinfo.typecode == 'b') {
+        if (bufinfo.typecode == MP_TYPECODE_C(uint8_t)) {
             *(uint8_t *)dest = value;
             dest += sizeof(uint8_t);
-        } else if (bufinfo.typecode == 'h') {
+        } else if (bufinfo.typecode == MP_TYPECODE_C(uint16_t)) {
             *(uint16_t *)dest = value;
             dest += sizeof(uint16_t);
-        } else if (bufinfo.typecode == 'i') {
+        } else if (bufinfo.typecode == MP_TYPECODE_C(uint32_t)) {
             *(uint32_t *)dest = value;
             dest += sizeof(uint32_t);
         } else {
@@ -887,19 +887,19 @@ static mp_obj_t rp2_state_machine_put(size_t n_args, const mp_obj_t *args) {
         data = mp_obj_get_int_truncated(args[1]);
         bufinfo.buf = &data;
         bufinfo.len = sizeof(uint32_t);
-        bufinfo.typecode = 'I';
+        bufinfo.typecode = MP_TYPECODE_C(uint32_t);
     }
     const uint8_t *src = bufinfo.buf;
     const uint8_t *src_top = src + bufinfo.len;
     while (src < src_top) {
         uint32_t value;
-        if (bufinfo.typecode == 'B' || bufinfo.typecode == MP_TYPECODE_BYTEARRAY) {
+        if (bufinfo.typecode == MP_TYPECODE_C(uint8_t) || bufinfo.typecode == MP_TYPECODE_BYTEARRAY) {
             value = *(uint8_t *)src;
             src += sizeof(uint8_t);
-        } else if (bufinfo.typecode == 'H') {
+        } else if (bufinfo.typecode == MP_TYPECODE_C(uint16_t)) {
             value = *(uint16_t *)src;
             src += sizeof(uint16_t);
-        } else if (bufinfo.typecode == 'I') {
+        } else if (bufinfo.typecode == MP_TYPECODE_C(uint32_t)) {
             value = *(uint32_t *)src;
             src += sizeof(uint32_t);
         } else {
@@ -936,7 +936,7 @@ static mp_int_t rp2_state_machine_get_buffer(mp_obj_t o_in, mp_buffer_info_t *bu
     rp2_state_machine_obj_t *self = MP_OBJ_TO_PTR(o_in);
 
     bufinfo->len = 4;
-    bufinfo->typecode = 'I';
+    bufinfo->typecode = MP_TYPECODE_C(uint32_t);
 
     if (flags & MP_BUFFER_WRITE) {
         bufinfo->buf = (void *)&self->pio->txf[self->sm];

--- a/ports/stm32/bufhelper.c
+++ b/ports/stm32/bufhelper.c
@@ -25,6 +25,7 @@
  */
 
 #include "py/obj.h"
+#include "py/binary.h"
 #include "bufhelper.h"
 
 void pyb_buf_get_for_send(mp_obj_t o, mp_buffer_info_t *bufinfo, byte *tmp_data) {
@@ -32,7 +33,7 @@ void pyb_buf_get_for_send(mp_obj_t o, mp_buffer_info_t *bufinfo, byte *tmp_data)
         tmp_data[0] = mp_obj_get_int(o);
         bufinfo->buf = tmp_data;
         bufinfo->len = 1;
-        bufinfo->typecode = 'B';
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char);
     } else {
         mp_get_buffer_raise(o, bufinfo, MP_BUFFER_READ);
     }

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -680,8 +680,8 @@ static mp_obj_t pyb_can_recv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
             mp_raise_TypeError(NULL);
         }
         mp_obj_array_t *mv = MP_OBJ_TO_PTR(items[4]);
-        if (!(mv->typecode == (MP_OBJ_ARRAY_TYPECODE_FLAG_RW | MP_TYPECODE_BYTEARRAY)
-              || (mv->typecode | 0x20) == (MP_OBJ_ARRAY_TYPECODE_FLAG_RW | 'b'))) {
+        if (!(mv->typecode == (MP_TYPECODE_FLAG_RW | MP_TYPECODE_BYTEARRAY)
+              || (mv->typecode | 0x20) == (MP_TYPECODE_FLAG_RW | MP_TYPECODE_C(char)))) {
             mp_raise_ValueError(NULL);
         }
         mv->len = rx_dlc;

--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -680,7 +680,7 @@ static mp_obj_t pyb_can_recv(size_t n_args, const mp_obj_t *pos_args, mp_map_t *
             mp_raise_TypeError(NULL);
         }
         mp_obj_array_t *mv = MP_OBJ_TO_PTR(items[4]);
-        if (!(mv->typecode == (MP_OBJ_ARRAY_TYPECODE_FLAG_RW | BYTEARRAY_TYPECODE)
+        if (!(mv->typecode == (MP_OBJ_ARRAY_TYPECODE_FLAG_RW | MP_TYPECODE_BYTEARRAY)
               || (mv->typecode | 0x20) == (MP_OBJ_ARRAY_TYPECODE_FLAG_RW | 'b'))) {
             mp_raise_ValueError(NULL);
         }

--- a/py/binary.c
+++ b/py/binary.c
@@ -49,40 +49,40 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
         case '<':
         case '>':
             switch (val_type) {
-                case 'b':
-                case 'B':
+                case MP_TYPECODE_C(signed char):
+                case MP_TYPECODE_C(unsigned char):
                     size = 1;
                     break;
-                case 'h':
-                case 'H':
+                case MP_TYPECODE_C(short):
+                case MP_TYPECODE_C(unsigned short):
                     size = 2;
                     break;
-                case 'i':
-                case 'I':
+                case MP_TYPECODE_C(int):
+                case MP_TYPECODE_C(unsigned int):
                     size = 4;
                     break;
-                case 'l':
-                case 'L':
+                case MP_TYPECODE_C(long):
+                case MP_TYPECODE_C(unsigned long):
                     size = 4;
                     break;
-                case 'q':
-                case 'Q':
+                case MP_TYPECODE_C(long long):
+                case MP_TYPECODE_C(unsigned long long):
                     size = 8;
                     break;
                 #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
-                case 'P':
-                case 'O':
-                case 'S':
+                case MP_TYPECODE_C(void *):
+                case MP_TYPECODE_OBJECT:
+                case MP_TYPECODE_C(char *):
                     size = sizeof(void *);
                     break;
                 #endif
-                case 'e':
+                case MP_TYPECODE_HALFFLOAT:
                     size = 2;
                     break;
-                case 'f':
+                case MP_TYPECODE_C(float):
                     size = 4;
                     break;
-                case 'd':
+                case MP_TYPECODE_C(double):
                     size = 8;
                     break;
             }
@@ -97,47 +97,47 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
             // particular (or any) ABI.
             switch (val_type) {
                 case MP_TYPECODE_BYTEARRAY:
-                case 'b':
-                case 'B':
+                case MP_TYPECODE_C(signed char):
+                case MP_TYPECODE_C(unsigned char):
                     align = size = 1;
                     break;
-                case 'h':
-                case 'H':
+                case MP_TYPECODE_C(short):
+                case MP_TYPECODE_C(unsigned short):
                     align = alignof(short);
                     size = sizeof(short);
                     break;
-                case 'i':
-                case 'I':
+                case MP_TYPECODE_C(int):
+                case MP_TYPECODE_C(unsigned int):
                     align = alignof(int);
                     size = sizeof(int);
                     break;
-                case 'l':
-                case 'L':
+                case MP_TYPECODE_C(long):
+                case MP_TYPECODE_C(unsigned long):
                     align = alignof(long);
                     size = sizeof(long);
                     break;
-                case 'q':
-                case 'Q':
+                case MP_TYPECODE_C(long long):
+                case MP_TYPECODE_C(unsigned long long):
                     align = alignof(long long);
                     size = sizeof(long long);
                     break;
                 #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
-                case 'P':
-                case 'O':
-                case 'S':
+                case MP_TYPECODE_C(void *):
+                case MP_TYPECODE_OBJECT:
+                case MP_TYPECODE_C(char *):
                     align = alignof(void *);
                     size = sizeof(void *);
                     break;
                 #endif
-                case 'e':
+                case MP_TYPECODE_HALFFLOAT:
                     align = 2;
                     size = 2;
                     break;
-                case 'f':
+                case MP_TYPECODE_C(float):
                     align = alignof(float);
                     size = sizeof(float);
                     break;
-                case 'd':
+                case MP_TYPECODE_C(double):
                     align = alignof(double);
                     size = sizeof(double);
                     break;
@@ -251,45 +251,45 @@ static uint16_t mp_encode_half_float(float x) {
 mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
     mp_int_t val = 0;
     switch (typecode) {
-        case 'b':
+        case MP_TYPECODE_C(signed char):
             val = ((signed char *)p)[index];
             break;
         case MP_TYPECODE_BYTEARRAY:
-        case 'B':
+        case MP_TYPECODE_C(unsigned char):
             val = ((unsigned char *)p)[index];
             break;
-        case 'h':
+        case MP_TYPECODE_C(short):
             val = ((short *)p)[index];
             break;
-        case 'H':
+        case MP_TYPECODE_C(unsigned short):
             val = ((unsigned short *)p)[index];
             break;
-        case 'i':
+        case MP_TYPECODE_C(int):
             return mp_obj_new_int(((int *)p)[index]);
-        case 'I':
+        case MP_TYPECODE_C(unsigned int):
             return mp_obj_new_int_from_uint(((unsigned int *)p)[index]);
-        case 'l':
+        case MP_TYPECODE_C(long):
             return mp_obj_new_int(((long *)p)[index]);
-        case 'L':
+        case MP_TYPECODE_C(unsigned long):
             return mp_obj_new_int_from_uint(((unsigned long *)p)[index]);
         #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-        case 'q':
+        case MP_TYPECODE_C(long long):
             return mp_obj_new_int_from_ll(((long long *)p)[index]);
-        case 'Q':
+        case MP_TYPECODE_C(unsigned long long):
             return mp_obj_new_int_from_ull(((unsigned long long *)p)[index]);
         #endif
         #if MICROPY_PY_BUILTINS_FLOAT
-        case 'f':
+        case MP_TYPECODE_C(float):
             return mp_obj_new_float_from_f(((float *)p)[index]);
-        case 'd':
+        case MP_TYPECODE_C(double):
             return mp_obj_new_float_from_d(((double *)p)[index]);
         #endif
             // Extension to CPython: array of objects
         #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
-        case 'O':
+        case MP_TYPECODE_OBJECT:
             return ((mp_obj_t *)p)[index];
         // Extension to CPython: array of pointers
-        case 'P':
+        case MP_TYPECODE_C(void *):
             return mp_obj_new_int((mp_int_t)(uintptr_t)((void **)p)[index]);
         #endif
     }
@@ -340,21 +340,21 @@ mp_obj_t mp_binary_get_val(char struct_type, char val_type, byte *p_base, byte *
 
     long long val = mp_binary_get_int(size, is_signed(val_type), (struct_type == '>'), p);
 
-    if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == 'O') {
+    if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == MP_TYPECODE_OBJECT) {
         return (mp_obj_t)(mp_uint_t)val;
-    } else if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == 'S') {
+    } else if (MICROPY_PY_STRUCT_UNSAFE_TYPECODES && val_type == MP_TYPECODE_C(char *)) {
         const char *s_val = (const char *)(uintptr_t)(mp_uint_t)val;
         return mp_obj_new_str_from_cstr(s_val);
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (val_type == 'e') {
+    } else if (val_type == MP_TYPECODE_HALFFLOAT) {
         return mp_obj_new_float_from_f(mp_decode_half_float(val));
-    } else if (val_type == 'f') {
+    } else if (val_type == MP_TYPECODE_C(float)) {
         union {
             uint32_t i;
             float f;
         } fpu = {val};
         return mp_obj_new_float_from_f(fpu.f);
-    } else if (val_type == 'd') {
+    } else if (val_type == MP_TYPECODE_C(double)) {
         union {
             uint64_t i;
             double f;
@@ -414,15 +414,15 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
     mp_uint_t val;
     switch (val_type) {
         #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
-        case 'O':
+        case MP_TYPECODE_OBJECT:
             val = (mp_uint_t)val_in;
             break;
         #endif
         #if MICROPY_PY_BUILTINS_FLOAT
-        case 'e':
+        case MP_TYPECODE_HALFFLOAT:
             val = mp_encode_half_float(mp_obj_get_float_to_f(val_in));
             break;
-        case 'f': {
+        case MP_TYPECODE_C(float): {
             union {
                 uint32_t i;
                 float f;
@@ -431,7 +431,7 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
             val = fp_sp.i;
             break;
         }
-        case 'd': {
+        case MP_TYPECODE_C(double): {
             union {
                 uint64_t i64;
                 uint32_t i32[2];
@@ -475,16 +475,16 @@ void mp_binary_set_val(char struct_type, char val_type, mp_obj_t val_in, byte *p
 void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_in) {
     switch (typecode) {
         #if MICROPY_PY_BUILTINS_FLOAT
-        case 'f':
+        case MP_TYPECODE_C(float):
             ((float *)p)[index] = mp_obj_get_float_to_f(val_in);
             break;
-        case 'd':
+        case MP_TYPECODE_C(double):
             ((double *)p)[index] = mp_obj_get_float_to_d(val_in);
             break;
         #endif
         #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
         // Extension to CPython: array of objects
-        case 'O':
+        case MP_TYPECODE_OBJECT:
             ((mp_obj_t *)p)[index] = val_in;
             break;
         #endif
@@ -503,50 +503,50 @@ void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_
 
 void mp_binary_set_val_array_from_int(char typecode, void *p, size_t index, mp_int_t val) {
     switch (typecode) {
-        case 'b':
+        case MP_TYPECODE_C(signed char):
             ((signed char *)p)[index] = val;
             break;
         case MP_TYPECODE_BYTEARRAY:
-        case 'B':
+        case MP_TYPECODE_C(unsigned char):
             ((unsigned char *)p)[index] = val;
             break;
-        case 'h':
+        case MP_TYPECODE_C(short):
             ((short *)p)[index] = val;
             break;
-        case 'H':
+        case MP_TYPECODE_C(unsigned short):
             ((unsigned short *)p)[index] = val;
             break;
-        case 'i':
+        case MP_TYPECODE_C(int):
             ((int *)p)[index] = val;
             break;
-        case 'I':
+        case MP_TYPECODE_C(unsigned int):
             ((unsigned int *)p)[index] = val;
             break;
-        case 'l':
+        case MP_TYPECODE_C(long):
             ((long *)p)[index] = val;
             break;
-        case 'L':
+        case MP_TYPECODE_C(unsigned long):
             ((unsigned long *)p)[index] = val;
             break;
         #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-        case 'q':
+        case MP_TYPECODE_C(long long):
             ((long long *)p)[index] = val;
             break;
-        case 'Q':
+        case MP_TYPECODE_C(unsigned long long):
             ((unsigned long long *)p)[index] = val;
             break;
         #endif
         #if MICROPY_PY_BUILTINS_FLOAT
-        case 'f':
+        case MP_TYPECODE_C(float):
             ((float *)p)[index] = (float)val;
             break;
-        case 'd':
+        case MP_TYPECODE_C(double):
             ((double *)p)[index] = (double)val;
             break;
         #endif
             // Extension to CPython: array of pointers
         #if MICROPY_PY_STRUCT_UNSAFE_TYPECODES
-        case 'P':
+        case MP_TYPECODE_C(void *):
             ((void **)p)[index] = (void *)(uintptr_t)val;
             break;
         #endif

--- a/py/binary.c
+++ b/py/binary.c
@@ -96,7 +96,7 @@ size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign) {
             // formal support for that is different from actually supporting
             // particular (or any) ABI.
             switch (val_type) {
-                case BYTEARRAY_TYPECODE:
+                case MP_TYPECODE_BYTEARRAY:
                 case 'b':
                 case 'B':
                     align = size = 1;
@@ -254,7 +254,7 @@ mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index) {
         case 'b':
             val = ((signed char *)p)[index];
             break;
-        case BYTEARRAY_TYPECODE:
+        case MP_TYPECODE_BYTEARRAY:
         case 'B':
             val = ((unsigned char *)p)[index];
             break;
@@ -506,7 +506,7 @@ void mp_binary_set_val_array_from_int(char typecode, void *p, size_t index, mp_i
         case 'b':
             ((signed char *)p)[index] = val;
             break;
-        case BYTEARRAY_TYPECODE:
+        case MP_TYPECODE_BYTEARRAY:
         case 'B':
             ((unsigned char *)p)[index] = val;
             break;

--- a/py/binary.h
+++ b/py/binary.h
@@ -32,7 +32,7 @@
 // Use special typecode to differentiate repr() of bytearray vs array.array('B')
 // (underlyingly they're same).  Can't use 0 here because that's used to detect
 // type-specification errors due to end-of-string.
-#define BYTEARRAY_TYPECODE 1
+#define MP_TYPECODE_BYTEARRAY 1
 
 size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign);
 mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index);

--- a/py/binary.h
+++ b/py/binary.h
@@ -34,6 +34,9 @@
 // type-specification errors due to end-of-string.
 #define MP_TYPECODE_BYTEARRAY 1
 
+// Used only for memoryview types, set in "typecode" to indicate a writable memoryview
+#define MP_TYPECODE_FLAG_RW (0x80)
+
 size_t mp_binary_get_size(char struct_type, char val_type, size_t *palign);
 mp_obj_t mp_binary_get_val_array(char typecode, void *p, size_t index);
 void mp_binary_set_val_array(char typecode, void *p, size_t index, mp_obj_t val_in);

--- a/py/binary.h
+++ b/py/binary.h
@@ -33,6 +33,32 @@
 // (underlyingly they're same).  Can't use 0 here because that's used to detect
 // type-specification errors due to end-of-string.
 #define MP_TYPECODE_BYTEARRAY 1
+#define MP_TYPECODE_OBJECT 'O'
+#define MP_TYPECODE_CALLBACK 'C'
+#define MP_TYPECODE_VOID 'v'
+#define MP_TYPECODE_HALFFLOAT 'e'
+
+// array/memoryview of the given C type
+#define MP_TYPECODE_C(type) _Generic((type)0, \
+    char : 'b', \
+    signed char : 'b', \
+    unsigned char : 'B', \
+    short : 'h', \
+    unsigned short : 'H', \
+    int : 'i', \
+    unsigned int : 'I', \
+    long : 'l', \
+    unsigned long : 'L', \
+    long long : 'q', \
+    unsigned long long : 'Q', \
+    float : 'f', \
+    double : 'd', \
+    char _MP_TYPECODES_UNCRUSTIFY_WORKAROUND_STAR: 'S', \
+    const char _MP_TYPECODES_UNCRUSTIFY_WORKAROUND_STAR: 's', \
+    void _MP_TYPECODES_UNCRUSTIFY_WORKAROUND_STAR: 'P', \
+    const void _MP_TYPECODES_UNCRUSTIFY_WORKAROUND_STAR: 'p' \
+    )
+#define _MP_TYPECODES_UNCRUSTIFY_WORKAROUND_STAR *
 
 // Used only for memoryview types, set in "typecode" to indicate a writable memoryview
 #define MP_TYPECODE_FLAG_RW (0x80)

--- a/py/modio.c
+++ b/py/modio.c
@@ -54,7 +54,7 @@ static mp_obj_t iobase_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 static mp_uint_t iobase_read_write(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode, qstr qst) {
     mp_obj_t dest[3];
     mp_load_method(obj, qst, dest);
-    mp_obj_array_t ar = {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, size, buf};
+    mp_obj_array_t ar = {{&mp_type_bytearray}, MP_TYPECODE_BYTEARRAY, 0, size, buf};
     dest[2] = MP_OBJ_FROM_PTR(&ar);
     mp_obj_t ret_obj = mp_call_method_n_kw(1, 0, dest);
     if (ret_obj == mp_const_none) {

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -281,7 +281,7 @@ static mp_obj_t array_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
 
 static int typecode_for_comparison(int typecode, bool *is_unsigned) {
     if (typecode == MP_TYPECODE_BYTEARRAY) {
-        typecode = 'B';
+        typecode = MP_TYPECODE_C(unsigned char);
     }
     if (typecode <= 'Z') {
         typecode += 32; // to lowercase

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -241,7 +241,7 @@ static mp_obj_t memoryview_make_new(const mp_obj_type_t *type_in, size_t n_args,
 
     // test if the object can be written to
     if (mp_get_buffer(args[0], &bufinfo, MP_BUFFER_RW)) {
-        self->typecode |= MP_OBJ_ARRAY_TYPECODE_FLAG_RW; // indicate writable buffer
+        self->typecode |= MP_TYPECODE_FLAG_RW; // indicate writable buffer
     }
 
     return MP_OBJ_FROM_PTR(self);
@@ -503,7 +503,7 @@ static mp_obj_t array_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value
                 uint8_t *dest_items = o->items;
                 #if MICROPY_PY_BUILTINS_MEMORYVIEW
                 if (o->base.type == &mp_type_memoryview) {
-                    if (!(o->typecode & MP_OBJ_ARRAY_TYPECODE_FLAG_RW)) {
+                    if (!(o->typecode & MP_TYPECODE_FLAG_RW)) {
                         // store to read-only memoryview not allowed
                         return MP_OBJ_NULL;
                     }
@@ -568,7 +568,7 @@ static mp_obj_t array_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value
             #if MICROPY_PY_BUILTINS_MEMORYVIEW
             if (o->base.type == &mp_type_memoryview) {
                 index += o->memview_offset;
-                if (value != MP_OBJ_SENTINEL && !(o->typecode & MP_OBJ_ARRAY_TYPECODE_FLAG_RW)) {
+                if (value != MP_OBJ_SENTINEL && !(o->typecode & MP_TYPECODE_FLAG_RW)) {
                     // store to read-only memoryview
                     return MP_OBJ_NULL;
                 }
@@ -594,7 +594,7 @@ static mp_int_t array_get_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_ui
     bufinfo->typecode = o->typecode & TYPECODE_MASK;
     #if MICROPY_PY_BUILTINS_MEMORYVIEW
     if (o->base.type == &mp_type_memoryview) {
-        if (!(o->typecode & MP_OBJ_ARRAY_TYPECODE_FLAG_RW) && (flags & MP_BUFFER_WRITE)) {
+        if (!(o->typecode & MP_TYPECODE_FLAG_RW) && (flags & MP_BUFFER_WRITE)) {
             // read-only memoryview
             return 1;
         }

--- a/py/objarray.c
+++ b/py/objarray.c
@@ -73,7 +73,7 @@ static mp_int_t array_get_buffer(mp_obj_t o_in, mp_buffer_info_t *bufinfo, mp_ui
 static void array_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_array_t *o = MP_OBJ_TO_PTR(o_in);
-    if (o->typecode == BYTEARRAY_TYPECODE) {
+    if (o->typecode == MP_TYPECODE_BYTEARRAY) {
         mp_print_str(print, "bytearray(b");
         mp_str_print_quoted(print, o->items, o->len, true);
     } else {
@@ -98,7 +98,7 @@ static mp_obj_array_t *array_new(char typecode, size_t n) {
     int typecode_size = mp_binary_get_size('@', typecode, NULL);
     mp_obj_array_t *o = m_new_obj(mp_obj_array_t);
     #if MICROPY_PY_BUILTINS_BYTEARRAY && MICROPY_PY_ARRAY
-    o->base.type = (typecode == BYTEARRAY_TYPECODE) ? &mp_type_bytearray : &mp_type_array;
+    o->base.type = (typecode == MP_TYPECODE_BYTEARRAY) ? &mp_type_bytearray : &mp_type_array;
     #elif MICROPY_PY_BUILTINS_BYTEARRAY
     o->base.type = &mp_type_bytearray;
     #else
@@ -131,7 +131,7 @@ static mp_obj_t array_construct(char typecode, mp_obj_t initializer) {
     // other arrays can only be raw-initialised from bytes and bytearray objects
     mp_buffer_info_t bufinfo;
     if (((MICROPY_PY_BUILTINS_BYTEARRAY
-          && typecode == BYTEARRAY_TYPECODE)
+          && typecode == MP_TYPECODE_BYTEARRAY)
          || (MICROPY_PY_ARRAY
              && (mp_obj_is_type(initializer, &mp_type_bytes)
                  || (MICROPY_PY_BUILTINS_BYTEARRAY && mp_obj_is_type(initializer, &mp_type_bytearray)))))
@@ -186,11 +186,11 @@ static mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
 
     if (n_args == 0) {
         // no args: construct an empty bytearray
-        return MP_OBJ_FROM_PTR(array_new(BYTEARRAY_TYPECODE, 0));
+        return MP_OBJ_FROM_PTR(array_new(MP_TYPECODE_BYTEARRAY, 0));
     } else if (mp_obj_is_int(args[0])) {
         // 1 arg, an integer: construct a blank bytearray of that length
         mp_uint_t len = mp_obj_get_int(args[0]);
-        mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, len);
+        mp_obj_array_t *o = array_new(MP_TYPECODE_BYTEARRAY, len);
         memset(o->items, 0, len);
         return MP_OBJ_FROM_PTR(o);
     } else {
@@ -203,7 +203,7 @@ static mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
             mp_raise_TypeError(MP_ERROR_TEXT("string argument without an encoding"));
             #endif
         }
-        return array_construct(BYTEARRAY_TYPECODE, args[0]);
+        return array_construct(MP_TYPECODE_BYTEARRAY, args[0]);
     }
 }
 #endif
@@ -280,7 +280,7 @@ static mp_obj_t array_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
 }
 
 static int typecode_for_comparison(int typecode, bool *is_unsigned) {
-    if (typecode == BYTEARRAY_TYPECODE) {
+    if (typecode == MP_TYPECODE_BYTEARRAY) {
         typecode = 'B';
     }
     if (typecode <= 'Z') {
@@ -674,7 +674,7 @@ size_t mp_obj_array_len(mp_obj_t self_in) {
 
 #if MICROPY_PY_BUILTINS_BYTEARRAY
 mp_obj_t mp_obj_new_bytearray(size_t n, const void *items) {
-    mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, n);
+    mp_obj_array_t *o = array_new(MP_TYPECODE_BYTEARRAY, n);
     memcpy(o->items, items, n);
     return MP_OBJ_FROM_PTR(o);
 }
@@ -682,7 +682,7 @@ mp_obj_t mp_obj_new_bytearray(size_t n, const void *items) {
 // Create bytearray which references specified memory area
 mp_obj_t mp_obj_new_bytearray_by_ref(size_t n, void *items) {
     mp_obj_array_t *o = mp_obj_malloc(mp_obj_array_t, &mp_type_bytearray);
-    o->typecode = BYTEARRAY_TYPECODE;
+    o->typecode = MP_TYPECODE_BYTEARRAY;
     o->free = 0;
     o->len = n;
     o->items = items;

--- a/py/objarray.h
+++ b/py/objarray.h
@@ -29,9 +29,6 @@
 
 #include "py/obj.h"
 
-// Used only for memoryview types, set in "typecode" to indicate a writable memoryview
-#define MP_OBJ_ARRAY_TYPECODE_FLAG_RW (0x80)
-
 // Bit size used for mp_obj_array_t.free member.
 #define MP_OBJ_ARRAY_FREE_SIZE_BITS (8 * sizeof(size_t) - 8)
 

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -34,6 +34,7 @@
 #include "py/runtime.h"
 #include "py/cstack.h"
 #include "py/objtuple.h"
+#include "py/binary.h"
 
 #if MICROPY_PY_BUILTINS_STR_OP_MODULO
 static mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_t *args, mp_obj_t dict);
@@ -2064,7 +2065,7 @@ mp_int_t mp_obj_str_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_u
         GET_STR_DATA_LEN(self_in, str_data, str_len);
         bufinfo->buf = (void *)str_data;
         bufinfo->len = str_len;
-        bufinfo->typecode = 'B'; // bytes should be unsigned, so should unicode byte-access
+        bufinfo->typecode = MP_TYPECODE_C(unsigned char); // bytes should be unsigned, so should unicode byte-access
         return 0;
     } else {
         // can't write to a string


### PR DESCRIPTION
### Summary
This PR collects together all of the macro constants associated with the "typecode" value used across several different modules to encode information about the type identity of an associated pointer or memory buffer. These values were previously scattered across the codebase, often leading to confusion about the C API, resulting in e.g. defective memoryview objects with no typecode except for the read-write flag.

With this change:
- Anyone searching for information about the typecode values is led to a single location where they are all listed.
- Other aliases for the same types can be used transparently: For instance, `MP_TYPECODE_C(custom_typedefed_int_t)` would automatically pick the appropriate typecode letter at compile time thanks to the semantics of `_Generic`.
- Instances where an incorrect association from typecode to C type have been made will be a lot more obvious to inspection. For instance, take the following bug:
    ```C
    case 'q':
        long double *x = obj;
        return quad_float_op(*x);
    ```
    Maybe you already know reflexively that that's NOT actually what `'q'` means, but it's still a lot easier to spot if you instead write it like:
    ```C
    case MP_TYPECODE_C(long long int):
        long double *x = obj;
        return quad_float_op(*x);
    ```

### Testing
I've run the test suite across unix and rp2 on my own hardware. All extant tests pass; though as a pure refactor, this change can't be checked directly.

Some of the changes touch port-specific code for devices I don't have access to; hopefully CI will catch anything aggressively defective, but this ought to be tested on those other devices.

### Trade-offs and Alternatives
Using `_Generic` limits compatibility to C11 and above. If that's a problem, potentially separate macros for each type could be declared instead --- but that's only marginally useful than single-letter typecodes.

Potentially, it would be better to use the stdint names for the typecodes, i.e. `uint8_t` instead of `unsigned char`; and in several of the places I've refactored there might be a more semantic typename to use as the argument --- the actual typename of the associated buffer, or perhaps even a `typeof` expression involving that buffer.



