### PR TITLE
zephyr/filesystem: Improve use of the zephyr filesystem.

### DIFF
--- a/ports/zephyr/zephyr_filesystem.c
+++ b/ports/zephyr/zephyr_filesystem.c
@@ -71,21 +71,25 @@ typedef struct _zephyr_fs_obj_t {
 
 const char *zephyr_fs_make_path(zephyr_fs_obj_t *self, mp_obj_t path_in) {
     const char *path = mp_obj_str_get_str(path_in);
+    size_t path_len = strlen(path);
+    size_t l = vstr_len(&self->root_dir);
 
     if (path[0] != '/') {
-        size_t l = vstr_len(&self->root_dir);
         size_t lc = vstr_len(&self->cur_dir);
         vstr_add_str(&self->root_dir, "/");
         vstr_add_strn(&self->root_dir, self->cur_dir.buf, lc);
-        vstr_add_str(&self->root_dir, path);
-        path = vstr_null_terminated_str(&self->root_dir);
-        self->root_dir.len = l;
-    } else {
-        size_t l = vstr_len(&self->root_dir);
-        vstr_add_str(&self->root_dir, path);
-        path = vstr_null_terminated_str(&self->root_dir);
-        self->root_dir.len = l;
     }
+
+    if (path_len > 0 &&
+        (path[path_len - 1] == '.' && (path_len == 1 || path[path_len - 2] == '/'))) {
+        // if path ends with '/.', remove the trailing dot
+        path_len--;
+    }
+
+    vstr_add_strn(&self->root_dir, path, path_len);
+    path = vstr_null_terminated_str(&self->root_dir);
+    self->root_dir.len = l;
+
     return path;
 }
 

--- a/ports/zephyr/zephyr_filesystem.c
+++ b/ports/zephyr/zephyr_filesystem.c
@@ -657,19 +657,25 @@ static MP_DEFINE_CONST_FUN_OBJ_1(zephyr_fs_umount_obj, zephyr_fs_umount);
 
 static mp_obj_t zephyr_fs_mount(mp_obj_t self_in, mp_obj_t readonly, mp_obj_t mkfs) {
     zephyr_fs_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    struct fs_mount_t *mount = self->mount;
     int err;
     (void)readonly;
     (void)mkfs;
 
-    err = fs_mount(self->mount);
+    if (sys_dnode_is_linked(&mount->node) && (mount->flags & FS_MOUNT_FLAG_AUTOMOUNT) != 0) {
+        // Already mounted with automount, nothing to do
+        return mp_const_none;
+    }
+
+    err = fs_mount(mount);
     if (err == -EBUSY) {
-        err = fs_unmount(self->mount);
+        err = fs_unmount(mount);
         if (err < 0) {
             mp_raise_msg_varg(&mp_type_OSError,
                 MP_ERROR_TEXT("error un-mounting Zephyr File System: %q"), mp_errno_to_str(MP_OBJ_NEW_SMALL_INT(-err)));
             return mp_const_none;
         }
-        err = fs_mount(self->mount);
+        err = fs_mount(mount);
     }
 
     if (err == -EROFS) {

--- a/ports/zephyr/zephyr_filesystem.c
+++ b/ports/zephyr/zephyr_filesystem.c
@@ -453,6 +453,10 @@ static mp_obj_t zephyr_fs_chdir(mp_obj_t vfs_in, mp_obj_t path_in) {
         return mp_const_none;
     }
 
+    if (stats.type != FS_DIR_ENTRY_DIR) {
+        mp_raise_OSError(MP_ENOTDIR);
+    }
+
     vstr_reset(&self->cur_dir);
     vstr_add_strn(&self->cur_dir, chdir.buf, lc);
 


### PR DESCRIPTION
### Summary

Generally improves the use of the zephyr filesystem. For more infos read the commit messages.

Especially useful, if zephyr subsystems should also have access to the filesystem.


### Testing

I tested it locally on a fpga board with a sdcard, that is formated with the fat fs.


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

