### PR TITLE
zephyr/modzsensor: Add additional sensor type constants.

### DIFF
--- a/ports/zephyr/modzsensor.c
+++ b/ports/zephyr/modzsensor.c
@@ -212,6 +212,10 @@ static const mp_rom_map_elem_t mp_module_zsensor_globals_table[] = {
     C(VOC),
     C(GAS_RES),
     C(VOLTAGE),
+    C(VSHUNT),
+    C(CURRENT),
+    C(POWER),
+    C(RESISTANCE),
 #undef C
 #define C(name) { MP_ROM_QSTR(MP_QSTR_ATTR_##name), MP_ROM_INT(SENSOR_ATTR_##name) }
     C(SAMPLING_FREQUENCY),


### PR DESCRIPTION
### Summary

Add additional sensor type constants.
Commonly used by power and current measurement sensors.


### Testing

builds and seems to work


### Trade-offs and Alternatives

none

