### PR TITLE
py: adjust zip iter implementation to not use `mp_obj_tulpe_del()` and then remove that function

### DIFF
--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -251,12 +251,6 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
     return MP_OBJ_FROM_PTR(o);
 }
 
-void mp_obj_tuple_del(mp_obj_t self_in) {
-    assert(mp_obj_is_type(self_in, &mp_type_tuple));
-    mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
-    m_del_var(mp_obj_tuple_t, items, mp_obj_t, self->len, self);
-}
-
 /******************************************************************************/
 /* tuple iterator                                                             */
 

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -56,8 +56,6 @@ static inline void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **it
     *items = &self->items[0];
 }
 
-void mp_obj_tuple_del(mp_obj_t self_in);
-
 extern const mp_obj_type_t mp_type_attrtuple;
 
 #define MP_DEFINE_ATTRTUPLE(tuple_obj_name, fields, nitems, ...) \

--- a/py/objzip.c
+++ b/py/objzip.c
@@ -50,18 +50,19 @@ static mp_obj_t zip_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
 static mp_obj_t zip_iternext(mp_obj_t self_in) {
     mp_check_self(mp_obj_is_type(self_in, &mp_type_zip));
     mp_obj_zip_t *self = MP_OBJ_TO_PTR(self_in);
-    if (self->n_iters == 0) {
-        return MP_OBJ_STOP_ITERATION;
-    }
-    mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(self->n_iters, NULL));
-
+    mp_obj_tuple_t *tuple = NULL;
     for (size_t i = 0; i < self->n_iters; i++) {
         mp_obj_t next = mp_iternext(self->iters[i]);
         if (next == MP_OBJ_STOP_ITERATION) {
-            mp_obj_tuple_del(MP_OBJ_FROM_PTR(tuple));
             return MP_OBJ_STOP_ITERATION;
         }
+        if (tuple == NULL) {
+            tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(self->n_iters, NULL));
+        }
         tuple->items[i] = next;
+    }
+    if (tuple == NULL) {
+        return MP_OBJ_STOP_ITERATION;
     }
     return MP_OBJ_FROM_PTR(tuple);
 }


### PR DESCRIPTION
### Summary

There is only one location in the code base where `mp_obj_tuple_del()` is used: in the `zip` iteration implementation.  And it's not strictly needed there, it's only a very minor optimization to reclaim an unused tuple.

This PR reworks the zip iter implementation so it doesn't need `mp_obj_tuple_del()`.  It should now have slightly better GC behaviour: it only allocates the return tuple if needed, instead of allocating it and then freeing it when the zip iterator is exhausted.  So the change will reduce memory churn by a little.

Then, `mp_obj_tuple_del()` is removed to save code size.

### Testing

There are existing tests for `zip` that will test this change in CI.

### Trade-offs and Alternatives

In the case where `zip` is called with uneven iterators, and there is a shorter iterator after a longer one (eg `zip([1,2],[3])`), then on the last iteration it'll now allocate the return tuple without explicitly freeing it.  But that's likely an uncommon scenario, and anyway the GC will reclaim the memory at some point.

IMO it's better to optimize for (1) the common case of not allocating at all when the iterator is exhausted and (2) for code size, which is what this PR does.