### PR TITLE
RP2: Support for DMA Timers

### DIFF
--- a/docs/library/rp2.DMA.rst
+++ b/docs/library/rp2.DMA.rst
@@ -5,7 +5,7 @@ class DMA -- access to the RP2040's DMA controller
 ==================================================
 
 The :class:`DMA` class offers access to the RP2040's Direct Memory Access (DMA)
-controller, providing the ability move data between memory blocks and/or IO registers. The DMA
+controller, providing the ability to move data between memory blocks and/or IO registers. The DMA
 controller has its own, separate read and write bus master connections onto the bus fabric and
 each DMA channel can independently read data from one address and write it back to another
 address, optionally incrementing one or both pointers, allowing it to perform transfers on behalf
@@ -13,6 +13,10 @@ of the processor while the processor carries out other tasks or enters a low pow
 RP2040's DMA controller has 12 independent DMA channels that can run concurrently. For full
 details of the RP2040's DMA system see section 2.5 of the `RP2040 Datasheet
 <https://datasheets.raspberrypi.org/rp2040/rp2040-datasheet.pdf>`_.
+
+The companion class :class:`DMATimer` provides access to the DMA controller's pacing timers.
+These timers can be used to control the speed of transfers into memory or peripherals that do
+not have their own transfer request signalling.
 
 Examples
 --------
@@ -138,7 +142,8 @@ Methods
       disables chaining (this is the default).
 
     - *treq_sel*: ``int`` Select a Transfer Request signal. See section 2.5.3 in the RP2040
-      datasheet for details.
+      datasheet for details. You may also pass a :class:`DMATimer` instance to use that timer
+      for pacing the transfer.
 
     - *irq_quiet*: ``bool`` Do not generate interrupt at the end of each transfer. Interrupts
       will instead be generated when a zero value is written to the trigger
@@ -148,7 +153,7 @@ Methods
     - *bswap*: ``bool`` If set to true, bytes in words or half-words will be reversed before
       writing (default: ``True``).
 
-    - *sniff_en*: ``bool`` Set to ``True`` to allow data to be accessed by the chips sniff
+    - *sniff_en*: ``bool`` Set to ``True`` to allow data to be accessed by the chip's sniff
       hardware (default: ``False``).
 
     - *write_err*: ``bool`` Setting this to ``True`` will clear a previously reported write
@@ -291,3 +296,69 @@ below is a Pythonic version of the example in sub-section 2.5.6.2.
 
 This example idles while waiting for the transfer to complete; alternatively it could
 set an interrupt handler and return immediately.
+
+class DMATimer -- pacing timers for DMA transfers
+=================================================
+
+The RP2040 and RP2350 DMA controllers provide four "pacing" timers that can be used to
+control the rate at which DMA transfers take place. In the absence of specifying a transfer
+request signal using the ``treq_sel`` parameter in the control configuration the DMA controller
+will try to transfer data as fast as the bus will allow, which can be as fast as the system
+clock speed. Often I/O operations should happen
+at some lower rate, and it is also sometimes valuable to moderate the rate of transfers from
+memory to memory in order to avoid overloading the bus (particularly when using external
+PSRAM, which is much slower than the on-chip SRAM). By using a :class:`DMATimer` the user
+can select a rate that is a rational fraction of the system clock speed. Each timer can
+independently trigger transfer requests at rate that is ``X/Y`` times the system clock,
+where ``X < Y``.
+
+:class:`DMATimer` objects can be used directly as the value for treq_sel passed into the
+:meth:`DMA.pack_ctrl()` function, since the value if ``int(dma_timer)`` is the index
+of the transfer request selector for the timer. Thus if you want to pace a transfer to
+run at 10,000 operations per second you can use::
+
+    dma = rp2.DMA()
+    timer = rp2.DMATimer(freq=10000)
+    ctrl = d.pack_ctrl(treq_sel=timer)  # Default control value with paced by the timer
+    dma.config(read=src, write=dst, count=length, ctrl=ctrl, trigger=True)
+
+Note: The underlying DMA pacing timer will get released when a :class:`DMATimer` gets
+garbage collected. If you are setting in motion a DMA transfer that is not expected to
+complete before the timer object goes out of scope then it is a good idea to keep a
+reference to it so that the timer does not get reassigned to some other caller (which
+might change the frequency on you).
+
+Constructor
+-----------
+
+.. class:: DMATimer(timer_id=None, *, freq=None, ratio=None)
+
+    Claim one of the DMA pacing timers for exclusive use and optionally set the frequency or ratio.
+
+    - *timer_id*: Which timer to use. Leave empty to select any unclaimed timer.
+    - *freq*: The optional value to assign to the :attr:`freq` attribute.
+    - *ratio*: The optional value to assign to the :attr:`ratio` attribute.
+
+    If both ``freq`` and ``ratio`` are provided then ``ratio`` is used.
+
+Methods
+-------
+
+.. method:: DMATimer.close()
+
+    Release the exclusive claim on the underlying timer.
+
+Attributes
+----------
+
+.. attribute:: DMATimer.ratio
+
+    Set or read the ``(X, Y)`` tuple for the system clock division ratio. When setting the ratio
+    both X and Y need to in the range 0 < X, Y < 65536.
+
+.. attribute:: DMATimer.freq
+
+    Set or read the DMATimer frequency in Hz. When setting, the frequency will be set to the closest
+    frequency that can be achieved by the divider. Reading the frequency back will show the actual
+    selected frequency, to the nearest 1Hz. The requested value needs be less than or equal to the
+    system clock speed and greater than or equal to 1/65535 of the system clock.

