### PR TITLE
tests/run-tests.py: Broaden the check for raw REPL failure.

### DIFF
--- a/tests/run-natmodtests.py
+++ b/tests/run-natmodtests.py
@@ -193,7 +193,7 @@ def run_tests(target_truth, target, args, resolved_arch):
         elif error is not None:
             result = "FAIL"
             extra = " - " + str(error)
-            if extra == " - could not enter raw repl":
+            if str(error).startswith("could not enter raw repl"):
                 raw_repl_failure_count += 1
         else:
             # Check result against truth

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -995,7 +995,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             rm_f(filename_expected)
             rm_f(filename_mupy)
         else:
-            if output_mupy == b"could not enter raw repl\nCRASH":
+            if output_mupy.startswith(b"could not enter raw repl"):
                 extra_info = "raw REPL failed"
                 raw_repl_failure_count.increment()
             print("FAIL ", test_file, extra_info)


### PR DESCRIPTION
### Summary

This is a follow up to 6436f8b93fa07a6abe0120f6c8d05538dd8b021e / #18768 that catches more cases of a failed raw REPL.

If the target device is broken in a certain way then it can have a serial write error instead of just not returning any data.  In that case the error raised by `pyboard.py` is "could not enter raw repl: Write timeout", which is slightly different to "could not enter raw repl" (the latter is raised when a serial read fails to return the correct data).

The patch here accounts for all cases of a failed raw REPL by using `str.startswith()` instead of a string equality.

### Testing

This can be tested on RPI_PICO_W and RPI_PICO2_W which currently crash in the specific way needed to trigger the write timeout when running the `tests/extmod/socket_badconstructor.py` test.  In particular adding the following code to the end of a test (eg `tests/extmod/random_extra.py`) will trigger the issue:

    import socket
    try:
        s = socket.socket(socket.AF_INET, socket.SOCK_RAW, None)
    except TypeError:
        pass

With the fix here, the `run-tests.py` and `run-natmodtests.py` will abort early if that code is added (prior to the fix they would continue to run all tests and take a long time).
