### PR TITLE
unix: Remove usages of the  `MICROPY_FORCE_32BIT` flag.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -16,6 +16,10 @@ endif
 # If the build directory is not given, make it reflect the variant name.
 BUILD ?= build-$(VARIANT)
 
+ifneq ($(MICROPY_FORCE_32BIT),)
+$(warning *** The MICROPY_FORCE_32BIT flag is no longer affecting builds, please update your environment ***)
+endif
+
 include ../../py/mkenv.mk
 -include mpconfigport.mk
 include $(VARIANT_DIR)/mpconfigvariant.mk
@@ -107,11 +111,7 @@ endif
 # while cross-compile ports require gcc, so we test here for OSX and
 # if necessary override the value of 'CC' set in py/mkenv.mk
 ifeq ($(UNAME_S),Darwin)
-ifeq ($(MICROPY_FORCE_32BIT),1)
-CC = clang -m32
-else
 CC = clang
-endif
 # Use clang syntax for map file
 LDFLAGS_ARCH = -Wl,-map,$@.map -Wl,-dead_strip
 else
@@ -174,11 +174,7 @@ ifeq ($(MICROPY_STANDALONE),1)
 GIT_SUBMODULES += lib/libffi
 DEPLIBS += libffi
 LIBFFI_CFLAGS := -I$(shell ls -1d $(BUILD)/lib/libffi/include)
- ifeq ($(MICROPY_FORCE_32BIT),1)
-  LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib32/libffi.a
- else
-  LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib/libffi.a
- endif
+LIBFFI_LDFLAGS = $(BUILD)/lib/libffi/out/lib/libffi.a
 else
 # Use system version of libffi.
 LIBFFI_CFLAGS := $(shell pkg-config --cflags libffi)
@@ -237,12 +233,6 @@ SRC_QSTR += $(SRC_C) $(SRC_CXX) $(SHARED_SRC_C)
 
 ifneq ($(FROZEN_MANIFEST),)
 CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
-endif
-
-ifeq ($(MICROPY_FORCE_32BIT),1)
-ifeq ($(RUN_TESTS_MPY_CROSS_FLAGS),)
-RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-march=x86'
-endif
 endif
 
 ifeq ($(CROSS_COMPILE),arm-linux-gnueabi-)

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -240,7 +240,9 @@ CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 endif
 
 ifeq ($(MICROPY_FORCE_32BIT),1)
+ifeq ($(RUN_TESTS_MPY_CROSS_FLAGS),)
 RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-march=x86'
+endif
 endif
 
 ifeq ($(CROSS_COMPILE),arm-linux-gnueabi-)

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -19,7 +19,7 @@ To build the unix port locally then you will need:
 
 * git command line executable, unless you downloaded a source .tar.xz file from
   https://micropython.org/download/
-* gcc (or clang for macOS) toolchain
+* an appropriate GCC or Clang toolchain for your target (macOS only supports Clang)
 * GNU Make
 * Python 3.x
 
@@ -167,7 +167,7 @@ optimisations, assertions enabled, and debug symbols.
 
 ### Sanitizers
 
-Sanitizers are extra runtime checks supported by gcc and clang. The CI process
+Sanitizers are extra runtime checks supported by GCC and Clang. The CI process
 supports building with the "undefined behavior" (UBSan) or "address" (ASan)
 sanitizers. The script `tools/ci.sh` is the source of truth about how to build
 and run in these modes.
@@ -182,3 +182,125 @@ Several classes of checks are disabled via compiler flags:
   check is intended to make sure locals in a "returned from" stack frame are not
   used. However, this mode interferes with various assumptions that
   MicroPython's stack checking, NLR, and GC rely on.
