### PR TITLE
zephyr: fix i2c port

### DIFF
--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -75,6 +75,7 @@
 #define MICROPY_PY_MACHINE          (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE "ports/zephyr/modmachine.c"
 #define MICROPY_PY_MACHINE_I2C      (1)
+#define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 #ifdef CONFIG_I2C_TARGET
 #define MICROPY_PY_MACHINE_I2C_TARGET (1)
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/zephyr/machine_i2c_target.c"


### PR DESCRIPTION
### Summary

in zephyr every transfer transfer
has to end with a stop unless the
deprecated option
CONFIG_I2C_ALLOW_NO_STOP_TRANSACTIONS
is activated.

Therefore implement support for
MP_MACHINE_I2C_FLAG_WRITE1.

### Testing

tested on a stm32h573I_dk.

### Trade-offs and Alternatives

None