### PR TITLE
zephyr: Put heap in noinit linker area.

### DIFF
--- a/ports/zephyr/main.c
+++ b/ports/zephyr/main.c
@@ -83,7 +83,7 @@ DT_FOREACH_STATUS_OKAY(micropython_heap, MICROPY_HEAP_DEFINE)
 #include "modmachine.h"
 #include "modzephyr.h"
 
-static char heap[MICROPY_HEAP_SIZE];
+static __noinit char heap[MICROPY_HEAP_SIZE];
 
 #if defined(CONFIG_USB_DEVICE_STACK_NEXT)
 extern int mp_usbd_init(void);


### PR DESCRIPTION
### Summary

By putting the heap in the noinit area instead of the bss area, zephyr won't memset it to zero durring start. This improves startup time, in particular if the heap is very big. The system heap of zephyr is also in the same section.


### Testing

Got a board here with 1 GiB of RAM and I set the heap size to half of it, it took almost a minute to boot without of this. With this it booted almost instantly.

### Trade-offs and Alternatives

None

