### PR TITLE
Some run-tests improvements

### DIFF
--- a/tests/cmdline/cmd_file_variable.py.exp
+++ b/tests/cmdline/cmd_file_variable.py.exp
@@ -1,1 +1,1 @@
-__file__ = cmdline/cmd_file_variable.py
+__file__ = \.\*cmdline/cmd_file_variable.py

--- a/tests/cmdline/cmd_module_atexit.py.exp
+++ b/tests/cmdline/cmd_module_atexit.py.exp
@@ -1,3 +1,3 @@
-['cmdline.cmd_module_atexit', 'cmdline/cmd_module_atexit.py']
+['cmdline.cmd_module_atexit', '\.\*cmdline/cmd_module_atexit.py']
 start
 done

--- a/tests/cmdline/cmd_module_atexit_exc.py.exp
+++ b/tests/cmdline/cmd_module_atexit_exc.py.exp
@@ -1,3 +1,3 @@
-['cmdline.cmd_module_atexit_exc', 'cmdline/cmd_module_atexit_exc.py']
+['cmdline.cmd_module_atexit_exc', '\.\*cmdline/cmd_module_atexit_exc.py']
 start
 done

--- a/tests/cmdline/cmd_showbc.py.exp
+++ b/tests/cmdline/cmd_showbc.py.exp
@@ -1,4 +1,4 @@
-File cmdline/cmd_showbc.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 63 bytes)
+File \.\*cmdline/cmd_showbc.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 63 bytes)
 Raw bytecode (code_info_size=18, bytecode_size=45):
  10 20 01 60 20 84 7d 64 60 88 07 64 60 69 20 62
  64 20 32 00 16 05 32 01 16 05 81 2a 01 53 33 02
@@ -47,7 +47,7 @@ arg names:
 42 IMPORT_STAR
 43 LOAD_CONST_NONE
 44 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 46\[68\] bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 46\[68\] bytes)
 Raw bytecode (code_info_size=8\[46\], bytecode_size=382):
  a8 12 9\[bf\] 03 05 60 60 26 22 24 64 22 24 25 25 24
  26 23 63 22 22 25 23 23 2f 6c 25 65 25 25 69 68
@@ -411,7 +411,7 @@ arg names:
 379 RETURN_VALUE
 380 LOAD_CONST_NONE
 381 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 59 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 59 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=51):
  a8 10 0a 05 80 82 34 38 81 57 c0 57 c1 57 c2 57
  c3 57 c4 57 c5 57 c6 57 c7 57 c8 c9 82 57 ca 57
@@ -470,7 +470,7 @@ arg names:
 48 POP_TOP
 49 LOAD_CONST_NONE
 50 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 20 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 20 bytes)
 Raw bytecode (code_info_size=9, bytecode_size=11):
  a1 01 0b 05 06 80 88 40 00 82 2a 01 53 b0 21 00
  01 c1 51 63
@@ -489,7 +489,7 @@ arg names: a
 08 STORE_FAST 1
 09 LOAD_CONST_NONE
 10 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 21 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 21 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=13):
  88 40 0a 05 80 8f 23 23 51 67 59 81 67 59 81 5e
  51 68 59 51 63
@@ -513,7 +513,7 @@ arg names:
 10 POP_TOP
 11 LOAD_CONST_NONE
 12 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'Class' (descriptor: \.\+, bytecode @\.\+ 1\[56\] bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'Class' (descriptor: \.\+, bytecode @\.\+ 1\[56\] bytes)
 Raw bytecode (code_info_size=\[56\], bytecode_size=10):
  00 \.\+ 11 0f 16 10 10 02 16 11 51 63
 arg names:
@@ -528,7 +528,7 @@ arg names:
 06 STORE_NAME __qualname__
 08 LOAD_CONST_NONE
 09 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 18 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 18 bytes)
 Raw bytecode (code_info_size=6, bytecode_size=12):
  19 08 05 12 80 9c 12 13 12 14 b0 15 05 36 00 59
  51 63
@@ -545,7 +545,7 @@ arg names: self
 09 POP_TOP
 10 LOAD_CONST_NONE
 11 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block '<genexpr>' (descriptor: \.\+, bytecode @\.\+ 28 bytes)
