### PR TITLE
Fix multiple unicode issues in mpremote.

### DIFF
--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -492,6 +492,7 @@ def do_command_expansion(args):
 
     last_arg_idx = len(args)
     pre = []
+    exp_args = ()  # Initialize to empty tuple for commands with no expected args
     while args and args[0] in _command_expansions:
         cmd = args.pop(0)
         exp_args, exp_sub, _ = _command_expansions[cmd]
@@ -518,7 +519,7 @@ def do_command_expansion(args):
         args[0:0] = exp_sub
         last_arg_idx = len(exp_sub)
 
-    if last_arg_idx < len(args) and "=" in args[last_arg_idx]:
+    if exp_args and last_arg_idx < len(args) and "=" in args[last_arg_idx]:
         # Extra unknown arguments given.
         arg = args[last_arg_idx].split("=", 1)[0]
         usage_error(cmd, exp_args, f"given unexpected argument {arg}")

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -559,6 +559,13 @@ class State:
 
 
 def main():
+    if sys.platform == "win32":
+        # Configure stdout/stderr before any imports that might print: on some Windows
+        # consoles the default code page/encoding can't represent all Unicode.
+        from .console import ConsoleWindows
+
+        ConsoleWindows.configure_unicode_output()
+
     config = load_user_config()
     prepare_command_expansions(config)
 

--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -53,6 +53,14 @@ class TransportExecError(TransportError):
 listdir_result = namedtuple("dir_result", ["name", "st_mode", "st_ino", "st_size"])
 
 
+def _quote_path(path: str) -> str:
+    """
+    Properly escape a path string for use in Python code sent to the REPL.
+    Uses repr() to handle all special characters including quotes, backslashes, and Unicode characters.
+    """
+    return repr(path)
+
+
 # Takes a Transport error (containing the text of an OSError traceback) and
 # raises it as the corresponding OSError-derived exception.
 def _convert_filesystem_error(e, info):
@@ -84,7 +92,7 @@ class Transport:
             buf.extend(b.replace(b"\x04", b""))
 
         cmd = "import os\nfor f in os.ilistdir(%s):\n print(repr(f), end=',')" % (
-            ("'%s'" % src) if src else ""
+            _quote_path(src) if src else ""
         )
         try:
             buf.extend(b"[")
@@ -101,7 +109,7 @@ class Transport:
     def fs_stat(self, src):
         try:
             self.exec("import os")
-            return os.stat_result(self.eval("tuple(os.stat(%s))" % ("'%s'" % src)))
+            return os.stat_result(self.eval("tuple(os.stat(%s))" % _quote_path(src)))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, src) from None
 
@@ -122,8 +130,8 @@ class Transport:
 
     def fs_printfile(self, src, chunk_size=256):
         cmd = (
-            "with open('%s') as f:\n while 1:\n"
-            "  b=f.read(%u)\n  if not b:break\n  print(b,end='')" % (src, chunk_size)
+            "with open(%s) as f:\n while 1:\n"
+            "  b=f.read(%u)\n  if not b:break\n  print(b,end='')" % (_quote_path(src), chunk_size)
         )
         try:
             self.exec(cmd, data_consumer=stdout_write_bytes)
@@ -137,7 +145,7 @@ class Transport:
         contents = bytearray()
 
         try:
-            self.exec("f=open('%s','rb')\nr=f.read" % src)
+            self.exec("f=open(%s,'rb')\nr=f.read" % _quote_path(src))
             while True:
                 chunk = self.eval("r({})".format(chunk_size))
                 if not chunk:
@@ -157,7 +165,7 @@ class Transport:
             written = 0
 
         try:
-            self.exec("f=open('%s','wb')\nw=f.write" % dest)
+            self.exec("f=open(%s,'wb')\nw=f.write" % _quote_path(dest))
             while data:
                 chunk = data[:chunk_size]
                 self.exec("w(" + repr(chunk) + ")")
