### PR TITLE
docs/rp2: Update general and PIO docs for RP2350 support.

### DIFF
--- a/docs/rp2/general.rst
+++ b/docs/rp2/general.rst
@@ -4,17 +4,18 @@ General information about the RP2xxx port
 =========================================
 
 The rp2 port supports boards powered by the Raspberry Pi Foundation's RP2xxx
-family of microcontrollers, most notably the Raspberry Pi Pico that employs
-the RP2040.
+family of microcontrollers, including the RP2040 and RP2350.
 
 Technical specifications and SoC datasheets
 -------------------------------------------
 
-For detailed technical specifications, please refer to the `datasheets
-<https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf>`_
+RP2040
+^^^^^^
 
 The RP2040 microcontroller is manufactured on a 40 nm silicon process in a 7x7mm
-QFN-56 SMD package. The key features include:
+QFN-56 SMD package.
+
+The key features include:
 
 * 133 MHz dual ARM Cortex-M0+ cores (overclockable to over 400 MHz)
 * 264KB SRAM in six independent banks
@@ -34,3 +35,32 @@ The peripherals include:
 * 16 PWM channels
 * USB 1.1 controller
 * 8 PIO state machines
+
+For detailed technical specifications, please refer to the `rp2040-datasheet
+<https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf>`_
+
+RP2350
+^^^^^^
+
+The RP2350 microcontroller is manufactured on a 40 nm silicon process and is available in
+QFN-60 (RP2350A) or QFN-80 (RP2350B) packages.
+
+The key features include:
+
+* Dual-core Arm Cortex-M33 or Hazard3 RISC-V processors at up to 150MHz 
+* 520KB on-chip SRAM 
+* Support for up to 16MB of off-chip Flash memory via QSPI 
+* USB 2.0 Full-Speed/Low-Speed controller 
+* 30 GPIO pins (RP2350A) or 48 GPIO pins (RP2350B) 
+
+The peripherals include:
+
+* 2 UARTs 
+* 2 SPI controllers 
+* 2 I2C controllers 
+* 24 PWM channels 
+* 12 PIO state machines 
+* HSTX high-speed transmitter 
+
+For detailed technical specifications, please refer to the `rp2350-datasheet
+<https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf>`_ 


### PR DESCRIPTION
### Summary
This change updates rp2 port documentation to include support for the Raspberry Pi RP2350 microcontroller. 
Previously, the docs (general.rst and pio.rst) only referenced the RP2040, despite RP2350 compatibility being already available. 

Key additions cover RP2350 technical specs and PIO enhancements.

close: #17829 

### Testing
The documentation was built and verified locally. 
