### PR TITLE
esp32: Add dupterm polling to mp_hal_stdin_rx_chr

### DIFF
--- a/ports/esp32/mphalport.c
+++ b/ports/esp32/mphalport.c
@@ -138,6 +138,12 @@ int mp_hal_stdin_rx_chr(void) {
         if (c != -1) {
             return c;
         }
+        #if MICROPY_PY_OS_DUPTERM
+        c = mp_os_dupterm_rx_chr();
+        if (c >= 0) {
+            return c;
+        }
+        #endif
         MICROPY_EVENT_POLL_HOOK
     }
 }


### PR DESCRIPTION
## Summary

The ESP32 port's [mp_hal_stdin_rx_chr()](cci:1://file:///Users/jep/github/micropython-1.27/ports/esp32/mphalport.c:128:0-150:1) currently only reads from the local `stdin_ringbuf`, ignoring any dupterm streams. This means that Python's [input()](cci:1://file:///Users/jep/github/mpDirect/httpserver/modwebrepl.c:247:0-262:1) function never receives data from dupterm-based interfaces like WebREPL.

This PR adds a call to `mp_os_dupterm_rx_chr()` in the main polling loop, consistent with other ports.

## Problem

When running a script that uses [input()](cci:1://file:///Users/jep/github/mpDirect/httpserver/modwebrepl.c:247:0-262:1) over WebREPL (or any other dupterm stream), the function hangs indefinitely waiting for UART input because the ESP32 port's [mp_hal_stdin_rx_chr()](cci:1://file:///Users/jep/github/micropython-1.27/ports/esp32/mphalport.c:128:0-150:1) never checks the dupterm stream for available characters.

## Solution

Add dupterm polling after checking the local ringbuf, matching the pattern used in other ports:

- [ports/stm32/mphalport.c](cci:7://file:///Users/jep/github/micropython-1.27/ports/stm32/mphalport.c:0:0-0:0) - already includes `mp_os_dupterm_rx_chr()` check
- [ports/rp2/mphalport.c](cci:7://file:///Users/jep/github/micropython-1.27/ports/rp2/mphalport.c:0:0-0:0) - already includes `mp_os_dupterm_rx_chr()` check  
- `ports/unix/mphalport.c` - already includes `mp_os_dupterm_rx_chr()` check

## Testing

Tested with WebREPL over WebSocket on ESP32-P4, confirming that [input()](cci:1://file:///Users/jep/github/mpDirect/httpserver/modwebrepl.c:247:0-262:1) now correctly receives and returns user input.