### PR TITLE
py: clean up some header declarations and make some helper functions inline

### DIFF
--- a/py/bc.c
+++ b/py/bc.c
@@ -102,7 +102,7 @@ static MP_NORETURN void fun_pos_args_mismatch(mp_obj_fun_bc_t *f, size_t expecte
     #elif MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED
     mp_raise_msg_varg(&mp_type_TypeError,
         MP_ERROR_TEXT("%q() takes %d positional arguments but %d were given"),
-        mp_obj_fun_get_name(MP_OBJ_FROM_PTR(f)), expected, given);
+        mp_obj_fun_bc_get_name(f), expected, given);
     #endif
 }
 

--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "py/builtin.h"
+#include "py/objlist.h"
 #include "py/objmodule.h"
 
 #if MICROPY_PY_BUILTINS_HELP

--- a/py/misc.h
+++ b/py/misc.h
@@ -253,24 +253,12 @@ void vstr_cut_head_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_tail_bytes(vstr_t *vstr, size_t bytes_to_cut);
 void vstr_cut_out_bytes(vstr_t *vstr, size_t byte_pos, size_t bytes_to_cut);
 void vstr_printf(vstr_t *vstr, const char *fmt, ...);
-
-/** non-dynamic size-bounded variable buffer/string *************/
-
-#define CHECKBUF(buf, max_size) char buf[max_size + 1]; size_t buf##_len = max_size; char *buf##_p = buf;
-#define CHECKBUF_RESET(buf, max_size) buf##_len = max_size; buf##_p = buf;
-#define CHECKBUF_APPEND(buf, src, src_len) \
-    { size_t l = MIN(src_len, buf##_len); \
-      memcpy(buf##_p, src, l); \
-      buf##_len -= l; \
-      buf##_p += l; }
-#define CHECKBUF_APPEND_0(buf) { *buf##_p = 0; }
-#define CHECKBUF_LEN(buf) (buf##_p - buf)
-
 #ifdef va_start
 void vstr_vprintf(vstr_t *vstr, const char *fmt, va_list ap);
 #endif
 
-// Debugging helpers
+/** debugging helpers *******************************************/
+
 int DEBUG_printf(const char *fmt, ...);
 
 extern mp_uint_t mp_verbose_flag;

--- a/py/obj.h
+++ b/py/obj.h
@@ -1179,11 +1179,6 @@ mp_obj_t mp_obj_complex_binary_op(mp_binary_op_t op, mp_float_t lhs_real, mp_flo
 #define mp_obj_is_float(o) (false)
 #endif
 
-// tuple
-void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
-void mp_obj_tuple_del(mp_obj_t self_in);
-mp_int_t mp_obj_tuple_hash(mp_obj_t self_in);
-
 // dict
 typedef struct _mp_obj_dict_t {
     mp_obj_base_t base;

--- a/py/obj.h
+++ b/py/obj.h
@@ -1248,8 +1248,6 @@ typedef struct _mp_obj_fun_builtin_var_t {
     } fun;
 } mp_obj_fun_builtin_var_t;
 
-qstr mp_obj_fun_get_name(mp_const_obj_t fun);
-
 mp_obj_t mp_identity(mp_obj_t self);
 MP_DECLARE_CONST_FUN_OBJ_1(mp_identity_obj);
 

--- a/py/obj.h
+++ b/py/obj.h
@@ -1184,14 +1184,6 @@ void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
 void mp_obj_tuple_del(mp_obj_t self_in);
 mp_int_t mp_obj_tuple_hash(mp_obj_t self_in);
 
-// list
-mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg);
-mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value);
-void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
-void mp_obj_list_set_len(mp_obj_t self_in, size_t len);
-void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
-mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
-
 // dict
 typedef struct _mp_obj_dict_t {
     mp_obj_base_t base;

--- a/py/obj.h
+++ b/py/obj.h
@@ -1258,9 +1258,6 @@ typedef struct _mp_obj_module_t {
     mp_obj_base_t base;
     mp_obj_dict_t *globals;
 } mp_obj_module_t;
-static inline mp_obj_dict_t *mp_obj_module_get_globals(mp_obj_t module) {
-    return ((mp_obj_module_t *)MP_OBJ_TO_PTR(module))->globals;
-}
 
 // staticmethod and classmethod types; defined here so we can make const versions
 // this structure is used for instances of both staticmethod and classmethod

--- a/py/objfun.c
+++ b/py/objfun.c
@@ -132,8 +132,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 /******************************************************************************/
 /* byte code functions                                                        */
 
-qstr mp_obj_fun_get_name(mp_const_obj_t fun_in) {
-    const mp_obj_fun_bc_t *fun = MP_OBJ_TO_PTR(fun_in);
+qstr mp_obj_fun_bc_get_name(const mp_obj_fun_bc_t *fun) {
     const byte *bc = fun->bytecode;
 
     #if MICROPY_ENABLE_NATIVE_CODE
@@ -181,7 +180,7 @@ static mp_obj_t fun_bc_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 static void fun_bc_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_fun_bc_t *o = MP_OBJ_TO_PTR(o_in);
-    mp_printf(print, "<function %q at 0x%p>", mp_obj_fun_get_name(o_in), o);
+    mp_printf(print, "<function %q at 0x%p>", mp_obj_fun_bc_get_name(o), o);
 }
 #endif
 
@@ -359,16 +358,15 @@ void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
         // not load attribute
         return;
     }
+    const mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
     if (attr == MP_QSTR___name__) {
-        dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_get_name(self_in));
+        dest[0] = MP_OBJ_NEW_QSTR(mp_obj_fun_bc_get_name(self));
     }
     if (attr == MP_QSTR___globals__) {
-        mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
         dest[0] = MP_OBJ_FROM_PTR(self->context->module.globals);
     }
     #if MICROPY_PY_FUNCTION_ATTRS_CODE
     if (attr == MP_QSTR___code__) {
-        const mp_obj_fun_bc_t *self = MP_OBJ_TO_PTR(self_in);
         if (self->base.type == &mp_type_fun_bc
             || self->base.type == &mp_type_gen_wrap) {
             #if MICROPY_PY_BUILTINS_CODE <= MICROPY_PY_BUILTINS_CODE_BASIC

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -51,6 +51,7 @@ typedef struct _mp_obj_fun_asm_t {
 } mp_obj_fun_asm_t;
 
 mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_module_context_t *cm, struct _mp_raw_code_t *const *raw_code_table);
+qstr mp_obj_fun_get_name(mp_const_obj_t fun);
 void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
 #if MICROPY_ENABLE_NATIVE_CODE

--- a/py/objfun.h
+++ b/py/objfun.h
@@ -51,7 +51,7 @@ typedef struct _mp_obj_fun_asm_t {
 } mp_obj_fun_asm_t;
 
 mp_obj_t mp_obj_new_fun_bc(const mp_obj_t *def_args, const byte *code, const mp_module_context_t *cm, struct _mp_raw_code_t *const *raw_code_table);
-qstr mp_obj_fun_get_name(mp_const_obj_t fun);
+qstr mp_obj_fun_bc_get_name(const mp_obj_fun_bc_t *fun);
 void mp_obj_fun_bc_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest);
 
 #if MICROPY_ENABLE_NATIVE_CODE

--- a/py/objgenerator.c
+++ b/py/objgenerator.c
@@ -147,7 +147,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 static void gen_instance_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_gen_instance_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "<generator object '%q' at %p>", mp_obj_fun_get_name(MP_OBJ_FROM_PTR(self->code_state.fun_bc)), self);
+    mp_printf(print, "<generator object '%q' at %p>", mp_obj_fun_bc_get_name(self->code_state.fun_bc), self);
 }
 
 mp_vm_return_kind_t mp_obj_gen_resume(mp_obj_t self_in, mp_obj_t send_value, mp_obj_t throw_value, mp_obj_t *ret_val) {

--- a/py/objlist.c
+++ b/py/objlist.c
@@ -489,25 +489,6 @@ mp_obj_t mp_obj_new_list(size_t n, mp_obj_t *items) {
     return MP_OBJ_FROM_PTR(o);
 }
 
-void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
-    *len = self->len;
-    *items = self->items;
-}
-
-void mp_obj_list_set_len(mp_obj_t self_in, size_t len) {
-    // trust that the caller knows what it's doing
-    // TODO realloc if len got much smaller than alloc
-    mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
-    self->len = len;
-}
-
-void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
-    mp_obj_list_t *self = MP_OBJ_TO_PTR(self_in);
-    size_t i = mp_get_index(self->base.type, self->len, index, false);
-    self->items[i] = value;
-}
-
 /******************************************************************************/
 /* list iterator                                                              */
 

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -37,5 +37,11 @@ typedef struct _mp_obj_list_t {
 
 void mp_obj_list_init(mp_obj_list_t *o, size_t n);
 mp_obj_t mp_obj_list_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);
+mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg);
+mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
+mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value);
+void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
+void mp_obj_list_set_len(mp_obj_t self_in, size_t len);
+void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
 
 #endif // MICROPY_INCLUDED_PY_OBJLIST_H

--- a/py/objlist.h
+++ b/py/objlist.h
@@ -40,8 +40,24 @@ mp_obj_t mp_obj_list_make_new(const mp_obj_type_t *type_in, size_t n_args, size_
 mp_obj_t mp_obj_list_append(mp_obj_t self_in, mp_obj_t arg);
 mp_obj_t mp_obj_list_sort(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs);
 mp_obj_t mp_obj_list_remove(mp_obj_t self_in, mp_obj_t value);
-void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
-void mp_obj_list_set_len(mp_obj_t self_in, size_t len);
-void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value);
+
+static inline void mp_obj_list_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
+    mp_obj_list_t *self = (mp_obj_list_t *)MP_OBJ_TO_PTR(self_in);
+    *len = self->len;
+    *items = self->items;
+}
+
+static inline void mp_obj_list_set_len(mp_obj_t self_in, size_t len) {
+    // trust that the caller knows what it's doing
+    // TODO realloc if len got much smaller than alloc
+    mp_obj_list_t *self = (mp_obj_list_t *)MP_OBJ_TO_PTR(self_in);
+    self->len = len;
+}
+
+static inline void mp_obj_list_store(mp_obj_t self_in, mp_obj_t index, mp_obj_t value) {
+    mp_obj_list_t *self = (mp_obj_list_t *)MP_OBJ_TO_PTR(self_in);
+    size_t i = mp_get_index(self->base.type, self->len, index, false);
+    self->items[i] = value;
+}
 
 #endif // MICROPY_INCLUDED_PY_OBJLIST_H

