### PR TITLE
zephyr: Fix macro for getting erase_block_size.

### DIFF
--- a/ports/zephyr/zephyr_storage.c
+++ b/ports/zephyr/zephyr_storage.c
@@ -188,7 +188,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
 // Note: Some flash controllers have erase-block-size, others (like QSPI NOR) don't
 // For devices without this property, use 4096 as a common default for NOR flash
 #define FLASH_AREA_GET_ERASE_SIZE(part) \
-    DT_PROP_OR(DT_MTD_FROM_FIXED_PARTITION(part), erase_block_size, 4096)
+    DT_PROP_OR(DT_GPARENT(part), erase_block_size, 4096)
 
 // Create a static tuple for each partition containing (id, erase_block_size)
 #define FLASH_AREA_DEFINE_TUPLE(part) \


### PR DESCRIPTION
A minimal change to PR  #18185  (already merged) that corrects the macro that tries to fetch erase-block-size from the board dts.

I attach a test that compares the values obtained by the original macro and mine on a number of different boards.

[test_erase_block_size.zip](https://github.com/user-attachments/files/25232281/test_erase_block_size.zip)
