### PR TITLE
rp2: Switch all RNG sources from ROSC to pico_rand.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -236,6 +236,7 @@ set(PICO_SDK_COMPONENTS
     pico_platform_compiler
     pico_platform_panic
     pico_platform_sections
+    pico_rand
     pico_runtime
     pico_runtime_init
     pico_stdio

--- a/ports/rp2/lwip_inc/lwipopts.h
+++ b/ports/rp2/lwip_inc/lwipopts.h
@@ -9,11 +9,11 @@
 #define LWIP_ND6_NUM_DESTINATIONS       4
 #define LWIP_ND6_QUEUEING               0
 
-#define LWIP_RAND() rosc_random_u32()
+#define LWIP_RAND() get_rand_32()
 
 // Include common lwIP configuration.
 #include "extmod/lwip-include/lwipopts_common.h"
 
-extern uint32_t rosc_random_u32(void);
+#include "pico/rand.h"
 
 #endif // MICROPY_INCLUDED_RP2_LWIP_LWIPOPTS_H

--- a/ports/rp2/main.c
+++ b/ports/rp2/main.c
@@ -53,7 +53,6 @@
 #include "pico/stdlib.h"
 #include "pico/binary_info.h"
 #include "pico/unique_id.h"
-#include "hardware/structs/rosc.h"
 #if MICROPY_PY_LWIP
 #include "lwip/init.h"
 #include "lwip/apps/mdns.h"
@@ -314,22 +313,3 @@ void MP_WEAK __assert_func(const char *file, int line, const char *func, const c
     panic("Assertion failed");
 }
 #endif
-
-#define POLY (0xD5)
-
-uint8_t rosc_random_u8(size_t cycles) {
-    static uint8_t r;
-    for (size_t i = 0; i < cycles; ++i) {
-        r = ((r << 1) | rosc_hw->randombit) ^ (r & 0x80 ? POLY : 0);
-        mp_hal_delay_us_fast(1);
-    }
-    return r;
-}
-
-uint32_t rosc_random_u32(void) {
-    uint32_t value = 0;
-    for (size_t i = 0; i < 4; ++i) {
-        value = value << 8 | rosc_random_u8(32);
-    }
-    return value;
-}

--- a/ports/rp2/mbedtls/mbedtls_port.c
+++ b/ports/rp2/mbedtls/mbedtls_port.c
@@ -24,6 +24,8 @@
  * THE SOFTWARE.
  */
 #include <py/mpconfig.h>
+#include <py/misc.h>
+#include <string.h>
 
 #ifdef MICROPY_SSL_MBEDTLS
 
@@ -33,12 +35,13 @@
 #include "mbedtls/platform_time.h"
 #include "pico/aon_timer.h"
 
-extern uint8_t rosc_random_u8(size_t cycles);
+#include "pico/rand.h"
 
 int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
     *olen = len;
-    for (size_t i = 0; i < len; i++) {
-        output[i] = rosc_random_u8(8);
+    for (size_t i = 0; i < len; i += 8) {
+        uint64_t rand64 = get_rand_64();
+        memcpy(output + i, &rand64, MIN(len - i, 8));
     }
     return 0;
 }

--- a/ports/rp2/modos.c
+++ b/ports/rp2/modos.c
@@ -25,15 +25,15 @@
  */
 
 #include "py/runtime.h"
-
-uint8_t rosc_random_u8(size_t cycles);
+#include "pico/rand.h"
 
 static mp_obj_t mp_os_urandom(mp_obj_t num) {
     mp_int_t n = mp_obj_get_int(num);
     vstr_t vstr;
     vstr_init_len(&vstr, n);
-    for (int i = 0; i < n; i++) {
-        vstr.buf[i] = rosc_random_u8(8);
+    for (int i = 0; i < n; i += 8) {
+        uint64_t rand64 = get_rand_64();
+        memcpy(vstr.buf + i, &rand64, MIN(n - i, 8));
     }
     return mp_obj_new_bytes_from_vstr(&vstr);
 }

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -158,7 +158,7 @@
 #define MICROPY_PY_TIME_GMTIME_LOCALTIME_MKTIME (1)
 #define MICROPY_PY_TIME_TIME_TIME_NS            (1)
 #define MICROPY_PY_TIME_INCLUDEFILE             "ports/rp2/modtime.c"
-#define MICROPY_PY_RANDOM_SEED_INIT_FUNC        (rosc_random_u32())
+#define MICROPY_PY_RANDOM_SEED_INIT_FUNC        (get_rand_32())
 #define MICROPY_PY_MACHINE                      (1)
 #define MICROPY_PY_MACHINE_INCLUDEFILE          "ports/rp2/modmachine.c"
 #define MICROPY_PY_MACHINE_RESET                (1)
@@ -292,7 +292,7 @@ typedef intptr_t mp_off_t;
 #define BINARY_INFO_ID_MP_FROZEN 0x4a99d719
 #define MICROPY_FROZEN_LIST_ITEM(name, file) bi_decl(bi_string(BINARY_INFO_TAG_MICROPYTHON, BINARY_INFO_ID_MP_FROZEN, name))
 
-extern uint32_t rosc_random_u32(void);
+#include "pico/rand.h"
 extern void lwip_lock_acquire(void);
 extern void lwip_lock_release(void);
 


### PR DESCRIPTION
### Summary

Switches to `pico_rand` from Pico SDK as random source. That implementation seems much more mature and is using various RNG sources depending on the available hardware.

Maintainer's note: The current RNG source is ROSC and RP2040 datasheet says *"This does not meet the requirements of randomness for security systems because it can be compromised, but it may be useful in less critical applications."*

### Testing

I tested it by running my code on the Seeed Studio XIAO RP2350 and benchmarking it.

The original implementation using `rosc_random_u8`:
```
os.urandom benchmark
-------------------------------------------------------
Size:    1B | 1000 calls | 0.018s | 54.25 KB/s
Size:    4B | 1000 calls | 0.043s | 90.84 KB/s
Size:   16B | 1000 calls | 0.140s | 111.61 KB/s
Size:   32B | 1000 calls | 0.270s | 115.74 KB/s
Size:   64B | 1000 calls | 0.528s | 118.37 KB/s
Size:  128B | 1000 calls | 1.045s | 119.62 KB/s
Size:  256B | 1000 calls | 2.087s | 119.79 KB/s
Size:  512B | 1000 calls | 4.159s | 120.22 KB/s
Size: 1024B | 1000 calls | 8.330s | 120.05 KB/s
Size: 2048B | 1000 calls | 16.788s | 119.13 KB/s
Size: 4096B | 1000 calls | 33.673s | 118.79 KB/s
Size: 8192B | 1000 calls | 66.781s | 119.79 KB/s
-------------------------------------------------------
```

My new implementation using `get_rand_64` from `pico_rand`:
```
os.urandom benchmark
-------------------------------------------------------
Size:    1B | 1000 calls | 0.013s | 75.12 KB/s
Size:    4B | 1000 calls | 0.013s | 300.48 KB/s
Size:   16B | 1000 calls | 0.016s | 976.56 KB/s
Size:   32B | 1000 calls | 0.024s | 1302.08 KB/s
Size:   64B | 1000 calls | 0.037s | 1689.19 KB/s
Size:  128B | 1000 calls | 0.065s | 1923.08 KB/s
Size:  256B | 1000 calls | 0.127s | 1968.50 KB/s
Size:  512B | 1000 calls | 0.241s | 2074.69 KB/s
Size: 1024B | 1000 calls | 0.493s | 2028.40 KB/s
Size: 2048B | 1000 calls | 1.110s | 1801.80 KB/s
Size: 4096B | 1000 calls | 2.341s | 1708.67 KB/s
Size: 8192B | 1000 calls | 4.118s | 1942.69 KB/s
-------------------------------------------------------
```


### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

