### PR TITLE
py: Fix two segfaults due to accessing uninitialized memory.

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -199,7 +199,8 @@ static void mp_obj_class_lookup(struct class_lookup_data *lookup, const mp_obj_t
         // Previous code block takes care about attributes defined in .locals_dict,
         // but some attributes of native types may be handled using .load_attr method,
         // so make sure we try to lookup those too.
-        if (lookup->obj != NULL && !lookup->is_type && mp_obj_is_native_type(type) && type != &mp_type_object /* object is not a real type */) {
+        if (lookup->obj != NULL && !lookup->is_type && mp_obj_is_native_type(type) && type != &mp_type_object /* object is not a real type */
+            && mp_obj_is_instance_type(lookup->obj->base.type)) {
             mp_load_method_maybe(lookup->obj->subobj[0], lookup->attr, lookup->dest);
             if (lookup->dest[0] != MP_OBJ_NULL) {
                 return;

--- a/tests/basics/class_super_native.py
+++ b/tests/basics/class_super_native.py
@@ -1,0 +1,38 @@
+# Test that super() handles native type subclasses without crashing.
+# This tests the fix for a crash in mp_obj_class_lookup() when
+# lookup->obj was accessed incorrectly.
+
+# Test 1: Subclass of native type with super()
+class MyList(list):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.custom = "initialized"
+
+ml = MyList([1, 2, 3])
+print(len(ml))
+print(ml.custom)
+
+# Test 2: Exception subclass with super().__init__()
+class MyError(ValueError):
+    def __init__(self, msg, code):
+        super().__init__(msg)
+        self.code = code
+
+try:
+    raise MyError("error occurred", 42)
+except MyError as e:
+    print("caught:", e.args[0])
+    print("code:", e.code)
+
+# Test 3: Multiple levels of inheritance with native base
+class MyList2(MyList):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.custom2 = "also initialized"
+
+ml2 = MyList2([4, 5, 6])
+print(len(ml2))
+print(ml2.custom)
+print(ml2.custom2)
+
+print("done")

--- a/tests/basics/class_super_native.py.exp
+++ b/tests/basics/class_super_native.py.exp
@@ -1,0 +1,8 @@
+3
+initialized
+caught: error occurred
+code: 42
+3
+initialized
+also initialized
+done

--- a/tests/basics/subclass_native_exc_noinit.py
+++ b/tests/basics/subclass_native_exc_noinit.py
@@ -1,0 +1,66 @@
+# Test that exception subclasses work even if super().__init__() is not called.
+# This tests the fix for a crash in get_native_exception() when subobj[0]
+# contains the sentinel value (native_base_init_wrapper_obj).
+#
+# The crash originally occurred when an exception without initialized native base
+# propagated through generator frames, triggering traceback addition code.
+
+class FooError(RuntimeError):
+    def __init__(self, msg=()):
+        # Deliberately NOT calling super().__init__()
+        pass
+
+class NoFoo(FooError):
+    pass
+
+# Test 1: Basic raise/catch
+try:
+    raise NoFoo()
+except NoFoo as e:
+    print("caught NoFoo")
+
+# Test 2: Exception propagating through multiple generator frames
+# This is the pattern that triggers the crash - traceback gets added
+# as exception propagates through each generator frame
+def gen1():
+    yield 1
+    def gen2():
+        yield 2
+        def gen3():
+            yield 3
+            raise NoFoo()
+        g3 = gen3()
+        next(g3)
+        yield next(g3)
+    g2 = gen2()
+    next(g2)
+    yield next(g2)
+
+try:
+    g = gen1()
+    next(g)
+    next(g)
+except NoFoo:
+    print("caught from nested generators")
+
+# Test 3: Exception created via __new__ returning different subclass
+class ErrorFactory(RuntimeError):
+    def __new__(cls, code):
+        if code == 1:
+            return super().__new__(NoFoo)
+        return super().__new__(cls)
+    def __init__(self, code):
+        pass  # No super().__init__()
+
+def gen_factory():
+    yield 1
+    raise ErrorFactory(1)  # Returns NoFoo instance
+
+try:
+    g = gen_factory()
+    next(g)
+    next(g)
+except NoFoo:
+    print("caught factory-created exception")
+
+print("done")

--- a/tests/basics/subclass_native_exc_noinit.py.exp
+++ b/tests/basics/subclass_native_exc_noinit.py.exp
@@ -1,0 +1,4 @@
+caught NoFoo
+caught from nested generators
+caught factory-created exception
+done


### PR DESCRIPTION
### Summary

Accessing obj->subobj[0] without verifying that it contains a valid object (instead of a type, or a non-initialized object) is not a good idea.

### Testing

My MoaT package has extensive MicroPython testcases. Before applying this PR the MicroPython process reliably segfaulted. This no longer happens.

Closes #17117 .