### PR TITLE
py: clean up definition and use of `mp_handle_pending()`

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -147,7 +147,7 @@ void mpy_wiznet_yield(void) {
     #if MICROPY_PY_THREAD
     MICROPY_THREAD_YIELD();
     #else
-    mp_handle_pending(true);
+    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
     #endif
 }
 

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -156,7 +156,7 @@ void socket_events_handler(void) {
 #endif // MICROPY_PY_SOCKET_EVENTS
 
 static inline void check_for_exceptions(void) {
-    mp_handle_pending(true);
+    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
 }
 
 #if MICROPY_HW_ENABLE_MDNS_QUERIES

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -309,7 +309,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         MICROPY_PY_SOCKET_EVENTS_HANDLER \
         MP_THREAD_GIL_EXIT(); \
@@ -324,7 +323,6 @@ void *esp_native_code_commit(void *, size_t, void *);
 #endif
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         MICROPY_PY_SOCKET_EVENTS_HANDLER \
             MICROPY_PY_WAIT_FOR_INTERRUPT; \

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -309,7 +309,7 @@ void *esp_native_code_commit(void *, size_t, void *);
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         MICROPY_PY_SOCKET_EVENTS_HANDLER \
         MP_THREAD_GIL_EXIT(); \
         ulTaskNotifyTake(pdFALSE, 1); \
@@ -323,7 +323,7 @@ void *esp_native_code_commit(void *, size_t, void *);
 #endif
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         MICROPY_PY_SOCKET_EVENTS_HANDLER \
             MICROPY_PY_WAIT_FOR_INTERRUPT; \
     } while (0);

--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -197,7 +197,7 @@ void mp_hal_delay_ms(mp_uint_t ms) {
     uint64_t dt;
     uint64_t t0 = esp_timer_get_time();
     for (;;) {
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MICROPY_PY_SOCKET_EVENTS_HANDLER
         MP_THREAD_GIL_EXIT();
         uint64_t t1 = esp_timer_get_time();
@@ -240,7 +240,7 @@ void mp_hal_delay_us(mp_uint_t us) {
         if (dt + pend_overhead < us) {
             // we have enough time to service pending events
             // (don't use MICROPY_EVENT_POLL_HOOK because it also yields)
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         }
     }
 }

--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -275,7 +275,7 @@ static mp_obj_t esp_scan(mp_obj_t self_in) {
         // esp_scan_list variable to NULL without disabling interrupts
         if (MP_STATE_THREAD(mp_pending_exception) != NULL) {
             esp_scan_list = NULL;
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         }
         ets_loop_iter();
     }

--- a/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
@@ -5,7 +5,7 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
     } while (0);
 
 // MIMXRT1170_EVK has 2 user LEDs

--- a/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
@@ -5,7 +5,6 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
     } while (0);
 

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -224,7 +224,6 @@ extern const struct _mp_obj_type_t network_lan_type;
 #ifndef  MICROPY_EVENT_POLL_HOOK
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         __WFE(); \
     } while (0);

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -224,7 +224,7 @@ extern const struct _mp_obj_type_t network_lan_type;
 #ifndef  MICROPY_EVENT_POLL_HOOK
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         __WFE(); \
     } while (0);
 #endif

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -379,7 +379,7 @@ long unsigned int rng_generate_random_word(void);
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         __WFI(); \
     } while (0);
 

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -379,7 +379,6 @@ long unsigned int rng_generate_random_word(void);
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         __WFI(); \
     } while (0);

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -137,7 +137,7 @@
 #ifndef MICROPY_PY_THREAD
 #define MICROPY_PY_THREAD                       (1)
 #define MICROPY_PY_THREAD_GIL                   (0)
