### PR TITLE
ports: clean up duplicated and dummy help/open builtins

### DIFF
--- a/ports/nrf/main.c
+++ b/ports/nrf/main.c
@@ -312,11 +312,6 @@ mp_lexer_t *mp_lexer_new_from_file(qstr filename) {
 mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
-
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    mp_raise_OSError(MP_EPERM);
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
 #endif
 #endif
 

--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -353,10 +353,11 @@ long unsigned int rng_generate_random_word(void);
 #include "boardmodules.h"
 #endif // BOARD_SPECIFIC_MODULES
 
-// extra built in names to add to the global namespace
+#if MICROPY_MBFS
+// The builtins.open function must be explicitly added when using the micro:bit filesystem.
 #define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_help), MP_ROM_PTR(&mp_builtin_help_obj) }, \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) }, \
+    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
+#endif
 
 // extra constants
 #define MICROPY_PORT_CONSTANTS \

--- a/ports/pic16bit/main.c
+++ b/ports/pic16bit/main.c
@@ -110,11 +110,6 @@ mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
-
 void nlr_jump_fail(void *val) {
     while (1) {
         ;

--- a/ports/pic16bit/mpconfigport.h
+++ b/ports/pic16bit/mpconfigport.h
@@ -79,10 +79,6 @@
 
 typedef int mp_off_t;
 
-// extra builtin names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #define MP_STATE_PORT MP_STATE_VM
 
 #define MICROPY_MPHALPORT_H "pic16bit_mphal.h"

--- a/ports/powerpc/main.c
+++ b/ports/powerpc/main.c
@@ -115,11 +115,6 @@ mp_import_stat_t mp_import_stat(const char *path) {
     return MP_IMPORT_STAT_NO_EXIST;
 }
 
-mp_obj_t mp_builtin_open(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
-    return mp_const_none;
-}
-MP_DEFINE_CONST_FUN_OBJ_KW(mp_builtin_open_obj, 1, mp_builtin_open);
-
 void nlr_jump_fail(void *val) {
     while (1) {
         ;

--- a/ports/powerpc/mpconfigport.h
+++ b/ports/powerpc/mpconfigport.h
@@ -94,10 +94,6 @@
 
 typedef long mp_off_t;
 
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #define MICROPY_HW_BOARD_NAME "bare-metal"
 #define MICROPY_HW_MCU_NAME "POWERPC"
 

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -181,10 +181,6 @@ typedef long mp_off_t;
 
 #define MP_SSIZE_MAX (0x7fffffff)
 
-// extra built in names to add to the global namespace
-#define MICROPY_PORT_BUILTINS \
-    { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
-
 #if MICROPY_PY_THREAD
 #define MICROPY_EVENT_POLL_HOOK \
     do { \


### PR DESCRIPTION
### Summary

Following on from 6e71cde6aad2b2ed3d431d8d94c9bd2ee52e319d, this cleans up the remaining ports in their configuration of `builtins.open`:
- nrf: remove duplicated help/open
- pic16bit: remove dummy open
- powerpc: remove dummy open
- zephyr: remove duplicate open

See the individual commits for further details.

### Testing

Tested nrf port on ARDUINO_NANO_33_BLE_SENSE, MICROBIT and MICROBIT with MBFS enabled.

Tested building pic16bit port.

Tested zephyr port on bbc_microbit_v2.

CI will also build these ports.

### Trade-offs and Alternatives

This is a simplification of the configuration, because builtin help and open are managed by the core.
