### PR TITLE
mimxrt/boards/PHYBOARD_RT1170: Update use of mp_handle_pending().

### DIFF
--- a/ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.h
+++ b/ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.h
@@ -5,8 +5,7 @@
 
 #define MICROPY_EVENT_POLL_HOOK \
     do { \
-        extern void mp_handle_pending(bool); \
-        mp_handle_pending(true); \
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
     } while (0);
 
 // phyBOARD-RT1170 SoM onboard LEDs (red and green from phyCORE SoM)


### PR DESCRIPTION
### Summary

Update use of `mp_handle_pending()` on the new `PHYBOARD_RT1170`, following commits adbdded1854757ae992db150d3feaf9c4ffebbf2 and 0c7726a89c2ac39042f6d0f19ff98cbb50136113.

### Testing

The board now builds locally (it's not built as part of CI).

### Trade-offs and Alternatives

We could remove this custom definition of `MICROPY_EVENT_POLL_HOOK` for this board.  @andrewleech do you know why it needed to be different to the mimxrt's default macro for this?  Doesn't the WFE work correctly on that MCU?