### PR TITLE
rp2/clocks_extra: Set VREG like the Pico SDK does: needed for 200 MHz.

### DIFF
--- a/ports/rp2/clocks_extra.c
+++ b/ports/rp2/clocks_extra.c
@@ -14,6 +14,7 @@
 #include "hardware/irq.h"
 #include "hardware/gpio.h"
 #include "hardware/ticks.h"
+#include "hardware/vreg.h"
 
 #if PICO_RP2040
 // The RTC clock frequency is 48MHz divided by power of 2 (to ensure an integer
@@ -85,6 +86,13 @@ void runtime_init_clocks_optional_usb(bool init_usb) {
         0,             // No aux mux
         XOSC_HZ,
         XOSC_HZ);
+
+    #if SYS_CLK_VREG_VOLTAGE_AUTO_ADJUST && defined(SYS_CLK_VREG_VOLTAGE_MIN)
+    if (vreg_get_voltage() < SYS_CLK_VREG_VOLTAGE_MIN) {
+        vreg_set_voltage(SYS_CLK_VREG_VOLTAGE_MIN);
+        busy_wait_at_least_cycles((uint32_t)((SYS_CLK_VREG_VOLTAGE_AUTO_ADJUST_DELAY_US * (uint64_t)XOSC_HZ) / 1000000));
+    }
+    #endif
 
     /// \tag::configure_clk_sys[]
     // CLK SYS = PLL SYS (usually) 125MHz / 1 = 125MHz


### PR DESCRIPTION
### Summary

The RP2040 now supports running at 200&nbsp;MHz, but the datasheet says that speed requires an elevated core supply of 1.15 V.  The SDK implements that [in runtime_clocks_init](https://github.com/raspberrypi/pico-sdk/blob/2.2.0/src/rp2_common/pico_runtime_init/runtime_init_clocks.c#L91), but we do not call that function because we override it in clocks_extra.c.

### Testing

On a Pololu Zumo 2040 Robot (RP2 port), I read the RP2040 VSEL bitfield using the expression `machine.mem32[0x40064000] >> 4 & 15`.  It was 11 (the default) before this patch and 12 after.  Additional patches were needed to set the Zumo's speed to 200 MHz in the Pico SDK and to make Micropython respect the settings for the Zumo 2040 in the Pico SDK. Those patches were confirmed separately using `machine.freq()` and the RP2040 frequency counter.
