### PR TITLE
tests/multi_net: Exclude TLS/SSL tests for axTLS, and use `getrandbits()` for random port

### DIFF
--- a/tests/multi_net/asyncio_tls_server_client.py
+++ b/tests/multi_net/asyncio_tls_server_client.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_cert_required_error.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/asyncio_tls_server_client_readline.py
+++ b/tests/multi_net/asyncio_tls_server_client_readline.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/asyncio_tls_server_client_verify_error.py
+++ b/tests/multi_net/asyncio_tls_server_client_verify_error.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/ssl_cert_ec.py
+++ b/tests/multi_net/ssl_cert_ec.py
@@ -7,6 +7,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/ssl_cert_rsa.py
+++ b/tests/multi_net/ssl_cert_rsa.py
@@ -7,6 +7,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_check_hostname_error.py
+++ b/tests/multi_net/sslcontext_check_hostname_error.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_getpeercert.py
+++ b/tests/multi_net/sslcontext_getpeercert.py
@@ -9,6 +9,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_server_client.py
+++ b/tests/multi_net/sslcontext_server_client.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_server_client_ciphers.py
+++ b/tests/multi_net/sslcontext_server_client_ciphers.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(tls, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_server_client_files.py
+++ b/tests/multi_net/sslcontext_server_client_files.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_verify_callback.py
+++ b/tests/multi_net/sslcontext_verify_callback.py
@@ -9,6 +9,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(tls, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_verify_error.py
+++ b/tests/multi_net/sslcontext_verify_error.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/sslcontext_verify_time_error.py
+++ b/tests/multi_net/sslcontext_verify_time_error.py
@@ -8,6 +8,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(ssl, "CERT_REQUIRED"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/tcp_recv_peek.py
+++ b/tests/multi_net/tcp_recv_peek.py
@@ -9,7 +9,7 @@ import random
 
 # Server
 def instance0():
-    PORT = random.randrange(10000, 50000)
+    PORT = 10000 + random.getrandbits(15)
     multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
     s = socket.socket()
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/tests/multi_net/tls_dtls_server_client.py
+++ b/tests/multi_net/tls_dtls_server_client.py
@@ -7,6 +7,10 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+if not hasattr(tls, "PROTOCOL_DTLS_SERVER"):
+    print("SKIP")
+    raise SystemExit
+
 PORT = 8000
 
 # These are test certificates. See tests/README.md for details.

--- a/tests/multi_net/udp_recv_dontwait.py
+++ b/tests/multi_net/udp_recv_dontwait.py
@@ -11,7 +11,7 @@ except ImportError:
 
 # Server
 def instance0():
-    PORT = random.randrange(10000, 50000)
+    PORT = 10000 + random.getrandbits(15)
     multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/tests/multi_net/udp_recv_peek.py
+++ b/tests/multi_net/udp_recv_peek.py
@@ -6,7 +6,7 @@ import time
 
 # Server
 def instance0():
-    PORT = random.randrange(10000, 50000)
+    PORT = 10000 + random.getrandbits(15)
     multitest.globals(IP=multitest.get_network_ip(), PORT=PORT)
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
### Summary

This PR adjusts the `tests/multi_net` tests so they run on the esp8266 port:
- The axTLS implementation of the tls module only has a basic set of features.  In particular it doesn't support the CERT_REQUIRED constant nor DTLS, nor can it load the `ec_key.der` key when acting as a server.  So skip tests that require these features, which ends up being all the ssl/tls mult tests (esp8266 can still run standard networking tests that use ssl/tls, just not the multi_net tests).
- When generating a random port number, use `random.getrandbits()`, which is guaranteed to exist on all ports that have the `random` module (but `randrange()` is not).

### Testing

Tested running all `multi_net` tests on esp8266, esp32, RPI_PICO_W and unix ports.  Apart from the TCP RST tests (covered by a separate PR #18547) the tests either pass or skip.  In particular the updated ssl/tls tests still run and pass on all ports except esp8266.

### Trade-offs and Alternatives

esp8266 is now Tier 3, so we could just ignore test errors on that port.  But I still find it useful to run tests on that hardware because it helps define a more minimal port.  An esp8266 board is also included in the Octoprobe hardware set up, so it's good to have the tests passing or skipping there.

The change to use `getrandbits()` is also potentially useful for other ports that don't enable all random features.