+
+### Notes about x86 (i686) support
+
+It used to be possible to create an x86 (32-bits) build on a x64 (64-bits) host
+by passing `MICROPY_FORCE_32BIT=1` to `make`.  That option was retired: x86
+usage has declined quite a bit in the past few years, and MicroPython now
+supports at least one more mixed 32/64-bits target architecture for which
+enabling `MICROPY_FORCE_32BIT` would make builds fail.
+
+x86 will be treated as a cross-compilation target from now on.  This means you
+will need to install a suitable compiler (on Ubuntu you can install either the
+`gcc-i686-linux-gnu` and `g++-i686-linux-gnu` packages for GCC, or the `clang`
+package for Clang, for example) and pass the appropriate command arguments to
+`make` depending on which compiler you chose.
+
+### Building x86 (i686) code with GCC
+
+For GCC, you will need to pass the toolchain's command prefix to the
+`CROSS_COMPILE` command line variable.
+
+This change is also extended to native modules, for which you may need to pass
+the toolchain's command prefix to the `CROSS` command line variable if your
+x86 compiler cannot be invoked with `i686-linux-gnu-gcc`.
+
+Or, as an example:
+
+```bash
+$ printf "%s %s %s %s\n" $(lsb_release -d | cut -f 2) $(uname -m)
+Ubuntu 24.04.4 LTS x86_64
+
+$ i686-linux-gnu-gcc --version | head -n 1
+i686-linux-gnu-gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+
+$ CROSS_COMPILE=i686-linux-gnu- make -C ports/unix
+make: Entering directory '/ports/unix'
+Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
+...
+LINK build-standard/micropython
+   text    data     bss     dec     hex filename
+ 723115   36104    2124  761343   b9dff build-standard/micropython
+make: Leaving directory '/ports/unix'
+
+$ file -b ports/unix/build-standard/micropython | cut -d, -f-2
+ELF 32-bit LSB pie executable, Intel 80386
+
+# `i686-linux-gnu-` is the default prefix for x86 native modules now, it has
+# been explicitly mentioned here in case you want to see how to set it.
+
+$ make -C examples/natmod/features0 ARCH=x86 CROSS=i686-linux-gnu-
+make: Entering directory '/examples/natmod/features0'
+GEN build/features0.config.h
+CC features0.c
+LINK build/features0.o
+arch:         EM_386
+text size:    192
+bss size:     0
+GOT entries:  4
+GEN features0.mpy
+make: Leaving directory '/examples/natmod/features0'
+
+$ cd examples/natmod/features0 && ../../../ports/unix/build-standard/micropython
+MicroPython v1.29.0-preview.490.gb4c58f7ba5.dirty on 2026-07-04; linux [GCC 13.3.0] version
+Type "help()" for more information.
+>>> import features0
+>>> features0.factorial(10)
+3628800
+```
+
+### Building x86 (i686) code with Clang
+
+For Clang, you will need need to pass both the name of the compiler to invoke
+as the `CC` command line variable and the extra command line arguments needed
+to let Clang know you are building an i686 binary as the `CFLAGS_EXTRA` and
+`LDFLAGS_EXTRA` command line variables (usually
+`--target=i686-unknown-linux-gnu`).
+
+For native modules, since linking is not done by the compiler, only the `CC`
+and `CFLAGS_EXTRA` arguments are needed.
+
+Or, as an example:
+
+```bash
+$ printf "%s %s %s %s\n" $(lsb_release -d | cut -f 2) $(uname -m)
+Ubuntu 24.04.4 LTS x86_64
+
+$ clang --version | head -1
+Ubuntu clang version 18.1.3 (1ubuntu1)
+
+$ clang -print-targets | grep -i 32-bit.x86
+    x86         - 32-bit X86: Pentium-Pro and above
+
+$ make -C ports/unix CC=clang CFLAGS_EXTRA="--target=i686-unknown-linux-gnu" LDFLAGS_EXTRA='--target=i686-unknown-linux-gnu'
+make: Entering directory '/ports/unix'
+Use make V=1 or set BUILD_VERBOSE in your environment to increase build verbosity.
+...
+LINK build-standard/micropython
+   text    data     bss     dec     hex filename
+ 836241   34748    2052  873041   d5251 build-standard/micropython
+make: Leaving directory '/ports/unix'
+
+$ file -b ports/unix/build-standard/micropython | cut -d, -f-2
+ELF 32-bit LSB pie executable, Intel 80386
+
+$ make -C examples/natmod/features0 ARCH=x86 CC=clang CFLAGS_EXTRA="--target=i686-unknown-linux-gnu"
+make: Entering directory '/examples/natmod/features0'
+GEN build-x86/features0.config.h
+CC features0.c
+LINK build-x86/features0.o
+arch:         EM_386
+text size:    180
+bss size:     0
+GOT entries:  2
+GEN features0.mpy
+make: Leaving directory '/examples/natmod/features0'
+
+$ cd examples/natmod/features0 && ../../../ports/unix/build-standard/micropython
+MicroPython v1.29.0-preview.490.gb4c58f7ba5.dirty on 2026-07-04; linux [Clang 18.1.3] version
+Type "help()" for more information.
+>>> import features0
+>>> features0.factorial(10)
+3628800
+```

