### PR TITLE
extmod/vfs_reader: Process pending events during file reads.

### DIFF
--- a/extmod/vfs_reader.c
+++ b/extmod/vfs_reader.c
@@ -56,6 +56,7 @@ static mp_uint_t mp_reader_vfs_readbyte(void *data) {
             return MP_READER_EOF;
         } else {
             int errcode;
+            mp_event_handle_nowait();
             reader->buflen = mp_stream_rw(reader->file, reader->buf, reader->bufsize, &errcode, MP_STREAM_RW_READ | MP_STREAM_RW_ONCE);
             if (errcode != 0) {
                 // TODO handle errors properly


### PR DESCRIPTION
### Summary

Call mp_event_handle_nowait() in the VFS reader buffer refill path so that pending scheduled events (USB task, network poll, etc.) get processed during long-running import/parse/compile operations.

Without this, importing a large Python module from the filesystem blocks for too long causing TinyUSB event queue to overflow. For example, on renesas-ra, running a script that imports iperf3 via mpremote run, asserts, most likely due to SOF interrupts not getting processing:

```
  #0  queue_event at lib/tinyusb/src/device/usbd.c:382
  #1  dcd_event_handler at lib/tinyusb/src/device/usbd.c:1318
  #2  dcd_event_sof at lib/tinyusb/src/device/dcd.h:237
  #3  dcd_int_handler at lib/tinyusb/src/portable/renesas/rusb2/dcd_rusb2.c:964
  #4  <signal handler called>
  #5  disk_ioctl at extmod/vfs_fat_diskio.c:125
  #6  validate at lib/oofatfs/ff.c:3359
  #7  f_read at lib/oofatfs/ff.c:3625
  #8  file_obj_read at extmod/vfs_fat_file.c:75
  #9  mp_stream_rw at py/stream.c:60
  #10 mp_reader_vfs_readbyte at extmod/vfs_reader.c:59
  #11 next_char at py/lexer.c:174
  #12 mp_lexer_to_next at py/lexer.c:713
  #13 mp_parse at py/parse.c:1167
```
### Testing

I tested this with a simple script and a script that imports `iperf3` from the filesystem. The simple script runs, while the other overflows 100% of the time. With this fix, both run fine.

**Note I only tested this on RA port, other ports are likely affected, if they have SOF enabled, but perhaps faster MCUs mask this issues. Also, I might be missing side-effects on other ports and/or corner cases, so please review carefully.**

### Trade-offs and Alternatives

Increasing the queue size to 256 also fixes the issue, as done previously, however, a bigger import might overflow that, so it's best to fix the underlying issue.