### PR TITLE
esp32: Allow excluding main.c for component builds.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -107,10 +107,14 @@ if(MICROPY_PY_TINYUSB)
         ${MICROPY_BOARD_DIR})
 endif()
 
+# Only include main.c for standalone builds, not when used as ESP-IDF component
+if(NOT MICROPY_COMPONENT_BUILD)
+    list(APPEND MICROPY_SOURCE_PORT main.c)
+endif()
+
 list(APPEND MICROPY_SOURCE_PORT
     panichandler.c
     adc.c
-    main.c
     ppp_set_auth.c
     uart.c
     usb.c


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant. -->

This commit introduces a new CMake option MICROPY_COMPONENT_BUILD that allows excluding main.c from the build when MicroPython is integrated as an ESP-IDF component in an external project.

When MicroPython is used as a component, the host application typically provides its own app_main() and mp_task() functions, leading to multiple definition errors at link time.

The option defaults to OFF, preserving existing behavior for all
standard MicroPython builds.

Example usage in an external ESP-IDF project:
  set(MICROPY_COMPONENT_BUILD ON)

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

I compiled the esp32 port for all supported targets out and in tree and the builds completed cleanly. 