-#define MICROPY_THREAD_YIELD()                  mp_handle_pending(true)
+#define MICROPY_THREAD_YIELD()                  mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS)
 #endif
 
 // Extended modules

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -170,7 +170,6 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         __WFE(); \
     } while (0);

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -170,7 +170,7 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         __WFE(); \
     } while (0);
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -234,7 +234,7 @@ typedef long mp_off_t;
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         if (pyb_thread_enabled) { \
             MP_THREAD_GIL_EXIT(); \
             pyb_thread_yield(); \
@@ -248,7 +248,7 @@ typedef long mp_off_t;
 #else
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         __WFI(); \
     } while (0);
 

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -234,7 +234,6 @@ typedef long mp_off_t;
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         if (pyb_thread_enabled) { \
             MP_THREAD_GIL_EXIT(); \
@@ -249,7 +248,6 @@ typedef long mp_off_t;
 #else
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         __WFI(); \
     } while (0);

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -675,7 +675,7 @@ static mp_obj_t extra_coverage(void) {
         mp_sched_unlock();
 
         // shouldn't do anything while scheduler is locked
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
 
         // unlock scheduler
         mp_sched_unlock();
@@ -691,7 +691,7 @@ static mp_obj_t extra_coverage(void) {
         mp_sched_keyboard_interrupt();
         nlr_buf_t nlr;
         if (nlr_push(&nlr) == 0) {
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
@@ -700,30 +700,30 @@ static mp_obj_t extra_coverage(void) {
         // setting the keyboard interrupt (twice) and cancelling it during mp_handle_pending
         mp_sched_keyboard_interrupt();
         mp_sched_keyboard_interrupt();
-        mp_handle_pending(false);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
 
         // setting keyboard interrupt and a pending event (intr should be handled first)
         mp_sched_schedule(MP_OBJ_FROM_PTR(&mp_builtin_print_obj), MP_OBJ_NEW_SMALL_INT(10));
         mp_sched_keyboard_interrupt();
         if (nlr_push(&nlr) == 0) {
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
             nlr_pop();
         } else {
             mp_obj_print_exception(&mp_plat_print, MP_OBJ_FROM_PTR(nlr.ret_val));
         }
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
 
         coverage_sched_function_continue = true;
         mp_sched_schedule_node(&mp_coverage_sched_node, coverage_sched_function);
         for (int i = 0; i < 3; ++i) {
             mp_printf(&mp_plat_print, "loop\n");
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         }
         // Clear this flag to prevent the function scheduling itself again
         coverage_sched_function_continue = false;
         // Will only run the first time through this loop, then not scheduled again
         for (int i = 0; i < 3; ++i) {
-            mp_handle_pending(true);
+            mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         }
     }
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -157,14 +157,14 @@ static int execute_from_lexer(int source_kind, const void *source, mp_parse_inpu
         }
 
         mp_hal_set_interrupt_char(-1);
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         nlr_pop();
         return 0;
 
     } else {
         // uncaught exception
         mp_hal_set_interrupt_char(-1);
-        mp_handle_pending(false);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
         return handle_uncaught_exception(nlr.ret_val);
     }
 }
@@ -631,12 +631,12 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 if (nlr_push(&nlr) == 0) {
                     mod = mp_builtin___import__(MP_ARRAY_SIZE(import_args), import_args);
                     mp_hal_set_interrupt_char(-1);
-                    mp_handle_pending(true);
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
                     nlr_pop();
                 } else {
                     // uncaught exception
                     mp_hal_set_interrupt_char(-1);
-                    mp_handle_pending(false);
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
                     ret = handle_uncaught_exception(nlr.ret_val) & 0xff;
                     break;
                 }

--- a/ports/unix/modsocket.c
+++ b/ports/unix/modsocket.c
@@ -210,7 +210,7 @@ static mp_obj_t socket_connect(mp_obj_t self_in, mp_obj_t addr_in) {
             int err = errno;
             if (self->blocking) {
                 if (err == EINTR) {
-                    mp_handle_pending(true);
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
                     continue;
                 }
                 // EINPROGRESS on a blocking socket means the operation timed out

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -95,7 +95,7 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     tv.tv_sec = (suseconds_t)ipart;
     int res;
     while (1) {
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MP_THREAD_GIL_EXIT();
         res = sleep_select(0, NULL, NULL, NULL, &tv);
         MP_THREAD_GIL_ENTER();
@@ -114,7 +114,7 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #else
     int seconds = mp_obj_get_int(arg);
     for (;;) {
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MP_THREAD_GIL_EXIT();
         seconds = sleep(seconds);
         MP_THREAD_GIL_ENTER();

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -99,7 +99,7 @@ static inline void mp_hal_delay_us(mp_uint_t us) {
             if (ret == -1) { \
                 int err = errno; \
                 if (err == EINTR) { \
-                    mp_handle_pending(true); \
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
                     continue; \
                 } \
                 raise; \

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -76,7 +76,6 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
     } while (0);
 

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -76,7 +76,7 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
     } while (0);
 
 // Whether the VM will periodically call mp_js_hook(), which checks for

--- a/ports/webassembly/mphalport.h
+++ b/ports/webassembly/mphalport.h
@@ -51,7 +51,7 @@ int mp_hal_get_interrupt_char(void);
             if (ret == -1) { \
                 int err = errno; \
                 if (err == EINTR) { \
-                    mp_handle_pending(true); \
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
                     continue; \
                 } \
                 raise; \

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -168,7 +168,6 @@ typedef long mp_off_t;
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         MP_THREAD_GIL_EXIT(); \
         k_msleep(1); \
@@ -177,7 +176,6 @@ typedef long mp_off_t;
 #else
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
         mp_handle_pending(true); \
         k_msleep(1); \
     } while (0);

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -168,7 +168,7 @@ typedef long mp_off_t;
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         MP_THREAD_GIL_EXIT(); \
         k_msleep(1); \
         MP_THREAD_GIL_ENTER(); \
@@ -176,7 +176,7 @@ typedef long mp_off_t;
 #else
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
         k_msleep(1); \
     } while (0);
 #endif

--- a/ports/zephyr/mphalport.c
+++ b/ports/zephyr/mphalport.c
@@ -52,7 +52,7 @@ void mp_hal_wait_sem(struct k_sem *sem, uint32_t timeout_ms) {
         k_poll_event_init(&wait_events[1], K_POLL_TYPE_SEM_AVAILABLE, K_POLL_MODE_NOTIFY_ONLY, sem);
     }
     for (;;) {
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MP_THREAD_GIL_EXIT();
         k_timeout_t wait;
         uint32_t dt = mp_hal_ticks_ms() - t0;

--- a/py/profile.c
+++ b/py/profile.c
@@ -173,7 +173,7 @@ static mp_obj_t mp_prof_callback_invoke(mp_obj_t callback, prof_callback_args_t 
     mp_prof_is_executing = false;
 
     if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {
-        mp_handle_pending(true);
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
     }
     return top;
 }

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -52,10 +52,11 @@ typedef enum {
     MP_ARG_KW_ONLY   = 0x200,
 } mp_arg_flag_t;
 
+// These first two enum values match the original signature of `mp_handle_pending(bool)`.
 typedef enum {
+    MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS = false,
+    MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS = true,
     MP_HANDLE_PENDING_CALLBACKS_ONLY,
-    MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS,
-    MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS,
 } mp_handle_pending_behaviour_t;
 
 typedef union _mp_arg_val_t {

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -108,13 +108,7 @@ void mp_sched_keyboard_interrupt(void);
 void mp_sched_vm_abort(void);
 #endif
 
-void mp_handle_pending_internal(mp_handle_pending_behaviour_t behavior);
-
-static inline void mp_handle_pending(bool raise_exc) {
-    mp_handle_pending_internal(raise_exc ?
-        MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS :
-        MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
-}
+void mp_handle_pending(mp_handle_pending_behaviour_t behavior);
 
 #if MICROPY_ENABLE_SCHEDULER
 void mp_sched_lock(void);

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -213,7 +213,7 @@ MP_REGISTER_ROOT_POINTER(mp_sched_item_t sched_queue[MICROPY_SCHEDULER_DEPTH]);
 
 // Called periodically from the VM or from "waiting" code (e.g. sleep) to
 // process background tasks and pending exceptions (e.g. KeyboardInterrupt).
-void mp_handle_pending_internal(mp_handle_pending_behaviour_t behavior) {
+void mp_handle_pending(mp_handle_pending_behaviour_t behavior) {
     bool handle_exceptions = (behavior != MP_HANDLE_PENDING_CALLBACKS_ONLY);
     bool raise_exceptions = (behavior == MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
 

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -263,7 +263,7 @@ void mp_event_handle_nowait(void) {
     #else
     // Process any port layer (non-blocking) events.
     MICROPY_INTERNAL_EVENT_HOOK;
-    mp_handle_pending(true);
+    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
     #endif
 }
 

--- a/py/vm.c
+++ b/py/vm.c
@@ -1346,7 +1346,7 @@ pending_exception_check:
                 MICROPY_VM_HOOK_LOOP
 
                 // Check for pending exceptions or scheduled tasks to run.
-                // Note: it's safe to just call mp_handle_pending(true), but
+                // Note: it's safe to just call mp_handle_pending(...), but
                 // we can inline the check for the common case where there is
                 // neither.
                 if (
@@ -1368,7 +1368,7 @@ pending_exception_check:
                 #endif
                 ) {
                     MARK_EXC_IP_SELECTIVE();
-                    mp_handle_pending(true);
+                    mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
                 }
 
                 #if MICROPY_PY_THREAD_GIL

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -137,7 +137,7 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
             mp_call_function_0(module_fun);
         }
         mp_hal_set_interrupt_char(-1); // disable interrupt
-        mp_handle_pending(true); // handle any pending exceptions (and any callbacks)
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         nlr_pop();
         ret = PYEXEC_NORMAL_EXIT;
         if (exec_flags & EXEC_FLAG_PRINT_EOF) {
@@ -146,7 +146,7 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
     } else {
         // uncaught exception
         mp_hal_set_interrupt_char(-1); // disable interrupt
-        mp_handle_pending(false); // clear any pending exceptions (and run any callbacks)
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS);
 
         if (exec_flags & EXEC_FLAG_SOURCE_IS_READER) {
             const mp_reader_t *reader = source;


### PR DESCRIPTION
### Summary

Commit c57aebf790c40125b663231ec4307d2a3f3cf193 added more functionality to `mp_handle_pending()`, passing in an enum instead of a bool to select whether exceptions are ignored, cleared or raised.

That commit attempted to keep the original behaviour of `mp_handle_pending(bool)` with a bool argument by making it static-inline, but that doesn't work in all cases (see #18663).

This PR cleans up the definition and use of this function:
- remove incorrect and unnecessary declarations of `extern void mp_handle_pending(bool);` in `mpconfigport.h`
- reorder enum so their numerical values match the original bool argument, namely that `true` maps to `MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS` and `false` maps to `MP_HANDLE_PENDING_CALLBACKS_AND_CLEAR_EXCEPTIONS`
- remove the static-inline definition
- rename `mp_handle_pending_internal()` to `mp_handle_pending()`

Functionality should be unchanged, and backwards compatibility with `mp_handle_pending()` should be retained.

Fixes issue #18663.

### Testing

Tested locally on PYBV10.

CI will also test the change (the unix port already has special coverage testing for `mp_handle_pending()`).

### Trade-offs and Alternatives

This touches all code that calls `mp_handle_pending()` but that's necessary to fully clean it up.

The enum for `mp_handle_pending_behaviour_t` now defines the first and second values as `false` and `true`, which is a bit awkward but will explicitly retain backwards compatibility.