### PR TITLE
Fix #17722: Invalid syntax assertion with walrus in function call

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -2445,6 +2445,10 @@ static void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
             } else if (MP_PARSE_NODE_STRUCT_KIND(pns_arg) == PN_argument) {
                 #if MICROPY_PY_ASSIGN_EXPR
                 if (MP_PARSE_NODE_IS_STRUCT_KIND(pns_arg->nodes[1], PN_argument_3)) {
+                    if (n_keyword > 0) {
+                        compile_syntax_error(comp, (mp_parse_node_t)pns_arg, MP_ERROR_TEXT("positional arg after keyword arg"));
+                        return;
+                    }
                     compile_namedexpr_helper(comp, pns_arg->nodes[0], ((mp_parse_node_struct_t *)pns_arg->nodes[1])->nodes[0]);
                     n_positional++;
                 } else

--- a/tests/basics/assign_expr_syntaxerror.py
+++ b/tests/basics/assign_expr_syntaxerror.py
@@ -6,6 +6,13 @@ def test(code):
     except SyntaxError:
         print('SyntaxError')
 
+def test_exec(code):
+    try:
+        exec(code)
+        print('no SyntaxError')
+    except SyntaxError:
+        print('SyntaxError')
+
 test("x := 1")
 test("((x, y) := 1)")
 test("([i := i + 1 for i in range(4)])")
@@ -14,3 +21,17 @@ test("([[(i := j) for i in range(2)] for j in range(2)])")
 
 # this is currently allowed in MicroPython, but not in CPython
 test("([[(j := i) for i in range(2)] for j in range(2)])")
+
+# walrus expression as positional argument after keyword argument
+test_exec("print(end='', (x:=1))")
+
+# additional walrus after keyword tests using compile() for better coverage
+def test_compile(code):
+    try:
+        compile(code, "", "exec")
+        print('no SyntaxError')
+    except SyntaxError:
+        print('SyntaxError')
+
+test_compile("f(x=1, y:=2)")
+test_compile("f(a=1, b=2, c:=3)")

--- a/tests/basics/assign_expr_syntaxerror.py.exp
+++ b/tests/basics/assign_expr_syntaxerror.py.exp
@@ -4,3 +4,6 @@ SyntaxError
 SyntaxError
 SyntaxError
 [[0, 1], [0, 1]]
+SyntaxError
+SyntaxError
+SyntaxError


### PR DESCRIPTION
This PR fixes issue #17722 where using the walrus operator (:=) in certain function call contexts triggers an invalid syntax assertion.

**Changes:**
- Add proper syntax validation for walrus operator in function call arguments
- Prevents assertion failure with edge case walrus usage

**Testing:**
- Verified fix handles the reported edge case
- Existing walrus operator tests pass

Fixes #17722