### PR TITLE
extmod/network_cyw43: Fix STA default netif after AP mode switch.

### DIFF
--- a/extmod/network_cyw43.c
+++ b/extmod/network_cyw43.c
@@ -148,6 +148,11 @@ static mp_obj_t network_cyw43_active(size_t n_args, const mp_obj_t *args) {
         }
         cyw43_wifi_set_up(self->cyw, self->itf, value, get_country_code());
         if_active[self->itf] = value;
+
+        if (value && self->itf == CYW43_ITF_STA) {
+            netif_set_default(&self->cyw->netif[self->itf]);
+        }
+
         return mp_const_none;
     }
 }


### PR DESCRIPTION
### Summary

After switching from AP mode back to STA mode, `netif_default` remains pointing to the AP `netif`. This causes all outbound TCP connections to fail with `EHOSTUNREACH (errno 113)` because traffic routes through the now-defunct AP gateway instead of the STA gateway.

The root cause is in cyw43_wifi_set_up() in cyw43_ctrl.c: when STA is reactivated, `itf_state` bit 0 is still set from the initial boot, so `cyw43_tcpip_init(STA)` is skipped entirely and with it, the only call to `netif_set_default(STA)`.

This fix adds an explicit `netif_set_default()` call in `network_cyw43_active()` whenever STA is activated, ensuring STA is always the default route regardless of `itf_state`.


### Testing

 Tested on OpenMV AE3 & OpenMV RT1062
  - Boot in STA mode, verify relay server reachable — PASS
  - Switch to AP mode via BLE, verify AP clients can connect — PASS
  - Switch back to STA mode, verify relay server reachable without `deinit()` or `machine.reset()` — PASS 
  - Rapid AP↔STA cycling 10x — PASS, no errno 113

### Trade-offs and Alternatives

The fix is a redundant `netif_set_default()` call on every STA activation, even when STA is already the default. 

The ideal fix would be in `cyw43_wifi_set_up()` in cyw43_ctrl.c (the upstream cyw43-driver), either by clearing itf_state bit 0 on STA teardown or by calling `cyw43_tcpip_deinit(STA)` in the up=false path. However, that driver is maintained separately. This fix in the MicroPython binding layer is self-contained and does not require upstream driver changes. [georgerobotics/cyw43-driver/pull/145]

The alternative that I tried and worked is calling `wlan.deinit()` which resets the entire CYW43 chip, killing BLE and requiring full reinitialization (~3-4 seconds of downtime).