+File \.\*cmdline/cmd_showbc.py, code block '<genexpr>' (descriptor: \.\+, bytecode @\.\+ 28 bytes)
 Raw bytecode (code_info_size=9, bytecode_size=19):
  c3 40 0c 09 03 03 03 80 3b 53 b2 53 53 4b 0b c3
  25 01 44 39 25 00 67 59 42 33 51 63
@@ -568,7 +568,7 @@ arg names: * * *
 15 JUMP 4
 17 LOAD_CONST_NONE
 18 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block '<listcomp>' (descriptor: \.\+, bytecode @\.\+ 26 bytes)
+File \.\*cmdline/cmd_showbc.py, code block '<listcomp>' (descriptor: \.\+, bytecode @\.\+ 26 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=18):
  4b 0c 0a 03 03 03 80 3c 2b 00 b2 5f 4b 0b c3 25
  01 44 39 25 00 2f 14 42 33 63
@@ -588,7 +588,7 @@ arg names: * * *
 13 STORE_COMP 20
 15 JUMP 4
 17 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block '<dictcomp>' (descriptor: \.\+, bytecode @\.\+ 28 bytes)
+File \.\*cmdline/cmd_showbc.py, code block '<dictcomp>' (descriptor: \.\+, bytecode @\.\+ 28 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=20):
  53 0c 0b 03 03 03 80 3d 2c 00 b2 5f 4b 0d c3 25
  01 44 39 25 00 25 00 2f 19 42 31 63
@@ -609,7 +609,7 @@ arg names: * * *
 15 STORE_COMP 25
 17 JUMP 4
 19 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'closure' (descriptor: \.\+, bytecode @\.\+ 20 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'closure' (descriptor: \.\+, bytecode @\.\+ 20 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=12):
  19 0c 0c 03 80 6f 25 23 25 00 81 f2 c1 81 27 00
  29 00 51 63
@@ -629,7 +629,7 @@ arg names: *
 08 DELETE_DEREF 0
 10 LOAD_CONST_NONE
 11 RETURN_VALUE
-File cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 13 bytes)
+File \.\*cmdline/cmd_showbc.py, code block 'f' (descriptor: \.\+, bytecode @\.\+ 13 bytes)
 Raw bytecode (code_info_size=8, bytecode_size=5):
  9a 01 0a 05 03 08 80 8b b1 25 00 f2 63
 arg names: * b

--- a/tests/cmdline/cmd_showbc_const.py.exp
+++ b/tests/cmdline/cmd_showbc_const.py.exp
@@ -1,4 +1,4 @@
-File cmdline/cmd_showbc_const.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 198 bytes)
+File \.\*cmdline/cmd_showbc_const.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 198 bytes)
 Raw bytecode (code_info_size=40, bytecode_size=158):
  2c 4c 01 60 2c 46 22 65 27 4a 83 0c 20 27 40 20
  27 20 27 40 60 20 27 24 40 60 40 24 27 47 24 27

--- a/tests/cmdline/cmd_showbc_opt.py.exp
+++ b/tests/cmdline/cmd_showbc_opt.py.exp
@@ -1,4 +1,4 @@
-File cmdline/cmd_showbc_opt.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 35 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 35 bytes)
 Raw bytecode (code_info_size=13, bytecode_size=22):
  00 16 01 60 20 64 40 84 07 64 40 84 07 32 00 16
  02 32 01 16 03 32 02 16 04 32 03 16 05 32 04 16
@@ -27,7 +27,7 @@ arg names:
 18 STORE_NAME f4
 20 LOAD_CONST_NONE
 21 RETURN_VALUE