--- a/py/objmodule.h
+++ b/py/objmodule.h
@@ -44,4 +44,8 @@ mp_obj_t mp_module_get_builtin(qstr module_name, bool extensible);
 
 void mp_module_generic_attr(qstr attr, mp_obj_t *dest, const uint16_t *keys, mp_obj_t *values);
 
+static inline mp_obj_dict_t *mp_obj_module_get_globals(mp_obj_t module) {
+    return ((mp_obj_module_t *)MP_OBJ_TO_PTR(module))->globals;
+}
+
 #endif // MICROPY_INCLUDED_PY_OBJMODULE_H

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -251,13 +251,6 @@ mp_obj_t mp_obj_new_tuple(size_t n, const mp_obj_t *items) {
     return MP_OBJ_FROM_PTR(o);
 }
 
-void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
-    assert(mp_obj_is_tuple_compatible(self_in));
-    mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);
-    *len = self->len;
-    *items = &self->items[0];
-}
-
 void mp_obj_tuple_del(mp_obj_t self_in) {
     assert(mp_obj_is_type(self_in, &mp_type_tuple));
     mp_obj_tuple_t *self = MP_OBJ_TO_PTR(self_in);

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -28,6 +28,9 @@
 
 #include "py/obj.h"
 
+// type check is done on getiter method to allow tuple, namedtuple, attrtuple
+#define mp_obj_is_tuple_compatible(o) (MP_OBJ_TYPE_GET_SLOT_OR_NULL(mp_obj_get_type(o), iter) == mp_obj_tuple_getiter)
+
 typedef struct _mp_obj_tuple_t {
     mp_obj_base_t base;
     size_t len;
@@ -45,7 +48,14 @@ mp_obj_t mp_obj_tuple_unary_op(mp_unary_op_t op, mp_obj_t self_in);
 mp_obj_t mp_obj_tuple_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs);
 mp_obj_t mp_obj_tuple_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value);
 mp_obj_t mp_obj_tuple_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf);
