### PR TITLE
zephyr: Also print nodelabels when printing device names.

### DIFF
--- a/ports/zephyr/machine_i2c.c
+++ b/ports/zephyr/machine_i2c.c
@@ -49,7 +49,8 @@ typedef struct _machine_hard_i2c_obj_t {
 
 static void machine_hard_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_hard_i2c_obj_t *self = self_in;
-    mp_printf(print, "%s", self->dev->name);
+    const char *name = zephyr_device_get_name(self->dev);
+    mp_printf(print, "<I2C %s>", name);
 }
 
 mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {

--- a/ports/zephyr/machine_pin.c
+++ b/ports/zephyr/machine_pin.c
@@ -69,7 +69,8 @@ static void gpio_callback_handler(const struct device *port, struct gpio_callbac
 
 static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pin_obj_t *self = self_in;
-    mp_printf(print, "<Pin %p %d>", self->port, self->pin);
+    const char *port_name = zephyr_device_get_name(self->port);
+    mp_printf(print, "<Pin %s %d>", port_name, self->pin);
 }
 
 // pin.init(mode, pull=None, *, value)

--- a/ports/zephyr/machine_pwm.c
+++ b/ports/zephyr/machine_pwm.c
@@ -69,7 +69,8 @@ static void configure_pwm(machine_pwm_obj_t *self) {
 static void mp_machine_pwm_print(const mp_print_t *print, mp_obj_t self_in,
     mp_print_kind_t kind) {
     machine_pwm_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<PWM Controller %p channel=%d ", self->pwm, self->channel);
+    const char *name = zephyr_device_get_name(self->pwm);
+    mp_printf(print, "<PWM Controller %s channel=%d ", name, self->channel);
 
     if (self->duty_ns != VALUE_NOT_SET) {
         mp_printf(print, " duty_ns=%d", self->duty_ns);

--- a/ports/zephyr/machine_spi.c
+++ b/ports/zephyr/machine_spi.c
@@ -55,8 +55,9 @@ typedef struct _machine_hard_spi_obj_t {
 
 static void machine_hard_spi_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_hard_spi_obj_t *self = self_in;
+    const char *name = zephyr_device_get_name(self->dev);
     mp_printf(print, "SPI(%s, baudrate=%u, polarity=%u, phase=%u, bits=%u, firstbit=%s)",
-        self->dev->name,
+        name,
         self->config.frequency,
         (self->config.operation & 0x2) >> 1,
         (self->config.operation & 0x4) >> 2,

--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -46,6 +46,12 @@ static mp_obj_t sensor_make_new(const mp_obj_type_t *type, size_t n_args, size_t
     return MP_OBJ_FROM_PTR(o);
 }
 
+static void sensor_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    mp_obj_sensor_t *self = self_in;
+    const char *name = zephyr_device_get_name(self->dev);
+    mp_printf(print, "<Sensor %s>", name);
+}
+
 static mp_obj_t sensor_measure(mp_obj_t self_in) {
     mp_obj_sensor_t *self = MP_OBJ_TO_PTR(self_in);
     int st = sensor_sample_fetch(self->dev);
@@ -173,6 +179,7 @@ static MP_DEFINE_CONST_OBJ_TYPE(
     MP_QSTR_Sensor,
     MP_TYPE_FLAG_NONE,
     make_new, sensor_make_new,
+    print, sensor_print,
     locals_dict, &sensor_locals_dict
     );
 

--- a/ports/zephyr/zephyr_device.c
+++ b/ports/zephyr/zephyr_device.c
@@ -47,3 +47,15 @@ const struct device *zephyr_device_find(mp_obj_t name) {
 
     return dev;
 }
+
+const char *zephyr_device_get_name(const struct device *dev) {
+    #ifdef CONFIG_DEVICE_DT_METADATA
+    const struct device_dt_nodelabels *nl = device_get_dt_nodelabels(dev);
+
+    if (nl != NULL && nl->num_nodelabels > 0) {
+        return nl->nodelabels[0];
+    }
+    #endif
+
+    return dev->name;
+}

--- a/ports/zephyr/zephyr_device.h
+++ b/ports/zephyr/zephyr_device.h
@@ -28,3 +28,4 @@
 #include "py/obj.h"
 
 const struct device *zephyr_device_find(mp_obj_t name);
+const char *zephyr_device_get_name(const struct device *dev);


### PR DESCRIPTION
### Summary

Also print nodelabels when printing device names. This way it is more verbose.
Added a shared function for it.

### Testing

tested on a stm32h573I_dk.

### Trade-offs and Alternatives

not having a more verbose info.
