### PR TITLE
zephyr: Add per board customization of modmachine.

### DIFF
--- a/ports/zephyr/modmachine.c
+++ b/ports/zephyr/modmachine.c
@@ -40,11 +40,16 @@
 #define MICROPY_PY_MACHINE_RESET_ENTRY
 #endif
 
+#ifndef MICROPY_PY_MACHINE_BOARD_EXTRA_GLOBALS
+#define MICROPY_PY_MACHINE_BOARD_EXTRA_GLOBALS
+#endif
+
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
     MICROPY_PY_MACHINE_RESET_ENTRY \
     { MP_ROM_QSTR(MP_QSTR_reset_cause), MP_ROM_PTR(&machine_reset_cause_obj) }, \
     { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) }, \
     { MP_ROM_QSTR(MP_QSTR_Timer), MP_ROM_PTR(&machine_timer_type) }, \
+    MICROPY_PY_MACHINE_BOARD_EXTRA_GLOBALS \
 
 static mp_obj_t machine_reset(void) {
     sys_reboot(SYS_REBOOT_COLD);
@@ -62,3 +67,8 @@ MP_DEFINE_CONST_FUN_OBJ_0(machine_reset_cause_obj, machine_reset_cause);
 static void mp_machine_idle(void) {
     k_yield();
 }
+
+// A board can provide additional machine-module implementation in this file.
+#ifdef MICROPY_PY_MACHINE_BOARD_INCLUDEFILE
+#include MICROPY_PY_MACHINE_BOARD_INCLUDEFILE
+#endif


### PR DESCRIPTION
I'm implementing a few board specific functions that logically pertain to `modmachine.c`, for a board catered by the generic Zephyr port.

The proposed change implements a way to add board-level customization, using an include file, by adding a new `#define` to your build:

```
MICROPY_PY_MACHINE_BOARD_INCLUDEFILE="/path/to/your/modmachine_board_specific_functions.c"
```

I've also added another customization, a `MICROPY_PY_MACHINE_BOARD_EXTRA_GLOBALS` macro that is appended to `MICROPY_PY_MACHINE_EXTRA_GLOBALS`.

This change only adds a customization path, it's transparent to current code.