### PR TITLE
code_size: Use same ubuntu as ports_esp32.

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
### Summary

https://github.com/micropython/micropython/pull/18227 led to failures building the esp32 port during the code size step.

One difference I noticed between the two workflows is the Python version, which is due to the Ubuntu version. This causes the esp-idf cache to not be usable, among other things.

### Testing

Neither Damien nor I have had success at reproducing this locally, so I'll be checking what happens during the CI run on github.

### Trade-offs and Alternatives

It might be the case that using actions/setup-python to install a specific python version would be preferable. I was not able to determine right away why the code size build refers to 22.04 instead of 24.04 or latest.
