### PR TITLE
mpy-cross/main: Fix build on Loongarch64 and S390x.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -34,7 +35,7 @@
 #include "py/persistentcode.h"
 #include "py/runtime.h"
 #include "py/gc.h"
-#include "py/parsenum.h"
+#include "py/parsenumbase.h"
 #include "genhdr/mpversion.h"
 #ifdef _WIN32
 #include "ports/windows/fmode.h"
@@ -228,45 +229,35 @@ static char *backslash_to_forwardslash(char *path) {
 }
 
 // This will need to be reworked in case mpy-cross needs to set more bits than
-// what its small int representation allows to fit in there.
-static bool parse_integer(const char *value, mp_uint_t *integer) {
+// what `unsigned long` can fit.
+static bool parse_integer(const char *value, unsigned long *integer) {
     assert(value && "Attempting to parse a NULL string");
     assert(integer && "Attempting to store into a NULL integer buffer");
 
     size_t value_length = strlen(value);
-    int base = 10;
-    if (value_length > 2 && value[0] == '0') {
-        if ((value[1] | 0x20) == 'b') {
-            base = 2;
-        } else if ((value[1] | 0x20) == 'x') {
-            base = 16;
-        } else {
-            return false;
-        }
+    int base = 0;
+    size_t skip = mp_parse_num_base(value, value_length, &base);
+    // These can trip strtoul up.
+    if (base < 2 || value_length == skip || value[skip] == '+') {
+        return false;
     }
-
-    bool valid = false;
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        mp_obj_t parsed = mp_parse_num_integer(value, value_length, base, NULL);
-        if (mp_obj_is_small_int(parsed)) {
-            *integer = MP_OBJ_SMALL_INT_VALUE(parsed);
-            valid = true;
-        }
-        nlr_pop();
+    errno = 0;
+    char *end = NULL;
+    *integer = strtoul(value + skip, &end, base);
+    if (end != (value + value_length) || errno != 0) {
+        return false;
     }
-
-    return valid;
+    return true;
 }
 
 #if MICROPY_EMIT_NATIVE && MICROPY_EMIT_RV32
-static bool parse_rv32_flags_string(const char *source, mp_uint_t *flags) {
+static bool parse_rv32_flags_string(const char *source, unsigned long *flags) {
     assert(source && "Flag arguments string is NULL.");
     assert(flags && "Collected flags pointer is NULL.");
 
     const char *current = source;
     const char *end = source + strlen(source);
-    mp_uint_t collected_flags = 0;
+    unsigned long collected_flags = 0;
     while (current < end) {
         const char *separator = strchr(current, ',');
         if (separator == NULL) {
@@ -439,10 +430,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
         #if MICROPY_EMIT_NATIVE && MICROPY_EMIT_RV32
         if (mp_dynamic_compiler.native_arch == MP_NATIVE_ARCH_RV32IMC) {
             mp_dynamic_compiler.backend_options = (void *)&rv32_options;
-            mp_uint_t raw_flags = 0;
+            unsigned long raw_flags = 0;
             if (parse_integer(arch_flags, &raw_flags) || parse_rv32_flags_string(arch_flags, &raw_flags)) {
-                if ((raw_flags & ~((mp_uint_t)RV32_EXT_ALL)) == 0) {
-                    rv32_options.allowed_extensions = raw_flags;
+                if ((raw_flags & ~((unsigned long)RV32_EXT_ALL)) == 0) {
+                    rv32_options.allowed_extensions = (uint8_t)raw_flags;
                     processed = true;
                 }
             }


### PR DESCRIPTION
### Summary

This PR fixes a build error occurring in `mpy-cross` when building on Linux for Loongarch64 and S390x platforms.

GCC would report an error about certain variables not being part of the setjmp scope when parsing the raw architecture flag bits value, as the definitions for those values occurred outside the setjmp scope but they had to be saved and restored as part of the error recovery mechanism.

To work around that, MicroPython's code is used only for detecting the argument base and then a C standard library function is used to perform the string to integer conversion using the detected base.

This fixes #18564.

<hr>

Incidentally, should I submit a PR to add those two architectures to the platform module?  Debian today started to officially support Loongarch64, and both architectures are targets for QEMU... (Maybe Loongarch64 may end up as a CI target in the future?).

### Testing

`mpy-cross` was built successfully using the Loongarch64 cross-compiler available from https://github.com/loong64/cross-tools/releases/tag/20250911 for both glibc and musl, and using the S390x cross-compiler provided by Ubuntu 24.04LTS (gcc-s390x-linux-gnu).

It seems to work under user mode QEMU emulation, but if somebody with real hardware wants to test these changes out, be my guest :)