-void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
+
+static inline void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items) {
+    assert(mp_obj_is_tuple_compatible(self_in));
+    mp_obj_tuple_t *self = (mp_obj_tuple_t *)MP_OBJ_TO_PTR(self_in);
+    *len = self->len;
+    *items = &self->items[0];
+}
+
 void mp_obj_tuple_del(mp_obj_t self_in);
 
 extern const mp_obj_type_t mp_type_attrtuple;
@@ -62,8 +72,5 @@ void mp_obj_attrtuple_print_helper(const mp_print_t *print, const qstr *fields, 
 #endif
 
 mp_obj_t mp_obj_new_attrtuple(const qstr *fields, size_t n, const mp_obj_t *items);
-
-// type check is done on getiter method to allow tuple, namedtuple, attrtuple
-#define mp_obj_is_tuple_compatible(o) (MP_OBJ_TYPE_GET_SLOT_OR_NULL(mp_obj_get_type(o), iter) == mp_obj_tuple_getiter)
 
 #endif // MICROPY_INCLUDED_PY_OBJTUPLE_H

--- a/py/objtuple.h
+++ b/py/objtuple.h
@@ -45,6 +45,8 @@ mp_obj_t mp_obj_tuple_unary_op(mp_unary_op_t op, mp_obj_t self_in);
 mp_obj_t mp_obj_tuple_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs);
 mp_obj_t mp_obj_tuple_subscr(mp_obj_t base, mp_obj_t index, mp_obj_t value);
 mp_obj_t mp_obj_tuple_getiter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf);
+void mp_obj_tuple_get(mp_obj_t self_in, size_t *len, mp_obj_t **items);
+void mp_obj_tuple_del(mp_obj_t self_in);
 
 extern const mp_obj_type_t mp_type_attrtuple;
 


### PR DESCRIPTION
### Summary

This PR cleans up a few header declarations:
- removes unused CHECKBUF macros (they were last used 9.5 years ago...!)
- moves some tuple, list, fun and module helper function declarations from `py/obj.h` to specific headers like `py/objtuple.h` (because they are internal helpers more than general API functions)
- renames `mp_obj_fun_get_name()` to `mp_obj_fun_bc_get_name()` and changes the argument signature to make it clear what the argument must be

Then it makes some tuple and list functions inline.  That's only possible because their declarations were moved to their respective headers (`py/objtuple.h` and `py/objlist.h`).  This reduces code size by 50 to 100 bytes, which is a pretty nice saving.

### Testing

Built locally.  Will also be built and tested by CI.

### Trade-offs and Alternatives

There is a little bit of code churn here, but IMO it's worth it to get the code size savings.

Renaming `mp_obj_fun_get_name()` to `mp_obj_fun_bc_get_name()` is also arguably not necessary, but I doubt this is ever used by anyone, it's really an internal helper that shouldn't be used externally to the code in `py/`.