--- a/ports/rp2/modrp2.c
+++ b/ports/rp2/modrp2.c
@@ -95,6 +95,7 @@ static const mp_rom_map_elem_t rp2_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PIO),                 MP_ROM_PTR(&rp2_pio_type) },
     { MP_ROM_QSTR(MP_QSTR_StateMachine),        MP_ROM_PTR(&rp2_state_machine_type) },
     { MP_ROM_QSTR(MP_QSTR_DMA),                 MP_ROM_PTR(&rp2_dma_type) },
+    { MP_ROM_QSTR(MP_QSTR_DMATimer),            MP_ROM_PTR(&rp2_dma_timer_type) },
     { MP_ROM_QSTR(MP_QSTR_bootsel_button),      MP_ROM_PTR(&rp2_bootsel_button_obj) },
 
     #if MICROPY_PY_NETWORK_CYW43

--- a/ports/rp2/modrp2.h
+++ b/ports/rp2/modrp2.h
@@ -32,6 +32,7 @@ extern const mp_obj_type_t rp2_flash_type;
 extern const mp_obj_type_t rp2_pio_type;
 extern const mp_obj_type_t rp2_state_machine_type;
 extern const mp_obj_type_t rp2_dma_type;
+extern const mp_obj_type_t rp2_dma_timer_type;
 
 void rp2_pio_init(void);
 void rp2_pio_deinit(void);

--- a/ports/rp2/rp2_dma.c
+++ b/ports/rp2/rp2_dma.c
@@ -34,6 +34,7 @@
 
 #include "hardware/irq.h"
 #include "hardware/dma.h"
+#include "hardware/clocks.h"
 
 #define CHANNEL_CLOSED 0xff
 
@@ -56,6 +57,216 @@ typedef struct _rp2_dma_ctrl_field_t {
     uint16_t read_only : 1;
     // 7 bits available here.
 } rp2_dma_ctrl_field_t;