-File cmdline/cmd_showbc_opt.py, code block 'f0' (descriptor: \.\+, bytecode @\.\+ 8 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block 'f0' (descriptor: \.\+, bytecode @\.\+ 8 bytes)
 Raw bytecode (code_info_size=6, bytecode_size=2):
  08 08 02 60 40 22 80 63
 arg names:
@@ -39,7 +39,7 @@ arg names:
   bc=2 line=7
 00 LOAD_CONST_SMALL_INT 0
 01 RETURN_VALUE
-File cmdline/cmd_showbc_opt.py, code block 'f1' (descriptor: \.\+, bytecode @\.\+ 22 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block 'f1' (descriptor: \.\+, bytecode @\.\+ 22 bytes)
 Raw bytecode (code_info_size=9, bytecode_size=13):
  11 0e 03 08 80 0a 23 22 20 b0 44 42 51 63 12 07
  82 34 01 59 51 63
@@ -61,7 +61,7 @@ arg names: x
 10 POP_TOP
 11 LOAD_CONST_NONE
 12 RETURN_VALUE
-File cmdline/cmd_showbc_opt.py, code block 'f2' (descriptor: \.\+, bytecode @\.\+ 10 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block 'f2' (descriptor: \.\+, bytecode @\.\+ 10 bytes)
 Raw bytecode (code_info_size=7, bytecode_size=3):
  11 0a 04 08 80 11 23 12 09 65
 arg names: x
@@ -72,7 +72,7 @@ arg names: x
   bc=3 line=19
 00 LOAD_GLOBAL Exception
 02 RAISE_OBJ
-File cmdline/cmd_showbc_opt.py, code block 'f3' (descriptor: \.\+, bytecode @\.\+ 24 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block 'f3' (descriptor: \.\+, bytecode @\.\+ 24 bytes)
 Raw bytecode (code_info_size=9, bytecode_size=15):
  11 0e 05 08 80 16 22 22 23 42 42 42 43 b0 43 3b
  12 07 82 34 01 59 51 63
@@ -94,7 +94,7 @@ arg names: x
 12 POP_TOP
 13 LOAD_CONST_NONE
 14 RETURN_VALUE
-File cmdline/cmd_showbc_opt.py, code block 'f4' (descriptor: \.\+, bytecode @\.\+ 24 bytes)
+File \.\*cmdline/cmd_showbc_opt.py, code block 'f4' (descriptor: \.\+, bytecode @\.\+ 24 bytes)
 Raw bytecode (code_info_size=9, bytecode_size=15):
  11 0e 06 08 80 1d 22 22 23 42 42 42 40 b0 43 3b
  12 07 82 34 01 59 51 63

--- a/tests/cmdline/cmd_verbose.py.exp
+++ b/tests/cmdline/cmd_verbose.py.exp
@@ -1,4 +1,4 @@
-File cmdline/cmd_verbose.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 12 bytes)
+File \.\*cmdline/cmd_verbose.py, code block '<module>' (descriptor: \.\+, bytecode @\.\+ 12 bytes)
 Raw bytecode (code_info_size=4, bytecode_size=8):
  08 04 01 40 11 02 81 34 01 59 51 63
 arg names:

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -841,8 +841,20 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     skip_tests = [os.path.realpath(base_path(skip_test)) for skip_test in skip_tests]
 
     def run_one_test(test_file):
-        test_file = test_file.replace("\\", "/")
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
+        # If test_file is one of our own tests always make it relative to our tests/ dir and
+        # otherwise use the abosulte path, irregardless of actual path passed,
+        # such that display and result output is always the same.
+        try:
+            test_file_relpath = os.path.relpath(test_file, start=base_path())
+            if not test_file_relpath.startswith(".."):
+                test_file = test_file_relpath
+            else:
+                test_file = test_file_abspath
+        except ValueError:
+            # Path on different drive on Windows.
+            test_file = test_file_abspath
+        test_file = test_file.replace("\\", "/")
 
         if args.filters:
             # Default verdict is the opposite of the first action

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -887,6 +887,10 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             print("skip ", test_file)
             test_results.append((test_file, "skip", ""))
             return
+        elif args.dry_run:
+            print("found", test_file)
+            test_results.append((test_file, "found", ""))
+            return
 
         # Run the test on the MicroPython target.
         output_mupy = run_micropython(pyb, args, test_file, test_file_abspath)
@@ -1108,6 +1112,11 @@ the last matching regex is used:
         metavar="REGEX",
         dest="filters",
         help="include test by regex on path/name.py",
+    )
+    cmd_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show tests which would run (though might still be skipped at runtime)",
     )
     cmd_parser.add_argument(
         "--emit", default="bytecode", help="MicroPython emitter to use (bytecode or native)"

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -838,6 +838,8 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             # Works but CPython uses '\' path separator
             skip_tests.add("import/import_file.py")
 
+    skip_tests = [os.path.realpath(base_path(skip_test)) for skip_test in skip_tests]
+
     def run_one_test(test_file):
         test_file = test_file.replace("\\", "/")
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
@@ -869,7 +871,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         is_fstring = test_name.startswith("string_fstring")
         is_inlineasm = test_name.startswith("asm")
 
-        skip_it = test_file in skip_tests
+        skip_it = os.path.realpath(test_file) in skip_tests
         skip_it |= skip_native and is_native
         skip_it |= skip_endian and is_endian
         skip_it |= skip_int_big and is_int_big

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -313,15 +313,21 @@ def create_test_report(args, test_results, testcase_count=None):
         r for r in test_results if r[1] == "skip" and r[2] == "too large"
     )
     failed_tests = list(r for r in test_results if r[1] == "fail")
+    dry_run = getattr(args, "dry_run", False)
+    if dry_run:
+        found_tests = list(r for r in test_results if r[1] == "found")
 
     num_tests_performed = len(passed_tests) + len(failed_tests)
 
-    testcase_count_info = ""
-    if testcase_count is not None:
-        testcase_count_info = " ({} individual testcases)".format(testcase_count)
-    print("{} tests performed{}".format(num_tests_performed, testcase_count_info))
+    if dry_run:
+        print("{} tests found".format(len(found_tests)))
+    else:
+        testcase_count_info = ""
+        if testcase_count is not None:
+            testcase_count_info = " ({} individual testcases)".format(testcase_count)
+        print("{} tests performed{}".format(num_tests_performed, testcase_count_info))
 
-    print("{} tests passed".format(len(passed_tests)))
+        print("{} tests passed".format(len(passed_tests)))
 
     if len(skipped_tests) > 0:
         print(

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -192,7 +192,7 @@ def main():
             command.append("-v")
         else:
             command.append("-q")
-        command.append(".")
+        command.extend(files if files else ["."])
         subprocess.check_call(command, cwd=TOP)
 
 


### PR DESCRIPTION
### Summary

Fix confusing issues like

```
>cd micropython/tests
>./run-tests.py -d extmod
...
180 tests passed
22 tests skipped

>./run-tests.py -d ./extmod
...
180 tests passed
21 tests skipped
1 tests failed: ./extmod/ssl_poll.py
```

by comparing full paths for the `skip_tests` logic.

Fix
```
>./run-tests.py -d .
...
FAIL ./run-internalbench.py
<hangs, probably because of recursively calling into run-tests.py again>
```

by running the normal test suite since the directory passed is our own tests/ directory.

Make test display and output consistent, such that

```
>./run-tests.py
...
pass extmod/btree1.py
...

>./run-tests.py -d ./extmod
...
pass ./extmod/btree1.py
...

>./run-tests.py -d /full/path/to/extmod
...
pass /full/path/to/extmod/btree1.py
...
```

instead will always use the first form extmod/btree1.py, both in display and results.json, and in case of failure will also always output the same .out/.exp files (so not e.g. extmod_btree1.py.exp for the first case but _full_path_to_extmod_btree1.py.exp for the second case).

Add a `--dry-run` argument to show which test files would be ran (only implemented for run-tests, not run-multitests etc, would that be wanted?):

```
> ./run-tests.py --dry-run -d ./extmod
...
found ./extmod/re_span.py
found ./extmod/json_loads_int_64.py
skip  ./extmod/ssl_poll.py
found ./extmod/select_poll_basic.py
...
```

### Testing

Commands shown above and in the commit message were all tested successfully on unix and windows ports.

### Trade-offs and Alternatives

Trade-off: code is somewhat more complex, `realpath` might hit filesystem and be slower.

Alternative implementation: the overall proper fix would probably be to put any path which enters or is used in run-tests.py to be wrapped in `pathlib.Path(<somepath>).resolve()` (maybe even add an `expanduser` there) so any comparison just works and the various realpath/abspath calls and having to differentiate test_file/test_file_abspath/... can be gone.

Alternative usage: learn to use run-tests.py 'properly' as to workaround these issues (I for one can apparently not do that because I've ran into this quite way too much :) )