### PR TITLE
extmod/modlwip: Always set the lwip_socket_ioctl() return value.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -1579,13 +1579,12 @@ static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
     }
 
     lwip_socket_obj_t *socket = MP_OBJ_TO_PTR(self_in);
-    mp_uint_t ret;
+    mp_uint_t ret = 0;
 
     MICROPY_PY_LWIP_ENTER
 
     if (request == MP_STREAM_POLL) {
         uintptr_t flags = arg;
-        ret = 0;
 
         if (flags & MP_STREAM_POLL_RD) {
             if (socket->state == STATE_LISTENING) {
@@ -1691,7 +1690,6 @@ static mp_uint_t lwip_socket_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_
 
         socket->pcb.tcp = NULL;
         socket->state = _ERR_BADF;
-        ret = 0;
     }
 
     MICROPY_PY_LWIP_EXIT


### PR DESCRIPTION
### Summary

If the return value is set only when certain condition are true, the compiler sometimes raises an error.

### Testing

Compiled & tested with Teensy 4.1, MIMXRT1170_EVK, MIMXRT1020_EVK

Without the change, compiling for MIMXRT1170_EVK and MIMXRT1020 failed but not for Teensy4.1, which is strange. The compiler should complain always, since the change is not board- or port-related. Tried with two compiler versions (13.2 and 14.2).

Networking works with the change. Tested with iperf3, tcp & udp, and some sets of the test suite.

### Trade-offs and Alternatives

The code size could be somewhat smaller, since two assignments are replaced by one.
