### PR TITLE
tools/ci.sh: Update Unix/x86 target to Ubuntu 24.04 LTS.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -103,9 +103,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   coverage_32bit:
-    runs-on: ubuntu-22.04 # use 22.04 to get libffi-dev:i386
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_32bit_setup
     - name: Build
@@ -121,9 +126,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   nanbox:
-    runs-on: ubuntu-22.04 # use 22.04 to get libffi-dev:i386
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_32bit_setup
     - name: Build
@@ -135,9 +145,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   longlong:
-    runs-on: ubuntu-22.04 # use 22.04 to get libffi-dev:i386
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_32bit_setup
     - name: Build
@@ -218,9 +233,14 @@ jobs:
       run: tests/run-tests.py --print-failures
 
   repr_b:
-    runs-on: ubuntu-22.04 # use 22.04 to get libffi-dev:i386
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
     - name: Install packages
       run: tools/ci.sh unix_32bit_setup
     - name: Build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -777,9 +777,8 @@ function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
     sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
-    sudo pip3 install setuptools
-    sudo pip3 install pyelftools
-    sudo pip3 install ar
+    python -m pip install pyelftools
+    python -m pip install ar
     gcc --version
     python3 --version
 }


### PR DESCRIPTION
### Summary

This PR updates the Unix/x86 CI targets to the latest Ubuntu LTS OS image.

Unix/x86 CI jobs were pinned to Ubuntu 22.04 due to a dependency on the i386 version of `libffi-dev`.

Turns out that the pinning wasn't really needed.  Updating the base image, overriding the Python binary for the `runner` user, and installing the required Python packages using the installation's `pip` module was enough to make all tested x86 variants build and pass tests.

### Testing

Besides manual builds, this was successfully built and tested by CI on my own branch.

<hr>

This doesn't address the fact that x86 natmods still rely on `gcc -m32`, and that 32-bits CI jobs expect to be executed on x64.  This PR originally changed the 32-bits compiler first (`gcc-i686-linux-gnu` conflicts with `gcc-multilib`) and then the OS image, but in doing so it raises a few issues related to `MICROPY_FORCE_32BIT`.

I reckon it'd be helpful to either retire `MICROPY_FORCE_32BIT` or to add another variable that identifies the target platform.
`MICROPY_FORCE_32BIT` fails to build 32-bits binaries on AArch64 and RISC-V 64 since it forces `-m32` to the compiler/linker command line, and that only works on x86.

I'd personally retire the option: CI jobs can easily provide an explicit 32-bits cross-compilation target if they so require, and people that need to build x86 MicroPython interpreters are probably skilled enough to provide the necessary cross-compilation flags when running `make`.

Retiring that option also makes it easier to eventually run Unix tests on Linux/Arm64 too, since there'd be no platform dependency on x86/x64 anymore as far as CI is concerned, and GitHub started providing Arm64 runners last year.