### PR TITLE
mimxrt: Increase resolution of RTC to 1/32768 seconds.

### DIFF
--- a/ports/mimxrt/fatfs_port.c
+++ b/ports/mimxrt/fatfs_port.c
@@ -26,14 +26,12 @@
  */
 
 #include "lib/oofatfs/ff.h"
-#include "fsl_snvs_lp.h"
-
+#include "shared/timeutils/timeutils.h"
+#include "modmachine.h"
 
 MP_WEAK DWORD get_fattime(void) {
-    snvs_lp_srtc_datetime_t srtcDate;
-
-    SNVS_LP_SRTC_GetDatetime(SNVS, &srtcDate);
-
-    return ((srtcDate.year - 1980) << 25) | (srtcDate.month << 21) | (srtcDate.day << 16) |
-           (srtcDate.hour << 11) | ((srtcDate.minute << 5) | (srtcDate.second / 2));
+    uint64_t seconds = machine_rtc_get_seconds();
+    timeutils_struct_time_t tm;
+    timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
+    return ((tm.tm_year - 1980) << 25) | ((tm.tm_mon) << 21) | ((tm.tm_mday) << 16) | ((tm.tm_hour) << 11) | ((tm.tm_min) << 5) | (tm.tm_sec / 2);
 }

--- a/ports/mimxrt/mbedtls/mbedtls_port.c
+++ b/ports/mimxrt/mbedtls/mbedtls_port.c
@@ -30,8 +30,8 @@
 
 #include "mbedtls_config_port.h"
 #if defined(MBEDTLS_HAVE_TIME) || defined(MBEDTLS_HAVE_TIME_DATE)
-#include "fsl_snvs_lp.h"
 #include "shared/timeutils/timeutils.h"
+#include "modmachine.h"
 #include "mbedtls/platform_time.h"
 #endif
 
@@ -49,9 +49,7 @@ int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t 
 #if defined(MBEDTLS_HAVE_TIME)
 time_t mimxrt_rtctime_seconds(time_t *timer) {
     // Get date and date in CPython order.
-    snvs_lp_srtc_datetime_t date;
-    SNVS_LP_SRTC_GetDatetime(SNVS, &date);
-    return timeutils_seconds_since_epoch(date.year, date.month, date.day, date.hour, date.minute, date.second);
+    return machine_rtc_get_seconds();
 }
 
 mbedtls_ms_time_t mbedtls_ms_time(void) {

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -42,6 +42,8 @@ void mimxrt_sdram_init(void);
 void machine_i2s_init0();
 void machine_i2s_deinit_all(void);
 void machine_rtc_start(void);
+uint64_t machine_rtc_get_ticks(void);
+uint64_t machine_rtc_get_seconds(void);
 void machine_rtc_alarm_helper(int seconds, bool repeat);
 void machine_uart_set_baudrate(mp_obj_t uart, uint32_t baudrate);
 

--- a/ports/mimxrt/modtime.c
+++ b/ports/mimxrt/modtime.c
@@ -25,30 +25,17 @@
  * THE SOFTWARE.
  */
 
-#include "py/obj.h"
 #include "shared/timeutils/timeutils.h"
-#include "fsl_snvs_lp.h"
+#include "modmachine.h"
 
 // Get the localtime.
 static void mp_time_localtime_get(timeutils_struct_time_t *tm) {
     // Get current date and time.
-    snvs_lp_srtc_datetime_t t;
-    SNVS_LP_SRTC_GetDatetime(SNVS, &t);
-    tm->tm_year = t.year;
-    tm->tm_mon = t.month;
-    tm->tm_mday = t.day;
-    tm->tm_hour = t.hour;
-    tm->tm_min = t.minute;
-    tm->tm_sec = t.second;
-    tm->tm_wday = timeutils_calc_weekday(t.year, t.month, t.day);
-    tm->tm_yday = timeutils_year_day(t.year, t.month, t.day);
+    uint64_t seconds = machine_rtc_get_seconds();
+    timeutils_seconds_since_epoch_to_struct_time(seconds, tm);
 }
 
 // Return the number of seconds since the Epoch.
 static mp_obj_t mp_time_time_get(void) {
-    snvs_lp_srtc_datetime_t t;
-    SNVS_LP_SRTC_GetDatetime(SNVS, &t);
-    return timeutils_obj_from_timestamp(
-        timeutils_seconds_since_epoch(t.year, t.month, t.day, t.hour, t.minute, t.second)
-        );
+    return timeutils_obj_from_timestamp(machine_rtc_get_seconds());
 }


### PR DESCRIPTION
### Summary

Currently the mimxrt port has a resolution of only 1 second for `machine.RTC().datetime()` and `time.time_ns()`.  This means (among other things) that it fails the `tests/extmod/time_time_ns.py` test, which requires requires at least 5ms of resolution.

The underlying RTC hardware is just a 64-bit counter (which is great, IMO better than storing y/m/d/h/m/s values), and the HAL functions `SNVS_LP_SRTC_GetDatetime()` and `SNVS_LP_SRTC_SetDatetime()` do conversions between y/m/d/h/m/s and this 64-bit value, which counts at a rate of 32kHz.

This PR changes the RTC code to access the 64-bit counter directly and therefore improve resolution of all RTC functions to 1/32768 seconds.

That makes things much simpler because it a lot of places the code wants to know the number of seconds since the Epoch.  Currently it uses a combination of `SNVS_LP_SRTC_GetDatetime()` and `timeutils_seconds_since_epoch()` which converts the 64-bit counter to date-time and then back to seconds.  Those operations are computationally expensive.

With this PR, getting the number of seconds since the Epoch is as simple as reading the 64-bit counter and dividing by 32768.  We can leverage a lot of the timeutils functions to simplify everything, and make it similar to other ports like rp2.

Benefits of this change:
- simpler, more efficient code to get/set RTC
- `machine.RTC().datetime()` now has a non-zero value in the last slot, being the number of microseconds, and has a resolution of 1/32768 seconds
- `time.time_ns()` now has a resolution of 1/32768 seconds
- the `extmod/time_time_ns.py` test now passes

### Testing

Tested on TEENSY40 running the full test suite.  Everything now passes (`time_time_ns.py` was the remaining failing test).

### Trade-offs and Alternatives

As far as I can see, this is an improvement all round :smile: 

Note that `machine_rtc_get_ticks()` must loop until the high and low parts of the 64-bit number are consistent.  I disabled interrupts while it did that to make sure it completes even if there are many IRQs firing.
