### PR TITLE
extmod/asyncio: Add async IRQ context manager.

### DIFF
--- a/extmod/asyncio/__init__.py
+++ b/extmod/asyncio/__init__.py
@@ -11,6 +11,7 @@ _attrs = {
     "gather": "funcs",
     "Event": "event",
     "ThreadSafeFlag": "event",
+    "Interrupt": "event",
     "Lock": "lock",
     "open_connection": "stream",
     "start_server": "stream",

--- a/tests/extmod/asyncio_interrupt.py
+++ b/tests/extmod/asyncio_interrupt.py
@@ -1,0 +1,60 @@
+try:
+    import time
+    import asyncio
+    import machine
+
+    machine.Timer
+except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+async def block(n):  # Blocking task
+    while True:
+        time.sleep_ms(5)
+        await asyncio.sleep_ms(0)
+
+
+async def timer_test(iters=5, target_ms=100, err_limit_us=100):
+    target_us = target_ms * 1000
+
+    tasks = []
+    for n in range(10):
+        tasks.append(asyncio.create_task(block(n)))
+
+    irq = asyncio.Interrupt()
+    tim = machine.Timer()
+
+    for x in range(iters):
+        t0_us = time.ticks_us()
+        tim.init(mode=machine.Timer.ONE_SHOT, period=target_ms, callback=irq, hard=False)
+        async with irq:  # body of this with-block runs as an interrupt handler, with arg set to the value passed to irq()
+            t1_us = time.ticks_us()
+        tim.deinit()
+
+        dt_us = time.ticks_diff(t1_us, t0_us)
+        err_us = dt_us - target_us
+
+        if 0 <= err_us < err_limit_us:
+            print("{} OK <{}".format(x, err_limit_us))
+        else:
+            print("{} FAIL {}".format(x, err_us))
+
+    tim.init(mode=machine.Timer.ONE_SHOT, period=target_ms, callback=irq, hard=False)
+    try:
+        async with irq as arg:
+            assert arg is tim
+            raise Exception("test")
+    except Exception as e:
+        assert e.args[0] == "test"
+        print("Exception OK")
+    tim.deinit()
+
+    tim.init(mode=machine.Timer.ONE_SHOT, period=target_ms, callback=irq, hard=False)
+    async with irq as arg:
+        await asyncio.sleep(0)
+        print("Premature Exit OK")
+    tim.deinit()
+
+
+asyncio.run(timer_test())

--- a/tests/extmod/asyncio_interrupt.py.exp
+++ b/tests/extmod/asyncio_interrupt.py.exp
@@ -1,0 +1,7 @@
+0 OK <100
+1 OK <100
+2 OK <100
+3 OK <100
+4 OK <100
+Exception OK
+Premature Exit OK


### PR DESCRIPTION
### Summary
This PR adds a new async context manager that arranges for its body to run as an interrupt service routine rather than through the normal async event loop. (Or, broadly, directly in the context of any other way that the context object might be called as a function; though the main use-case is to pass it in as the `irq=` parameter of any relevant machine object.)

Asyncs are an excellent abstraction for some of the fundamental state-management challenges of interrupt-driven programming, but the latency performance of existing methods of integrating IRQs to async coroutines isn't good enough to enable some applications that would benefit from it, even with the queueing-priority improvement in https://github.com/micropython/micropython/pull/18826.

### Testing
This PR includes automated tests of all ways I'm aware that control flow could need to leave the interrupt context and return to the event loop, as well as measurements of a loose 100-microsecond latency target. (This might need to be relaxed, if there's targets much less performant than the rp2 boards I've tested against.)

### Trade-offs and Alternatives
This is just as much of a foot-gun as any other kind of interrupt handler; the only difference is ease of use.

TODO: how to deal with situations where the IRQ fires before the context can be opened?