### PR TITLE
zephyr: Resolve problem with FatFs lib.

### DIFF
--- a/ports/zephyr/Kconfig
+++ b/ports/zephyr/Kconfig
@@ -34,6 +34,7 @@ config MICROPY_HEAP_SIZE
 
 config MICROPY_VFS_FAT
 	bool "FatFS file system"
+	depends on !FAT_FILESYSTEM_ELM
 
 config MICROPY_VFS_LFS1
 	bool "LittleFs version 1 file system"


### PR DESCRIPTION
### Summary

Zephyr and Micropython both have a variant of FatFs, but having both enabled leads to build fails.


### Testing

Tested with zephyr


### Trade-offs and Alternatives

