### PR TITLE
docs/library/network.PPP: Document the optional poll() argument.

### DIFF
--- a/docs/library/network.PPP.rst
+++ b/docs/library/network.PPP.rst
@@ -90,11 +90,14 @@ Methods
 
    See `AbstractNIC.ifconfig`.
 
-.. method:: PPP.poll()
+.. method:: PPP.poll([irq_arg])
 
    Poll the underlying stream for data, and pass it up the PPP stack.
    This is called automatically if the stream is a UART with a RXIDLE interrupt,
    so it's not usually necessary to call it manually.
+
+   The optional *irq_arg* argument is ignored, this argument exists only so this
+   function is compatible with the :func:`machine.UART.irq` *handler* argument.
 
 Constants
 ---------


### PR DESCRIPTION
### Summary

This argument isn't expected to be called from Python code, but - [as pointed out](https://github.com/orgs/micropython/discussions/18724) - it doesn't make sense how the `irq()` mechanism works otherwise. This is useful context if implementing a wrapper for another type of stream.

*This work was funded through GitHub Sponsors.*