--- a/ports/unix/mpconfigport.mk
+++ b/ports/unix/mpconfigport.mk
@@ -1,8 +1,5 @@
 # Enable/disable modules and 3rd-party libs to be included in interpreter
 
-# Build 32-bit binaries on a 64-bit host
-MICROPY_FORCE_32BIT = 0
-
 # This variable can take the following values:
 #  0 - no readline, just simple stdin input
 #  1 - use MicroPython version of readline

--- a/ports/unix/variants/longlong/mpconfigvariant.h
+++ b/ports/unix/variants/longlong/mpconfigvariant.h
@@ -32,7 +32,7 @@
 
 // We build it on top of REPR C, which uses memory-efficient floating point
 // objects encoded directly mp_obj_t (30 bits only).
-// Therefore this variant should be built using MICROPY_FORCE_32BIT=1
+// Therefore this variant should be built for a 32-bits target.
 
 #define MICROPY_OBJ_REPR               (MICROPY_OBJ_REPR_C)
 #define MICROPY_FLOAT_IMPL             (MICROPY_FLOAT_IMPL_FLOAT)

--- a/ports/unix/variants/longlong/mpconfigvariant.mk
+++ b/ports/unix/variants/longlong/mpconfigvariant.mk
@@ -1,7 +1,7 @@
 # build interpreter with "bigints" implemented as "longlong"
 
-# otherwise, small int is essentially 64-bit
-MICROPY_FORCE_32BIT := 1
+# This needs to be built for a 32-bits target, otherwise small ints will
+# essentially be 64-bit wide.
 
 MICROPY_PY_FFI := 0
 

--- a/ports/unix/variants/nanbox/mpconfigvariant.mk
+++ b/ports/unix/variants/nanbox/mpconfigvariant.mk
@@ -1,3 +1,4 @@
 # build interpreter with nan-boxing as object model (object repr D)
 
-MICROPY_FORCE_32BIT = 1
+# This needs to be built for a 32-bits target, as object representation D is
+# only meant to work on 32-bits machines.

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -29,6 +29,13 @@ PROG ?= micropython
 QSTR_DEFS += ../unix/qstrdefsport.h
 QSTR_GLOBAL_DEPENDENCIES += $(VARIANT_DIR)/mpconfigvariant.h
 
+# Enable building 32-bit code on 64-bit hosts.
+ifeq ($(MICROPY_FORCE_32BIT),1)
+CC += -m32
+CXX += -m32
+LD += -m32
+endif
+
 # include py core make definitions
 include $(TOP)/py/py.mk
 include $(TOP)/extmod/extmod.mk

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -48,8 +48,8 @@ CLEAN_EXTRA += $(MOD).mpy .mpy_ld_cache-$(ARCH)
 ifeq ($(ARCH),x86)
 
 # x86
-CROSS =
-CFLAGS_ARCH += -m32 -fno-stack-protector
+CROSS = i686-linux-gnu-
+CFLAGS_ARCH += -fno-stack-protector
 MICROPY_FLOAT_IMPL ?= double
 
 else ifeq ($(ARCH),x64)

--- a/py/py.mk
+++ b/py/py.mk
@@ -21,13 +21,6 @@ QSTR_GLOBAL_REQUIREMENTS += $(HEADER_BUILD)/mpversion.h
 # some code is performance bottleneck and compiled with other optimization options
 CSUPEROPT = -O3
 
