### PR TITLE
Gcdebugprintf

### DIFF
--- a/ports/windows/micropython.vcxproj
+++ b/ports/windows/micropython.vcxproj
@@ -87,6 +87,7 @@
   <ItemGroup>
     <ClCompile Include="@(PyCoreSource)" />
     <ClCompile Include="@(PyExtModSource)" />
+    <ClCompile Include="$(PyBaseDir)shared\libc\printf.c" />
     <ClCompile Include="$(PyBaseDir)shared\readline\*.c" />
     <ClCompile Include="$(PyBaseDir)shared\runtime\gchelper_generic.c" />
     <ClCompile Include="$(PyBaseDir)shared\runtime\pyexec.c" />

--- a/py/gc.c
+++ b/py/gc.c
@@ -439,6 +439,7 @@ void gc_collect_root(void **ptrs, size_t len) {
         size_t block = BLOCK_FROM_PTR(area, ptr);
         if (ATB_GET_KIND(area, block) == AT_HEAD) {
             // An unmarked head: mark it, and mark all its children
+            TRACE_MARK(ptr_block, ptr);
             ATB_HEAD_TO_MARK(area, block);
             #if MICROPY_GC_SPLIT_HEAP
             gc_mark_subtree(area, block);


### PR DESCRIPTION
### Summary

Debugging a possible gc issue with the msvc port I ran into a couple of issues:
- there's no DEBUG_printf definition so enabling MICROPY_DEBUG_VERBOSE lead to a linker error
- it seems as if a whole bunch of root pointers weren't being freed despite being unmarked, but that was simply because they were marked yet marking them was not logged


### Testing

Compiles and the gc debug output is now complete.


### Trade-offs and Alternatives

The last commit is more of an RFC: haven't used it enough to really assess its usefullness, on the other hand it shouldn't hurt either. Unless someone is relying on automated parsing of the output and looking for the literal `gc_mark(` string.
