### PR TITLE
py/objtype: Add type validation for super() first argument

### DIFF
--- a/tests/basics/subclass_native_init.py
+++ b/tests/basics/subclass_native_init.py
@@ -75,3 +75,14 @@ a = L(range(5))
 print(a)
 a.reinit()
 print(a)
+
+# test that corrupted self in __init__ raises TypeError instead of segfault
+# (see issue #17728)
+class BadList(list):
+    def __init__(self, n):
+        self = n  # corrupt local self variable
+        super().__init__([])
+try:
+    BadList(42)
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
Fixes #17728

**Root cause:** \
ative_base_init_wrapper()\ casts \rgs[0]\ (self) to \mp_obj_instance_t\ without validation. When \__init__\ corrupts self (e.g., \self = integer\), \super().__init__()\ dereferences an invalid pointer causing segfault.

**Fix:** Add validation before accessing self:
- Check \mp_obj_is_obj()\ to ensure self is a heap object, not a small int
- Check \mp_obj_is_instance_type()\ to verify self is an instance type
- Raise \TypeError\ with clear message if validation fails

**Impact:** Prevents segfault from improper self assignment in \__init__\. Now raises proper \TypeError\ instead of crashing, matching CPython behavior.

**Test:** Added test case in \	ests/basics/subclass_native_init.py\ that verifies corrupted self raises \TypeError\.