### PR TITLE
py/objarray: Avoid double zero init on sized bytearrays.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -191,7 +191,10 @@ static mp_obj_t bytearray_make_new(const mp_obj_type_t *type_in, size_t n_args, 
         // 1 arg, an integer: construct a blank bytearray of that length
         mp_uint_t len = mp_obj_get_int(args[0]);
         mp_obj_array_t *o = array_new(BYTEARRAY_TYPECODE, len);
+        // If this config is set then the GC clears all memory, so we don't need to.
+        #if !MICROPY_GC_CONSERVATIVE_CLEAR
         memset(o->items, 0, len);
+        #endif
         return MP_OBJ_FROM_PTR(o);
     } else {
         // 1 arg: construct the bytearray from that

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -282,7 +282,10 @@ static mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
         }
         vstr_t vstr;
         vstr_init_len(&vstr, len);
+        // If this config is set then the GC clears all memory, so we don't need to.
+        #if !MICROPY_GC_CONSERVATIVE_CLEAR
         memset(vstr.buf, 0, len);
+        #endif
         return mp_obj_new_bytes_from_vstr(&vstr);
     }
 


### PR DESCRIPTION
As per the implementation of m_malloc0, if `MICROPY_GC_CONSERVATIVE_CLEAR` is set then all RAM is guaranteed to be zero-init by gc_alloc.

py/objarray.c: Guard the explicit zero init in bytearray_make_new against being run, initialising the RAM to zero a second time, if this flag is set.

py/objstr.c: Guard the explicit zero init in bytes_make_new against being run, initialising the RAM to zero a second time, if this flag is set.

Note that `MICROPY_GC_CONSERVATIVE_CLEAR` is default enabled by `MICROPY_ENABLE_GC`, and no ports currently override this value.

We stumbled across this inconsistency when testing the timings of allocating, collecting and collecting/freeing PSRAM, with a script looking something like the following:

```python
import gc
import time

t_start = time.ticks_us()
gc.collect()
t_taken = time.ticks_diff(time.ticks_us(), t_start)
baseline = t_taken / 1000
print(f"Baseline: {t_taken / 1000:.2f}ms")


for y in range(1, 41):
    b4 = gc.mem_free()
    t_start = time.ticks_us()
    test = bytearray(1024 * y * 10)
    alloc_time_ms = time.ticks_diff(time.ticks_us(), t_start) / 1000
    af = gc.mem_free()

    t_start = time.ticks_us()
    gc.collect()
    t_taken = time.ticks_diff(time.ticks_us(), t_start)

    ram_used = (b4 - af) / 1024
    time_ms = t_taken / 1000
    factor = (time_ms - baseline) / ram_used

    del test
    
    t_start = time.ticks_us()
    gc.collect()
    collect_time_ms =  time.ticks_diff(time.ticks_us(), t_start) / 1000
    print(f"{int(ram_used):4d} {time_ms: 7.2f} {collect_time_ms: 7.2f} {alloc_time_ms: 7.2f} {factor: 6.2f}")

```

We had a custom `image` class which did its own allocation via `m_malloc` internally, and found - quite unintentionally - that it was twice as fast to allocate our custom `image` versus an identically sized `bytearray`. A little sleuthing revealed that `bytearray` ignores the value of `MICROPY_GC_CONSERVATIVE_CLEAR` and will zero (using `memset()`) RAM that is already guaranteed to be zeroed by `gc_alloc`, eg:

https://github.com/micropython/micropython/blob/cef2538b109c00cf1a833f253df737ad7b2f3996/py/objarray.c#L190-L196

when `gc_alloc` already does:

https://github.com/micropython/micropython/blob/edab53c1daf0156092680fe72dba9f87d0cbbb31/py/gc.c#L885-L888

### Testing

To ensure no non-zero values leaked into bytearrays I ran this very basic test with various maximum sizes:

```python
for s in range(1024):
    if sum(bytearray(s)) > 0:
        raise RuntimeError(f"{s}: FAIL! - Non zero init bytearray found.")
```

And here are the `bytes(n)` alloc times, on PSRAM with an RP2350 clocked to 200MHz both before and after the change`:

| size (kb) | before (ms) | after (ms) |
|----------|--------|-----|
|  10 |  2.05 |  1.59 |
|  20 |  5.25 |  3.75 |
|  30 |  9.25 |  6.12 |
|  40 | 12.87 |  8.36 |
|  50 | 16.31 | 10.53 |
|  60 | 19.69 | 12.67 |
|  70 | 23.01 | 14.81 |
|  80 | 26.33 | 16.92 |
|  90 | 29.63 | 19.03 |
| 100 | 32.92 | 21.14 |
| 110 | 36.22 | 23.25 |
| 120 | 39.50 | 25.36 |
| 130 | 42.79 | 27.47 |
| 140 | 46.09 | 29.58 |
| 150 | 49.36 | 31.68 |
| 160 | 52.64 | 33.80 |
| 170 | 55.95 | 35.89 |
| 180 | 59.23 | 38.02 |
| 190 | 62.51 | 40.10 |
| 200 | 65.80 | 42.22 |

### Trade-offs and Alternatives

I am unsure if there is some subtle caveat for `gc_alloc` zero init that might cause problems specifically with a bytearray, but afaict this change is minimal and gives us bytearray allocations in roughly half the time.

This is less noticeable on SRAM (tested on RP2350) where a 200k allocation takes 2.6ms, but on PSRAM it brings a 200k `bytearray` alloc from roughly 50ms down to 25ms, and a modest 10k alloc from 2ms down to 1ms. The alloc time for sizes between these two extremes is linear.