### PR TITLE
extmod/modlwip.c: fix issue #3594

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -463,6 +463,8 @@ static void udp_raw_incoming(lwip_socket_obj_t *socket, struct pbuf *p, const ip
         slot->peer_addr = *addr;
         slot->peer_port = port;
         socket->incoming.udp_raw.iput = (socket->incoming.udp_raw.iput + 1) % LWIP_INCOMING_PACKET_QUEUE_LEN;
+        // Notify user callback of the new packet
+        exec_user_callback(socket);
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

Fixes issue #3594.

This change will notify the modlwip user callback of a newly-received UDP or RAW packet.

User callbacks allow code to respond to incoming messages without blocking or polling. User callbacks are optional, and if no callback is registered the code has no effect.

The mechanism is the same as for TCP: when a connection is accepted or a TCP packet is received, a user callback is executed. 

A particular need for callbacks is found in any application that runs as a background service. For example, the user callback feature is used in webrepl.py for TCP: https://github.com/micropython/micropython-lib/blob/6ae440a8a144233e6e703f6759b7e7a0afaa37a4/micropython/net/webrepl/webrepl.py#L104 . This change allows similar services to be written for UDP.

### Testing

Tested on RPi Pico 2 W with ports/rp2 with a test program: 

[test_3594_fix.py](https://github.com/user-attachments/files/24508787/test_3594_fix.py)

This fix is not platform specific, and should work on all ports that include modlwip.

### Trade-offs and Alternatives

Without this fix, the only way for a Python program to receive UDP messages is by blocking or polling, as there is no way for LwIP to notify Python code that a message has been received. The message waits in a queue until user code calls `recvfrom` or similar. This small increase in code size allows UDP messages to be processed immediately without blocking or polling.