### PR TITLE
py/builtinhelp: Add options for changing help('modules') format.

### DIFF
--- a/py/builtinhelp.c
+++ b/py/builtinhelp.c
@@ -33,6 +33,14 @@
 
 #if MICROPY_PY_BUILTINS_HELP
 
+#if MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS <= 0
+#error "MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS must be more than 0"
+#endif
+
+#if MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH <= 0
+#error "MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH must be more than 0"
+#endif
+
 const char mp_help_default_text[] =
     "Welcome to MicroPython!\n"
     "\n"
@@ -93,12 +101,10 @@ static void mp_help_print_modules(void) {
     mp_obj_list_sort(1, &list, (mp_map_t *)&mp_const_empty_map);
 
     // print the list of modules in a column-first order
-    #define NUM_COLUMNS (4)
-    #define COLUMN_WIDTH (18)
     size_t len;
     mp_obj_t *items;
     mp_obj_list_get(list, &len, &items);
-    unsigned int num_rows = (len + NUM_COLUMNS - 1) / NUM_COLUMNS;
+    unsigned int num_rows = (len + MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS - 1) / MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS;
     for (unsigned int i = 0; i < num_rows; ++i) {
         unsigned int j = i;
         for (;;) {
@@ -107,9 +113,9 @@ static void mp_help_print_modules(void) {
             if (j >= len) {
                 break;
             }
-            int gap = COLUMN_WIDTH - l;
+            int gap = MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH - l;
             while (gap < 1) {
-                gap += COLUMN_WIDTH;
+                gap += MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH;
             }
             while (gap--) {
                 mp_print_str(MP_PYTHON_PRINTER, " ");

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1569,6 +1569,16 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_BUILTINS_HELP_MODULES (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Use this to configure output of help('modules')
+#ifndef MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS
+#define MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS (4)
+#endif
+
+// Use this to configure output of help('modules')
+#ifndef MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH
+#define MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH (18)
+#endif
+
 // Whether to provide mem-info related functions in micropython module
 #ifndef MICROPY_PY_MICROPYTHON_MEM_INFO
 #define MICROPY_PY_MICROPYTHON_MEM_INFO (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)


### PR DESCRIPTION
This commit allow to change count and width of columns for help('modules') output by mpconfigport.h.

### Summary

Hello, MicoPython community.
We are porting MicroPython on our device. We recently ran into a problem. Width of screen of our device is so small. Default format of `help('modules')` is poorly displayed. We would like to be able to change it by `NUM_COLUMNS` and `COLUMN_WIDTH`.


### Testing

Tested on unix port.

```diff
diff --git a/ports/unix/mpconfigport.h b/ports/unix/mpconfigport.h
index e290935bc..a586c4f81 100644
--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -121,6 +121,9 @@ typedef long mp_off_t;
 // port modtime functions use time_t
 #define MICROPY_TIMESTAMP_IMPL      (MICROPY_TIMESTAMP_IMPL_TIME_T)
 
+#define MICROPY_PY_BUILTINS_HELP_NUM_COLUMNS (2)
+#define MICROPY_PY_BUILTINS_HELP_COLUMN_WIDTH (22)
+
 // Assume that select() call, interrupted with a signal, and erroring
 // with EINTR, updates remaining timeout value.
 #define MICROPY_SELECT_REMAINING_TIME (1)
```
Result:

```
MicroPython 9b9d8cc783-dirty on 2026-01-28; linux [GCC 13.1.0] version
Type "help()" for more information.
>>> help("modules")
__main__              io
_asyncio              json
_thread               machine
argparse              math
array                 micropython
asyncio/__init__      mip/__init__
asyncio/core          mip/__main__
asyncio/event         os
asyncio/funcs         platform
asyncio/lock          random
asyncio/stream        re
binascii              requests/__init__
btree                 select
builtins              socket
cmath                 ssl
collections           struct
cryptolib             sys
deflate               termios
errno                 time
ffi                   tls
framebuf              uasyncio
gc                    uctypes
hashlib               vfs
heapq                 websocket
Plus any modules on the filesystem
>>>
```
