### PR TITLE
ports/unix: Process pending callbacks during time.sleep().

### DIFF
--- a/extmod/btstack/modbluetooth_btstack.c
+++ b/extmod/btstack/modbluetooth_btstack.c
@@ -193,10 +193,10 @@ static bool controller_static_addr_available = false;
 static const uint8_t read_static_address_command_complete_prefix[] = { 0x0e, 0x1b, 0x01, 0x09, 0xfc };
 #endif
 
-static void btstack_packet_handler_generic(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
+static void btstack_dispatch_hci_event(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
     (void)channel;
     (void)size;
-    DEBUG_printf("btstack_packet_handler_generic(packet_type=%u, packet=%p)\n", packet_type, packet);
+    DEBUG_printf("btstack_dispatch_hci_event(packet_type=%u, packet=%p)\n", packet_type, packet);
     if (packet_type != HCI_EVENT_PACKET) {
         return;
     }
@@ -372,6 +372,12 @@ static void btstack_packet_handler_generic(uint8_t packet_type, uint16_t channel
     }
 }
 
+static void btstack_packet_handler_generic(uint8_t packet_type, uint16_t channel, uint8_t *packet, uint16_t size) {
+    btstack_dispatch_hci_event(packet_type, channel, packet, size);
+    // Raised after dispatching, so a waiter sees the state this event carried.
+    mp_hal_signal_event();
+}
+
 static btstack_packet_callback_registration_t hci_event_callback_registration = {
     .callback = &btstack_packet_handler_generic
 };
@@ -510,12 +516,16 @@ static void btstack_init_deinit_timeout_handler(btstack_timer_source_t *ds) {
     // This signals both the loops in mp_bluetooth_init and mp_bluetooth_deinit,
     // as well as ports that run a polling loop.
     mp_bluetooth_btstack_state = MP_BLUETOOTH_BTSTACK_STATE_TIMEOUT;
+    // Runs off the run loop's timer, not its event dispatch, so raise here too.
+    mp_hal_signal_event();
 }
 
 #if !MICROPY_BLUETOOTH_USE_MP_HAL_GET_MAC_STATIC_ADDRESS
 static void btstack_static_address_ready(void *arg) {
     DEBUG_printf("btstack_static_address_ready.\n");
     *(volatile bool *)arg = true;
+    // Called from the run loop, which may not be the thread waiting on the flag.
+    mp_hal_signal_event();
 }
 #endif
 

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -19,6 +19,7 @@
 #include "py/stream.h"
 #include "py/binary.h"
 #include "py/bc.h"
+#include "py/mphal.h"
 
 // expected output of this file is found in extra_coverage.py.exp
 
@@ -795,11 +796,15 @@ static mp_obj_t extra_coverage(void) {
         mp_sched_unlock();
         mp_printf(&mp_plat_print, "unlocked\n");
 
-        // drain pending callbacks, and test mp_event_wait_indefinite(), mp_event_wait_ms()
-        mp_event_wait_indefinite(); // the unix port only waits 500us in this call
+        // drain pending callbacks, and test mp_event_wait_ms()
         while (mp_sched_num_pending()) {
             mp_event_wait_ms(1);
         }
+
+        // test mp_event_wait_indefinite(), raising the wake event first so the
+        // wait has something to return on
+        mp_hal_signal_event();
+        mp_event_wait_indefinite();
 
         // setting the keyboard interrupt and raising it during mp_handle_pending
         mp_sched_keyboard_interrupt();

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -495,6 +495,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     mp_init();
 
+    #if MICROPY_ENABLE_SCHEDULER && !defined(_WIN32)
+    mp_unix_init_sched_signal();
+    #endif
+
     #if MICROPY_EMIT_NATIVE
     // Set default emitter options
     MP_STATE_VM(default_emit_opt) = emit_opt;
@@ -736,6 +740,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     #if defined(MICROPY_UNIX_COVERAGE)
     gc_sweep_all();
+    #endif
+
+    #if MICROPY_ENABLE_SCHEDULER && !defined(_WIN32)
+    mp_unix_deinit_sched_signal();
     #endif
 
     mp_deinit();

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -495,6 +495,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
 
     mp_init();
 
+    mp_hal_wake_event_init();
+
     #if MICROPY_EMIT_NATIVE
     // Set default emitter options
     MP_STATE_VM(default_emit_opt) = emit_opt;
@@ -737,6 +739,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #if defined(MICROPY_UNIX_COVERAGE)
     gc_sweep_all();
     #endif
+
+    mp_hal_wake_event_deinit();
 
     mp_deinit();
 

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -42,6 +42,10 @@ static inline int msec_sleep_tv(struct timeval *tv) {
     return 0;
 }
 #define sleep_select(a, b, c, d, e) msec_sleep_tv((e))
+#elif MICROPY_ENABLE_SCHEDULER
+// Sleep with the scheduler wakeup signal able to interrupt the wait, so a
+// scheduled callback aborts the sleep with EINTR to be processed promptly.
+#define sleep_select(a, b, c, d, e) mp_unix_sched_select((e))
 #else
 #define sleep_select select
 #endif

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -88,32 +88,35 @@ static MP_DEFINE_CONST_FUN_OBJ_0(mod_time_clock_obj, mod_time_clock);
 
 static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
     if (val < 0) {
         mp_raise_ValueError(MP_ERROR_TEXT("sleep length must be non-negative"));
     }
     mp_float_t ipart;
-    tv.tv_usec = (time_t)MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
-    tv.tv_sec = (suseconds_t)ipart;
-    int res;
-    while (1) {
+    mp_float_t fpart = MICROPY_FLOAT_C_FUN(modf)(val, &ipart);
+    // Track the remaining duration explicitly: relying on select() updating
+    // the timeout to the time not slept is Linux-specific behaviour.
+    uint64_t remain_us = (uint64_t)ipart * 1000000
+        + (uint64_t)MICROPY_FLOAT_C_FUN(round)(fpart * MICROPY_FLOAT_CONST(1000000.));
+    for (;;) {
         mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
+        struct timeval tv;
+        tv.tv_sec = (time_t)(remain_us / 1000000);
+        tv.tv_usec = (suseconds_t)(remain_us % 1000000);
+        mp_uint_t t0 = mp_hal_ticks_us();
         MP_THREAD_GIL_EXIT();
-        res = sleep_select(0, NULL, NULL, NULL, &tv);
+        int res = sleep_select(0, NULL, NULL, NULL, &tv);
         MP_THREAD_GIL_ENTER();
-        #if MICROPY_SELECT_REMAINING_TIME
-        // TODO: This assumes Linux behavior of modifying tv to the remaining
-        // time.
-        if (res != -1 || errno != EINTR) {
+        if (res == -1 && errno != EINTR) {
+            RAISE_ERRNO(res, errno);
+        }
+        // Per-iteration unsigned tick difference is wrap-safe.
+        uint64_t elapsed_us = (mp_uint_t)(mp_hal_ticks_us() - t0);
+        if (res == 0 || elapsed_us >= remain_us) {
             break;
         }
-        // printf("select: EINTR: %ld:%ld\n", tv.tv_sec, tv.tv_usec);
-        #else
-        break;
-        #endif
+        remain_us -= elapsed_us;
     }
-    RAISE_ERRNO(res, errno);
     #else
     int seconds = mp_obj_get_int(arg);
     if (seconds < 0) {

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -90,6 +90,9 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #if MICROPY_PY_BUILTINS_FLOAT
     struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
+    if (val < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sleep length must be non-negative"));
+    }
     mp_float_t ipart;
     tv.tv_usec = (time_t)MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
     tv.tv_sec = (suseconds_t)ipart;
@@ -113,6 +116,9 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     RAISE_ERRNO(res, errno);
     #else
     int seconds = mp_obj_get_int(arg);
+    if (seconds < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sleep length must be non-negative"));
+    }
     for (;;) {
         mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MP_THREAD_GIL_EXIT();

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -90,6 +90,14 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #if MICROPY_PY_BUILTINS_FLOAT
     struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
+    #else
+    mp_int_t val = mp_obj_get_int(arg);
+    #endif
+    if (val < 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sleep length must be non-negative"));
+    }
+
+    #if MICROPY_PY_BUILTINS_FLOAT
     mp_float_t ipart;
     tv.tv_usec = (time_t)MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
     tv.tv_sec = (suseconds_t)ipart;
@@ -112,7 +120,7 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     }
     RAISE_ERRNO(res, errno);
     #else
-    int seconds = mp_obj_get_int(arg);
+    int seconds = (int)val;
     for (;;) {
         mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         MP_THREAD_GIL_EXIT();

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -36,16 +36,6 @@
 #include "py/runtime.h"
 #include "shared/timeutils/timeutils.h"
 
-#ifdef _WIN32
-static inline int msec_sleep_tv(struct timeval *tv) {
-    msec_sleep(tv->tv_sec * 1000.0 + tv->tv_usec / 1000.0);
-    return 0;
-}
-#define sleep_select(a, b, c, d, e) msec_sleep_tv((e))
-#else
-#define sleep_select select
-#endif
-
 // mingw32 defines CLOCKS_PER_SEC as ((clock_t)<somevalue>) but preprocessor does not handle casts
 #if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
 #define MP_REMOVE_BRACKETSA(x)
@@ -112,13 +102,12 @@ static mp_obj_t mp_time_sleep(mp_obj_t arg) {
         tv.tv_usec = (suseconds_t)(remain_us % 1000000);
         mp_uint_t t0 = mp_hal_ticks_us();
         MP_THREAD_GIL_EXIT();
-        int res = sleep_select(0, NULL, NULL, NULL, &tv);
+        int res = mp_hal_wake_event_wait_tv(&tv);
         MP_THREAD_GIL_ENTER();
         if (res == -1 && errno != EINTR) {
             RAISE_ERRNO(res, errno);
         }
-        // An unsigned tick difference can only under-count on wrap, so the
-        // sleep never ends early.
+        // An unsigned difference can only under-count on wrap, never ending early.
         uint64_t elapsed_us = (mp_uint_t)(mp_hal_ticks_us() - t0);
         if (res == 0 || elapsed_us >= remain_us) {
             break;

--- a/ports/unix/modtime.c
+++ b/ports/unix/modtime.c
@@ -88,37 +88,43 @@ static MP_DEFINE_CONST_FUN_OBJ_0(mod_time_clock_obj, mod_time_clock);
 
 static mp_obj_t mp_time_sleep(mp_obj_t arg) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    struct timeval tv;
     mp_float_t val = mp_obj_get_float(arg);
+    // Rejects NaN, and values too large for the microsecond count below.
+    bool val_ok = val >= 0 && val <= (mp_float_t)(UINT64_MAX / 1000000);
     #else
     mp_int_t val = mp_obj_get_int(arg);
+    bool val_ok = val >= 0;
     #endif
-    if (val < 0) {
-        mp_raise_ValueError(MP_ERROR_TEXT("sleep length must be non-negative"));
+    if (!val_ok) {
+        mp_raise_ValueError(MP_ERROR_TEXT("sleep length out of range"));
     }
 
     #if MICROPY_PY_BUILTINS_FLOAT
     mp_float_t ipart;
-    tv.tv_usec = (time_t)MICROPY_FLOAT_C_FUN(round)(MICROPY_FLOAT_C_FUN(modf)(val, &ipart) * MICROPY_FLOAT_CONST(1000000.));
-    tv.tv_sec = (suseconds_t)ipart;
-    int res;
-    while (1) {
+    mp_float_t fpart = MICROPY_FLOAT_C_FUN(modf)(val, &ipart);
+    // Tracked here because not all platforms update the timeout on return.
+    uint64_t remain_us = (uint64_t)ipart * 1000000
+        + (uint64_t)MICROPY_FLOAT_C_FUN(round)(fpart * MICROPY_FLOAT_CONST(1000000.));
+    for (;;) {
         mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
+        struct timeval tv;
+        tv.tv_sec = (time_t)(remain_us / 1000000);
+        tv.tv_usec = (suseconds_t)(remain_us % 1000000);
+        mp_uint_t t0 = mp_hal_ticks_us();
         MP_THREAD_GIL_EXIT();
-        res = sleep_select(0, NULL, NULL, NULL, &tv);
+        int res = sleep_select(0, NULL, NULL, NULL, &tv);
         MP_THREAD_GIL_ENTER();
-        #if MICROPY_SELECT_REMAINING_TIME
-        // TODO: This assumes Linux behavior of modifying tv to the remaining
-        // time.
-        if (res != -1 || errno != EINTR) {
+        if (res == -1 && errno != EINTR) {
+            RAISE_ERRNO(res, errno);
+        }
+        // An unsigned tick difference can only under-count on wrap, so the
+        // sleep never ends early.
+        uint64_t elapsed_us = (mp_uint_t)(mp_hal_ticks_us() - t0);
+        if (res == 0 || elapsed_us >= remain_us) {
             break;
         }
-        // printf("select: EINTR: %ld:%ld\n", tv.tv_sec, tv.tv_usec);
-        #else
-        break;
-        #endif
+        remain_us -= elapsed_us;
     }
-    RAISE_ERRNO(res, errno);
     #else
     int seconds = (int)val;
     for (;;) {

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -221,6 +221,15 @@ static inline unsigned long mp_random_seed_init(void) {
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();
 
+// Wake blocking waits when a callback is scheduled (see unix_mphal.c).
+// MICROPY_ENABLE_SCHEDULER cannot be tested here because it is given its
+// default value later, in py/mpconfig.h; guarding on _WIN32 alone is safe
+// because py/scheduler.c only uses this hook when the scheduler is enabled.
+#ifndef _WIN32
+void mp_hal_signal_event(void);
+#define MICROPY_SCHED_HOOK_SCHEDULED mp_hal_signal_event()
+#endif
+
 #ifndef MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE
 #define MICROPY_PY_BLUETOOTH_ENABLE_CENTRAL_MODE (1)
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -121,10 +121,6 @@ typedef long mp_off_t;
 // port modtime functions use time_t
 #define MICROPY_TIMESTAMP_IMPL      (MICROPY_TIMESTAMP_IMPL_TIME_T)
 
-// Assume that select() call, interrupted with a signal, and erroring
-// with EINTR, updates remaining timeout value.
-#define MICROPY_SELECT_REMAINING_TIME (1)
-
 // Disable stackless by default.
 #ifndef MICROPY_STACKLESS
 #define MICROPY_STACKLESS           (0)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -128,10 +128,6 @@ typedef long mp_off_t;
 // port modtime functions use time_t
 #define MICROPY_TIMESTAMP_IMPL      (MICROPY_TIMESTAMP_IMPL_TIME_T)
 
-// Assume that select() call, interrupted with a signal, and erroring
-// with EINTR, updates remaining timeout value.
-#define MICROPY_SELECT_REMAINING_TIME (1)
-
 // Disable stackless by default.
 #ifndef MICROPY_STACKLESS
 #define MICROPY_STACKLESS           (0)

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -114,6 +114,14 @@ static inline void mp_hal_delay_us(mp_uint_t us) {
 
 void mp_hal_get_random(size_t n, uint8_t *buf);
 
+#if MICROPY_ENABLE_SCHEDULER && !defined(_WIN32)
+struct timeval;
+void mp_unix_init_sched_signal(void);
+void mp_unix_deinit_sched_signal(void);
+int mp_unix_sched_select(struct timeval *tv);
+void mp_unix_sched_sleep(uint32_t timeout_ms);
+#endif
+
 #if MICROPY_PY_BLUETOOTH
 enum {
     MP_HAL_MAC_BDADDR,

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -37,6 +37,16 @@
 #define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
 #endif
 
+// Wait for an event (scheduled callback) or timeout. A wakeup signal
+// raised by mp_hal_signal_event() aborts the wait.
+#if MICROPY_ENABLE_SCHEDULER && !defined(_WIN32)
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
+    do { \
+        MP_THREAD_GIL_EXIT(); \
+        mp_unix_sched_sleep(TIMEOUT_MS); \
+        MP_THREAD_GIL_ENTER(); \
+    } while (0)
+#else
 // In lieu of a WFI(), slow down polling from being a tight loop.
 //
 // Note that we don't delay for the full TIMEOUT_MS, as execution
@@ -47,6 +57,7 @@
         mp_hal_delay_us(500); \
         MP_THREAD_GIL_ENTER(); \
     } while (0)
+#endif
 
 // The port provides `mp_hal_stdio_mode_raw()` and `mp_hal_stdio_mode_orig()`.
 #define MICROPY_HAL_HAS_STDIO_MODE_SWITCH (1)

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <sys/time.h>
 
 #ifndef CHAR_CTRL_C
 #define CHAR_CTRL_C (3)
@@ -37,14 +38,11 @@
 #define MICROPY_END_ATOMIC_SECTION(x) (void)x; mp_thread_unix_end_atomic_section()
 #endif
 
-// In lieu of a WFI(), slow down polling from being a tight loop.
-//
-// Note that we don't delay for the full TIMEOUT_MS, as execution
-// can't be woken from the delay.
+// Block until the timeout expires or the wake event is raised.
 #define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
     do { \
         MP_THREAD_GIL_EXIT(); \
-        mp_hal_delay_us(500); \
+        mp_hal_wake_event_wait_ms(TIMEOUT_MS); \
         MP_THREAD_GIL_ENTER(); \
     } while (0)
 
@@ -123,6 +121,15 @@ void mp_hal_wake_event_deinit(void);
 // replaces the no-op fallback in py/mphal.h.
 #define mp_hal_signal_event mp_hal_signal_event
 void mp_hal_signal_event(void);
+
+// Wait for the wake event or the timeout, whichever is first; may return early
+// regardless.  MP_HAL_WAKE_EVENT_FOREVER waits with no timeout at all.
+#define MP_HAL_WAKE_EVENT_FOREVER ((mp_uint_t)-1)
+void mp_hal_wake_event_wait_ms(mp_uint_t timeout_ms);
+
+// As above with a timeval, for sub-millisecond resolution; NULL waits with no
+// timeout.  Returns 0 on timeout, or -1 with errno EINTR if cut short.
+int mp_hal_wake_event_wait_tv(struct timeval *tv);
 
 #if MICROPY_PY_BLUETOOTH
 enum {

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -114,6 +114,16 @@ static inline void mp_hal_delay_us(mp_uint_t us) {
 
 void mp_hal_get_random(size_t n, uint8_t *buf);
 
+// The wake event ends a blocking wait when something needs attention.  It
+// latches, so a raise between waits isn't lost.
+void mp_hal_wake_event_init(void);
+void mp_hal_wake_event_deinit(void);
+
+// Raises it, from any thread or from a signal handler.  Defining the name
+// replaces the no-op fallback in py/mphal.h.
+#define mp_hal_signal_event mp_hal_signal_event
+void mp_hal_signal_event(void);
+
 #if MICROPY_PY_BLUETOOTH
 enum {
     MP_HAL_MAC_BDADDR,

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -29,12 +29,119 @@
 #include <string.h>
 #include <time.h>
 #include <sys/time.h>
+#include <sys/select.h>
 #include <fcntl.h>
+#include <signal.h>
 
 #include "py/mphal.h"
 #include "py/mpthread.h"
 #include "py/runtime.h"
 #include "extmod/misc.h"
+
+#if MICROPY_ENABLE_SCHEDULER && !defined(_WIN32)
+
+// Signal used to wake blocking waits when a callback is scheduled. Use a
+// real-time signal if available, above those used by mpthreadport.c.
+// Fall back to SIGURG, which is ignored by default and rarely used.
+#ifdef SIGRTMIN
+#define MP_SCHED_SIGNAL (SIGRTMIN + 7)
+#else
+#define MP_SCHED_SIGNAL (SIGURG)
+#endif
+
+// Longest single event wait, so an indefinite wait degrades to bounded
+// latency in case a wakeup is ever missed.
+#define MP_SCHED_SLEEP_MAX_MS (1000)
+
+static bool sched_signal_installed;
+
+static void sched_sighandler(int signum) {
+    (void)signum;
+}
+
+void mp_unix_init_sched_signal(void) {
+    struct sigaction sa;
+    sa.sa_flags = 0; // No SA_RESTART: pselect() returns EINTR.
+    sa.sa_handler = sched_sighandler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(MP_SCHED_SIGNAL, &sa, NULL) != 0) {
+        // Signal unavailable on this platform: waits fall back to plain
+        // timeouts and mp_hal_signal_event() does nothing.
+        return;
+    }
+    // Mask delivery of the signal in every thread (children inherit this
+    // mask). Raising it then never interrupts any thread; it just stays
+    // queued on the process until a waiter accepts it by unmasking it
+    // inside pselect(), in mp_unix_sched_select().
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, MP_SCHED_SIGNAL);
+    #if MICROPY_PY_THREAD
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
+    #else
+    sigprocmask(SIG_BLOCK, &set, NULL);
+    #endif
+    sched_signal_installed = true;
+}
+
+void mp_unix_deinit_sched_signal(void) {
+    if (!sched_signal_installed) {
+        return;
+    }
+    sched_signal_installed = false;
+    // SIG_IGN discards any still-pending signal; SIG_DFL would terminate
+    // the process on a late delivery (real-time signals default to Term).
+    struct sigaction sa;
+    sa.sa_flags = 0;
+    sa.sa_handler = SIG_IGN;
+    sigemptyset(&sa.sa_mask);
+    sigaction(MP_SCHED_SIGNAL, &sa, NULL);
+}
+
+void mp_hal_signal_event(void) {
+    if (sched_signal_installed) {
+        // Async-signal-safe. Delivery is masked in every thread, so this
+        // only marks the signal pending for a waiter; no thread is
+        // interrupted.
+        kill(getpid(), MP_SCHED_SIGNAL);
+    }
+}
+
+// Sleep for the given duration or until woken by mp_hal_signal_event().
+// pselect() unmasks the wakeup signal only while waiting, so a wakeup
+// raised at any earlier point is still pending and aborts the wait
+// immediately. Returns 0 on timeout, -1 with errno EINTR on wakeup.
+int mp_unix_sched_select(struct timeval *tv) {
+    if (!sched_signal_installed) {
+        return select(0, NULL, NULL, NULL, tv);
+    }
+    struct timespec ts;
+    ts.tv_sec = tv->tv_sec;
+    ts.tv_nsec = tv->tv_usec * 1000;
+    sigset_t waitmask;
+    #if MICROPY_PY_THREAD
+    pthread_sigmask(SIG_BLOCK, NULL, &waitmask);
+    #else
+    sigprocmask(SIG_BLOCK, NULL, &waitmask);
+    #endif
+    sigdelset(&waitmask, MP_SCHED_SIGNAL);
+    return pselect(0, NULL, NULL, NULL, &ts, &waitmask);
+}
+
+// Wait for an event (scheduled callback) or timeout, for
+// MICROPY_INTERNAL_WFE. May wake spuriously, at most once per stale
+// pending signal; callers loop and re-check for events.
+void mp_unix_sched_sleep(uint32_t timeout_ms) {
+    if (MP_STATE_VM(sched_state) == MP_SCHED_PENDING) {
+        return;
+    }
+    if (timeout_ms > MP_SCHED_SLEEP_MAX_MS) {
+        timeout_ms = MP_SCHED_SLEEP_MAX_MS;
+    }
+    struct timeval tv = {timeout_ms / 1000, (timeout_ms % 1000) * 1000};
+    mp_unix_sched_select(&tv);
+}
+#endif
 
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 25)
@@ -44,8 +151,6 @@
 #endif
 
 #ifndef _WIN32
-#include <signal.h>
-
 static void sighandler(int signum) {
     if (signum == SIGINT) {
         #if MICROPY_ASYNC_KBD_INTR
@@ -57,6 +162,13 @@ static void sighandler(int signum) {
         mp_obj_exception_clear_traceback(MP_OBJ_FROM_PTR(&MP_STATE_VM(mp_kbd_exception)));
         sigset_t mask;
         sigemptyset(&mask);
+        #if MICROPY_ENABLE_SCHEDULER
+        // Keep the scheduler wakeup signal masked: it must stay pending
+        // until accepted by a waiter (see mp_unix_init_sched_signal). This
+        // also restores the steady-state mask when the longjmp cuts short
+        // a pselect() that had it temporarily unmasked.
+        sigaddset(&mask, MP_SCHED_SIGNAL);
+        #endif
         // On entry to handler, its signal is blocked, and unblocked on
         // normal exit. As we instead perform longjmp, unblock it manually.
         sigprocmask(SIG_SETMASK, &mask, NULL);

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -85,6 +85,11 @@ void mp_hal_wake_event_init(void) {
         fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
         exit(1);
     }
+    if (wake_event_fd >= FD_SETSIZE) {
+        // Waiting on it uses select(), and FD_SET() is undefined from here up.
+        fprintf(stderr, "FATAL: wake event fd %d exceeds FD_SETSIZE\n", wake_event_fd);
+        exit(1);
+    }
 }
 
 void mp_hal_wake_event_deinit(void) {
@@ -100,6 +105,14 @@ void mp_hal_wake_event_deinit(void) {
     close(rd);
 }
 
+static void wake_event_drain(int fd) {
+    // Empty it fully or the next wait returns at once: an eventfd reads its
+    // counter in one go, a self-pipe holds a byte per raise.
+    char buf[64];
+    while (read(fd, buf, sizeof(buf)) > 0) {
+    }
+}
+
 void mp_hal_signal_event(void) {
     int fd = wake_event_wr_fd;
     if (fd < 0) {
@@ -112,6 +125,35 @@ void mp_hal_signal_event(void) {
     ssize_t ret = write(fd, &token, sizeof(token));
     (void)ret;
     errno = errno_save;
+}
+
+int mp_hal_wake_event_wait_tv(struct timeval *tv) {
+    // Only the thread that runs scheduled callbacks may consume the event: one
+    // taken by another thread is one the thread that can act on it never sees.
+    // Other threads just wait out the timeout.
+    int fd = wake_event_fd;
+    if (fd < 0 || !mp_sched_thread_can_run_callbacks()) {
+        return select(0, NULL, NULL, NULL, tv);
+    }
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+    int ret = select(fd + 1, &rfds, NULL, NULL, tv);
+    if (ret > 0) {
+        wake_event_drain(fd);
+        errno = EINTR;
+        return -1;
+    }
+    return ret;
+}
+
+void mp_hal_wake_event_wait_ms(mp_uint_t timeout_ms) {
+    if (timeout_ms == MP_HAL_WAKE_EVENT_FOREVER) {
+        mp_hal_wake_event_wait_tv(NULL);
+        return;
+    }
+    struct timeval tv = {timeout_ms / 1000, (timeout_ms % 1000) * 1000};
+    mp_hal_wake_event_wait_tv(&tv);
 }
 
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
@@ -322,8 +364,11 @@ uint64_t mp_hal_time_ns(void) {
 void mp_hal_delay_ms(mp_uint_t ms) {
     if (ms) {
         mp_uint_t start = mp_hal_ticks_ms();
-        while (mp_hal_ticks_ms() - start < ms) {
-            mp_event_wait_ms(1);
+        mp_uint_t elapsed = 0;
+        // The wait can return early, so loop until the time is up.
+        while (elapsed < ms) {
+            mp_event_wait_ms(ms - elapsed);
+            elapsed = mp_hal_ticks_ms() - start;
         }
     } else {
         mp_handle_pending(true);

--- a/ports/unix/unix_mphal.c
+++ b/ports/unix/unix_mphal.c
@@ -25,16 +25,94 @@
  */
 
 #include <unistd.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <errno.h>
 #include <sys/time.h>
+#include <sys/select.h>
 #include <fcntl.h>
 
 #include "py/mphal.h"
 #include "py/mpthread.h"
 #include "py/runtime.h"
 #include "extmod/misc.h"
+
+#ifdef __linux__
+#include <sys/eventfd.h>
+// An eventfd is read and written as a 64-bit counter.
+typedef uint64_t wake_event_token_t;
+#else
+// The self-pipe carries one byte per wakeup.
+typedef uint8_t wake_event_token_t;
+#endif
+
+// The wake event: a Linux eventfd, or a self-pipe elsewhere.  Reading
+// wake_event_fd drains it, writing wake_event_wr_fd raises it; on Linux both
+// are the same descriptor, and both are negative when not initialised.
+static int wake_event_fd = -1;
+static int wake_event_wr_fd = -1;
+
+#ifndef __linux__
+static int set_cloexec_nonblock(int fd) {
+    // pipe2() would do this atomically at creation but is absent on macOS.
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) != 0) {
+        return -1;
+    }
+    return fcntl(fd, F_SETFD, FD_CLOEXEC);
+}
+#endif
+
+void mp_hal_wake_event_init(void) {
+    #ifdef __linux__
+    wake_event_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    wake_event_wr_fd = wake_event_fd;
+    #else
+    int fds[2];
+    if (pipe(fds) == 0) {
+        if (set_cloexec_nonblock(fds[0]) == 0 && set_cloexec_nonblock(fds[1]) == 0) {
+            wake_event_fd = fds[0];
+            wake_event_wr_fd = fds[1];
+        } else {
+            close(fds[0]);
+            close(fds[1]);
+        }
+    }
+    #endif
+    if (wake_event_fd < 0) {
+        fprintf(stderr, "FATAL: cannot create wake event: %s\n", strerror(errno));
+        exit(1);
+    }
+}
+
+void mp_hal_wake_event_deinit(void) {
+    // Cleared before closing, so a concurrent raise is dropped rather than
+    // written to a reused descriptor.
+    int rd = wake_event_fd;
+    int wr = wake_event_wr_fd;
+    wake_event_fd = -1;
+    wake_event_wr_fd = -1;
+    if (wr != rd) {
+        close(wr);
+    }
+    close(rd);
+}
+
+void mp_hal_signal_event(void) {
+    int fd = wake_event_wr_fd;
+    if (fd < 0) {
+        return;
+    }
+    // Reachable from a signal handler, so no allocation, and errno is
+    // preserved.  A failed write means the event is already raised.
+    int errno_save = errno;
+    wake_event_token_t token = 1;
+    ssize_t ret = write(fd, &token, sizeof(token));
+    (void)ret;
+    errno = errno_save;
+}
 
 #if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 25)

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -29,6 +29,9 @@
 #include "py/mphal.h"
 #include "py/mpthread.h"
 
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <windows.h>
 #include <unistd.h>
@@ -270,6 +273,34 @@ void msec_sleep(double msec) {
     }
     SleepEx((DWORD)msec, TRUE);
 }
+
+// The wake event.  Auto-reset, so a wait consumes it atomically, a raise with
+// nothing waiting latches for the next wait, and repeated raises coalesce.
+static HANDLE wake_event = NULL;
+
+void mp_hal_wake_event_init(void) {
+    wake_event = CreateEvent(NULL, FALSE, FALSE, NULL);
+    if (wake_event == NULL) {
+        fprintf(stderr, "FATAL: cannot create wake event: %lu\n", (unsigned long)GetLastError());
+        exit(1);
+    }
+}
+
+void mp_hal_wake_event_deinit(void) {
+    // Cleared before closing, so a concurrent raise is dropped rather than
+    // signalled on a reused handle.
+    HANDLE h = wake_event;
+    wake_event = NULL;
+    CloseHandle(h);
+}
+
+void mp_hal_signal_event(void) {
+    HANDLE h = wake_event;
+    if (h != NULL) {
+        SetEvent(h);
+    }
+}
+
 
 #ifdef _MSC_VER
 int usleep(__int64 usec) {

--- a/ports/windows/windows_mphal.c
+++ b/ports/windows/windows_mphal.c
@@ -301,6 +301,45 @@ void mp_hal_signal_event(void) {
     }
 }
 
+// INFINITE is the all-ones DWORD, so a finite wait of 49 days stops one
+// millisecond short of it and the caller loops for the rest.
+static DWORD wake_event_wait_dword(uint64_t ms) {
+    return ms < INFINITE ? (DWORD)ms : INFINITE - 1;
+}
+
+int mp_hal_wake_event_wait_tv(struct timeval *tv) {
+    DWORD ms;
+    if (tv == NULL) {
+        ms = INFINITE;
+    } else {
+        // Round up, so a sub-millisecond sleep waits rather than spinning to
+        // the deadline; the timer granularity is coarser than that anyway.
+        ms = wake_event_wait_dword((uint64_t)tv->tv_sec * 1000 + ((uint64_t)tv->tv_usec + 999) / 1000);
+    }
+    if (!mp_sched_thread_can_run_callbacks()) {
+        SleepEx(ms, TRUE);
+        return 0;
+    }
+    // Anything but a timeout, including WAIT_IO_COMPLETION from the alertable
+    // wait, sends the caller back round to recompute what is left.
+    if (WaitForSingleObjectEx(wake_event, ms, TRUE) != WAIT_TIMEOUT) {
+        errno = EINTR;
+        return -1;
+    }
+    return 0;
+}
+
+void mp_hal_wake_event_wait_ms(mp_uint_t timeout_ms) {
+    DWORD ms = timeout_ms == MP_HAL_WAKE_EVENT_FOREVER
+        ? INFINITE : wake_event_wait_dword(timeout_ms);
+    // Only the thread that runs scheduled callbacks may consume the event.
+    if (!mp_sched_thread_can_run_callbacks()) {
+        SleepEx(ms, TRUE);
+        return;
+    }
+    // Alertable, so queued APCs still run.
+    WaitForSingleObjectEx(wake_event, ms, TRUE);
+}
 
 #ifdef _MSC_VER
 int usleep(__int64 usec) {
@@ -310,14 +349,13 @@ int usleep(__int64 usec) {
 #endif
 
 void mp_hal_delay_ms(mp_uint_t ms) {
-    #if MICROPY_ENABLE_SCHEDULER
     mp_uint_t start = mp_hal_ticks_ms();
-    while (mp_hal_ticks_ms() - start < ms) {
-        mp_event_wait_ms(1);
+    mp_uint_t elapsed = 0;
+    // The wait can return early, so loop until the time is up.
+    while (elapsed < ms) {
+        mp_event_wait_ms(ms - elapsed);
+        elapsed = mp_hal_ticks_ms() - start;
     }
-    #else
-    msec_sleep((double)ms);
-    #endif
 }
 
 void mp_hal_get_random(size_t n, uint8_t *buf) {

--- a/ports/windows/windows_mphal.h
+++ b/ports/windows/windows_mphal.h
@@ -27,17 +27,6 @@
 #include "sleep.h"
 #include "ports/unix/mphalport.h"
 
-// Don't use the unix version of this macro.
-#undef MICROPY_INTERNAL_WFE
-
-#if MICROPY_ENABLE_SCHEDULER
-// Use minimum 1mSec sleep to make sure there is effectively a wait period:
-// something like usleep(500) truncates and ends up calling Sleep(0).
-#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) msec_sleep(MAX(1.0, (double)(TIMEOUT_MS)))
-#else
-#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) /* No-op */
-#endif
-
 #define MICROPY_HAL_HAS_VT100 (0)
 
 void mp_hal_move_cursor_back(unsigned int pos);

--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -164,9 +164,6 @@
 #define MICROPY_PY_THREAD_GIL_VM_DIVISOR    (32)
 #endif
 
-void mp_hal_signal_event(void);
-#define MICROPY_SCHED_HOOK_SCHEDULED mp_hal_signal_event()
-
 #define MICROPY_PY_SYS_PLATFORM "zephyr"
 
 #ifdef CONFIG_BOARD

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -22,6 +22,9 @@
 void mp_hal_init(void);
 void mp_hal_wait_event(bool exit_on_event, struct k_sem *sem, uint32_t timeout_ms);
 
+#define mp_hal_signal_event mp_hal_signal_event
+void mp_hal_signal_event(void);
+
 static inline mp_uint_t mp_hal_ticks_us(void) {
     return k_cyc_to_ns_floor64(k_cycle_get_32()) / 1000;
 }

--- a/ports/zephyr/src/zephyr_getchar.c
+++ b/ports/zephyr/src/zephyr_getchar.c
@@ -22,7 +22,6 @@
 
 extern int mp_interrupt_char;
 void mp_sched_keyboard_interrupt(void);
-void mp_hal_signal_event(void);
 
 #define UART_BUFSIZE (512)
 static uint8_t uart_ringbuf[UART_BUFSIZE];
@@ -35,7 +34,6 @@ static int console_irq_input_hook(uint8_t ch) {
         return 1;
     }
     if (ch == mp_interrupt_char) {
-        mp_hal_signal_event();
         mp_sched_keyboard_interrupt();
         return 1;
     } else {

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -759,12 +759,6 @@ typedef uint64_t mp_uint_t;
 #define MICROPY_VM_HOOK_RETURN
 #endif
 
-// Hook for mp_sched_schedule when a function gets scheduled on sched_queue
-// (this macro executes within an atomic section)
-#ifndef MICROPY_SCHED_HOOK_SCHEDULED
-#define MICROPY_SCHED_HOOK_SCHEDULED
-#endif
-
 // Whether to include the garbage collector
 #ifndef MICROPY_ENABLE_GC
 #define MICROPY_ENABLE_GC (0)

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -112,4 +112,12 @@ uint64_t mp_hal_time_ns(void);
 #define MICROPY_INTERNAL_EVENT_HOOK (void)0
 #endif
 
+// Ends a blocking MICROPY_INTERNAL_WFE(), so the waiter re-evaluates its wait
+// conditions.  May be called from an interrupt, and always from within an
+// atomic section.
+#ifndef mp_hal_signal_event
+// Fallback definition for ports whose wait cannot be ended early.
+#define mp_hal_signal_event() (void)0
+#endif
+
 #endif // MICROPY_INCLUDED_PY_MPHAL_H

--- a/py/mphal.h
+++ b/py/mphal.h
@@ -113,8 +113,8 @@ uint64_t mp_hal_time_ns(void);
 #endif
 
 // Ends a blocking MICROPY_INTERNAL_WFE(), so the waiter re-evaluates its wait
-// conditions.  May be called from an interrupt, and always from within an
-// atomic section.
+// conditions.  May be called from a signal handler or interrupt, and not
+// necessarily from within an atomic section.
 #ifndef mp_hal_signal_event
 // Fallback definition for ports whose wait cannot be ended early.
 #define mp_hal_signal_event() (void)0

--- a/py/runtime.h
+++ b/py/runtime.h
@@ -118,6 +118,16 @@ bool mp_sched_schedule(mp_obj_t function, mp_obj_t arg);
 bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback);
 #endif
 
+// Whether scheduled callbacks may run on the calling thread: without a GIL
+// they run on the main thread only, to avoid races.
+static inline bool mp_sched_thread_can_run_callbacks(void) {
+    #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
+    return mp_thread_is_main_thread();
+    #else
+    return true;
+    #endif
+}
+
 // Handles any pending MicroPython events without waiting for an interrupt or event.
 void mp_event_handle_nowait(void);
 

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -243,12 +243,8 @@ void mp_handle_pending(mp_handle_pending_behaviour_t behavior) {
 
     // Handle any pending callbacks.
     #if MICROPY_ENABLE_SCHEDULER
-    bool run_scheduler = (MP_STATE_VM(sched_state) == MP_SCHED_PENDING);
-    #if MICROPY_PY_THREAD && !MICROPY_PY_THREAD_GIL
-    // Avoid races by running the scheduler on the main thread, only.
-    // (Not needed if GIL enabled, as GIL ensures thread safety here.)
-    run_scheduler = run_scheduler && mp_thread_is_main_thread();
-    #endif
+    bool run_scheduler = (MP_STATE_VM(sched_state) == MP_SCHED_PENDING)
+        && mp_sched_thread_can_run_callbacks();
     if (run_scheduler) {
         mp_sched_run_pending();
     }

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -156,6 +156,9 @@ void mp_sched_unlock(void) {
             #endif
             mp_sched_num_pending()) {
             MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
+            // Only one callback runs per mp_handle_pending(), so raise again
+            // for those still queued.  Each run removes one, so this ends.
+            mp_hal_signal_event();
         } else {
             MP_STATE_VM(sched_state) = MP_SCHED_IDLE;
         }

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -42,6 +42,9 @@ void MICROPY_WRAP_MP_SCHED_EXCEPTION(mp_sched_exception)(mp_obj_t exc) {
         MP_STATE_VM(sched_state) = MP_SCHED_PENDING;
     }
     #endif
+
+    // Outside the atomic section, which isn't async-signal-safe on all ports.
+    mp_hal_signal_event();
 }
 
 #if MICROPY_KBD_EXCEPTION

--- a/py/scheduler.c
+++ b/py/scheduler.c
@@ -170,7 +170,7 @@ bool MICROPY_WRAP_MP_SCHED_SCHEDULE(mp_sched_schedule)(mp_obj_t function, mp_obj
         uint8_t iput = IDX_MASK(MP_STATE_VM(sched_idx) + MP_STATE_VM(sched_len)++);
         MP_STATE_VM(sched_queue)[iput].func = function;
         MP_STATE_VM(sched_queue)[iput].arg = arg;
-        MICROPY_SCHED_HOOK_SCHEDULED;
+        mp_hal_signal_event();
         ret = true;
     } else {
         // schedule queue is full
@@ -196,7 +196,7 @@ bool mp_sched_schedule_node(mp_sched_node_t *node, mp_sched_callback_t callback)
             MP_STATE_VM(sched_tail)->next = node;
         }
         MP_STATE_VM(sched_tail) = node;
-        MICROPY_SCHED_HOOK_SCHEDULED;
+        mp_hal_signal_event();
         ret = true;
     } else {
         // already scheduled

--- a/tests/ports/unix/time_sleep_sched.py
+++ b/tests/ports/unix/time_sleep_sched.py
@@ -1,0 +1,37 @@
+# Test time.sleep() handling of scheduled callbacks and negative values.
+
+try:
+    import micropython
+
+    micropython.schedule
+    # The duration check below passes a float sleep length.
+    50 / 1000
+except (ImportError, AttributeError, TypeError):
+    print("SKIP")
+    raise SystemExit
+
+import time
+
+# A negative sleep raises ValueError. Which numeric branch this exercises
+# (float or integer) depends on the build's float support.
+try:
+    time.sleep(-1)
+    print("FAIL: no ValueError")
+except ValueError:
+    print("ValueError")
+
+# A callback scheduled before the sleep is processed during the sleep call.
+result = []
+micropython.schedule(lambda _: result.append(1), None)
+time.sleep(0)
+print("callback:", result)
+
+# Sleep still sleeps for the requested duration.
+# Compute the float from integers at runtime as some builds lack float literals.
+start = time.ticks_ms()
+time.sleep(50 / 1000)
+elapsed = time.ticks_diff(time.ticks_ms(), start)
+if 50 <= elapsed < 500:
+    print("timing ok")
+else:
+    print("timing FAIL:", elapsed, "ms")

--- a/tests/ports/unix/time_sleep_sched.py.exp
+++ b/tests/ports/unix/time_sleep_sched.py.exp
@@ -1,0 +1,3 @@
+ValueError
+callback: [1]
+timing ok

--- a/tests/ports/unix/time_sleep_signal.py
+++ b/tests/ports/unix/time_sleep_signal.py
@@ -1,0 +1,35 @@
+# Test time.sleep() handling of scheduled callbacks and negative values.
+
+try:
+    import micropython
+
+    micropython.schedule
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+import time
+
+# A negative sleep raises ValueError. Which numeric branch this exercises
+# (float or integer) depends on the build's float support.
+try:
+    time.sleep(-1)
+    print("FAIL: no ValueError")
+except ValueError:
+    print("ValueError")
+
+# A callback scheduled before the sleep is processed during the sleep call.
+result = []
+micropython.schedule(lambda _: result.append(1), None)
+time.sleep(0)
+print("callback:", result)
+
+# Sleep still sleeps for the requested duration.
+# Compute the float from integers at runtime as some builds lack float literals.
+start = time.ticks_ms()
+time.sleep(50 / 1000)
+elapsed = time.ticks_diff(time.ticks_ms(), start)
+if 40 <= elapsed < 500:
+    print("timing ok")
+else:
+    print("timing FAIL:", elapsed, "ms")

--- a/tests/ports/unix/time_sleep_signal.py.exp
+++ b/tests/ports/unix/time_sleep_signal.py.exp
@@ -1,0 +1,3 @@
+ValueError
+callback: [1]
+timing ok

--- a/tests/ports/unix/time_sleep_thread_wakeup.py
+++ b/tests/ports/unix/time_sleep_thread_wakeup.py
@@ -1,0 +1,43 @@
+# Test that a callback scheduled from another thread wakes a blocking
+# time.sleep() promptly, and that the sleep still runs to completion.
+
+try:
+    import _thread
+    import micropython
+
+    micropython.schedule
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+import time
+
+cb_at = []
+start = time.ticks_ms()
+
+
+def cb(_):
+    cb_at.append(time.ticks_diff(time.ticks_ms(), start))
+
+
+def worker():
+    time.sleep_ms(50)
+    micropython.schedule(cb, None)
+
+
+_thread.start_new_thread(worker, ())
+time.sleep(500 / 1000)
+total = time.ticks_diff(time.ticks_ms(), start)
+
+# The callback should run near the 50ms schedule point, well before the
+# sleep finishes.
+if cb_at and cb_at[0] < 300:
+    print("callback prompt")
+else:
+    print("callback FAIL:", cb_at)
+
+# The sleep must still complete its full duration.
+if 500 <= total < 2000:
+    print("duration ok")
+else:
+    print("duration FAIL:", total)

--- a/tests/ports/unix/time_sleep_thread_wakeup.py
+++ b/tests/ports/unix/time_sleep_thread_wakeup.py
@@ -1,0 +1,69 @@
+# Test that a callback scheduled from another thread wakes a blocking
+# time.sleep() promptly, and that the sleep still runs to completion.
+
+try:
+    import _thread
+    import micropython
+
+    micropython.schedule
+    # The sleeps below are given float lengths.
+    50 / 1000
+except (ImportError, AttributeError, TypeError):
+    print("SKIP")
+    raise SystemExit
+
+import time
+
+cb_at = []
+start = time.ticks_ms()
+
+
+def cb(_):
+    cb_at.append(time.ticks_diff(time.ticks_ms(), start))
+
+
+def worker():
+    time.sleep_ms(50)
+    micropython.schedule(cb, None)
+
+
+_thread.start_new_thread(worker, ())
+time.sleep(500 / 1000)
+total = time.ticks_diff(time.ticks_ms(), start)
+
+# The callback should run near the 50ms schedule point, well before the
+# sleep finishes.
+if cb_at and cb_at[0] < 400:
+    print("callback prompt")
+else:
+    print("callback FAIL:", cb_at)
+
+# The sleep must still complete its full duration.
+if 500 <= total < 2000:
+    print("duration ok")
+else:
+    print("duration FAIL:", total)
+
+# A sleep on a non-main thread must also honour its full duration. Without a
+# GIL such a thread cannot run scheduled callbacks so it does not wait on the
+# wake event at all; with one it does, and re-enters the wait until its
+# deadline.
+slept = []
+
+
+def sleeper():
+    t0 = time.ticks_ms()
+    time.sleep(200 / 1000)
+    slept.append(time.ticks_diff(time.ticks_ms(), t0))
+
+
+_thread.start_new_thread(sleeper, ())
+# Queue work while the other thread is inside its sleep.
+time.sleep_ms(50)
+micropython.schedule(lambda _: None, None)
+time.sleep_ms(400)
+
+if slept and 200 <= slept[0] < 1000:
+    print("thread sleep ok")
+else:
+    print("thread sleep FAIL:", slept)

--- a/tests/ports/unix/time_sleep_thread_wakeup.py.exp
+++ b/tests/ports/unix/time_sleep_thread_wakeup.py.exp
@@ -1,0 +1,2 @@
+callback prompt
+duration ok

--- a/tests/ports/unix/time_sleep_thread_wakeup.py.exp
+++ b/tests/ports/unix/time_sleep_thread_wakeup.py.exp
@@ -1,0 +1,3 @@
+callback prompt
+duration ok
+thread sleep ok


### PR DESCRIPTION
### Summary

UPDATE: this PR has been through quite a few iterations now. The description below is the original back story, but for details on the latest version of the code see https://github.com/micropython/micropython/pull/18810#issuecomment-5213471983

---

`time.sleep()` on the Unix port blocks in a single `select()` call for the full
requested duration. Any scheduled callbacks — BLE polling (NimBLE), soft timers,
`micropython.schedule()` — are starved until the sleep returns. This is
particularly visible when using the Unix port as a BLE host: a `time.sleep(6)`
during a BLE scan returns zero results because NimBLE never gets polled.

`time.sleep_ms()` doesn't have this problem because it routes through
`mp_hal_delay_ms()` which polls every 1ms.

This PR caps each `select()` call inside `mp_time_sleep()` to 10ms and loops,
calling `mp_handle_pending()` each iteration. Uses `mp_hal_ticks_ms()` to
track wall-clock elapsed time, recomputing remaining time each iteration.
This also handles EINTR naturally without special-casing. The float and
non-float branches are unified into a single loop operating in milliseconds.

### Testing

- `tests/micropython/schedule_sleep.py` passes.
- `time.sleep(0.001)` sleeps ~1ms, `time.sleep(0.1)` ~100ms, `time.sleep(1)` ~1000ms.
- `micropython.schedule()` callback fires within <1ms during a 50ms sleep
  (previously would not fire until sleep completed).
- BLE scan with `time.sleep(6)` on Unix port with STM32WB55 HCI adapter
  returns devices (previously returned 0).

### Trade-offs and Alternatives

Precision is now millisecond-level (matching `time.sleep_ms()` behaviour) rather
than the previous sub-millisecond float precision. This is the same granularity
as `mp_hal_delay_ms()` and sufficient for the Unix port.