@@ -171,25 +179,25 @@ class Transport:
 
     def fs_mkdir(self, path):
         try:
-            self.exec("import os\nos.mkdir('%s')" % path)
+            self.exec("import os\nos.mkdir(%s)" % _quote_path(path))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, path) from None
 
     def fs_rmdir(self, path):
         try:
-            self.exec("import os\nos.rmdir('%s')" % path)
+            self.exec("import os\nos.rmdir(%s)" % _quote_path(path))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, path) from None
 
     def fs_rmfile(self, path):
         try:
-            self.exec("import os\nos.remove('%s')" % path)
+            self.exec("import os\nos.remove(%s)" % _quote_path(path))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, path) from None
 
     def fs_touchfile(self, path):
         try:
-            self.exec("f=open('%s','a')\nf.close()" % path)
+            self.exec("f=open(%s,'a')\nf.close()" % _quote_path(path))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, path) from None
 
@@ -202,8 +210,8 @@ class Transport:
             return getattr(hashlib, algo)(data).digest()
         try:
             self.exec(
-                "buf = memoryview(bytearray({chunk_size}))\nwith open('{path}', 'rb') as f:\n while True:\n  n = f.readinto(buf)\n  if n == 0:\n   break\n  h.update(buf if n == {chunk_size} else buf[:n])\n".format(
-                    chunk_size=chunk_size, path=path
+                "buf = memoryview(bytearray({chunk_size}))\nwith open({path}, 'rb') as f:\n while True:\n  n = f.readinto(buf)\n  if n == 0:\n   break\n  h.update(buf if n == {chunk_size} else buf[:n])\n".format(
+                    chunk_size=chunk_size, path=_quote_path(path)
                 )
             )
             return self.eval("h.digest()")

--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -552,6 +552,8 @@ class RemoteCommand:
         self.fout.write(self.buf4)
 
     def wr_bytes(self, b):
+        if isinstance(b, str):
+            b = bytes(b, "utf8")
         self.wr_s32(self.buffer_nbytes(b))
         self.fout.write(b)
 

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -50,3 +50,19 @@ fi
 ```
 
 The `MPREMOTE_DEVICE` environment variable contains the device path passed via `-t`.
+
+## Using the RAM Disk
+
+Tests that need a writable filesystem can use `ramdisk.py` to create a temporary
+FAT filesystem in RAM:
+
+```bash
+TEST_DIR=$(dirname $0)
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
+```
+Defaults to: block_size=512, num_blocks=50, mount_path='/ramdisk', do_chdir=True
+Custom parameters can be passed via `exec`:
+
+```bash
+$MPREMOTE exec "mount_path='/__ramdisk'; do_chdir=False" run "${TEST_DIR}/ramdisk.py"
+```

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -25,5 +25,28 @@ To run a single test do:
 
     $ ./run-mpremote-tests.sh ./test_filesystem.sh
 
-Each test should print "OK" if it passed.  Otherwise it will print "CRASH", or "FAIL"
-and a diff of the expected and actual test output.
+To run tests against a specific device:
+
+    $ ./run-mpremote-tests.sh -t /dev/ttyACM0
+    $ ./run-mpremote-tests.sh -t rfc2217://localhost:2217
+
+Device shortcuts are supported: `a0` → `/dev/ttyACM0`, `u0` → `/dev/ttyUSB0`, `c0` → `COM0`.
+
+Each test should print "OK" if it passed.  Otherwise it will print "CRASH", "FAIL"
+(with a diff of expected vs actual output), or "skip" if the test was skipped.
+
+## Skipping Tests
+
+Tests can skip themselves by outputting `SKIP` on a line by itself and exiting with
+code 0. This is useful when a test is not applicable to a particular device or
+configuration.
+
+Example in a test script:
+```bash
+if [[ "${MPREMOTE_DEVICE}" == rfc2217://* ]]; then
+    echo "SKIP"
+    exit 0
+fi
+```
+
+The `MPREMOTE_DEVICE` environment variable contains the device path passed via `-t`.

--- a/tools/mpremote/tests/ramdisk.py
+++ b/tools/mpremote/tests/ramdisk.py
@@ -1,0 +1,56 @@
+# Creates a RAM disk for testing.
+# Usage: mpremote run ramdisk.py
+# Or with custom parameters:
+#   mpremote exec "block_size=1024; num_blocks=100; mount_path='/myram'" run ramdisk.py
+#   mpremote exec "mount_path='/__ramdisk'; do_chdir=False" run ramdisk.py
+# Defaults: block_size=512, num_blocks=50, mount_path='/ramdisk', do_chdir=True
+
+import os
+
+
+class RAMBlockDev:
+    def __init__(self, block_size, num_blocks):
+        self.block_size = block_size
+        self.data = bytearray(block_size * num_blocks)
+
+    def readblocks(self, block_num, buf):
+        for i in range(len(buf)):
+            buf[i] = self.data[block_num * self.block_size + i]
+
+    def writeblocks(self, block_num, buf):
+        for i in range(len(buf)):
+            self.data[block_num * self.block_size + i] = buf[i]
+
+    def ioctl(self, op, arg):
+        if op == 4:  # get number of blocks
+            return len(self.data) // self.block_size
+        if op == 5:  # get block size
+            return self.block_size
+
+
+# Use globals if set via exec, otherwise use defaults
+try:
+    block_size
+except NameError:
+    block_size = 512
+
+try:
+    num_blocks
+except NameError:
+    num_blocks = 50
+
+try:
+    mount_path
+except NameError:
+    mount_path = "/ramdisk"
+
+try:
+    do_chdir
+except NameError:
+    do_chdir = True
+
+bdev = RAMBlockDev(block_size, num_blocks)
+os.VfsFat.mkfs(bdev)
+os.mount(bdev, mount_path)
+if do_chdir:
+    os.chdir(mount_path)

--- a/tools/mpremote/tests/run-mpremote-tests.sh
+++ b/tools/mpremote/tests/run-mpremote-tests.sh
@@ -4,20 +4,84 @@ set -e
 TEST_DIR=$(dirname $0)
 MPREMOTE=${TEST_DIR}/../mpremote.py
 
+# Parse command line options
+DEVICE=""
+TESTS=""
+
+show_help() {
+    echo "Usage: $(basename $0) [-t <device>] [test_file.sh ...]"
+    echo ""
+    echo "Run mpremote tests against a MicroPython target."
+    echo ""
+    echo "Options:"
+    echo "  -t <device>   Test instance/device to connect to. Examples:"
+    echo "                  -t a0              Connect to /dev/ttyACM0"
+    echo "                  -t u0              Connect to /dev/ttyUSB0"
+    echo "                  -t c0              Connect to COM0"
+    echo "                  -t /dev/ttyACM0    Connect to specified serial port"
+    echo "                  -t rfc2217://host:port  Connect via RFC2217"
+    echo "                If not specified, uses mpremote's auto-detection."
+    echo "  -h            Show this help message"
+    echo ""
+    echo "Arguments:"
+    echo "  test_file.sh  Specific test file(s) to run. If not specified,"
+    echo "                all test_*.sh files in the tests directory are run."
+    exit 0
+}
+
+while getopts "t:h" opt; do
+    case $opt in
+        t)
+            DEVICE="$OPTARG"
+            ;;
+        h)
+            show_help
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Convert device shortcuts to full paths (similar to run-tests.py)
+if [ -n "$DEVICE" ]; then
+    case "$DEVICE" in
+        a[0-9]*)
+            DEVICE="/dev/ttyACM${DEVICE#a}"
+            ;;
+        u[0-9]*)
+            DEVICE="/dev/ttyUSB${DEVICE#u}"
+            ;;
+        c[0-9]*)
+            DEVICE="COM${DEVICE#c}"
+            ;;
+    esac
+    # Set MPREMOTE_DEVICE for tests to use
+    export MPREMOTE_DEVICE="$DEVICE"
+    # Update MPREMOTE to include connect command
+    MPREMOTE="${MPREMOTE} connect ${DEVICE}"
+    echo "Using device: $DEVICE"
+fi
+
 if [ -z "$1" ]; then
     # Find tests matching test_*.sh
     TESTS=${TEST_DIR}/test_*.sh
 else
     # Specific test path from the command line.
-    TESTS="$1"
+    TESTS="$@"
 fi
 
 for t in $TESTS; do
     TMP=$(mktemp -d)
     echo -n "${t}: "
     # Strip CR and replace the random temp dir with a token.
-    if env MPREMOTE=${MPREMOTE} TMP="${TMP}" "${t}" 2>&1 | tr -d '\r' | sed "s,${TMP},"'${TMP},g' > "${t}.out"; then
-        if diff "${t}.out" "${t}.exp" > /dev/null; then
+    if env MPREMOTE="${MPREMOTE}" TMP="${TMP}" MPREMOTE_DEVICE="${DEVICE}" "${t}" 2>&1 | tr -d '\r' | sed "s,${TMP},"'${TMP},g' > "${t}.out"; then
+        # Check if test was skipped (matches main test runner convention)
+        if grep -q "^SKIP$" "${t}.out"; then
+            echo "skip"
+        elif diff "${t}.out" "${t}.exp" > /dev/null; then
             echo "OK"
         else
             echo "FAIL"

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -1,39 +1,11 @@
 #!/bin/bash
 set -e
 
-# Creates a RAM disk big enough to hold two copies of the test directory
-# structure.
-cat << EOF > "${TMP}/ramdisk.py"
-class RAMBlockDev:
-    def __init__(self, block_size, num_blocks):
-        self.block_size = block_size
-        self.data = bytearray(block_size * num_blocks)
-
-    def readblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            buf[i] = self.data[block_num * self.block_size + i]
-
-    def writeblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            self.data[block_num * self.block_size + i] = buf[i]
-
-    def ioctl(self, op, arg):
-        if op == 4: # get number of blocks
-            return len(self.data) // self.block_size
-        if op == 5: # get block size
-            return self.block_size
-
-import os
-
-bdev = RAMBlockDev(512, 50)
-os.VfsFat.mkfs(bdev)
-os.mount(bdev, '/ramdisk')
-os.chdir('/ramdisk')
-EOF
-
+# Get the test directory (where this script and ramdisk.py are located)
+TEST_DIR=$(dirname $0)
 
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume ls
 
 echo -----
@@ -108,7 +80,7 @@ cat << EOF > "${TMP}/package/subpackage/y.py"
 def y():
   print("y")
 EOF
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume cp -r "${TMP}/package" :
 $MPREMOTE resume ls : :package :package/subpackage
 $MPREMOTE resume exec "import package; package.x(); package.y()"
@@ -116,7 +88,7 @@ $MPREMOTE resume exec "import package; package.x(); package.y()"
 
 # Same thing except with a destination directory name.
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume cp -r "${TMP}/package" :package2
 $MPREMOTE resume ls : :package2 :package2/subpackage
 $MPREMOTE resume exec "import package2; package2.x(); package2.y()"
@@ -124,7 +96,7 @@ $MPREMOTE resume exec "import package2; package2.x(); package2.y()"
 
 # Copy to an existing directory, it will be copied inside.
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume mkdir :test
 $MPREMOTE resume cp -r "${TMP}/package" :test
 $MPREMOTE resume ls :test :test/package :test/package/subpackage
@@ -148,14 +120,14 @@ ls "${TMP}/copy" "${TMP}/copy/package2" "${TMP}/copy/package2/subpackage"
 
 # Copy from device to another location on the device with destination directory name.
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume cp -r "${TMP}/package" :
 $MPREMOTE resume cp -r :package :package3
 $MPREMOTE resume ls : :package3 :package3/subpackage
 
 # Copy from device to another location on the device into an existing directory.
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume cp -r "${TMP}/package" :
 $MPREMOTE resume mkdir :package4
 $MPREMOTE resume cp -r :package :package4
@@ -175,7 +147,7 @@ echo -----
 # Test rm -r functionality
 # start with a fresh ramdisk before each test
 # rm -r MCU current working directory
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume touch :a.py
 $MPREMOTE resume touch :b.py
 $MPREMOTE resume cp -r "${TMP}/package" :
@@ -185,7 +157,7 @@ $MPREMOTE resume ls :/ramdisk
 
 echo -----
 # rm -r relative subfolder
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume touch :a.py
 $MPREMOTE resume mkdir :testdir
 $MPREMOTE resume cp -r "${TMP}/package" :testdir/package
@@ -197,14 +169,14 @@ $MPREMOTE resume ls :testdir
 
 echo -----
 # rm -r non-existent path
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume ls :
 $MPREMOTE resume rm -r :nonexistent || echo "expect error"
 
 echo -----
 # rm -r absolute root
 # no -v to generate same output on stm32 and other ports
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume touch :a.py
 $MPREMOTE resume touch :b.py
 $MPREMOTE resume cp -r "${TMP}/package" :
@@ -215,7 +187,7 @@ $MPREMOTE resume ls :/ramdisk
 
 echo -----
 # rm -r relative mountpoint
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume touch :a.py
 $MPREMOTE resume touch :b.py
 $MPREMOTE resume cp -r "${TMP}/package" :
@@ -225,7 +197,7 @@ $MPREMOTE resume ls :/ramdisk
 
 echo -----
 # rm -r absolute mountpoint
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume touch :a.py
 $MPREMOTE resume touch :b.py
 $MPREMOTE resume cp -r "${TMP}/package" :

--- a/tools/mpremote/tests/test_fs_tree.sh
+++ b/tools/mpremote/tests/test_fs_tree.sh
@@ -1,39 +1,12 @@
 #!/bin/bash
 set -e
 
-# Creates a RAM disk big enough to hold two copies of the test directory
-# structure.
-cat << EOF > "${TMP}/ramdisk.py"
-class RAMBlockDev:
-    def __init__(self, block_size, num_blocks):
-        self.block_size = block_size
-        self.data = bytearray(block_size * num_blocks)
-
-    def readblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            buf[i] = self.data[block_num * self.block_size + i]
-
-    def writeblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            self.data[block_num * self.block_size + i] = buf[i]
-
-    def ioctl(self, op, arg):
-        if op == 4: # get number of blocks
-            return len(self.data) // self.block_size
-        if op == 5: # get block size
-            return self.block_size
-
-import os
-
-bdev = RAMBlockDev(512, 50)
-os.VfsFat.mkfs(bdev)
-os.mount(bdev, '/ramdisk')
-os.chdir('/ramdisk')
-EOF
+# Get the test directory (where this script and ramdisk.py are located)
+TEST_DIR=$(dirname $0)
 
 # setup 
 echo -----
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume ls
 
 echo -----

--- a/tools/mpremote/tests/test_mip_local_install.sh
+++ b/tools/mpremote/tests/test_mip_local_install.sh
@@ -10,37 +10,10 @@ PACKAGE=mip_example
 PACKAGE_DIR=${TMP}/example
 MODULE_DIR=${PACKAGE_DIR}/${PACKAGE}
 
+# Get the test directory (where this script and ramdisk.py are located)
+TEST_DIR=$(dirname $0)
+
 target=/__ramdisk
-block_size=512
-num_blocks=50
-
-# Create the smallest permissible ramdisk.
-cat << EOF > "${TMP}/ramdisk.py"
-class RAMBlockDev:
-    def __init__(self, block_size, num_blocks):
-        self.block_size = block_size
-        self.data = bytearray(block_size * num_blocks)
-
-    def readblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            buf[i] = self.data[block_num * self.block_size + i]
-
-    def writeblocks(self, block_num, buf):
-        for i in range(len(buf)):
-            self.data[block_num * self.block_size + i] = buf[i]
-
-    def ioctl(self, op, arg):
-        if op == 4: # get number of blocks
-            return len(self.data) // self.block_size
-        if op == 5: # get block size
-            return self.block_size
-
-import os
-
-bdev = RAMBlockDev(${block_size}, ${num_blocks})
-os.VfsFat.mkfs(bdev)
-os.mount(bdev, '${target}')
-EOF
 
 echo ----- Setup
 mkdir -p ${MODULE_DIR}
@@ -56,7 +29,7 @@ cat > ${PACKAGE_DIR}/package.json <<EOF
 }
 EOF
 
-$MPREMOTE run "${TMP}/ramdisk.py"
+$MPREMOTE exec "mount_path='${target}'; do_chdir=False" run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume mkdir ${target}/lib
 echo
 echo ---- Install package

--- a/tools/mpremote/tests/test_unicode.sh
+++ b/tools/mpremote/tests/test_unicode.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -e
+
+# Test Unicode and special character handling in mpremote.
+# These tests cover:
+# - Properly escaping quotes for commands (transport.py)
+# - Command expansion handling `=` (main.py)
+# - UTF-8 display and encoding fixes (console.py, transport.py)
+# - wr_bytes string to bytes conversion (transport_serial.py)
+
+# Create a RAM disk for testing
+# Get the test directory (where this script and ramdisk.py are located)
+TEST_DIR=$(dirname $0)
+
+# Initialize ramdisk for file tests
+$MPREMOTE run "${TEST_DIR}/ramdisk.py"
+
+echo -----
+# Test UTF-8 output via exec (tests stdout_write_bytes UTF-8 handling)
+$MPREMOTE resume exec "print('Hello 世界')"
+$MPREMOTE resume exec "print('Emoji: 🎉🐍')"
+$MPREMOTE resume exec "print('Accents: café, naïve, résumé')"
+
+echo -----
+# Test Files with single quotes in names (tests _quote_path in transport.py)
+$MPREMOTE resume touch ":quote'test.txt"
+$MPREMOTE resume ls :
+$MPREMOTE resume rm ":quote'test.txt"
+$MPREMOTE resume ls :
+
+echo -----
+# Test Writing and reading UTF-8 content (tests transport and wr_bytes)
+cat << EOF > "${TMP}/unicode_content.txt"
+Hello 世界
+Emoji: 🎉🐍
+Café résumé naïve
+EOF
+$MPREMOTE resume cp "${TMP}/unicode_content.txt" :
+$MPREMOTE resume cat :unicode_content.txt
+$MPREMOTE resume sha256sum :unicode_content.txt
+cat "${TMP}/unicode_content.txt" | sha256sum
+
+echo -----
+# This test writes UTF-8 content via mount and reads it back
+# https://github.com/micropython/micropython/issues/13055
+cat << EOF > "${TMP}/write_utf_to_mounted.py"
+with open("foo.txt", 'w', encoding='utf-8') as file:
+    file.write("🔢 Data" + '\n')
+    file.write("🔢 Data" + '\n')
+
+with open("foo.txt", 'r', encoding='utf-8') as file:
+    data = file.read()
+    print(data)
+EOF
+$MPREMOTE mount ${TMP} run "${TMP}/write_utf_to_mounted.py"
+
+
+echo -----
+# Test Command expansion with `=` sign (tests main.py fix)
+# The `=` in arguments should not cause errors
+$MPREMOTE resume exec "x = 'a=b'; print(x)"
+
+echo -----
+# Test eval with Unicode strings
+$MPREMOTE resume eval "'Hello 世界'"
+$MPREMOTE resume eval "repr('日本語')"
+
+echo -----
+# Test UTF-8 display on Windows
+# Testing mpremote on windows with bash is not straightforward,
+# but we can at least run the command that was problematic.
+$MPREMOTE resume exec "print('Hello World'); print('你好'); print('=' * 20)"
+
+echo -----

--- a/tools/mpremote/tests/test_unicode.sh.exp
+++ b/tools/mpremote/tests/test_unicode.sh.exp
@@ -1,0 +1,33 @@
+-----
+Hello 世界
+Emoji: 🎉🐍
+Accents: café, naïve, résumé
+-----
+touch :quote'test.txt
+ls :
+           0 quote'test.txt
+rm :quote'test.txt
+ls :
+-----
+cp ${TMP}/unicode_content.txt :
+Hello 世界
+Emoji: 🎉🐍
+Café résumé naïve
+sha256sum :unicode_content.txt
+8f22a7c6092948ff41897b28dca429cd6a3de87a5bd6e113d24adf91f3cbeeac
+8f22a7c6092948ff41897b28dca429cd6a3de87a5bd6e113d24adf91f3cbeeac  -
+-----
+🔢 Data
+🔢 Data
+
+Local directory ${TMP} is mounted at /remote
+-----
+a=b
+-----
+Hello 世界
+'日本語'
+-----
+Hello World
+你好
+====================
+-----


### PR DESCRIPTION
### Summary
This pull request addresses multiple issues related to the handling of special characters and Unicode in the `mpremote` tool. It fixes the escaping of quotes in filenames, ensures proper parsing of filenames containing equals signs, and resolves Unicode encoding errors on Windows consoles. These improvements enhance the usability of `mpremote` when dealing with diverse file names and character sets.

- Unicode-safe Windows console output: Detects modern consoles, sets UTF-8 code pages, wraps stdout/stderr when needed, and uses raw UTF-8 writes when possible; legacy consoles now handle split UTF-8 sequences safely.
- Robust stdout handling: Buffers partial UTF-8 sequences and strips CTRL-D without losing characters, improving REPL/output correctness for multibyte text.
- Safer path quoting: Filesystem commands now use repr-based quoting so filenames with quotes, backslashes, or Unicode work correctly (including equals-sign parsing).
- CLI parsing fix: Command expansion no longer misinterprets arguments containing =, preventing unexpected-argument errors.
- Transport write safety: Converts strings to UTF-8 bytes before writing to avoid encoding errors when writing unicode content  to a  host folder  using `mpremote mount <folder>`

Fixes: #13055 
Fixes: #15228 
Fixes: #18658 
Fixes: #18657 

This is a re-submit of #18670 which was unrecoverably closed due to user error.

</p>
</details> 

### Testing

- New test support: Adds ramdisk helper, enhanced test runner (device selection, skip handling), and Unicode/special-character coverage in the mpremote test suite.
-  New unicode tests have been added to the mpremote test suite, covering the scenarios mentioned in the issues.
  It should be noted that the current CI setup does not provide for Windows testing, so manual verification has been essential for confirming the fixes.

Manual testing was conducted on Windows pwsh , cmd.exe, MinGW and Linux in WSL2. 

<img width="1468" height="1306" alt="image" src="https://github.com/user-attachments/assets/bb0ce2a3-4b83-40dc-bd8d-fb7b622e3863" />


Manual testing was needed due to the lack of Windows support in the bash based testing framework, ensuring that the fixes work as intended across different environments.
Also tests for the mpremote REPL and Console cannot be not covered by the bash test suite.

I started work of a pytest configuration for mpremote to adds the ability to test the REPL and Console, parts that the bash suite is unable to test at all.
That will be submitted in a separate PR once stable across multiple platforms.

### Trade-offs and Alternatives

The changes made do not introduce significant trade-offs. The improvements in Unicode handling may slightly increase the complexity of the code, but they are necessary for robust functionality. Alternative approaches were considered, such as using different quoting mechanisms, but the current solutions provide the best balance of compatibility and simplicity.



