### PR TITLE
github: Use Python 3.11 in Windows CI runner, unbreak settrace tests

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -45,6 +45,12 @@ jobs:
     env:
       CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
     steps:
+    - name: Install Python 3.11
+      # As of 20260112 the default Python version in Windows image is 3.12, which breaks settrace tests
+      # Use 3.11 for now
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
     - name: Install Visual Studio ${{ matrix.visualstudio }}
       if: matrix.custom_vs_install
       shell: bash


### PR DESCRIPTION
### Summary

* Explicitly use Python 3.11 in the Windows runner. This is required because [GitHub recently bumped the default Python version from 3.9 to 3.12](https://github.com/actions/runner-images/issues/13468), and there is a known issue with the settrace tests on Python 3.12.

See also #16272 for the similar fix applied for MSYS2.

### Testing

CI related change only, so fully tested by CI!

### Trade-offs and Alternatives

Originally tried setting Python 3.13 here, and removing the similar MSYS2 workaround as the MSYS2 package is also Python 3.13 now. However it seems Python 3.13 settrace output is still subtly different from <3.12 output. See https://github.com/micropython/micropython/actions/runs/21231474274/job/61090675402 for a job run against Python 3.13.

Long term I think we need to either update the settrace test comparison output to match newer CPython, or convert to using .exp files with the output currently produced by MicroPython...