### PR TITLE
py/emitnative: Do not clobber index register on viper load/store.

### DIFF
--- a/py/asmthumb.h
+++ b/py/asmthumb.h
@@ -465,24 +465,28 @@ void asm_thumb_b_rel12(asm_thumb_t *as, int rel);
 #define ASM_LOAD8_REG_REG_REG(as, reg_dest, reg_base, reg_index) asm_thumb_ldrb_rlo_rlo_rlo((as), (reg_dest), (reg_base), (reg_index))
 #define ASM_LOAD16_REG_REG_REG(as, reg_dest, reg_base, reg_index) \
     do { \
-        asm_thumb_lsl_rlo_rlo_i5((as), (reg_index), (reg_index), 1); \
-        asm_thumb_ldrh_rlo_rlo_rlo((as), (reg_dest), (reg_base), (reg_index)); \
+        asm_thumb_lsl_rlo_rlo_i5((as), REG_TEMP2, (reg_index), 1); \
+        asm_thumb_ldrh_rlo_rlo_rlo((as), (reg_dest), (reg_base), REG_TEMP2); \
     } while (0)
 #define ASM_LOAD32_REG_REG_REG(as, reg_dest, reg_base, reg_index) \
     do { \
-        asm_thumb_lsl_rlo_rlo_i5((as), (reg_index), (reg_index), 2); \
-        asm_thumb_ldr_rlo_rlo_rlo((as), (reg_dest), (reg_base), (reg_index)); \
+        asm_thumb_lsl_rlo_rlo_i5((as), REG_TEMP2, (reg_index), 2); \
+        asm_thumb_ldr_rlo_rlo_rlo((as), (reg_dest), (reg_base), REG_TEMP2); \
     } while (0)
 #define ASM_STORE8_REG_REG_REG(as, reg_val, reg_base, reg_index) asm_thumb_strb_rlo_rlo_rlo((as), (reg_val), (reg_base), (reg_index))
 #define ASM_STORE16_REG_REG_REG(as, reg_val, reg_base, reg_index) \
     do { \
+        asm_thumb_op16((as), 0xB400 | (1 << reg_index)); \
         asm_thumb_lsl_rlo_rlo_i5((as), (reg_index), (reg_index), 1); \
         asm_thumb_strh_rlo_rlo_rlo((as), (reg_val), (reg_base), (reg_index)); \
+        asm_thumb_op16((as), 0xBC00 | (1 << reg_index)); \
     } while (0)
 #define ASM_STORE32_REG_REG_REG(as, reg_val, reg_base, reg_index) \
     do { \
+        asm_thumb_op16((as), 0xB400 | (1 << reg_index)); \
         asm_thumb_lsl_rlo_rlo_i5((as), (reg_index), (reg_index), 2); \
         asm_thumb_str_rlo_rlo_rlo((as), (reg_val), (reg_base), (reg_index)); \
+        asm_thumb_op16((as), 0xBC00 | (1 << reg_index)); \
     } while (0)
 
 #define ASM_CLR_REG(as, reg_dest) asm_thumb_mov_rlo_i8((as), (reg_dest), 0)

--- a/tests/micropython/viper_preserve_invariants.py
+++ b/tests/micropython/viper_preserve_invariants.py
@@ -1,0 +1,39 @@
+RESULTS = []
+
+LOAD_TEMPLATE_REG = """
+BUFFER = bytearray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+OFFSET = 1
+@micropython.viper
+def test_invariants_load{}_reg(buf: ptr{}, offset: int):
+    offset_copy1: int = offset
+    temporary1 = buf[offset]
+    offset_copy2: int = offset
+    temporary2 = buf[offset]
+    RESULTS.append(["LOAD{}", temporary1 == temporary2, offset == offset_copy1 == offset_copy2])
+test_invariants_load{}_reg(BUFFER, OFFSET)
+"""
+
+
+STORE_TEMPLATE_REG = """
+BUFFER = bytearray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+OFFSET = 1
+@micropython.viper
+def test_invariants_store{}_reg(buf: ptr{}, offset: int):
+    offset_copy: int = offset
+    value: uint = {}
+    buf[offset] = value
+    temporary = buf[offset]
+    RESULTS.append(["STORE{}", temporary == value, offset == offset_copy])
+test_invariants_store{}_reg(BUFFER, OFFSET)
+"""
+
+try:
+    for width, value in ((8, 0x11), (16, 0x1111), (32, 0x11111111)):
+        exec(LOAD_TEMPLATE_REG.format(width, width, width, width, width))
+        exec(STORE_TEMPLATE_REG.format(width, width, value, width, width, width))
+except MemoryError:
+    print("SKIP-TOO-LARGE")
+    raise SystemExit
+
+for line in RESULTS:
+    print(" ".join([str(i) for i in line]))

--- a/tests/micropython/viper_preserve_invariants.py.exp
+++ b/tests/micropython/viper_preserve_invariants.py.exp
@@ -1,0 +1,6 @@
+LOAD8 True True
+STORE8 True True
+LOAD16 True True
+STORE16 True True
+LOAD32 True True
+STORE32 True True


### PR DESCRIPTION
### Summary

Some register-indexed load/store Viper optimisations ended up being too aggressive, clobbering the index register in certain cases.  This went unnoticed as there was no test that covered that behaviour and no user actually reported any issue about this.

Only Thumb and RV32 emitters seem to be affected - x86, x64, Arm, and Xtensa/Xtensawin pass relevant tests without any code changes.

This was fixed by clobbering `REG_TEMP2` in all cases on RV32 and when doing loads on Thumb, and to use the stack to preserve the value of `REG_ARG2` for Thumb stores.  Thumb changes only involve halfword and word operations. 

This fixes #18800.

### Testing

The relevant viper tests were executed successfully on several QEMU targets: `MPS2_AN385`, `SABRELITE`, and `VIRT_RV32` (the latter was also checked with `MICROPY_EMIT_RV32_ZBA` turned off).

### Trade-offs and Alternatives

There is a size increase on Thumb, but that should be minor - hardcoding a destination register for scaled offsets makes RV32 code smaller, though.  On the other hand relevant save operations on Thumb will incur both a size (4 bytes per operation) and speed penalty.  For RV32 the size penalty is 4 bytes for word-sized operations and 2 bytes for halfword-sized operations.