### PR TITLE
zephyr/machine_timer: Protect the timer list from concurrent access.

### DIFF
--- a/ports/zephyr/machine_timer.c
+++ b/ports/zephyr/machine_timer.c
@@ -66,13 +66,14 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in);
 static void machine_timer_callback(struct k_timer *timer) {
     machine_timer_obj_t *self = (machine_timer_obj_t *)k_timer_user_data_get(timer);
 
+    if (self->mode == TIMER_MODE_ONE_SHOT) {
+        k_timer_stop(&self->my_timer);
+    }
+
     if (mp_irq_dispatch(self->callback, MP_OBJ_FROM_PTR(self), self->ishard) < 0) {
         // Uncaught exception; disable the callback so it doesn't run again.
         self->mode = TIMER_MODE_ONE_SHOT;
-    }
-
-    if (self->mode == TIMER_MODE_ONE_SHOT) {
-        machine_timer_deinit(self);
+        k_timer_stop(&self->my_timer);
     }
 }
 

--- a/ports/zephyr/machine_timer.c
+++ b/ports/zephyr/machine_timer.c
@@ -29,6 +29,7 @@
 
 #include "py/gc.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/runtime.h"
 #include "shared/runtime/mpirq.h"
@@ -101,9 +102,13 @@ static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args,
     k_timer_init(&self->my_timer, machine_timer_callback, NULL);
     k_timer_user_data_set(&self->my_timer, self);
 
-    // Add the timer to the linked-list of timers
+    // Add the timer to the linked-list of timers.  The list is also accessed
+    // from the timer callback which runs in IRQ context, so guard against
+    // concurrent modification.
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     self->next = MP_STATE_PORT(machine_timer_obj_head);
     MP_STATE_PORT(machine_timer_obj_head) = self;
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
 
     if (n_args > 0 || n_kw > 0) {
         mp_map_t kw_args;
@@ -164,7 +169,10 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
 
     k_timer_stop(&self->my_timer);
 
-    // remove it from the linked list
+    // Remove it from the linked list.  This can run in IRQ context (from the
+    // timer callback of a one-shot timer) as well as in thread context, so
+    // guard against concurrent modification.
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     for (machine_timer_obj_t *_timer = MP_STATE_PORT(machine_timer_obj_head); _timer != NULL; _timer = _timer->next) {
         if (_timer == self) {
             if (prev != NULL) {
@@ -178,6 +186,7 @@ static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
             prev = _timer;
         }
     }
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
 
     return mp_const_none;
 }


### PR DESCRIPTION
### Summary

`machine_timer_callback()` is the Zephyr `k_timer` expiry function, so it runs in IRQ context, and for a one-shot timer (or after a callback raised an uncaught exception) it calls `machine_timer_deinit()` to unlink the timer from the `machine_timer_obj_head` list. The same list is updated from thread context whenever a timer is created or deinitialised, with nothing serialising the two. A timer expiring in the middle of an insert or an unlink can corrupt the list: an entry is lost, or the list is left circular so a later traversal never terminates. Reported in https://github.com/micropython/micropython/issues/18728.

The first version of this PR removed the `machine_timer_deinit()` call from the IRQ path and only stopped the `k_timer` there. As pointed out in review, that leaks: the timer object is never unlinked, and because the list is a GC root, a program that creates many one-shot timers eventually exhausts the GC heap.

This version keeps the unlink where it is and instead guards both places that touch the list, the insert in `machine_timer_make_new()` and the unlink in `machine_timer_deinit()`, with `MICROPY_BEGIN_ATOMIC_SECTION()` / `MICROPY_END_ATOMIC_SECTION()`. On this port those map to `irq_lock()` / `irq_unlock()`, which nest, so reaching `machine_timer_deinit()` from the expiry function is safe.

Rebased onto current master.

### Testing

Built `ports/zephyr` for `qemu_cortex_m3` with `prj_minimal.conf` against Zephyr v4.4.0, the version the zephyr port CI job uses. I did not run the QEMU test suite locally (no `qemu-system-arm` on this machine), so the CI job covers that.

Also exercised on hardware, on an nRF5340 running a downstream fork of this port (NCS v3.1.0, TF-M non-secure build). That firmware already carried the same approach as the first version of this PR, stopping the `k_timer` in the expiry function and never unlinking, so it doubles as a measurement of the leak raised in review. I then applied this patch to it, so its timer code path matches this PR.

Before, with the unlink never running:

* 30 one-shot timers that fire and are then dropped lose 3360 bytes of GC heap. Repeatable to the byte across runs, and linear in the number of timers. Calling `deinit()` explicitly instead recovers all but 448 bytes, which confirms the unlink is what was missing.

After, with this patch:

* The same loop loses between 0 and 240 bytes, which is noise.
* Both reproductions from #18728 pass.
* Race stress: five rounds of 300 one-shot timers created back to back with `period=1`, so each expiry lands while the next timer is being inserted. No hang, and the heap is flat across rounds, between -736 and +128 bytes, where the unfixed code leaks about 33 KB per round. Under that burst 290 to 292 of each 300 soft callbacks run; the remainder are dropped by the scheduler queue, which is expected at that rate and unrelated to the list, and the memory figures confirm all 300 timers were unlinked.
* A 5 ms periodic timer running alongside 200 one-shot timers, with every third one `deinit()`ed from thread context to race the unlink in the expiry function: no hang, the periodic timer keeps ticking, and `deinit()` stops it.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.

