### PR TITLE
tools/mpremote: Add mip download and mpy version handling.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -325,7 +325,23 @@ The full list of supported commands are:
 
   .. code-block:: bash
 
-      $ mpremote mip install <packages...>
+      $ mpremote mip <sub-command> [options] <packages...>
+
+  ``<sub-command>`` may be:
+
+  - ``install`` to install packages on the connected device
+  - ``download`` to download packages to the local filesystem
+
+  Options are:
+
+  - ``-m``, ``--mpy``, ``--no-mpy``: download compiled ``.mpy`` files. Defaults
+    to on for ``install`` and off for ``download``.
+  - ``--mpy-version``: mpy version to download when using ``--mpy``. The default
+    is ``auto`` which probes the connected device;
+  - ``--target``: destination directory on the device (``install``) or local
+    filesystem (``download``). The default is ``/lib`` path for ``install`` and
+    ``./lib`` for ``download``.
+  - ``--index``: package index to use (defaults to :term:`micropython-lib`).
 
   See :ref:`packages` for more information.
 
@@ -739,6 +755,13 @@ Copy ``a.py`` and ``b.py`` from the local directory to the device, then run the
 
 Install the ``aioble`` package from :term:`micropython-lib` to the device.
 See :ref:`packages`.
+
+.. code-block:: bash
+
+  mpremote mip download aioble
+
+Download the ``aioble`` package from :term:`micropython-lib` to the local
+``./lib`` directory. See :ref:`packages`.
 
 .. code-block:: bash
 

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -336,12 +336,15 @@ The full list of supported commands are:
 
   - ``-m``, ``--mpy``, ``--no-mpy``: download compiled ``.mpy`` files. Defaults
     to on for ``install`` and off for ``download``.
-  - ``--mpy-version``: mpy version to download when using ``--mpy``. The default
-    is ``auto`` which probes the connected device;
+  - ``--mpy-version``: mpy version to download when using ``--mpy``. If unset,
+    connected device will be probed to get the matching version.
   - ``--target``: destination directory on the device (``install``) or local
     filesystem (``download``). The default is ``/lib`` path for ``install`` and
     ``./lib`` for ``download``.
   - ``--index``: package index to use (defaults to :term:`micropython-lib`).
+
+  The ``mpy`` option only affects downloads from the index, and will be ignored
+  for all other package specifications.
 
   See :ref:`packages` for more information.
 

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -232,9 +232,24 @@ def argparse_mip():
     cmd_parser = argparse.ArgumentParser(
         description="install packages from micropython-lib or third-party sources"
     )