+
+typedef struct _rp2_dma_timer_obj_t {
+    mp_obj_base_t base;
+    uint8_t timer_id;
+    bool closed;
+} rp2_dma_timer_obj_t;
+
+
+#define DMA_TIMER_MAX_TERMS 65536
+static inline void rp2_timer_find_best_ratio(uint32_t p, uint32_t q, uint32_t *x, uint32_t *y) {
+    // Find the values x and y such that x/y is the closest fraction to p/q for which
+    // both terms are less than DMA_TIMER_MAX_TERMS.
+
+    // This implementation computes the continued fraction and then checks if the
+    // best semi-convergent is obviously better (i.e. > a/2)
+
+    uint32_t h_curr = 1, k_curr = 0;
+    uint32_t h_prev = 0, k_prev = 1;
+
+    while (q != 0) {
+        uint32_t a = p / q;
+        uint32_t h_next = a * h_curr + h_prev;
+        uint32_t k_next = a * k_curr + k_prev;
+
+        if (h_next >= DMA_TIMER_MAX_TERMS || k_next >= DMA_TIMER_MAX_TERMS) {
+            // The next convergent would overflow. Check if there is obviously a better semi-convergent.
+            // If there is a value of n that is >= a/2 then it will always be better than the current ratio.
+            uint32_t n = DMA_TIMER_MAX_TERMS;
+            if (h_curr) {
+                n = (DMA_TIMER_MAX_TERMS - 1 - h_prev) / h_curr;
+            }
+            if (k_curr) {
+                uint32_t nk = (DMA_TIMER_MAX_TERMS - 1 - k_prev) / k_curr;
+                if (nk < n) {
+                    n = nk;
+                }
+            }
+
+            if (n != DMA_TIMER_MAX_TERMS && n > 0 && n >= (a + 1) / 2) {
+                *x = n * h_curr + h_prev;
+                *y = n * k_curr + k_prev;
+                return;
+            }
+            // We didn't find a better n, so break out of the loop
+            break;
+        }
+        uint32_t r = p % q;
+        p = q;
+        q = r;
+        h_prev = h_curr;
+        k_prev = k_curr;
+        h_curr = h_next;
+        k_curr = k_next;
+    }
+
+    *x = h_curr;
+    *y = k_curr;
+}
+
+static void rp2_dma_timer_set_freq(rp2_dma_timer_obj_t *self, mp_obj_t f_obj) {
+    const mp_int_t freq = mp_obj_get_int(f_obj);
+    uint32_t sys_clk_hz = clock_get_hz(clk_sys);
+
+    // Value needs to be between 1 and 1/65535 times the sysclk frequency
+    if (freq > sys_clk_hz || (sys_clk_hz / 65535) > freq) {
+        mp_raise_ValueError(MP_ERROR_TEXT("value out of range"));
+    }
+    uint32_t x, y;
+    rp2_timer_find_best_ratio(freq, sys_clk_hz, &x, &y);
+    dma_timer_set_fraction(self->timer_id, (uint16_t)x, (uint16_t)y);
+}
+
+static void rp2_dma_timer_set_ratio(rp2_dma_timer_obj_t *self, mp_obj_t o) {
+    // Value needs to be a 2-tuple
+    mp_obj_t *num_dom;
+    mp_obj_get_array_fixed_n(o, 2, &num_dom);
+
+    const mp_int_t numerator = mp_obj_get_int(num_dom[0]);
+    const mp_int_t denominator = mp_obj_get_int(num_dom[1]);
+    if (numerator < 1 || numerator > 65535 || denominator < 1 || denominator > 65535 || numerator > denominator) {
+        mp_raise_ValueError(MP_ERROR_TEXT("value out of range"));
+    }
+    dma_timer_set_fraction(self->timer_id, (uint16_t)numerator, (uint16_t)denominator);
+}
+
+static mp_obj_t rp2_dma_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    enum { ARG_id, ARG_freq, ARG_ratio };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_,     MP_ARG_OBJ,                  {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_freq,  MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+        { MP_QSTR_ratio, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
+    };
+    mp_arg_val_t parsed[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all_kw_array(n_args, n_kw, args, MP_ARRAY_SIZE(allowed_args), allowed_args, parsed);
+
+    int dma_timer_id;
+
+    if (parsed[ARG_id].u_obj != MP_OBJ_NULL) {
+        dma_timer_id = mp_obj_get_int(parsed[ARG_id].u_obj);
+        if (dma_timer_id < 0 || dma_timer_id >= 4) {
+            mp_raise_ValueError(MP_ERROR_TEXT("value out of range"));
+        }
+        if (dma_timer_is_claimed(dma_timer_id)) {
+            mp_raise_OSError(MP_EBUSY);
+        }
+        dma_timer_claim(dma_timer_id);
+    } else {
+        dma_timer_id = dma_claim_unused_timer(false);
+        if (dma_timer_id < 0) {
+            mp_raise_OSError(MP_EBUSY);
+        }
+    }
+
+    rp2_dma_timer_obj_t *self = mp_obj_malloc_with_finaliser(rp2_dma_timer_obj_t, &rp2_dma_timer_type);
+    self->timer_id = dma_timer_id;
+    self->closed = false;
+
+    // If you try to set both, "ratio" wins over "freq"
+    if (parsed[ARG_ratio].u_obj != MP_OBJ_NULL) {
+        rp2_dma_timer_set_ratio(self, parsed[ARG_ratio].u_obj);
+    } else if (parsed[ARG_freq].u_obj != MP_OBJ_NULL) {
+        rp2_dma_timer_set_freq(self, parsed[ARG_freq].u_obj);
+    }
+
+    // Return the DMA object.
+    return MP_OBJ_FROM_PTR(self);
+}
+
+static void rp2_dma_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    rp2_dma_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_printf(print, "%q(%u)", MP_QSTR_DMATimer, self->timer_id);
+}
+
+static void rp2_dma_timer_attr(mp_obj_t self_in, qstr attr_in, mp_obj_t *dest) {
+    rp2_dma_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (dest[0] == MP_OBJ_NULL) {
+        // Load attribute
+        if (attr_in == MP_QSTR_freq) {
+            uint32_t sys_clk_hz = clock_get_hz(clk_sys);
+            uint32_t reg_value = dma_hw->timer[self->timer_id];
+            uint32_t num = (reg_value >> DMA_TIMER0_X_LSB) & 0xffff;
+            uint32_t dom = (reg_value >> DMA_TIMER0_Y_LSB) & 0xffff;
+            uint64_t fx = ((uint64_t)sys_clk_hz) * ((uint64_t)num);
+            fx /= dom;
+            dest[0] = mp_obj_new_int_from_uint((uint)fx);
+        } else if (attr_in == MP_QSTR_ratio) {
+            uint32_t reg_value = dma_hw->timer[self->timer_id];
+            mp_obj_t num_dom[2];
+            num_dom[0] = mp_obj_new_int_from_uint((reg_value >> DMA_TIMER0_X_LSB) & 0xffff);
+            num_dom[1] = mp_obj_new_int_from_uint((reg_value >> DMA_TIMER0_Y_LSB) & 0xffff);
+
+            dest[0] = mp_obj_new_tuple(2, num_dom);
+        } else {
+            // Continue attribute search in locals dict.
+            dest[1] = MP_OBJ_SENTINEL;
+        }
+    } else {
+        // Set or delete attribute
+        if (dest[1] == MP_OBJ_NULL) {
+            // We don't support deleting attributes.
+            return;
+        }
+
+        if (attr_in == MP_QSTR_freq) {
+            rp2_dma_timer_set_freq(self, dest[1]);
+            dest[0] = MP_OBJ_NULL; // indicate success
+        } else if (attr_in == MP_QSTR_ratio) {
+            rp2_dma_timer_set_ratio(self, dest[1]);
+            dest[0] = MP_OBJ_NULL; // indicate success
+        }
+    }
+}
+
+static mp_obj_t rp2_dma_timer_unary_op(mp_unary_op_t op, mp_obj_t o_in) {
+    rp2_dma_timer_obj_t *self = MP_OBJ_TO_PTR(o_in);
+    if (op == MP_UNARY_OP_INT_MAYBE) {
+        // The value of int(timer) is the DMA pacing request index (treq_sel)
+        return mp_obj_new_int_from_uint((mp_uint_t)dma_get_timer_dreq(self->timer_id));
+    }
+    return MP_OBJ_NULL;
+}
+
+static mp_obj_t rp2_dma_timer_close(mp_obj_t self_in) {
+    rp2_dma_timer_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (!self->closed) {
+        dma_timer_unclaim(self->timer_id);
+        self->closed = true;
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(rp2_dma_timer_close_obj, rp2_dma_timer_close);
+
+static const mp_rom_map_elem_t rp2_dma_timer_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_close), MP_ROM_PTR(&rp2_dma_timer_close_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&rp2_dma_timer_close_obj) },
+};
+static MP_DEFINE_CONST_DICT(rp2_dma_timer_locals_dict, rp2_dma_timer_locals_dict_table);
+
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    rp2_dma_timer_type,
+    MP_QSTR_DMATimer,
+    MP_TYPE_FLAG_NONE,
+    make_new, rp2_dma_timer_make_new,
+    print, rp2_dma_timer_print,
+    attr, rp2_dma_timer_attr,
+    locals_dict, &rp2_dma_timer_locals_dict,
+    unary_op, rp2_dma_timer_unary_op
+    );
 
 static const rp2_dma_ctrl_field_t rp2_dma_ctrl_fields_table[] = {
     { MP_QSTR_enable, DMA_CH0_CTRL_TRIG_EN_LSB, 1, 0 },
@@ -158,7 +369,7 @@ static mp_obj_t rp2_dma_make_new(const mp_obj_type_t *type, size_t n_args, size_
     return MP_OBJ_FROM_PTR(self);
 }
 
-static void rp2_dma_error_if_closed(rp2_dma_obj_t *self) {
+static void rp2_dma_error_if_closed(rp2_dma_obj_t const *self) {
     if (self->channel == CHANNEL_CLOSED) {
         mp_raise_ValueError(MP_ERROR_TEXT("channel closed"));
     }

--- a/tests/ports/rp2/rp2_dma_timer.py
+++ b/tests/ports/rp2/rp2_dma_timer.py
@@ -1,0 +1,84 @@
+# Test rp2.DMATimer functionality.
+
+import time
+import machine
+import rp2
+import unittest
+
+K = 16
+
+SRC = bytes(i & 0xFF for i in range(K << 10))
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.timer = rp2.DMATimer(0)
+        self.dma = rp2.DMA()
+
+    def tearDown(self):
+        self.dma.close()
+        self.timer.close()
+
+    def test_printing(self):
+        timer = self.timer
+        self.assertEqual(str(timer), "DMATimer(0)")
+
+    def test_set_ratio_unity(self):
+        timer = self.timer
+        timer.ratio = (1, 1)
+        self.assertEqual(timer.ratio, (1, 1))
+
+    def test_set_ratio(self):
+        timer = self.timer
+        timer.ratio = (1, 1)
+        base_clock = timer.freq
+        num, den = (47, 97)
+        target = base_clock * num // den
+        timer.ratio = (num, den)
+        self.assertEqual(timer.freq, target)
+
+    def test_set_freq(self):
+        timer = self.timer
+        timer.ratio = (1, 1)
+        base_clock = timer.freq
+        num, den = (53, 101)
+        target = base_clock * num // den
+        timer.freq = target
+        self.assertEqual(timer.ratio, (num, den))
+
+    def test_speed_throttle(self):
+        def time_dma(d):
+            start = time.ticks_us()
+            d.active(1)
+            while d.active():
+                pass
+            end = time.ticks_us()
+            return time.ticks_diff(end, start)
+
+        speeds = [5000 * (10**i) for i in range(4)]
+        dma = self.dma
+        timer = self.timer
+        ctrl = dma.pack_ctrl(treq_sel=timer)
+        dest = bytearray(2048)
+
+        times = []
+        deltas = []
+
+        for i, speed in enumerate(speeds):
+            timer.freq = speed
+            dma.config(read=SRC, write=dest, count=len(dest) // 4, ctrl=ctrl)
+            t = time_dma(dma)
+            times.append(t)
+            if i > 0:
+                deltas.append(times[i - 1] - t)
+
+        # The ratio between the first two times should be very close to 10
+        self.assertIn(times[0] * 10 // times[1], range(95, 105))
+
+        # The ratios between successive deltas (which removes the overhead) should also be about 10
+        for i in range(len(deltas) - 1):
+            self.assertIn(deltas[i] * 10 // deltas[i + 1], range(95, 105))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

The RP2 DMA controller includes four pacing timers that can be used to control the rate of transfers. This PR adds a new `DMATimer` class to make it easy to use these timers with DMA channels being accessed through the existing `DMA` class.

The new `DMATimer` class allows the user to claim a specific timer or for one to be selected automatically from the free timers. Once selected, the rate can be set either by directly setting the divider `ratio` attribute to an X,Y tuple  or to a desired frequency by setting the `freq` attribute. In the later case the divider ratio will silently be set to the value that yields the closest frequency and the actual frequency (and divider ratio) can be read back using the attributes. The correct value needed for the `treq_sel` in the DMA configuration can be read from an attribute of the same name.

### Testing

The code has been tested on Pi Pico W and Pi Pico2 W boards, but should work directly on any board that supports the RP2 DMA class.

Setting the divider ratio, both directly and indirectly by setting the frequency, has been tested both for checks on input value ranges and also to ensure that the DMA transfer rates are correctly throttled by (performing timing checks for memory-memory transfers at various rates).

### Trade-offs and Alternatives

While this code is fairly small, a substantial part of the code is the Stern-Brocot search for the best divider ratio for the target frequency. This code is already simplified to remove the more complex check for the true best fit semi-convergent, accepting a good fit in exchange for removing some complex code, but it could be made even simpler is less good fits were acceptable. Note that unlike the divider for the SPI controller, the DMA timers support 16 bit numerator and denominator for the divider, so the linear searches used there are not appropriate here since the search space is too large for that to be efficient.

