### PR TITLE
Update RTC-Pins for ESP32C6

### DIFF
--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -32,6 +32,21 @@
     )
     #define RTC_LAST_EXT_PIN 21
 
+#elif CONFIG_IDF_TARGET_ESP32C6
+
+    #define RTC_VALID_EXT_PINS \
+    ( \
+    (1ll << 0) | \
+    (1ll << 1) | \
+    (1ll << 2) | \
+    (1ll << 3) | \
+    (1ll << 4) | \
+    (1ll << 5) | \
+    (1ll << 6) | \
+    (1ll << 7)   \
+    )
+    #define RTC_LAST_EXT_PIN 7
+
 #else
 
     #define RTC_VALID_EXT_PINS \


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
According to https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/#demo1-deep-sleep-with-external-wake-up and https://docs.espressif.com/projects/esp-idf/en/stable/esp32c6/api-reference/peripherals/gpio.html ESP32C6 supports RTC/LP on Pins 0-7 instead of the RTC-Pins that ESP32 uses.


<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->
With this change esp32.wake_on_ext1 can use all the pins, that enable wakeup.


### Testing

Manually tested on ESP32C6 Pin 1 only. Doesn't seem to make sense on any other board and I have no board available to test the other pins, because my board only makes LP-GPIO 0-2 available.
<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->
