### PR TITLE
py/modio: Add stream validation for BufferedWriter

### DIFF
--- a/py/modio.c
+++ b/py/modio.c
@@ -118,6 +118,8 @@ typedef struct _mp_obj_bufwriter_t {
 
 static mp_obj_t bufwriter_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     mp_arg_check_num(n_args, n_kw, 2, 2, false);
+    // Validate that first argument is a stream object with write capability
+    mp_get_stream_raise(args[0], MP_STREAM_OP_WRITE);
     size_t alloc = mp_obj_get_int(args[1]);
     mp_obj_bufwriter_t *o = mp_obj_malloc_var(mp_obj_bufwriter_t, buf, byte, alloc, type);
     o->stream = args[0];

--- a/tests/basics/io_buffered_writer.py
+++ b/tests/basics/io_buffered_writer.py
@@ -7,6 +7,12 @@ except (AttributeError, ImportError):
     print('SKIP')
     raise SystemExit
 
+# Test that BufferedWriter requires a valid stream object
+try:
+    io.BufferedWriter(None, 8)
+except (TypeError, OSError) as e:
+    print("caught error for invalid stream")
+
 bts = io.BytesIO()
 buf = io.BufferedWriter(bts, 8)
 

--- a/tests/basics/io_buffered_writer.py.exp
+++ b/tests/basics/io_buffered_writer.py.exp
@@ -1,3 +1,4 @@
+caught error for invalid stream
 b''
 b'foobarfo'
 b'foobarfoobar'


### PR DESCRIPTION
Fixes #17727

**Root cause:** \BufferedWriter\ constructor did not validate that the first argument is a valid stream object with write capability. Passing invalid objects (like \None\) could cause crashes later during write operations.

**Fix:** Add \mp_get_stream_raise(args[0], MP_STREAM_OP_WRITE)\ validation before using the stream argument.

**Test:** Added test case in \	ests/basics/io_buffered_writer.py\ that verifies \BufferedWriter(None, 8)\ raises an appropriate error.