### PR TITLE
py/emitbc: Handle invalid syntax gracefully instead of assertion

### DIFF
--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -353,7 +353,9 @@ bool mp_emit_bc_end_pass(emit_t *emit) {
     }
 
     // check stack is back to zero size
-    assert(emit->stack_size == 0);
+    if (emit->stack_size != 0) {
+        mp_raise_msg(&mp_type_SyntaxError, MP_ERROR_TEXT("invalid syntax"));
+    }
 
     // Calculate size of source code info section
     emit->n_info = emit->code_info_offset - emit->n_info;

--- a/tests/basics/builtin_compile.py
+++ b/tests/basics/builtin_compile.py
@@ -48,4 +48,10 @@ def test():
     # hashing a compiled function object
     print(type(hash(compile("", "", "exec"))))
 
+    # test invalid syntax that leaves emitter in bad state (issue #17817)
+    try:
+        compile("a\\\n", "", "eval")
+    except SyntaxError:
+        print("SyntaxError")
+
 test()


### PR DESCRIPTION
Fixes #17817

Root cause: When compile() is given syntactically invalid code like a line continuation at EOF, the parser may accept it but leave the emit stack in a non-zero state. The assertion in mp_emit_bc_end_pass() then fails.

Fix: Replace the assertion with a proper SyntaxError exception.

Test: Added test case in tests/basics/builtin_compile.py