### PR TITLE
tests: convert `tests/extmod/machine_spi_rate.py` to use target wiring, and add support for more ports

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -267,6 +267,7 @@ tests_requiring_slice = (
 
 # Tests that require `import target_wiring` to work.
 tests_requiring_target_wiring = (
+    "extmod/machine_spi_rate.py",
     "extmod/machine_uart_irq_txidle.py",
     "extmod/machine_uart_tx.py",
     "extmod_hardware/machine_encoder.py",

--- a/tests/target_wiring/NUCLEO_WB55.py
+++ b/tests/target_wiring/NUCLEO_WB55.py
@@ -6,3 +6,5 @@
 # LPUART(1) is on PA2/PA3.
 uart_loopback_args = ("LP1",)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,), (2,)]

--- a/tests/target_wiring/PYBx.py
+++ b/tests/target_wiring/PYBx.py
@@ -6,3 +6,5 @@
 # UART("XA") is on X1/X2  (usually UART(4) on PA0/PA1).
 uart_loopback_args = ("XA",)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,), (2,)]

--- a/tests/target_wiring/README.md
+++ b/tests/target_wiring/README.md
@@ -1,0 +1,67 @@
+# Target wiring
+
+Some tests require hardware configuration and/or external connections, for example
+bridging a pair of GPIO pins.  Each board that such tests run on needs to be configured
+individually.  That is achieved by providing a target wiring configuration script that
+defines the necessary hardware parameters for each test.
+
+## Selecting the target wiring
+
+There are three ways to provide the target wiring configuration:
+
+1. Specify it explicitly when running the test: `./run-tests.py --target-wiring <script>`
+
+2. Have a `target_wiring.py` file on the target device somewhere in the import path.
+
+3. Let the configuration be selected automatically.  In that case the best matching file
+   from this directory is chosen using the following logic: prefer an exact filename
+   match to `sys.implementation._build`, followed by a match to the start of
+   `sys.implementation._build` if the filename ends in "x", followed by a filename
+   that matches the port of the target device.
+
+## Target wiring variables
+
+A target wiring script should define the following variables if the corresponding test
+is to be supported.
+
+### UART tests
+
+UART tests require one UART to be connected in loopback mode, ie TX connected physically
+to RX. The variables are:
+
+    uart_loopback_args: tuple
+    uart_loopback_kwargs: dict
+
+The UART instance will be created using:
+
+    machine.UART(*uart_loopback_args, **uart_loopback_kwargs)
+
+### SPI tests
+
+SPI tests require one or more SPI instances.  They don't require any connections.
+The variables are:
+
+    spi_standalone_args_list: list[tuple]
+
+SPI instances will be created using:
+
+    for spi_args in spi_standalone_args_list:
+        machine.SPI(*spi_args)
+
+### Encoder tests
+
+Encoder tests require one encoder to be connected in loopback mode to two other GPIO
+pins. The variables are:
+
+    encoder_loopback_id: int
+    encoder_loopback_out_pins: tuple[Any, Any]
+    encoder_loopback_in_pins: tuple[Any, Any]
+
+The Encoder instance will be created using:
+
+    out0_pin, out1_pin = encoder_loopback_out_pins
+    in0_pin, in1_pin = encoder_loopback_in_pins
+    machine.Encoder(id, in0_pin, in1_pin)
+
+The two elements in both `encoder_loopback_out_pins` and `encoder_loopback_in_pins` will
+be used to create individual `machine.Pin` instances.

--- a/tests/target_wiring/alif.py
+++ b/tests/target_wiring/alif.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(0,)]

--- a/tests/target_wiring/esp32.py
+++ b/tests/target_wiring/esp32.py
@@ -4,8 +4,15 @@
 # - GPIO4 to GPIO5
 # - GPIO12 to GPIO13
 
+import sys
+
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {"tx": 4, "rx": 5}
+
+if "ESP32C" in sys.implementation._machine:
+    spi_standalone_args_list = [(1,)]
+else:
+    spi_standalone_args_list = [(1,), (2,)]
 
 encoder_loopback_id = 0
 encoder_loopback_out_pins = (4, 12)

--- a/tests/target_wiring/esp8266.py
+++ b/tests/target_wiring/esp8266.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,)]

--- a/tests/target_wiring/mimxrt.py
+++ b/tests/target_wiring/mimxrt.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = (1,)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [()]

--- a/tests/target_wiring/nrf.py
+++ b/tests/target_wiring/nrf.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = (0,)
 uart_loopback_kwargs = {}
+
+spi_standalone_args_list = [(1,)]

--- a/tests/target_wiring/renesas-ra.py
+++ b/tests/target_wiring/renesas-ra.py
@@ -1,0 +1,3 @@
+# Target wiring for general renesas-ra board.
+
+spi_standalone_args_list = [(0,)]

--- a/tests/target_wiring/rp2.py
+++ b/tests/target_wiring/rp2.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = (0,)
 uart_loopback_kwargs = {"tx": "GPIO0", "rx": "GPIO1"}
+
+spi_standalone_args_list = [(0,), (1,)]

--- a/tests/target_wiring/samd.py
+++ b/tests/target_wiring/samd.py
@@ -5,3 +5,5 @@
 
 uart_loopback_args = ()
 uart_loopback_kwargs = {"tx": "D1", "rx": "D0"}
+
+spi_standalone_args_list = [()]


### PR DESCRIPTION
### Summary

This PR converts `tests/extmod/machine_spi_rate.py` to use the target wiring mechanism, moving the port-specefic definition of the SPI instances that are being tested out of the `tests/extmod/machine_spi_rate.py` file and into the target wiring code.  As part of this, the test is changed to always use the default pins for the given SPI instance.

This simplifies the test, makes it easier to add support for new ports/boards, and allows reusing the `spi_standalone_args_list` definition in other tests (if needed one day).

It also adds SPI test support for the mimxrt, nrf, renesas-ra and samd ports.

### Testing

Tested by running `tests/extmod/machine_spi_rate.py` on (thanks to octoprobe hardware!):
- ARDUINO_NANO_33_BLE_SENSE
- ESP32_GENERIC_C3
- ESP32_GENERIC_P4
- ESP32_GENERIC_S3
- ESP8266_GENERIC
- PYBD_SF2
- PYBV10
- RPI_PICO
- RPI_PICO_W
- SEEED_XIAO_SAMD21
- TEENSY40

The test passes.

### Trade-offs and Alternatives

There are few decisions made here:
1. This is not technically "target wiring" because nothing needs to be wired up.  It just uses the SPI as-is to measure TX speed.  But I think it's still fair enough to configure the SPI instances in the target wiring definitions.  It keeps everything self contained.
2. Always use the default SPI pins for the given instance, instead of explicitly specifying them.  Most ports already did this in the test, except for rp2 and esp32, so it's not a big difference in the way the test works.  And this makes it much simpler to specify the SPI instances to test, you just specify the id (or `None` to use the default SPI instance).
3. ~~The new `spi_standalone_instances` variable in the target wiring is a little different in name to existing variables used there, but I think it's acceptable.~~ variable changed to `spi_standalone_args_list` to match better the other variables.