### PR TITLE
ports/renesas-ra: Fix Linker Error when building RA board from win

### DIFF
--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -432,9 +432,17 @@ $(TOP)/lib/fsp/README.md:
 	$(ECHO) "fsp submodule not found, fetching it now..."
 	(cd $(TOP) && git submodule update --init lib/fsp)
 
+# Do not alter the body of NL. The 2 new lines in it matters !
+define NL
+
+
+endef
+
 define GENERATE_ELF
 	$(ECHO) "LINK $(1)"
-	$(Q)$(LD) $(LDFLAGS) -o $(1) $(2) $(LDFLAGS_MOD) $(LIBS)
+	$(Q)$(file >$(BUILD)/obj.list,)
+	$(Q)$(foreach o,$(2),$(file >>$(BUILD)/obj.list,$(o)$(NL)))
+	$(Q)$(LD) $(LDFLAGS) -o $(1) @$(BUILD)/obj.list $(LDFLAGS_MOD) $(LIBS)
 	$(Q)$(SIZE) $(1)
 endef
 


### PR DESCRIPTION
### Summary

When building from windows and a particular **BOARD** consists of too many files,
the command buffer overflows and stops taking arguments, throwing the rest.
Then, when passed, the Linker complains about not everything was there:

    arm-none-eabi-ld.exe: cannot find build-<BOARD>/: No such file or directory

### Testing

In a Windows environment, just build for **VK-RA6M5** board.

### Trade-offs and Alternatives

Luckily **ld** has a solution: taking the arguments from a file !