-# Enable building 32-bit code on 64-bit host.
-ifeq ($(MICROPY_FORCE_32BIT),1)
-CC += -m32
-CXX += -m32
-LD += -m32
-endif
-
 # External modules written in C.
 ifneq ($(USER_C_MODULES),)
 # pre-define USERMOD variables as expanded so that variables are immediate

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -630,7 +630,11 @@ CI_UNIX_OPTS_REPR_B=(
     CFLAGS_EXTRA="-DMICROPY_OBJ_REPR=MICROPY_OBJ_REPR_B -DMICROPY_PY_UCTYPES=0 -Dmp_int_t=int32_t -Dmp_uint_t=uint32_t"
     MICROPY_FORCE_32BIT=1
     RUN_TESTS_MPY_CROSS_FLAGS="--mpy-cross-flags=\"-march=x86 -msmall-int-bits=30\""
+)
 
+CI_UNIX_OPTS_X86=(
+    CROSS_COMPILE=i686-linux-gnu-
+    RUN_TESTS_MPY_CROSS_FLAGS=${RUN_TESTS_MPY_CROSS_FLAGS:-"--mpy-cross-flags=\"-march=x86\""}
 )
 
 function ci_unix_build_helper {
@@ -793,20 +797,20 @@ function ci_unix_coverage_run_native_mpy_tests {
 function ci_unix_32bit_setup {
     sudo dpkg --add-architecture i386
     sudo apt-get update
-    sudo apt-get install gcc-multilib g++-multilib libffi-dev:i386
+    sudo apt-get install gcc-i686-linux-gnu g++-i686-linux-gnu patchelf libffi-dev:i386
     python -m pip install pyelftools
     python -m pip install ar
-    gcc --version
+    i686-linux-gnu-gcc --version
     python3 --version
 }
 
 function ci_unix_coverage_32bit_build {
-    ci_unix_build_helper VARIANT=coverage MICROPY_FORCE_32BIT=1
-    ci_unix_build_ffi_lib_helper gcc -m32
+    ci_unix_build_helper VARIANT=coverage MICROPY_FORCE_32BIT=1 "${CI_UNIX_OPTS_X86[@]}"
+    ci_unix_build_ffi_lib_helper i686-linux-gnu-gcc
 }
 
 function ci_unix_coverage_32bit_run_tests {
-    ci_unix_run_tests_full_helper coverage MICROPY_FORCE_32BIT=1
+    ci_unix_run_tests_full_helper coverage MICROPY_FORCE_32BIT=1 "${CI_UNIX_OPTS_X86[@]}"
 }
 
 function ci_unix_coverage_32bit_run_native_mpy_tests {
@@ -814,8 +818,8 @@ function ci_unix_coverage_32bit_run_native_mpy_tests {
 }
 
 function ci_unix_nanbox_build {
-    ci_unix_build_helper VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1"
-    ci_unix_build_ffi_lib_helper gcc -m32
+    ci_unix_build_helper VARIANT=nanbox CFLAGS_EXTRA="-DMICROPY_PY_MATH_CONSTANTS=1" "${CI_UNIX_OPTS_X86[@]}"
+    ci_unix_build_ffi_lib_helper i686-linux-gnu-gcc
 }
 
 function ci_unix_nanbox_run_tests {
@@ -823,7 +827,8 @@ function ci_unix_nanbox_run_tests {
 }
 
 function ci_unix_longlong_build {
-    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}"
+    ci_unix_build_helper VARIANT=longlong "${CI_UNIX_OPTS_SANITIZE_UNDEFINED[@]}" "${CI_UNIX_OPTS_X86[@]}"
+    patchelf --add-rpath "/usr/i686-linux-gnu/lib" ports/unix/build-longlong/micropython
 }
 
 function ci_unix_longlong_run_tests {
@@ -1026,14 +1031,14 @@ EOF
 }
 
 function ci_unix_repr_b_build {
-    ci_unix_build_helper "${CI_UNIX_OPTS_REPR_B[@]}"
-    ci_unix_build_ffi_lib_helper gcc -m32
+    ci_unix_build_helper "${CI_UNIX_OPTS_REPR_B[@]}" "${CI_UNIX_OPTS_X86[@]}"
+    ci_unix_build_ffi_lib_helper i686-linux-gnu-gcc
 }
 
 function ci_unix_repr_b_run_tests {
     # ci_unix_run_tests_full_no_native_helper is not used due to
     # https://github.com/micropython/micropython/issues/18105
-    ci_unix_run_tests_helper "${CI_UNIX_OPTS_REPR_B[@]}"
+    ci_unix_run_tests_helper "${CI_UNIX_OPTS_REPR_B[@]}" "${CI_UNIX_OPTS_X86[@]}"
 }
 
 ########################################################################################

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -628,7 +628,6 @@ CI_UNIX_OPTS_SANITIZE_UNDEFINED=(
 CI_UNIX_OPTS_REPR_B=(
     VARIANT=standard
     CFLAGS_EXTRA="-DMICROPY_OBJ_REPR=MICROPY_OBJ_REPR_B -DMICROPY_PY_UCTYPES=0 -Dmp_int_t=int32_t -Dmp_uint_t=uint32_t"
-    MICROPY_FORCE_32BIT=1
     RUN_TESTS_MPY_CROSS_FLAGS="--mpy-cross-flags=\"-march=x86 -msmall-int-bits=30\""
 )
 
@@ -805,12 +804,12 @@ function ci_unix_32bit_setup {
 }
 
 function ci_unix_coverage_32bit_build {
-    ci_unix_build_helper VARIANT=coverage MICROPY_FORCE_32BIT=1 "${CI_UNIX_OPTS_X86[@]}"
+    ci_unix_build_helper VARIANT=coverage "${CI_UNIX_OPTS_X86[@]}"
     ci_unix_build_ffi_lib_helper i686-linux-gnu-gcc
 }
 
 function ci_unix_coverage_32bit_run_tests {
-    ci_unix_run_tests_full_helper coverage MICROPY_FORCE_32BIT=1 "${CI_UNIX_OPTS_X86[@]}"
+    ci_unix_run_tests_full_helper coverage "${CI_UNIX_OPTS_X86[@]}"
 }
 
 function ci_unix_coverage_32bit_run_native_mpy_tests {


### PR DESCRIPTION
### Summary

This PR removes usage of the `MICROPY_FORCE_32BIT` build flag for the Unix port, and forces cross-compilation for x86 targets in doing so.

`MICROPY_FORCE_32BIT` has always been x64-specific and right now there is support for one more mixed 32/64-bits architecture (RISC-V) on which such flag would make builds fail.  Since x86 usage has declined over the years, this PR also treats x86 as a cross-compilation target, for which a separate toolchain is needed.

Now x86 builds on non-x86 hosts require having a `CROSS_COMPILE` variable passed to the makefile to force building an x86 binary.  This applies to native modules as well, so an i686 cross-compilation toolchain is now needed to build x86 native modules.  This also allows building x86 native modules on non-x86/x64 hosts, as long as the proper toolchain is installed.  Documentation for the Unix port has updated accordingly to show how to create x86 builds with these changes.

CI jobs had to be updated to force usage of the new cross-compiler for 32-bits builds.  This means that on Ubuntu the `gcc-i686-linux-gnu` and `g++-i686-linux-gnu` packages need to be installed instead of `gcc-multilib` and `g++-multilib`.

`MICROPY_FORCE_32BIT` hasn't been completely removed from MicroPython, though.  It is also used by the Windows port to create MinGW builds, and since it is the last remaining target needing such a thing and being limited to x86/x64 targets anyway it is not much of a deal to limit the flag support to that specific port.

This is one less roadblock in having the Unix port CI test suite run on AArch64-based runners (the only build-related issue is forcing usage of `x86_64-linux-gnu-` as the compiler for x64 native modules and on non-x64 hosts for an x64 QEMU-based target).

### Testing

Besides manual builds, this was successfully built and tested by CI on my own branch.