### PR TITLE
docs: fix machine.Encoder example (use Encoder instead of Counter)

### DIFF
--- a/docs/library/machine.Encoder.rst
+++ b/docs/library/machine.Encoder.rst
@@ -12,7 +12,7 @@ Minimal example usage::
 
     from machine import Pin, Encoder
 
-    counter = Counter(0, Pin(0, Pin.IN), Pin(1, Pin.IN))   # create Encoder for pins 0, 1 and begin counting
+    counter = Encoder(0, Pin(2, Pin.IN), Pin(5, Pin.IN))   # create Encoder for pins 2, 5 and begin counting
     value = counter.value()                                # retrieve current count
 
 Availability: **ESP32**


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

The machine.Encoder example has the Pin and Encoder class imported, but the counter object is instantiated using the Counter class, as below:

from machine import Pin, Encoder
counter = Counter(0, Pin(0, Pin.IN), Pin(1, Pin.IN))  # create Encoder for pins 0, 1 and begin counting
value = counter.value()  # retrieve current count


### Testing

I previewed the corrected example locally.
<img width="1037" height="632" alt="image" src="https://github.com/user-attachments/assets/32e4a590-6145-4078-9ecd-237af1fc2344" />



