### PR TITLE
tests: make the test runners abort early when the target is unresponsive

### DIFF
--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -278,7 +278,7 @@ def main():
         target_platform, target_arch, error = detect_architecture(target)
         if error:
             print("Cannot run tests: {}".format(error))
-            sys.exit(1)
+            sys.exit(2)
     target_arch = ARCH_MAPPINGS.get(target_arch, target_arch)
 
     if target_platform:

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1026,7 +1026,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     except TestError as er:
         for line in er.args[0]:
             print(line)
-        sys.exit(1)
+        sys.exit(2)
 
     # Return test results.
     return test_results.value, testcase_count.value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -206,7 +206,12 @@ def get_test_instance(test_instance, baudrate, user, password):
 
     pyb = pyboard.Pyboard(port, baudrate, user, password)
     pyboard.Pyboard.run_script_on_remote_target = run_script_on_remote_target
-    pyb.enter_raw_repl()
+    try:
+        pyb.enter_raw_repl()
+    except pyboard.PyboardError as e:
+        print("error: could not detect test instance")
+        print(e)
+        sys.exit(2)
     return pyb
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,12 @@ _RESULTS_FILE = "_results.json"
 # Maximum time to run a single test, in seconds.
 TEST_TIMEOUT = float(os.environ.get("MICROPY_TEST_TIMEOUT", 30))
 
+# Maximum time to wait to enter the raw REPL at the start of a test, in seconds.
+TEST_ENTER_RAW_REPL_TIMEOUT = 5
+
+# Maximum number of raw REPL failures to tolerate before aborting the entire test run.
+TEST_MAXIMUM_RAW_REPL_FAILURES = 3
+
 # mpy-cross is only needed if --via-mpy command-line arg is passed
 if os.name == "nt":
     MPYCROSS = os.getenv("MICROPY_MPYCROSS", base_path("../mpy-cross/build/mpy-cross.exe"))
@@ -271,8 +277,7 @@ def run_script_on_remote_target(pyb, args, test_file, is_special, requires_targe
         return True, script
 
     try:
-        had_crash = False
-        pyb.enter_raw_repl()
+        pyb.enter_raw_repl(timeout_overall=TEST_ENTER_RAW_REPL_TIMEOUT)
         if requires_target_wiring and pyb.target_wiring_script:
             pyb.exec_(
                 "import sys;sys.modules['target_wiring']=__build_class__(lambda:exec("


### PR DESCRIPTION
### Summary

Prior to this change, if a test crashed a board to the point that it was no longer responsive but the serial connection was still alive and able to read/write (eg due to an infinite loop with ctrl-C unavailable), it would take (30 + 10 * number-of-remaining-tests) seconds to finish the test run. That can be 10 minutes or more.

The change here aborts the test run if the target does not respond 4 times to when trying to enter the raw REPL at the start of a test.  Now, it only takes a maximum of (30 + 4 * 5) = 50 seconds to detect a crashed state and abort the entire test run.

This change is separated out from #17782.

### Testing

Can test this by adding the following to a test:

    import time, micropython
    micropython.kbd_intr(-1)
    while 1:
        time.sleep(1)

For example, add the above to the end of `tests/extmod/random_extra.py` and test via:

    $ ./run-tests.py -t a0 extmod/[r-z]*.py
    $ ./run-natmodtests.py -t a0 extmod/[r-z]*.py

Previously the `run-tests.py` run would take around 16 minutes.  Now it takes under a minute.

This has also been tested with octoprobe.  There are currently a few tests that fail with the native emitter and make a board unresponsive, and the octoprobe run takes around 19 hours.  With the change here it drops that to about 11.5 hours.
