### PR TITLE
ports/stm32/boards/stm32l072xz.ld: comment correction.

### DIFF
--- a/ports/stm32/boards/stm32l072xz.ld
+++ b/ports/stm32/boards/stm32l072xz.ld
@@ -1,5 +1,5 @@
 /*
-    GNU linker script for STM32F072xZ
+    GNU linker script for STM32L072xZ
 */
 
 /* Specify the memory areas */


### PR DESCRIPTION
Header comment said "STM32F072xZ" for the STM32L072xZ linker script.

### Summary

Searching for part features is improved with matching comments.

### Testing

Comment only. Comment now matches file name.