### PR TITLE
esp32: Actually read from dupterm.

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -138,6 +138,12 @@ int mp_hal_stdin_rx_chr(void) {
         if (c != -1) {
             return c;
         }
+        #if MICROPY_PY_OS_DUPTERM
+        int dupterm_c = mp_os_dupterm_rx_chr();
+        if (dupterm_c >= 0) {
+            return dupterm_c;
+        }
+        #endif
         MICROPY_EVENT_POLL_HOOK
     }
 }


### PR DESCRIPTION
### Summary

The esp32 port didn't read any dupterm input.

### Testing

Running my MoaT-Micro stack on an ESP32-S3, this patch is required to actually feed data to the REPL.