### PR TITLE
webassembly: Convert port to use new event waiting functions.

### DIFF
--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -74,11 +74,6 @@
 #define MICROPY_PY_JSFFI (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-    } while (0);
-
 // Whether the VM will periodically call mp_js_hook(), which checks for
 // interrupt characters on stdin (or equivalent input).
 #ifndef MICROPY_VARIANT_ENABLE_JS_HOOK


### PR DESCRIPTION
### Summary

The webassembly port does not have anything that needs polling when waiting for events, so it can just use the default (empty) definitions of `MICROPY_INTERNAL_WFE` and `MICROPY_INTERNAL_EVENT_HOOK`.

### Testing

Tested locally running the test suite with the webassembly pyscript variant.  Will also be tested as part of CI.