-    _bool_flag(cmd_parser, "mpy", "m", True, "download as compiled .mpy files (default)")
+    _bool_flag(
+        cmd_parser,
+        "mpy",
+        "m",
+        None,
+        "download as compiled .mpy files (install defaults to on; download defaults to off)",
+    )
     cmd_parser.add_argument(
-        "--target", type=str, required=False, help="destination direction on the device"
+        "--mpy-version",
+        type=str,
+        required=False,
+        help="mpy version to download when using --mpy (default: auto, probe connected device)",
+    )
+    cmd_parser.add_argument(
+        "--target",
+        type=str,
+        required=False,
+        help="destination directory on the device (install) or local fs (download)",
     )
     cmd_parser.add_argument(
         "--index",

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -8,7 +8,7 @@ Requirements:
   as `mpremote`.
 - If the device has an SDcard or other vfs mounted, the vfs's filesystem must be empty
   to pass the filesystem test.
-- Python 3.x, `bash` and various Unix tools such as `find`, `mktemp`, `sed`, `sort`, `tr`.
+- Python 3.x, `bash` and various Unix tools such as `find`, `mktemp`, `sed`, `sort`, `tr`, `diff`.
 - To test on Windows, you can either:
     - Run the (Linux) tests in WSL2 against a USB device that is passed though to WSL2.
     - Use the `Git Bash` terminal to run the tests against a device connected to a COM

--- a/tools/mpremote/tests/test_mip_local_download.sh
+++ b/tools/mpremote/tests/test_mip_local_download.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# This test the "mpremote mip download" from local files. It creates a package
+# and downloads it into a local directory. The package contents are then
+# verified on disk.
+
+set -e
+
+PACKAGE=mip_example
+PACKAGE_DIR="${TMP}/example"
+MODULE_DIR="${PACKAGE_DIR}/${PACKAGE}"
+
+TARGET_DIR="${TMP}/lib"
+
+echo ----- Setup
+mkdir -p "${MODULE_DIR}"
+echo "def hello(): print('Hello, world!')" > "${MODULE_DIR}/hello.py"
+echo "from .hello import hello" > "${MODULE_DIR}/__init__.py"
+cat > "${PACKAGE_DIR}/package.json" <<EOF
+{
+    "urls": [
+        ["${PACKAGE}/__init__.py", "${PACKAGE}/__init__.py"],
+        ["${PACKAGE}/hello.py", "${PACKAGE}/hello.py"]
+    ],
+    "version": "0.2"
+}
+EOF
+
+echo
+echo ---- Download package
+"${MPREMOTE}" mip download --target="${TARGET_DIR}" "${PACKAGE_DIR}/package.json"
+echo
+echo ---- Verify package
+diff -u "${MODULE_DIR}/__init__.py" "${TARGET_DIR}/${PACKAGE}/__init__.py"
+diff -u "${MODULE_DIR}/hello.py" "${TARGET_DIR}/${PACKAGE}/hello.py"

--- a/tools/mpremote/tests/test_mip_local_download.sh
+++ b/tools/mpremote/tests/test_mip_local_download.sh
@@ -30,6 +30,9 @@ echo
 echo ---- Download package
 "${MPREMOTE}" mip download --target="${TARGET_DIR}" "${PACKAGE_DIR}/package.json"
 echo
+echo ---- Download package with --mpy and --mpy-version set to get a warning
+"${MPREMOTE}" mip download --mpy-version=6 --mpy --target="${TARGET_DIR}" "${PACKAGE_DIR}/package.json"
+echo
 echo ---- Verify package
 diff -u "${MODULE_DIR}/__init__.py" "${TARGET_DIR}/${PACKAGE}/__init__.py"
 diff -u "${MODULE_DIR}/hello.py" "${TARGET_DIR}/${PACKAGE}/hello.py"

--- a/tools/mpremote/tests/test_mip_local_download.sh.exp
+++ b/tools/mpremote/tests/test_mip_local_download.sh.exp
@@ -1,0 +1,9 @@
+----- Setup
+
+---- Download package
+Install ${TMP}/example/package.json
+Installing: ${TMP}/lib/mip_example/__init__.py
+Installing: ${TMP}/lib/mip_example/hello.py
+Done
+
+---- Verify package

--- a/tools/mpremote/tests/test_mip_local_download.sh.exp
+++ b/tools/mpremote/tests/test_mip_local_download.sh.exp
@@ -6,4 +6,11 @@ Installing: ${TMP}/lib/mip_example/__init__.py
 Installing: ${TMP}/lib/mip_example/hello.py
 Done
 
+---- Download package with --mpy and --mpy-version set to get a warning
+Install ${TMP}/example/package.json
+Warning: --mpy and --mpy-version only affect downloads from index, package ${TMP}/example/package.json will be downloaded as-is
+Installing: ${TMP}/lib/mip_example/__init__.py
+Installing: ${TMP}/lib/mip_example/hello.py
+Done
+
 ---- Verify package


### PR DESCRIPTION

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/blob/master/CODEOFCONDUCT.md
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary
Adds a new sub-command for mpremote mip: `mpremote mip download`, inspired by `pip download`, which accept same packages and uses same logic as `mip install`, but downloads files to local filesystem instead of remote micropython board.
Fixes #18711.

A use case: run `mip download` for all the dependencies, and add `./lib` to `python.analysis.extraPaths` or whatever your ide/setup uses -- and now you have a proper code completion and go to definition working with same code obtained by same command as the code running on the board.

An issue on Raspberry Pi forums by someone else on this with more details: https://forums.raspberrypi.com/viewtopic.php?t=377948

### Testing

- tested that mip install maintains old behaviour with no changes.
- tested that mip download works without a connected device, but also works with connected devices when `--mpy` is set to download mpy files.

### Trade-offs and Alternatives

An alternative approach is to only keep `mip install` command and support both local and remote paths in the `--target` argument.
I have considered this alternative to adding `mip download` command and keeping `mip install`, but I have decided against it due to following reasons:

#### Backwards incompatibility in path handling
Many `mpremote` commands already support working with both local and remote filesystems, and `:` is used to reference remote filesystem.

The mip install doesn't follow that convention: it can only work with remote paths, so `mip install`'s `--target` argument treats all paths as remote, and doesn't support the `:` notation for remote paths.

Making `mip install` follow this convention would be a backwards incompatible change which I wanted to avoid.

#### Defaults for `mpy` argument

The `mip install` prefers `mpy` files instead of `py` files as those are a better default for files installed to the micropython environment.

However, preferring `mpy` files to `py` files for locally downloaded files is not a sane default: the `mpy` files won't help for most use-cases where local downloads of mip packages are needed.

Having multiple different commands makes the `mpy` defaulting easier: it makes more sense to have different defaults for different commands rather than to have the default value for a flag change depending what was provided in the other flag.

#### `pip download` command

There's a `pip download` command the `mip download` command matches, while the `pip install` arguably doesn't provide options to just download the packages to a given directory. This makes the `mip download` command be recognizable for people already familiar with `pip` commands.