### PR TITLE
stm32: Convert port to use new event waiting functions.

### DIFF
--- a/ports/stm32/can.c
+++ b/ports/stm32/can.c
@@ -180,7 +180,7 @@ int can_receive(CAN_HandleTypeDef *can, can_rx_fifo_t fifo, CanRxMsgTypeDef *msg
     // Wait for a message to become available, with timeout
     uint32_t start = HAL_GetTick();
     while ((*rfr & 3) == 0) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
         if (HAL_GetTick() - start >= timeout_ms) {
             return -MP_ETIMEDOUT;
         }

--- a/ports/stm32/cyw43_configport.h
+++ b/ports/stm32/cyw43_configport.h
@@ -62,6 +62,8 @@
 #define CYW43_SDPCM_SEND_COMMON_WAIT    __WFI();
 #define CYW43_DO_IOCTL_WAIT             __WFI();
 #define CYW43_HAL_UART_READCHAR_BLOCKING_WAIT __WFI()
+#undef CYW43_EVENT_POLL_HOOK
+#define CYW43_EVENT_POLL_HOOK           mp_event_wait_ms(1)
 
 #define cyw43_hal_uart_set_baudrate     mp_bluetooth_hci_uart_set_baudrate
 #define cyw43_hal_uart_write            mp_bluetooth_hci_uart_write

--- a/ports/stm32/fdcan.c
+++ b/ports/stm32/fdcan.c
@@ -284,7 +284,7 @@ HAL_StatusTypeDef can_transmit(CAN_HandleTypeDef *can, CanTxMsgTypeDef *txmsg, u
                 mp_raise_OSError(MP_ETIMEDOUT);
             }
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
     return HAL_FDCAN_AddMessageToTxFifoQ(can, txmsg, data);
 }
@@ -311,7 +311,7 @@ int can_receive(FDCAN_HandleTypeDef *can, can_rx_fifo_t fifo, FDCAN_RxHeaderType
                 return -MP_ETIMEDOUT;
             }
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 
     // Get pointer to incoming message

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -231,30 +231,6 @@ extern const struct _mp_obj_type_t network_lan_type;
 
 typedef long mp_off_t;
 
-#if MICROPY_PY_THREAD
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-        if (pyb_thread_enabled) { \
-            MP_THREAD_GIL_EXIT(); \
-            pyb_thread_yield(); \
-            MP_THREAD_GIL_ENTER(); \
-        } else { \
-            __WFI(); \
-        } \
-    } while (0);
-
-#define MICROPY_THREAD_YIELD() pyb_thread_yield()
-#else
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-        __WFI(); \
-    } while (0);
-
-#define MICROPY_THREAD_YIELD()
-#endif
-
 // Configuration for shared/runtime/softtimer.c.
 #define MICROPY_SOFT_TIMER_TICKS_MS uwTick
 

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -74,7 +74,7 @@ MP_WEAK int mp_hal_stdin_rx_chr(void) {
             return c;
         }
         #endif
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
 }
 

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -67,6 +67,26 @@ void mp_hal_set_interrupt_char(int c); // -1 to disable
 #define MICROPY_PY_LWIP_REENTER MICROPY_PY_PENDSV_REENTER
 #define MICROPY_PY_LWIP_EXIT    MICROPY_PY_PENDSV_EXIT
 
+// Port level Wait-for-Event macro.
+// Do not use this macro directly, include py/runtime.h and
+// call mp_event_wait_indefinite() or mp_event_wait_ms(timeout).
+#if MICROPY_PY_THREAD
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
+    do { \
+        if (pyb_thread_enabled) { \
+            MP_THREAD_GIL_EXIT(); \
+            pyb_thread_yield(); \
+            MP_THREAD_GIL_ENTER(); \
+        } else { \
+            __WFI(); \
+        } \
+    } while (0)
+#define MICROPY_THREAD_YIELD() pyb_thread_yield()
+#else
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFI()
+#define MICROPY_THREAD_YIELD()
+#endif
+
 // Timing functions.
 
 #if __CORTEX_M == 0

--- a/ports/stm32/systick.c
+++ b/ports/stm32/systick.c
@@ -100,7 +100,7 @@ void mp_hal_delay_ms(mp_uint_t Delay) {
             // This macro will execute the necessary idle behaviour.  It may
             // raise an exception, switch threads or enter sleep mode (waiting for
             // (at least) the SysTick interrupt).
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         } while (uwTick - start < Delay);
     } else {
         // IRQs disabled, so need to use a busy loop for the delay.

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -1116,7 +1116,7 @@ bool uart_rx_wait(machine_uart_obj_t *self, uint32_t timeout) {
         if (HAL_GetTick() - start >= timeout) {
             return false; // timeout
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 }
 
@@ -1169,7 +1169,7 @@ bool uart_tx_wait(machine_uart_obj_t *self, uint32_t timeout) {
         if (HAL_GetTick() - start >= timeout) {
             return false; // timeout
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 }
 

--- a/ports/stm32/usbd_hid_interface.c
+++ b/ports/stm32/usbd_hid_interface.c
@@ -53,7 +53,7 @@ int usbd_hid_rx(usbd_hid_itf_t *hid, size_t len, uint8_t *buf, uint32_t timeout_
         if (mp_hal_ticks_ms() - t0 >= timeout_ms || query_irq() == IRQ_STATE_DISABLED) {
             return -MP_ETIMEDOUT;
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 
     // Copy bytes from report to user buffer


### PR DESCRIPTION
### Summary

Convert the stm32 port from the old `MICROPY_EVENT_POLL_HOOK` macro to use the new `mp_event_wait_xxx()` functions in conjunction with `MICROPY_INTERNAL_WFE`.

This change should be functionally equivalent to the existing behaivour because `mp_event_wait_ms()` and `mp_event_wait_indefinite()` are equal to `mp_handle_pending(true); __WFI();`, which is what `MICROPY_EVENT_POLL_HOOK` was.

### Testing

Tested on PYBD_SF6 running the test suite.

### Trade-offs and Alternatives

The stm32 port doesn't have the ability to "wait for event" for an extended period of time, it only has `wfi`.  So that's all that is used for `MICROPY_INTERNAL_WFE`, similar to the renesas-ra port.

The `CYW43_EVENT_POLL_HOOK` macro needed to be overridden, otherwise it would just call `mp_event_handle_nowait()` which would create power hungry busy loops.