### PR TITLE
esp32: Increase minimum CMake version, fix build failures with older CMake

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -3,7 +3,8 @@
 # Note for maintainers: Where possible, functionality should be put into
 # esp32_common.cmake not this file. This is because this CMakeLists.txt file
 # needs to be duplicated for out-of-tree builds, and can easily get out of date.
-cmake_minimum_required(VERSION 3.12)
+
+cmake_minimum_required(VERSION 3.16)
 
 # Set the board if it's not already set.
 if(NOT MICROPY_BOARD)

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -289,6 +289,7 @@ endif()
 # Add additional extmod and usermod components.
 if (MICROPY_PY_BTREE)
     target_link_libraries(${MICROPY_TARGET} $<TARGET_OBJECTS:micropy_extmod_btree>)
+    target_link_libraries(${MICROPY_TARGET} "-u abort_")  # micropy_extmod_btree links to this symbol found in MICROPY_TARGET
 endif()
 target_link_libraries(${MICROPY_TARGET} usermod)
 


### PR DESCRIPTION
### Summary

*  ESP-IDF requires CMake min 3.16 now, so update the minimum version for the esp32 port to match.
* Fix a linker failure reported when using CMake 3.16 (#18589). Same failure occured with CMake 3.18.

The linker failure is because the esp32 port links the btree library (somewhat hackily) by adding its object files to the project's libmain linker arguments. However, the btree library depends on a symbol in libmain (`abort_`) which isn't resolved. It's unclear why the problem only exists on older CMake versions.

*This work was funded through GitHub Sponsors.*

### Testing

* Used Toolbox to spin up images of Debian 10 (bullseye, oldoldstable) and Debian 11 (bookworm, oldstable). These have CMake 3.18.4 and CMake 3.25.1 respectively.

### Trade-offs and Alternatives

* CMake 3.25 (Nov 2022) builds successfully without this change, so we could increase the minimum version to 3.25. However, it's possible the problem may also show up in a future CMake version as it seems to be mostly accidental why it works there.
* We could refactor the existing (somewhat hacky) approach used to link the btree library and make it a full ESP-IDF component in the esp32 port, but this is a non-trivial amount of work when it only depends on a single symbol in libmain.