### PR TITLE
extmod,rp2: Keep LWIP timer running if lwip poll_sockets() is called.

### DIFF
--- a/extmod/modlwip.c
+++ b/extmod/modlwip.c
@@ -95,6 +95,11 @@
 #define MICROPY_PY_LWIP_EXIT
 #endif
 
+#ifndef MICROPY_PY_LWIP_POLL_HOOK
+// Optional port-level hook called if/when LWIP is being polled
+#define MICROPY_PY_LWIP_POLL_HOOK
+#endif
+
 #ifdef MICROPY_PY_LWIP_SLIP
 #include "netif/slipif.h"
 #include "lwip/sio.h"
@@ -360,6 +365,7 @@ static inline bool socket_is_timedout(lwip_socket_obj_t *socket, mp_uint_t ticks
 }
 
 static inline void poll_sockets(void) {
+    MICROPY_PY_LWIP_POLL_HOOK
     mp_event_wait_ms(1);
 }
 

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -294,6 +294,7 @@ typedef intptr_t mp_off_t;
 #include "pico/rand.h"
 extern void lwip_lock_acquire(void);
 extern void lwip_lock_release(void);
+extern void lwip_poll_hook(void);
 
 #if MICROPY_PY_BLUETOOTH || MICROPY_PY_BLUETOOTH_CYW43
 // Bluetooth code only runs in the scheduler, no locking/mutex required.

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -51,6 +51,7 @@
 #define MICROPY_PY_LWIP_ENTER   lwip_lock_acquire();
 #define MICROPY_PY_LWIP_REENTER lwip_lock_acquire();
 #define MICROPY_PY_LWIP_EXIT    lwip_lock_release();
+#define MICROPY_PY_LWIP_POLL_HOOK lwip_poll_hook();
 
 // Port level Wait-for-Event macro
 //

--- a/tests/multi_wlan/getaddrinfo.py
+++ b/tests/multi_wlan/getaddrinfo.py
@@ -1,0 +1,39 @@
+# This is a regression test to ensure getaddrinfo() fails (after a timeout)
+# when Wi-Fi is disconnected.
+#
+# It doesn't require multiple instances, but it does require Wi-Fi to be present
+# but not active, and for no other network interface to be configured. The only
+# tests which already meet these conditions is here in multi_wlan tests.
+try:
+    from network import WLAN
+except (ImportError, NameError):
+    print("SKIP")
+    raise SystemExit
+
+import socket
+
+
+def instance0():
+    WLAN(WLAN.IF_AP).active(0)
+    wlan = WLAN(WLAN.IF_STA)
+    wlan.active(0)
+
+    multitest.next()
+
+    try:
+        socket.getaddrinfo("micropython.org", 80)
+    except OSError as er:
+        print(
+            "active(0) failed"
+        )  # This may fail with code -6 or -2 depending on whether WLAN has been active since reset
+
+    wlan.active(1)
+
+    try:
+        socket.getaddrinfo("micropython.org", 80)
+    except OSError as er:
+        print(
+            "active(1) failed", er.errno in (-2, -202)
+        )  # This one should always be -2 or -202 depending on port
+
+    wlan.active(0)

--- a/tests/multi_wlan/getaddrinfo.py.exp
+++ b/tests/multi_wlan/getaddrinfo.py.exp
@@ -1,0 +1,3 @@
+--- instance0 ---
+active(0) failed
+active(1) failed True


### PR DESCRIPTION
### Summary

Fixes rp2 issue where `socket.getaddrinfo()` could block indefinitely if an interface goes down and still has a DNS server configured, as the LWIP timer stops running (since #17272) and can't time out the DNS query.

Fixes #18797.

*This work was funded through GitHub Sponsors.*

### Testing

Was going to commit a regression test for this, but haven't found a good approach - the current `net_inet` tests don't know which interface is in use so they can't disable it, and the other `multi_wlan` tests don't assume internet connectivity. Suggestions welcome!

Manual test code is simple:

```
# have boot.py configure `wlan` interface and connect
print(wlan)
dns = socket.getaddrinfo('micropython.org', 80)
print(dns)
print('disconnecting and retrying...')
wlan.disconnect()
wlan.active(False)
time.sleep(1)
dns = socket.getaddrinfo('example.com', 80)
print(dns)
```

Hangs indefinitely without this fix. Fails after the DNS timeout with this fix.

### Trade-offs and Alternatives

* A different fix was submitted by @paul-matthews as #18801 (thanks!) Compared to that PR, this PR should have smaller code size impact and may help LWIP's internal accounting if there's other places MicroPython blocks in a loop calling `poll_sockets()` (unconfirmed).

  The other PR also immediately fails `getaddrinfo()` if no `netif` has the link up. I'm not sure if this is desirable behaviour or not, as there are cases where the link can "flap" (i.e. poor Wi-Fi signal, other end of network cable power cycles, etc) and in those cases the internal LWIP DNS retries may actually succeed. I think another way to implement "fast failures" may be to have either `wlan.disconnect()` or `wlan.active(False)` clear the DNS server setting (and/or release DHCP). Curious what you think, @paul-matthews?
* I also tried changing the "stop timer" logic to keep the timer running if any UDP sockets were active (currently this check is for active TCP sockets only). This would cover DNS and other possible UDP activity. However, this approach isn't viable as LWIP DHCP currently keeps a UDP pbuf registered even when the interface is down, and the LWIP mDNS resolver permanently registers a single static UDP pbuf on init and never removes it.