### PR TITLE
tools/ci.sh: Update Unix/Arm and Unix/MIPS targets to Ubuntu 24.04 LTS.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -266,10 +266,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   qemu_arm:
-    # ubuntu-22.04 is needed for older libffi.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_qemu_arm_setup
     - name: Build

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -247,10 +247,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   qemu_mips:
-    # ubuntu-22.04 is needed for older libffi.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_qemu_mips_setup
     - name: Build

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -288,6 +288,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_qemu_riscv64_setup
     - name: Build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -936,11 +936,11 @@ function ci_unix_qemu_mips_run_tests {
 
 function ci_unix_qemu_arm_setup {
     sudo apt-get update
-    sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
-    sudo apt-get install qemu-user
-    qemu-arm --version
-    sudo mkdir /etc/qemu-binfmt
-    sudo ln -s /usr/arm-linux-gnueabi/ /etc/qemu-binfmt/arm
+    sudo apt-get install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi libltdl-dev
+    sudo apt-get install qemu-user-static
+    qemu-arm-static --version
+    sudo mkdir -p /usr/gnemul
+    sudo ln -s /usr/arm-linux-gnueabi /usr/gnemul/qemu-arm
 }
 
 function ci_unix_qemu_arm_build {
@@ -950,12 +950,11 @@ function ci_unix_qemu_arm_build {
 
 function ci_unix_qemu_arm_run_tests {
     # Issues with ARM tests:
-    # - (i)listdir does not work, it always returns the empty list (it's an issue with the underlying C call)
     # - thread/stress_aes.py takes around 70 seconds
     # - thread/stress_recurse.py is flaky
     # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'vfs_posix.*\.py|thread/stress_recurse.py|thread/thread_gc1.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py')
 }
 
 function ci_unix_qemu_riscv64_setup {

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -961,8 +961,8 @@ function ci_unix_qemu_riscv64_setup {
     ci_gcc_riscv_setup
     sudo apt-get update
     sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libltdl-dev
-    sudo pip3 install pyelftools
-    sudo pip3 install ar
+    python3 -m pip install pyelftools
+    python3 -m pip install ar
     sudo apt-get install qemu-user-static
     qemu-riscv64-static --version
     sudo mkdir -p /usr/gnemul
@@ -977,13 +977,12 @@ function ci_unix_qemu_riscv64_build {
 
 function ci_unix_qemu_riscv64_run_tests {
     # Issues with RISCV-64 tests:
-    # - misc/sys_settrace_features.py doesn't work with CPython 3.12
     # - thread/stress_aes.py takes around 180 seconds
     # - thread/stress_recurse.py is flaky
     # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
     pushd tests
-    MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=200 ./run-tests.py --exclude 'misc/sys_settrace_features.py|thread/stress_recurse.py|thread/thread_gc1.py'
+    MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=200 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py'
     MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-natmodtests.py extmod/btree*.py extmod/deflate*.py extmod/framebuf*.py extmod/heapq*.py extmod/random_basic*.py extmod/re*.py
     popd
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -913,11 +913,11 @@ function ci_unix_macos_run_tests {
 
 function ci_unix_qemu_mips_setup {
     sudo apt-get update
-    sudo apt-get install gcc-mips-linux-gnu g++-mips-linux-gnu libc6-mips-cross
-    sudo apt-get install qemu-user
-    qemu-mips --version
-    sudo mkdir /etc/qemu-binfmt
-    sudo ln -s /usr/mips-linux-gnu/ /etc/qemu-binfmt/mips
+    sudo apt-get install gcc-mips-linux-gnu g++-mips-linux-gnu libc6-mips-cross libltdl-dev
+    sudo apt-get install qemu-user-static
+    qemu-mips-static --version
+    sudo mkdir -p /usr/gnemul
+    sudo ln -s /usr/mips-linux-gnu /usr/gnemul/qemu-mips
 }
 
 function ci_unix_qemu_mips_build {
@@ -927,11 +927,11 @@ function ci_unix_qemu_mips_build {
 
 function ci_unix_qemu_mips_run_tests {
     # Issues with MIPS tests:
-    # - thread/stress_aes.py takes around 50 seconds
+    # - thread/stress_aes.py takes around 90 seconds
     # - thread/stress_recurse.py is flaky
     # - thread/thread_gc1.py is flaky
     file ./ports/unix/build-coverage/micropython
-    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=90 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py')
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython MICROPY_TEST_TIMEOUT=180 ./run-tests.py --exclude 'thread/stress_recurse.py|thread/thread_gc1.py')
 }
 
 function ci_unix_qemu_arm_setup {


### PR DESCRIPTION
### Summary

This PR updates some of the Unix targets to run on a more recent Ubuntu LTS OS image.

The targets covered by this PR are Arm and MIPS, whose setup is largely equivalent to RV64 (which already runs on `ubuntu-latest`).

Besides a more recent version of QEMU to run the code with, the Arm sysroot now contains fixes for listdir/ilistdir issues which let previously excluded VFS Posix tests run once more.  However, the updated OS image uses CPython 3.12 which is not compatible with `tests/misc/sys_settrace_features.py`, which has been disabled in both affected targets.

x86/x64 targets can get the same treatment and run on a more recent OS image, but they require more changes that are not limited to the CI runner configuration or build/run commands [1].  That's better left to its own PR since it may require more thought to get it done properly.

### Testing

Besides manual build runs, CI runs have run successfully on my own repo branch.

### Trade-offs and Alternatives

The Unix/Arm port should - in theory - be able to load and run native modules, however there's no build configuration in `py/dynruntime.mk`.  As with the x86 changes that is better left to its own PR if that's something worth having.

<hr>

[1] The way to get 32-bit x86 targets to work on the newer OS image require treating that target as if it were a pure cross-compilation target, which means enabling `MICROPY_STANDALONE` and not using `gcc -m32` to build code but installing the i686 cross compilation packages and run `i686-linux-gnu-gcc` instead.

This works for the main executable and the FFI helper when built under CI but creates some interesting problems when it comes to native modules and interactive builds.

Native modules' `x86` build profile is still using `gcc -m32`, and using `i686-linux-gnu-gcc` as a default may or may not be an unacceptable compatibility break.  Then there's the usage of `MICROPY_FORCE_32BIT` by both the Unix port's makefile and by the CI build functions.  `MICROPY_FORCE_32BIT` isn't compatible with cross-compilation, as it assumes a x86 target since it appends the `-m32` flag to the compiler command line and forces the target architecture for MPY files to `x86`.

Whilst this works for x86/x64, there is already one more mixed 32/64 bits architecture currently supported (RV32/RV64) and one that's trivial to add (AArch32/AArch64) with which `MICROPY_FORCE_32BIT` wouldn't work, as `-m32` isn't a valid compiler flag.  Ignoring RISC-V and Arm, leaving the `-m32` flag in the compiler command line, together with `MICROPY_STANDALONE` would still yield a valid command line for `i686-linux-gnu-gcc`, but it would let `libffi` place its output files in `…/lib32` rather than `…/lib` - breaking the build script.