### PR TITLE
stm32/pin: Reduce footprint of pin structures.

### DIFF
--- a/ports/stm32/pin.h
+++ b/ports/stm32/pin.h
@@ -44,13 +44,14 @@ typedef struct {
 
 typedef struct {
     mp_obj_base_t base;
-    qstr name;
+    qstr_short_t name;
+    uint16_t pin_mask;
     uint32_t port   : 4; // Allows GPIOA through GPIOP
     uint32_t pin    : 4; // ST MCUs have a maximum of 16 pins per port
     uint32_t num_af : 4;
     uint32_t adc_channel : 5; // Some ARM processors use 32 bits/PORT
     uint32_t adc_num  : 3;  // 1 bit per ADC
-    uint32_t pin_mask;
+    // 12 bits available here
     pin_gpio_t *gpio;
     const pin_af_obj_t *af;
 } machine_pin_obj_t;


### PR DESCRIPTION
### Summary

As a followup to #18414, this PR performs a few minor changes to the structures used to store board pin information in the STM32 port, in order to reduce the impact on the .rodata section of the firmware of instances of those structures.

The pin objects structure ("machine_pin_obj_t") instead has its QSTR variable holder changed from "qstr" to "qstr_short_t", and some elements of that structure have been rearranged to remove enough padding bytes inside structure elements to let the linker allocate less data for instances of that structure.

Some size savings figures for a couple of boards:

| Board                  | Size before | Size after | Size delta |
|------------------------|-------------|------------|------------|
| `NUCLEO_F767ZI`        | 527820      | 527424     | 396        |
| `PYBV10`               | 367416      | 367228     | 188        |
| `WEACT_F411_BLACKPILL` | 329116      | 328972     | 144        |

(sizes are relevant to text sections reported by `size`)

In general, the more pins available, the bigger the savings.

### Testing

I've performed some manual GPIO testing on a NUCLEO-F767ZI and on a WEACT F411 BlackPill, and things seem to work (or so my logic analyser claims!).