### PR TITLE
py/runtime: Make import-all support non-modules via __dict__/__all__.

### DIFF
--- a/tests/basics/import_star_nonmodule.py
+++ b/tests/basics/import_star_nonmodule.py
@@ -1,0 +1,65 @@
+# Test "from x import *" where x is something other than a module.
+
+import sys
+
+try:
+    next(iter([]), 42)
+except TypeError:
+    # Two-argument version of next() not supported.  We are probably not at
+    # MICROPY_CONFIG_ROM_LEVEL_BASIC_FEATURES which is needed for "import *".
+    print("SKIP")
+    raise SystemExit
+
+print("== test with a class as a module ==")
+
+
+class M:
+    x = "a1"
+
+    def __init__(self):
+        self.x = "a2"
+
+
+sys.modules["mod"] = M
+from mod import *
+
+print(x)
+
+sys.modules["mod"] = M()
+from mod import *
+
+print(x)
+
+print("== test with a class as a module that overrides __all__ ==")
+
+
+class M:
+    __all__ = ("y",)
+    x = "b1"
+    y = "b2"
+
+    def __init__(self):
+        self.__all__ = ("x",)
+        self.x = "b3"
+        self.y = "b4"
+
+
+sys.modules["mod"] = M
+x = None
+from mod import *
+
+print(x, y)
+
+sys.modules["mod"] = M()
+from mod import *
+
+print(x, y)
+
+print("== test with objects that don't have a __dict__ ==")
+
+sys.modules["mod"] = 1
+try:
+    from mod import *
+    # MicroPython raises AttributeError, CPython raises ImportError.
+except (AttributeError, ImportError):
+    print("ImportError")


### PR DESCRIPTION
### Summary

Prior to this fix, `mp_import_all()` assumed that its argument was exactly a native module instance.  That would lead to a crash if something else was passed in, eg a user class via a custom `__import__` implementation or by writing to `sys.modules`.

MicroPython already supports injecting non-module objects into the import machinery, so it makes sense to round out that implementation by supporting `from x import *` where `x` is a non-module object.

Fixes issue #18639.

### Testing

A test has been added to exercise the new code.  It runs under CI.

### Trade-offs and Alternatives

This fixes a potential crash in the core runtime.  Although it's not common to hit this bug in real code, IMO it's worth fixing so that MicroPython fully supports importing from non-module objects, eg class instances.

The fix relies on the `__dict__` attribute always returning a native dict instance.  That's true in MicroPython, one can never override `__dict__` in a user-defined Python class.

In terms of performance, there is a minor overhead added by the lookup of `__dict__` in the module object.  But that's a relatively small overhead compared with the time for the full execution of `from x import *` which does many other operations include a store to the globals dict for each imported name.

When `MICROPY_CPYTHON_COMPAT` is disabled it doesn't use `__dict__` because that's not available.  In that case it just uses the old behaviour of assuming the given module is a true native module instance.