### PR TITLE
py/objtype: Ensures native attr handlers process subclass attribute stores

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -691,6 +691,25 @@ static void mp_obj_instance_load_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
 static bool mp_obj_instance_store_attr(mp_obj_t self_in, qstr attr, mp_obj_t value) {
     mp_obj_instance_t *self = MP_OBJ_TO_PTR(self_in);
 
+    // If there's a native base class with an attr handler, give it the chance to handle this
+    // store/delete before the value is stored in the instance dict.
+    // The handler follows the standard attr protocol (see mp_store_attr): it leaves dest[0] as
+    // MP_OBJ_SENTINEL if it doesn't own the attribute, in which case we fall through to normal
+    // dict storage.  Any exception it raises (e.g. a setter rejecting the value) propagates to
+    // the caller, exactly as in CPython.
+    const mp_obj_type_t *native_base = NULL;
+    if (instance_count_native_bases(self->base.type, &native_base) != 0 && native_base != &mp_type_object) {
+        if (MP_OBJ_TYPE_HAS_SLOT(native_base, attr)) {
+            mp_obj_t dest[2] = {MP_OBJ_SENTINEL, value};
+            MP_OBJ_TYPE_GET_SLOT(native_base, attr)(self->subobj[0], attr, dest);
+            if (dest[0] != MP_OBJ_SENTINEL) {
+                // The native attr handler handled the store/delete.
+                return true;
+            }
+            // The native attr handler doesn't own this attribute; fall through to dict storage.
+        }
+    }
+
     if (!(self->base.type->flags & MP_TYPE_FLAG_HAS_SPECIAL_ACCESSORS)) {
         // Class doesn't have any special accessors so skip their checks
         goto skip_special_accessors;

--- a/tests/basics/subclass_native_attrs.py
+++ b/tests/basics/subclass_native_attrs.py
@@ -1,0 +1,20 @@
+# Test that Python subclasses of native types with attr handlers properly delegate
+# attribute storage to the native type's attr handler.
+#
+# Three code paths are tested:
+# 1. SUCCESS: Native attr handler handles the attribute
+# 2. FALLBACK: Attr handler doesn't handle it, falls back to dict storage
+
+class MyException(Exception):
+    pass
+
+# Test 1: Basic subclass functionality
+e1 = MyException("hello", "world")
+assert e1.args == ("hello", "world"), "Subclass args failed"
+print("Subclass creation: OK")
+
+# Test 2: FALLBACK path - custom attributes fall back to dict storage
+e2 = MyException("Test PASS")
+e2.custom_attr = "test" # type: ignore
+assert e2.custom_attr == "test", "Custom attribute failed"  # type: ignore
+print("Dict fallback: OK")

--- a/tests/misc/cexample_subclass.py
+++ b/tests/misc/cexample_subclass.py
@@ -36,3 +36,14 @@ class SubTimer(AdvancedTimer):
 
 
 watch = SubTimer()
+
+# Storing the native "seconds" property must be delegated to the native attr
+# handler and not shadowed in the instance dict.
+# See https://github.com/micropython/micropython/issues/18592.
+print("seconds" in watch.__dict__)
+
+# Attributes that the native handler does not own fall through to normal
+# instance-dict storage, so a subclass can still hold arbitrary attributes.
+watch.extra = "hello"
+print(watch.extra)
+print("extra" in watch.__dict__)

--- a/tests/misc/cexample_subclass.py.exp
+++ b/tests/misc/cexample_subclass.py.exp
@@ -3,3 +3,6 @@ AttributeError
 AttributeError
 0
 123
+False
+hello
+True


### PR DESCRIPTION
## Summary

### Problem Description

When a Python class inherits from a native type that uses an `attr` handler to
implement properties, setting attributes on instances fails to call the native
property setters. Instead, the values are stored in the instance's members
dictionary, shadowing the native properties.

### Root Cause

In `objtype.c`:

- `mp_obj_instance_store_attr()` did not check whether the native base type has
  an `attr` handler before storing attributes in the instance's member
  dictionary.
- For LOAD operations, `mp_obj_class_lookup()` already delegates to the native
  subobject's `attr` handler, but there was no equivalent for STORE operations.

### Solution

Modified `mp_obj_instance_store_attr()` to give the native base's `attr` handler
a chance to handle the store/delete *before* the value is written to the
instance dict:

- **Check for a native base early:** Before any other processing, check whether
  the instance's type has a native base class with an `attr` handler.
- **Delegate to the native handler:** Call the handler following the standard
  `attr` protocol (the same convention used by `mp_store_attr`): `dest[0]` is
  passed as `MP_OBJ_SENTINEL` and `dest[1]` holds the value.
- **Respect the handler's signal:** If the handler owns the attribute it
  performs the store and marks it handled (leaves `dest[0] != MP_OBJ_SENTINEL`),
  and we return success. If it leaves `dest[0] == MP_OBJ_SENTINEL`, it doesn't
  own the attribute, so we fall through to the normal property/descriptor checks
  and dict storage.
- **Let exceptions propagate:** Any exception the handler raises (e.g. a setter
  rejecting an invalid value) propagates to the caller, exactly as in CPython
  for attribute assignment. No special-casing or catching of exceptions is
  needed.

This keeps the implementation small and consistent with how native `attr`
handlers already signal "not handled" elsewhere in the codebase (e.g. the
exception type's handler in `objexcept.c`).

Fixes #18592

## Testing

### `tests/misc/cexample_subclass.py` (extended)

Uses `cexample.AdvancedTimer` — a native type whose `attr` handler implements
`.seconds` as a read/write property and follows the sentinel protocol for every
other attribute. This is a dedicated, well-behaved C-level test object (built
into the unix `coverage` variant), independent of any module-specific quirks.

It verifies, *discriminatingly* (these assertions fail on the pre-fix code):

- **Store delegation (the bug fix):** after `self.seconds = 123`, the store was
  delegated to the native setter and is **not** shadowed in the instance dict
  (`"seconds" not in self.__dict__`).
- **Dict fall-through (Python behaviour preserved):** assigning an attribute the
  handler doesn't own (`self.extra = "hello"`) falls through to normal instance
  `__dict__` storage and reads back correctly.

Coverage of the added `objtype.c` block was confirmed with gcov: both outcomes
of the delegation branch are exercised by this single test (the handler-handled
path and the fall-through path).

### `tests/basics/subclass_native_attrs.py`

Exception-based regression test that runs on all ports: verifies that native
attribute access (`.args`) keeps working on a subclass while arbitrary Python
attributes still fall back to the instance dict.

## Notes

- **Catching `AttributeError`/`KeyError` from the handler (original approach):**
  An earlier version wrapped the handler call in `nlr_push`/`nlr_pop` and, on
  `AttributeError`/`KeyError`, fell back to dict storage. This was dropped per
  review: it's more complex, swallows genuine errors, and is not CPython-like.
  The sentinel protocol already provides a clean "not handled" signal, and real
  errors (e.g. a setter's `TypeError`) should propagate.
- **uctypes as the test vehicle (original test):** The first test was based on
  `uctypes`. It was replaced because the `uctypes` `attr` handler raises
  `KeyError` for unknown fields instead of leaving the sentinel, which coupled
  the test to a uctypes-specific quirk. `cexample.AdvancedTimer` keeps the test
  independent and discriminating.
- **Behavioural note:** A native type whose `attr` handler *raises* (rather than
  leaving the sentinel) for unknown attributes will, by design, propagate that
  exception in subclasses too instead of falling back to the dict. This matches
  the handler's own contract; well-behaved handlers that follow the sentinel
  protocol get dict fall-through for free.
