### PR TITLE
rp2: Correct bit access for rp2_state_machine_init.

### DIFF
--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -230,7 +230,7 @@ typedef struct _asm_pio_config_t {
 
 static void asm_pio_override_shiftctrl(mp_obj_t arg, uint32_t bits, uint32_t lsb, pio_sm_config *config) {
     if (arg != mp_const_none) {
-        config->shiftctrl = (config->shiftctrl & ~bits) | (mp_obj_get_int(arg) << lsb);
+        config->shiftctrl = (config->shiftctrl & ~bits) | ((mp_obj_get_int(arg) << lsb) & bits);
     }
 }
 


### PR DESCRIPTION
If you call `rp2.StateMachine.init()` with `pull_thresh=32` it will overwrite the `FJOIN_TX` bit in the `SMx_SHIFTCTRL` register. This PR fixes that issue.

### Summary

I had a PIO program in which the RXFIFO was not working. I traced it down to `asm_pio_override_shiftctrl()` shifting the high bit of my `pull_thresh` argument of 32 into the adjoining bit 30 (`FJOIN_TX`) of the `SMx_SHIFTCTRL` register. A threshold of 32 should be encoded as a 0 in bits 29:25 of this register.

This PR uses the bit mask provided as an argument to `asm_pio_override_shiftctrl()` to ensure that bits outside the field don't get stepped on.

### Testing

I tested this with an RP2350 board and a Segger JLINK to ensure that the values in the register were correct.
