### PR TITLE
Improving Unicode support in MicroPython.

### DIFF
--- a/docs/develop/writingtests.rst
+++ b/docs/develop/writingtests.rst
@@ -46,6 +46,11 @@ If you run your tests, this test should appear in the test output:
 Tests are run by comparing the output from the test target against the output from CPython.
 So any test should use print statements to indicate test results.
 
+When writing tests for name or string-related functionality, please add both English/ASCII
+as well as non-English/non-ASCII text and include Unicode examples.
+Please do add comments in English explaining the meaning and intent of the Unicode text.
+This help ensure Unicode support is tested and verified across different platforms.
+
 For tests that can't be compared to CPython (i.e. micropython-specific functionality),
 you can provide a ``.py.exp`` file which will be used as the truth for comparison.
 

--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -25,6 +25,35 @@ Functions and types
 
     |see_cpython| `python:bytes`.
 
+    .. method:: bytes.decode(encoding='utf-8', errors='strict')
+
+        Decode the bytes object to a string using the specified *encoding*.
+
+        MicroPython supports the following encodings:
+
+        - ``'utf-8'`` or ``'utf8'`` - UTF-8 encoding (default)
+        - ``'ascii'`` - ASCII encoding (subset of UTF-8)
+
+        The *errors* parameter controls how decoding errors are handled:
+
+        - ``'strict'`` - Raise a ``UnicodeError`` on invalid UTF-8 (default)
+        - ``'ignore'`` - Skip invalid bytes (requires ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``)
+        - ``'replace'`` - Replace invalid bytes with U+FFFD '�' (requires ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``)
+
+        .. note::
+            Error handler support depends on build configuration. On constrained
+            systems, only ``'strict'`` mode may be available.
+
+        Example::
+
+            >>> b'\xc2\xa9 2024'.decode('utf-8')  # © symbol
+            '© 2024'
+            >>> b'hello\xffworld'.decode('utf-8', 'ignore')  # Skip invalid bytes
+            'helloworld'
+
+        Raises ``LookupError`` if the encoding is not supported, or
+        ``UnicodeError`` if the data contains invalid UTF-8 and ``errors='strict'``.
+
 .. function:: callable()
 
 .. function:: chr()
@@ -143,6 +172,35 @@ Functions and types
 .. function:: staticmethod()
 
 .. class:: str()
+
+    .. method:: str.encode(encoding='utf-8')
+
+        Encode the string to bytes using the specified *encoding*.
+
+        MicroPython supports the following encodings:
+
+        - ``'utf-8'`` or ``'utf8'`` - UTF-8 encoding (default)
+        - ``'ascii'`` - ASCII encoding (subset of UTF-8)
+
+        Example::
+
+            >>> '© 2024'.encode('utf-8')  # Copyright symbol
+            b'\xc2\xa9 2024'
+
+        Raises ``LookupError`` if the encoding is not supported.
+
+    .. method:: str.center(width)
+
+        Return a centered string of length *width*. Padding is done using spaces.
+
+        When Unicode support is enabled (``MICROPY_PY_BUILTINS_STR_UNICODE``), this
+        method counts Unicode characters rather than bytes, ensuring proper alignment
+        for multi-byte UTF-8 characters.
+
+        Example::
+
+            >>> 'café'.center(10)  # é is 2 bytes in UTF-8
+            '   café   '
 
 .. function:: sum()
 

--- a/docs/reference/constrained.rst
+++ b/docs/reference/constrained.rst
@@ -251,7 +251,26 @@ instances so the process of eliminating Unicode can be painless.
     b = b'the quick brown fox'  # A bytes instance
 
 Where it is necessary to convert between strings and bytes the :meth:`str.encode`
-and the :meth:`bytes.decode` methods can be used. Note that both strings and bytes
+and the :meth:`bytes.decode` methods can be used. MicroPython validates the
+encoding parameter and only supports UTF-8 and ASCII. The :meth:`bytes.decode`
+method also supports error handlers (``'ignore'`` and ``'replace'``) for handling
+invalid UTF-8, when enabled in the build configuration.
+
+For memory-conscious applications processing untrusted data, using the ``'ignore'``
+error handler can be more efficient than ``'strict'`` mode (the default), as it
+avoids raising exceptions while still recovering valid text::
+
+    # Strict mode (default) raises an error on invalid UTF-8
+    try:
+        s = data.decode('utf-8')
+    except UnicodeError:
+        # Handle error
+        pass
+
+    # Ignore mode skips invalid bytes (more memory-efficient)
+    s = data.decode('utf-8', 'ignore')
+
+Note that both strings and bytes
 are immutable. Any operation which takes as input such an object and produces
 another implies at least one RAM allocation to produce the result. In the
 second line below a new bytes object is allocated. This would also occur if ``foo``

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -31,5 +31,6 @@ implementation and the best practices to use them.
    packages.rst
    asm_thumb2_index.rst
    filesystem.rst
+   unicode_support.rst
    pyboard.py.rst
    micropython2_migration.rst

--- a/docs/reference/unicode_support.rst
+++ b/docs/reference/unicode_support.rst
@@ -1,0 +1,201 @@
+.. _unicode_support:
+
+Unicode Support
+===============
+
+MicroPython provides Unicode support for strings, with the level of support
+depending on the build configuration.
+
+Terminology
+-----------
+
+This document uses the following Unicode terms:
+
+- **Code point**: a single Unicode value in the range U+0000 to U+10FFFF, for
+  example U+0041 ``A`` or U+1F600 😀.  MicroPython strings are sequences of
+  code points.
+- **Character**: informally used to mean a code point.  Be aware that a
+  user-perceived character (a *grapheme*) may consist of several code points,
+  such as a base letter followed by combining marks.
+- **Byte**: a single 8-bit value.  In UTF-8 each code point is stored as one to
+  four bytes (see below).
+
+Operations such as ``len()``, indexing and slicing act on code points, not on
+graphemes or display width, so a base letter followed by a combining mark counts
+as two code points.
+
+Character Encoding
+------------------
+
+MicroPython uses UTF-8 encoding for all strings. When Unicode support is enabled
+(``MICROPY_PY_BUILTINS_STR_UNICODE``), strings can contain any valid Unicode code
+point from U+0000 to U+10FFFF.
+
+ASCII characters (0-127) are stored in a single byte, making them as memory-efficient
+as on systems without Unicode support. Multi-byte UTF-8 code points use 2-4 bytes
+depending on the code point:
+
+- U+0000 to U+007F: 1 byte (ASCII)
+- U+0080 to U+07FF: 2 bytes
+- U+0800 to U+FFFF: 3 bytes
+- U+10000 to U+10FFFF: 4 bytes
+
+Encoding and Decoding
+----------------------
+
+The :meth:`bytes.decode` and :meth:`str.encode` methods support the following encodings:
+
+- UTF-8 (``'utf-8'`` or ``'utf8'``)
+- ASCII (``'ascii'``)
+
+Other encodings (such as ``'latin-1'``, ``'utf-16'``, etc.) are not supported and
+will raise ``LookupError``.
+
+Example::
+
+    >>> '日本語'.encode('utf-8')
+    b'\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e'
+    >>> b'\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e'.decode('utf-8')
+    '日本語'
+
+Error Handling
+~~~~~~~~~~~~~~
+
+When decoding bytes that contain invalid UTF-8 sequences, the ``errors`` parameter
+of :meth:`bytes.decode` controls the behavior:
+
+- ``'strict'`` (default): Raise ``UnicodeError``
+- ``'ignore'``: Skip invalid bytes (requires ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``)
+- ``'replace'``: Replace invalid bytes with U+FFFD � (requires ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``)
+
+Example::
+
+    >>> # Strict mode (default) raises an error
+    >>> b'hello\xffworld'.decode('utf-8')
+    UnicodeError: invalid UTF-8
+
+    >>> # Ignore mode skips invalid bytes
+    >>> b'hello\xffworld'.decode('utf-8', 'ignore')
+    'helloworld'
+
+    >>> # Replace mode substitutes replacement character
+    >>> b'hello\xffworld'.decode('utf-8', 'replace')
+    'hello�world'
+
+For memory-conscious applications, consider using ``'ignore'`` mode when processing
+untrusted or partially corrupted data, as it avoids raising exceptions while still
+recovering valid text.
+
+The same ``errors`` handling applies when decoding any bytes-like object, including
+via the ``str()`` constructor (for example ``str(buf, 'utf-8', 'replace')`` where
+``buf`` is a ``bytes``, ``bytearray``, ``memoryview`` or ``array`` object).
+
+
+String Methods
+--------------
+
+When Unicode support is enabled, string methods operate on code points rather than bytes:
+
+- :meth:`str.center` - Counts code points for width calculation
+- ``len(s)`` - Returns number of code points (not bytes)
+- String indexing and slicing work on code-point boundaries
+- No support for display width calculations (East Asian width, combining characters, etc.)
+
+Example::
+
+    >>> s = 'Hello 世界'
+    >>> len(s)           # 8 code points
+    8
+    >>> len(s.encode())  # 12 bytes
+    12
+    >>> s.center(12)     # Centered by code-point count
+    '  Hello 世界  '
+
+String Formatting
+-----------------
+
+The ``%c`` format specifier and ``{:c}`` format code support full Unicode:
+
+- Accepts code points from 0 to 0x10FFFF
+- Properly encodes multi-byte UTF-8 code points
+- Raises ``ValueError`` for invalid code points
+
+Example::
+
+    >>> '%c' % 65           # ASCII
+    'A'
+    >>> '%c' % 0x03B1       # Greek α
+    'α'
+    >>> '%c' % 0x1F600      # Emoji 😀
+    '😀'
+    >>> '{:c}'.format(0x4E2D)  # Chinese 中
+    '中'
+
+    >>> # Invalid code point
+    >>> '%c' % 0x110000
+    ValueError: %c arg not in range(0x110000)
+
+F-strings also support the ``:c`` format code::
+
+    >>> code_point = 0x2665  # Heart suit ♥
+    >>> f'I {code_point:c} Python'
+    'I ♥ Python'
+
+Build Configuration
+-------------------
+
+Unicode features are controlled by several build-time flags in ``mpconfigport.h``:
+
+``MICROPY_PY_BUILTINS_STR_UNICODE``
+    Enable Unicode string support. When enabled, strings can contain any valid
+    Unicode character and string operations work on character boundaries rather
+    than byte boundaries.
+
+    Default: Enabled at ``MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES`` and above.
+
+``MICROPY_PY_BUILTINS_STR_UNICODE_CHECK``
+    Enable UTF-8 validation during string operations. When disabled, string
+    operations may produce incorrect results with invalid UTF-8 sequences.
+
+    Default: Follows ``MICROPY_PY_BUILTINS_STR_UNICODE`` setting.
+
+``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``
+    Enable the ``'ignore'`` and ``'replace'`` error handlers for
+    :meth:`bytes.decode`. When enabled, invalid UTF-8 bytes can be either
+    skipped (``'ignore'``) or replaced with U+FFFD (``'replace'``).
+
+    Default: Enabled at ``MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES`` and above.
+
+Example Configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+For a constrained port with limited flash, disable error handlers::
+
+    #define MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS (0)
+
+For a port with more resources, enable all Unicode features::
+
+    #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+    // This automatically enables:
+    // - MICROPY_PY_BUILTINS_STR_UNICODE
+    // - MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+
+Limitations
+-----------
+
+MicroPython's Unicode support has some limitations compared to CPython:
+
+- Only UTF-8 and ASCII encodings are supported
+- No support for Unicode normalization
+- No locale-aware string operations
+- The ``errors`` parameter accepts only positional arguments (not keyword arguments)
+- String methods like ``upper()``, ``lower()``, etc. work correctly only for ASCII
+- The MicroPython interactive REPL and ``input()`` function currently have limited
+  Unicode support.  The line editor is unaware of the displayed width of characters:
+  wide characters (for example many CJK characters) take two terminal columns, while a
+  grapheme cluster (a base code point plus combining marks, or an emoji sequence) can
+  span several code points yet occupy a single column.  Because editing tracks code
+  points rather than displayed columns, line-editing keys such as backspace and the
+  left/right arrows may leave the cursor misaligned with the text shown on screen.
+  A workaround is to place the Unicode text in a UTF-8 encoded MicroPython script and
+  run it using ``mpremote run <script.py>``.

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -138,7 +138,7 @@ static mp_obj_t mp_builtin_chr(mp_obj_t o_in) {
     #if MICROPY_PY_BUILTINS_STR_UNICODE
     mp_uint_t c = mp_obj_get_int(o_in);
     if (c >= 0x110000) {
-        mp_raise_ValueError(MP_ERROR_TEXT("chr() arg not in range(0x110000)"));
+        mp_raise_ValueError(MP_ERROR_TEXT("char not in range(0x110000)"));
     }
     VSTR_FIXED(buf, 4);
     vstr_add_char(&buf, c);

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1375,6 +1375,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_BUILTINS_STR_UNICODE_CHECK (MICROPY_PY_BUILTINS_STR_UNICODE)
 #endif
 
+// Whether bytes.decode() supports the 'ignore' and 'replace' error handlers
+#ifndef MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+#define MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#endif
+
 // Whether str.center() method provided
 #ifndef MICROPY_PY_BUILTINS_STR_CENTER
 #define MICROPY_PY_BUILTINS_STR_CENTER (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -187,6 +187,62 @@ static void str_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
     }
 }
 
+#if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK && MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+// Build a new string from data containing invalid UTF-8, either skipping the
+// invalid bytes (errors=="ignore") or replacing them with U+FFFD
+// (errors=="replace").
+static mp_obj_t str_from_invalid_utf8(const mp_obj_type_t *type, const byte *str_data, size_t str_len, qstr errors) {
+    bool do_replace = (errors == MP_QSTR_replace);
+    vstr_t vstr;
+    vstr_init(&vstr, str_len);
+    const byte *p = str_data;
+    const byte *end = str_data + str_len;
+
+    while (p < end) {
+        byte c = *p;
+        if (c < 0x80) {
+            // Valid ASCII
+            vstr_add_byte(&vstr, c);
+            p++;
+        } else if (c >= 0xc0 && c < 0xf8) {
+            // Potential multi-byte sequence
+            uint8_t need = (0xe5 >> ((c >> 3) & 0x6)) & 3;
+            const byte *seq_start = p;
+            p++;
+
+            // Check continuation bytes
+            uint8_t got = 0;
+            while (got < need && p < end && UTF8_IS_CONT(*p)) {
+                got++;
+                p++;
+            }
+
+            if (got == need) {
+                // Valid complete sequence, decode and add the character
+                unichar ch = *seq_start & (0x7f >> need);
+                for (uint8_t i = 0; i < need; i++) {
+                    ch = (ch << 6) | (seq_start[i + 1] & 0x3f);
+                }
+                vstr_add_char(&vstr, ch);
+            } else if (do_replace) {
+                // Invalid or incomplete sequence - replace with U+FFFD
+                vstr_add_char(&vstr, 0xFFFD);
+            }
+            // For 'ignore' mode, do nothing (skip invalid bytes)
+        } else if (do_replace) {
+            // Invalid start byte - replace with U+FFFD
+            vstr_add_char(&vstr, 0xFFFD);
+            p++;
+        } else {
+            // Invalid start byte - skip for 'ignore' mode
+            p++;
+        }
+    }
+
+    return mp_obj_new_str_type_from_vstr(type, &vstr);
+}
+#endif // MICROPY_PY_BUILTINS_STR_UNICODE_CHECK && MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+
 mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     #if MICROPY_CPYTHON_COMPAT
     if (n_kw != 0) {
@@ -208,135 +264,60 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
             return mp_obj_new_str_type_from_vstr(type, &vstr);
         }
 
-        default: // 2 or 3 args
-            #if MICROPY_PY_BUILTINS_BYTEARRAY
-            if (mp_obj_is_type(args[0], &mp_type_bytes) || mp_obj_is_type(args[0], &mp_type_bytearray)) {
-            #else
+        default: { // 2 or 3 args
+            // Extract the source data.
+            const byte *str_data;
+            size_t str_len;
             if (mp_obj_is_type(args[0], &mp_type_bytes)) {
-                #endif
-                GET_STR_DATA_LEN(args[0], str_data, str_len);
-                GET_STR_HASH(args[0], str_hash);
-                if (str_hash == 0) {
-                    str_hash = qstr_compute_hash(str_data, str_len);
-                }
-
-                #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-                #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
-                // Check if error handler is specified (3rd argument)
-                const char *errors = "strict";
-                if (n_args >= 3 && args[2] != mp_const_none) {
-                    errors = mp_obj_str_get_str(args[2]);
-                }
-                #endif
-
-                // Fast path: if data is valid UTF-8, return directly
-                if (utf8_check(str_data, str_len)) {
-                    // Check if a qstr with this data already exists
-                    qstr q = qstr_find_strn((const char *)str_data, str_len);
-                    if (q != MP_QSTRnull) {
-                        return MP_OBJ_NEW_QSTR(q);
-                    }
-
-                    mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_str_copy(type, NULL, str_len));
-                    o->data = str_data;
-                    o->hash = str_hash;
-                    return MP_OBJ_FROM_PTR(o);
-                }
-
-                // Data has invalid UTF-8, handle based on error mode
-                #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
-                // Error handlers are enabled
-                #if !MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
-                // Raise NotImplementedError if 'replace' is used but not enabled
-                if (strcmp(errors, "replace") == 0) {
-                    mp_raise_NotImplementedError(NULL);
-                }
-                #endif
-
-                if (strcmp(errors, "ignore") == 0
-                    #if MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
-                    || strcmp(errors, "replace") == 0
-                    #endif
-                    ) {
-                    // Build new string skipping/replacing invalid bytes
-                    #if MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
-                    bool do_replace = strcmp(errors, "replace") == 0;
-                    #else
-                    const bool do_replace = false;
-                    #endif
-                    vstr_t vstr;
-                    vstr_init(&vstr, str_len);
-                    const byte *p = str_data;
-                    const byte *end = str_data + str_len;
-
-                    while (p < end) {
-                        byte c = *p;
-                        if (c < 0x80) {
-                            // Valid ASCII
-                            vstr_add_byte(&vstr, c);
-                            p++;
-                        } else if (c >= 0xc0 && c < 0xf8) {
-                            // Potential multi-byte sequence
-                            uint8_t need = (0xe5 >> ((c >> 3) & 0x6)) & 3;
-                            const byte *seq_start = p;
-                            p++;
-
-                            // Check continuation bytes
-                            uint8_t got = 0;
-                            while (got < need && p < end && UTF8_IS_CONT(*p)) {
-                                got++;
-                                p++;
-                            }
-
-                            if (got == need) {
-                                // Valid complete sequence, decode and add the character
-                                unichar ch = *seq_start & (0x7f >> need);
-                                for (uint8_t i = 0; i < need; i++) {
-                                    ch = (ch << 6) | (seq_start[i + 1] & 0x3f);
-                                }
-                                vstr_add_char(&vstr, ch);
-                            } else if (do_replace) {
-                                // Invalid or incomplete sequence - replace with U+FFFD
-                                vstr_add_char(&vstr, 0xFFFD);
-                            }
-                            // For 'ignore' mode, do nothing (skip invalid bytes)
-                        } else if (do_replace) {
-                            // Invalid start byte - replace with U+FFFD
-                            vstr_add_char(&vstr, 0xFFFD);
-                            p++;
-                        } else {
-                            // Invalid start byte - skip for 'ignore' mode
-                            p++;
-                        }
-                    }
-
-                    return mp_obj_new_str_type_from_vstr(type, &vstr);
-                } else {
-                    // Strict mode (or unrecognized error handler)
-                    mp_raise_msg(&mp_type_UnicodeError, NULL);
-                }
-                #else
-                // Error handlers are not enabled - just raise UnicodeError on invalid UTF-8
-                mp_raise_msg(&mp_type_UnicodeError, NULL);
-                #endif
-                #else
-                // Check if a qstr with this data already exists
-                qstr q = qstr_find_strn((const char *)str_data, str_len);
-                if (q != MP_QSTRnull) {
-                    return MP_OBJ_NEW_QSTR(q);
-                }
-
-                mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_str_copy(type, NULL, str_len));
-                o->data = str_data;
-                o->hash = str_hash;
-                return MP_OBJ_FROM_PTR(o);
-                #endif
+                // Immutable bytes can be referenced directly (zero-copy);
+                GET_STR_DATA_LEN(args[0], bytes_data, bytes_len);
+                str_data = bytes_data;
+                str_len = bytes_len;
             } else {
+                // any other buffer object is mutable sob its data must be copied.
                 mp_buffer_info_t bufinfo;
                 mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);
-                // This will utf-8 check the input.
-                return mp_obj_new_str(bufinfo.buf, bufinfo.len);
+                str_data = bufinfo.buf;
+                str_len = bufinfo.len;
             }
+
+            #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+            if (!utf8_check(str_data, str_len)) {
+                #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+                // Check if error handler is specified (3rd argument)
+                qstr errors = MP_QSTR_; // default to ""
+                if (n_args >= 3 && args[2] != mp_const_none) {
+                    errors = mp_obj_str_get_qstr(args[2]);
+                }
+                if (errors == MP_QSTR_ignore || errors == MP_QSTR_replace) {
+                    return str_from_invalid_utf8(type, str_data, str_len, errors);
+                }
+                #endif // MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+                mp_raise_msg(&mp_type_UnicodeError, NULL);
+            }
+            #endif // MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+
+            // Check if a qstr with this data already exists
+            qstr q = qstr_find_strn((const char *)str_data, str_len);
+            if (q != MP_QSTRnull) {
+                return MP_OBJ_NEW_QSTR(q);
+            }
+
+            if (!mp_obj_is_type(args[0], &mp_type_bytes)) {
+                // Source is a mutable buffer: copy the data.
+                return mp_obj_new_str_copy(type, str_data, str_len);
+            }
+
+            // Source is immutable bytes: reference its data without copying.
+            GET_STR_HASH(args[0], str_hash);
+            if (str_hash == 0) {
+                str_hash = qstr_compute_hash(str_data, str_len);
+            }
+            mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_str_copy(type, NULL, str_len));
+            o->data = str_data;
+            o->hash = str_hash;
+            return MP_OBJ_FROM_PTR(o);
+        }
     }
 }
 
@@ -1148,6 +1129,23 @@ static MP_NORETURN void terse_str_format_value_error(void) {
 #define terse_str_format_value_error()
 #endif
 
+// Print the character with the code point given by the integer object arg.
+// Used by both the str.format and the modulo (%c) formatters.
+static void mp_print_char(const mp_print_t *print, mp_obj_t arg, unsigned int flags, char fill, int width) {
+    #if MICROPY_FULL_CHECKS
+    mp_uint_t c = mp_obj_get_int(arg);
+    if (c >= 0x110000) {
+        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("char not in range(0x110000)"));
+    }
+    VSTR_FIXED(ch_vstr, 4);
+    vstr_add_char(&ch_vstr, c);
+    mp_print_strn(print, ch_vstr.buf, ch_vstr.len, flags, fill, width);
+    #else
+    char ch = mp_obj_get_int(arg);
+    mp_print_strn(print, &ch, 1, flags, fill, width);
+    #endif
+}
+
 static vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *arg_i, size_t n_args, const mp_obj_t *args, mp_map_t *kwargs) {
     vstr_t vstr;
     mp_print_t print;
@@ -1437,19 +1435,7 @@ static vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                     continue;
 
                 case 'c': {
-                    #if MICROPY_PY_BUILTINS_STR_UNICODE
-                    mp_uint_t c = mp_obj_get_int(arg);
-                    if (c >= 0x110000) {
-                        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("chr() arg not in range(0x110000)"));
-                    }
-                    VSTR_FIXED(ch_vstr, 4);
-                    vstr_add_char(&ch_vstr, c);
-                    mp_print_strn(&print, ch_vstr.buf, ch_vstr.len, flags, fill, width);
-                    vstr_clear(&ch_vstr);
-                    #else
-                    char ch = mp_obj_get_int(arg);
-                    mp_print_strn(&print, &ch, 1, flags, fill, width);
-                    #endif
+                    mp_print_char(&print, arg, flags, fill, width);
                     continue;
                 }
 
@@ -1742,21 +1728,7 @@ static mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_
                     }
                     mp_print_strn(&print, s, 1, flags, ' ', width);
                 } else if (arg_looks_integer(arg)) {
-                    #if MICROPY_PY_BUILTINS_STR_UNICODE
-                    mp_uint_t c = mp_obj_get_int(arg);
-                    if (c >= 0x110000) {
-                        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("%c arg not in range(0x110000)"));
-                    }
-                    vstr_t ch_vstr;
-                    vstr_init_len(&ch_vstr, 4);
-                    ch_vstr.len = 0;
-                    vstr_add_char(&ch_vstr, c);
-                    mp_print_strn(&print, ch_vstr.buf, ch_vstr.len, flags, ' ', width);
-                    vstr_clear(&ch_vstr);
-                    #else
-                    char ch = mp_obj_get_int(arg);
-                    mp_print_strn(&print, &ch, 1, flags, ' ', width);
-                    #endif
+                    mp_print_char(&print, arg, flags, ' ', width);
                 } else {
                     mp_raise_TypeError(MP_ERROR_TEXT("integer needed"));
                 }
@@ -2117,6 +2089,15 @@ MP_DEFINE_CONST_FUN_OBJ_1(str_islower_obj, str_islower);
 #if MICROPY_CPYTHON_COMPAT
 // These methods are superfluous in the presence of str() and bytes()
 // constructors.
+
+static void check_utf8_encoding(qstr encoding) {
+    if (!(encoding == MP_QSTR_utf_hyphen_8 || encoding == MP_QSTR_utf8 ||
+          encoding == MP_QSTR_ascii)) {
+        mp_raise_msg_varg(&mp_type_LookupError,
+            MP_ERROR_TEXT("encoding not supported: %q"), encoding);
+    }
+}
+
 // TODO: should accept kwargs too
 static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
     mp_obj_t new_args[2];
@@ -2126,16 +2107,7 @@ static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     } else if (n_args >= 2) {
-        // Validate encoding parameter
-        // MicroPython only supports UTF-8 encoding
-        const char *encoding = mp_obj_str_get_str(args[1]);
-
-        // Accept utf-8 and ascii (ascii is a subset of utf-8)
-        if (!(strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "utf8") == 0 ||
-              strcmp(encoding, "ascii") == 0)) {
-            mp_raise_msg_varg(&mp_type_LookupError,
-                MP_ERROR_TEXT("encoding not supported: %s"), encoding);
-        }
+        check_utf8_encoding(mp_obj_str_get_qstr(args[1]));
     }
     return mp_obj_str_make_new(&mp_type_str, n_args, 0, args);
 }
@@ -2150,16 +2122,7 @@ static mp_obj_t str_encode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     } else if (n_args >= 2) {
-        // Validate encoding parameter
-        // MicroPython only supports UTF-8 encoding
-        const char *encoding = mp_obj_str_get_str(args[1]);
-
-        // Accept utf-8 and ascii (ascii is a subset of utf-8)
-        if (!(strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "utf8") == 0 ||
-              strcmp(encoding, "ascii") == 0)) {
-            mp_raise_msg_varg(&mp_type_LookupError,
-                MP_ERROR_TEXT("encoding not supported: %s"), encoding);
-        }
+        check_utf8_encoding(mp_obj_str_get_qstr(args[1]));
     }
     return bytes_make_new(NULL, n_args, 0, args);
 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1418,8 +1418,19 @@ static vstr_t mp_obj_str_format_helper(const char *str, const char *top, int *ar
                     continue;
 
                 case 'c': {
+                    #if MICROPY_PY_BUILTINS_STR_UNICODE
+                    mp_uint_t c = mp_obj_get_int(arg);
+                    if (c >= 0x110000) {
+                        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("chr() arg not in range(0x110000)"));
+                    }
+                    VSTR_FIXED(ch_vstr, 4);
+                    vstr_add_char(&ch_vstr, c);
+                    mp_print_strn(&print, ch_vstr.buf, ch_vstr.len, flags, fill, width);
+                    vstr_clear(&ch_vstr);
+                    #else
                     char ch = mp_obj_get_int(arg);
                     mp_print_strn(&print, &ch, 1, flags, fill, width);
+                    #endif
                     continue;
                 }
 
@@ -1712,8 +1723,21 @@ static mp_obj_t str_modulo_format(mp_obj_t pattern, size_t n_args, const mp_obj_
                     }
                     mp_print_strn(&print, s, 1, flags, ' ', width);
                 } else if (arg_looks_integer(arg)) {
+                    #if MICROPY_PY_BUILTINS_STR_UNICODE
+                    mp_uint_t c = mp_obj_get_int(arg);
+                    if (c >= 0x110000) {
+                        mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("%c arg not in range(0x110000)"));
+                    }
+                    vstr_t ch_vstr;
+                    vstr_init_len(&ch_vstr, 4);
+                    ch_vstr.len = 0;
+                    vstr_add_char(&ch_vstr, c);
+                    mp_print_strn(&print, ch_vstr.buf, ch_vstr.len, flags, ' ', width);
+                    vstr_clear(&ch_vstr);
+                    #else
                     char ch = mp_obj_get_int(arg);
                     mp_print_strn(&print, &ch, 1, flags, ' ', width);
+                    #endif
                 } else {
                     mp_raise_TypeError(MP_ERROR_TEXT("integer needed"));
                 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -209,19 +209,104 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
         }
 
         default: // 2 or 3 args
-            // TODO: validate 2nd/3rd args
+            #if MICROPY_PY_BUILTINS_BYTEARRAY
+            if (mp_obj_is_type(args[0], &mp_type_bytes) || mp_obj_is_type(args[0], &mp_type_bytearray)) {
+            #else
             if (mp_obj_is_type(args[0], &mp_type_bytes)) {
+                #endif
                 GET_STR_DATA_LEN(args[0], str_data, str_len);
                 GET_STR_HASH(args[0], str_hash);
                 if (str_hash == 0) {
                     str_hash = qstr_compute_hash(str_data, str_len);
                 }
+
                 #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-                if (!utf8_check(str_data, str_len)) {
-                    mp_raise_msg(&mp_type_UnicodeError, NULL);
+                #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+                // Check if error handler is specified (3rd argument)
+                const char *errors = "strict";
+                if (n_args >= 3 && args[2] != mp_const_none) {
+                    errors = mp_obj_str_get_str(args[2]);
                 }
                 #endif
 
+                // Fast path: if data is valid UTF-8, return directly
+                if (utf8_check(str_data, str_len)) {
+                    // Check if a qstr with this data already exists
+                    qstr q = qstr_find_strn((const char *)str_data, str_len);
+                    if (q != MP_QSTRnull) {
+                        return MP_OBJ_NEW_QSTR(q);
+                    }
+
+                    mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_str_copy(type, NULL, str_len));
+                    o->data = str_data;
+                    o->hash = str_hash;
+                    return MP_OBJ_FROM_PTR(o);
+                }
+
+                // Data has invalid UTF-8, handle based on error mode
+                #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+                // Error handlers are enabled
+                bool do_ignore = strcmp(errors, "ignore") == 0;
+                bool do_replace = strcmp(errors, "replace") == 0;
+
+                if (do_ignore || do_replace) {
+                    // Build new string skipping/replacing invalid bytes
+                    vstr_t vstr;
+                    vstr_init(&vstr, str_len);
+                    const byte *p = str_data;
+                    const byte *end = str_data + str_len;
+
+                    while (p < end) {
+                        byte c = *p;
+                        if (c < 0x80) {
+                            // Valid ASCII
+                            vstr_add_byte(&vstr, c);
+                            p++;
+                        } else if (c >= 0xc0 && c < 0xf8) {
+                            // Potential multi-byte sequence
+                            uint8_t need = (0xe5 >> ((c >> 3) & 0x6)) & 3;
+                            const byte *seq_start = p;
+                            p++;
+
+                            // Check continuation bytes
+                            uint8_t got = 0;
+                            while (got < need && p < end && UTF8_IS_CONT(*p)) {
+                                got++;
+                                p++;
+                            }
+
+                            if (got == need) {
+                                // Valid complete sequence, decode and add the character
+                                unichar ch = *seq_start & (0x7f >> need);
+                                for (uint8_t i = 0; i < need; i++) {
+                                    ch = (ch << 6) | (seq_start[i + 1] & 0x3f);
+                                }
+                                vstr_add_char(&vstr, ch);
+                            } else if (do_replace) {
+                                // Invalid or incomplete sequence - replace with U+FFFD
+                                vstr_add_char(&vstr, 0xFFFD);
+                            }
+                            // For 'ignore' mode, do nothing (skip invalid bytes)
+                        } else if (do_replace) {
+                            // Invalid start byte - replace with U+FFFD
+                            vstr_add_char(&vstr, 0xFFFD);
+                            p++;
+                        } else {
+                            // Invalid start byte - skip for 'ignore' mode
+                            p++;
+                        }
+                    }
+
+                    return mp_obj_new_str_type_from_vstr(type, &vstr);
+                } else {
+                    // Strict mode (or unrecognized error handler)
+                    mp_raise_msg(&mp_type_UnicodeError, NULL);
+                }
+                #else
+                // Error handlers are not enabled - just raise UnicodeError on invalid UTF-8
+                mp_raise_msg(&mp_type_UnicodeError, NULL);
+                #endif
+                #else
                 // Check if a qstr with this data already exists
                 qstr q = qstr_find_strn((const char *)str_data, str_len);
                 if (q != MP_QSTRnull) {
@@ -232,6 +317,7 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
                 o->data = str_data;
                 o->hash = str_hash;
                 return MP_OBJ_FROM_PTR(o);
+                #endif
             } else {
                 mp_buffer_info_t bufinfo;
                 mp_get_buffer_raise(args[0], &bufinfo, MP_BUFFER_READ);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -246,11 +246,24 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
                 // Data has invalid UTF-8, handle based on error mode
                 #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
                 // Error handlers are enabled
-                bool do_ignore = strcmp(errors, "ignore") == 0;
-                bool do_replace = strcmp(errors, "replace") == 0;
+                #if !MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
+                // Raise NotImplementedError if 'replace' is used but not enabled
+                if (strcmp(errors, "replace") == 0) {
+                    mp_raise_NotImplementedError(NULL);
+                }
+                #endif
 
-                if (do_ignore || do_replace) {
+                if (strcmp(errors, "ignore") == 0
+                    #if MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
+                    || strcmp(errors, "replace") == 0
+                    #endif
+                    ) {
                     // Build new string skipping/replacing invalid bytes
+                    #if MICROPY_PY_BUILTINS_BYTES_DECODE_REPLACE
+                    bool do_replace = strcmp(errors, "replace") == 0;
+                    #else
+                    const bool do_replace = false;
+                    #endif
                     vstr_t vstr;
                     vstr_init(&vstr, str_len);
                     const byte *p = str_data;
@@ -2069,6 +2082,17 @@ static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         new_args[1] = MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8);
         args = new_args;
         n_args++;
+    } else if (n_args >= 2) {
+        // Validate encoding parameter
+        // MicroPython only supports UTF-8 encoding
+        const char *encoding = mp_obj_str_get_str(args[1]);
+
+        // Accept utf-8 and ascii (ascii is a subset of utf-8)
+        if (!(strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "utf8") == 0 ||
+              strcmp(encoding, "ascii") == 0)) {
+            mp_raise_msg_varg(&mp_type_LookupError,
+                MP_ERROR_TEXT("encoding not supported: %s"), encoding);
+        }
     }
     return mp_obj_str_make_new(&mp_type_str, n_args, 0, args);
 }
@@ -2082,6 +2106,17 @@ static mp_obj_t str_encode(size_t n_args, const mp_obj_t *args) {
         new_args[1] = MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8);
         args = new_args;
         n_args++;
+    } else if (n_args >= 2) {
+        // Validate encoding parameter
+        // MicroPython only supports UTF-8 encoding
+        const char *encoding = mp_obj_str_get_str(args[1]);
+
+        // Accept utf-8 and ascii (ascii is a subset of utf-8)
+        if (!(strcmp(encoding, "utf-8") == 0 || strcmp(encoding, "utf8") == 0 ||
+              strcmp(encoding, "ascii") == 0)) {
+            mp_raise_msg_varg(&mp_type_LookupError,
+                MP_ERROR_TEXT("encoding not supported: %s"), encoding);
+        }
     }
     return bytes_make_new(NULL, n_args, 0, args);
 }

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1061,14 +1061,33 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(str_rstrip_obj, 1, 2, str_rstrip);
 static mp_obj_t str_center(mp_obj_t str_in, mp_obj_t width_in) {
     GET_STR_DATA_LEN(str_in, str, str_len);
     mp_uint_t width = mp_obj_get_int(width_in);
+
+    #if MICROPY_PY_BUILTINS_STR_UNICODE
+    // Get character count (not byte count) for proper Unicode handling
+    size_t char_len = utf8_charlen(str, str_len);
+    if (char_len >= width) {
+        return str_in;
+    }
+    // Calculate padding: width is in characters, need to convert to bytes for allocation
+    mp_uint_t padding_chars = width - char_len;
+    // Padding is always spaces (1 byte each), plus the original string bytes
+    mp_uint_t total_bytes = padding_chars + str_len;
+    #else
+    // Non-Unicode build: byte length equals character length
     if (str_len >= width) {
         return str_in;
     }
+    mp_uint_t total_bytes = width;
+    #endif // MICROPY_PY_BUILTINS_STR_UNICODE
 
     vstr_t vstr;
-    vstr_init_len(&vstr, width);
-    memset(vstr.buf, ' ', width);
+    vstr_init_len(&vstr, total_bytes);
+    memset(vstr.buf, ' ', total_bytes);
+    #if MICROPY_PY_BUILTINS_STR_UNICODE
+    int left = padding_chars / 2;
+    #else
     int left = (width - str_len) / 2;
+    #endif // MICROPY_PY_BUILTINS_STR_UNICODE
     memcpy(vstr.buf + left, str, str_len);
     return mp_obj_new_str_type_from_vstr(mp_obj_get_type(str_in), &vstr);
 }

--- a/py/objstrunicode.c
+++ b/py/objstrunicode.c
@@ -57,9 +57,11 @@ static void uni_print_quoted(const mp_print_t *print, const byte *str_data, uint
     mp_printf(print, "%c", quote_char);
     const byte *s = str_data, *top = str_data + str_len;
     while (s < top) {
+        const byte *seq_start = s;
         unichar ch;
         ch = utf8_get_char(s);
         s = utf8_next_char(s);
+        size_t seq_len = s - seq_start;
         if (ch == quote_char) {
             mp_printf(print, "\\%c", quote_char);
         } else if (ch == '\\') {
@@ -72,11 +74,19 @@ static void uni_print_quoted(const mp_print_t *print, const byte *str_data, uint
             mp_print_str(print, "\\r");
         } else if (ch == '\t') {
             mp_print_str(print, "\\t");
-        } else if (ch < 0x100) {
+        } else if (ch <= 127) {
             mp_printf(print, "\\x%02x", ch);
+        } else if (ch < 0xD800) {
+            // Printable Unicode character (excluding surrogates) - output UTF-8 bytes directly
+            print->print_strn(print->data, (const char *)seq_start, seq_len);
+        } else if (ch >= 0xE000 && ch < 0x110000) {
+            // Printable Unicode character (after surrogates) - output UTF-8 bytes directly
+            print->print_strn(print->data, (const char *)seq_start, seq_len);
         } else if (ch < 0x10000) {
+            // Surrogate (0xD800-0xDFFF) - output as \uXXXX escape.
             mp_printf(print, "\\u%04x", ch);
         } else {
+            // Invalid (>=0x110000) - output as \UXXXXXXXX escape.
             mp_printf(print, "\\U%08x", ch);
         }
     }

--- a/tests/basics/string_tstring_basic1.py.exp
+++ b/tests/basics/string_tstring_basic1.py.exp
@@ -16,14 +16,14 @@ Template(strings=('\\k',), interpolations=())
 Invalid \x escape: SyntaxError
 Invalid \u escape: SyntaxError
 Invalid \U escape: SyntaxError
-Template(strings=('\x00\x01\xff',), interpolations=())
+Template(strings=('\x00\x01ÿ',), interpolations=())
 Template(strings=('A',), interpolations=())
-Template(strings=('\u03b1',), interpolations=())
-Template(strings=('\u2764',), interpolations=())
+Template(strings=('α',), interpolations=())
+Template(strings=('❤',), interpolations=())
 Template(strings=('A',), interpolations=())
-Template(strings=('\U0001f600',), interpolations=())
+Template(strings=('😀',), interpolations=())
 Template(strings=('ABC',), interpolations=())
-Unicode: Template(strings=('Unicode test:\nEmoji: ', '\nSpecial: ', ''), interpolations=(Interpolation('\U0001f40d', "'\\U0001f40d'", None, ''), Interpolation('\u03b1 \u03b2 \u03b3', "'\\u03b1 \\u03b2 \\u03b3'", None, '')))
+Unicode: Template(strings=('Unicode test:\nEmoji: ', '\nSpecial: ', ''), interpolations=(Interpolation('🐍', "'\\U0001f40d'", None, ''), Interpolation('α β γ', "'\\u03b1 \\u03b2 \\u03b3'", None, '')))
 
 === Trailing whitespace preservation (PEP 750) ===
 Expression with trailing spaces: |x|

--- a/tests/cpydiff/types_bytes_decode_encoding.py
+++ b/tests/cpydiff/types_bytes_decode_encoding.py
@@ -1,0 +1,19 @@
+"""
+categories: Types,bytes
+description: bytes.decode() only supports 'utf-8' and 'ascii' encodings, not other encodings like 'latin-1'
+cause: MicroPython is optimized for embedded systems and only includes UTF-8 and ASCII codec support to save memory. Other encodings would require additional codec tables.
+workaround: Convert data to UTF-8 before processing, or implement custom encoding/decoding if needed.
+"""
+
+# CPython supports many encodings, MicroPython only utf-8 and ascii
+try:
+    b"\xe9".decode("latin-1")  # 'é' in latin-1
+    print("latin-1 supported")
+except (ValueError, NotImplementedError, LookupError) as e:
+    print("latin-1 not supported:", type(e).__name__)
+
+try:
+    b"\x80".decode("cp1252")  # Euro sign in cp1252
+    print("cp1252 supported")
+except (ValueError, NotImplementedError, LookupError) as e:
+    print("cp1252 not supported:", type(e).__name__)

--- a/tests/cpydiff/types_bytes_decode_kwargs.py
+++ b/tests/cpydiff/types_bytes_decode_kwargs.py
@@ -1,0 +1,19 @@
+"""
+categories: Types,bytes
+description: bytes.decode() does not accept keyword arguments, only positional arguments
+cause: MicroPython optimizes for code size and does not implement keyword argument handling for bytes.decode()
+workaround: Use positional arguments instead of keyword arguments
+"""
+
+# CPython accepts keyword arguments, MicroPython only accepts positional
+b = b"hello\xffworld"
+
+try:
+    # Using keyword arguments
+    result = b.decode(encoding="utf-8", errors="ignore")
+    print("kwargs supported:", repr(result))
+except TypeError as e:
+    print("kwargs not supported: TypeError")
+    # Workaround: use positional arguments
+    result = b.decode("utf-8", "ignore")
+    print("positional args work:", repr(result))

--- a/tests/cpydiff/types_str_repr_nonprintable.py
+++ b/tests/cpydiff/types_str_repr_nonprintable.py
@@ -1,0 +1,11 @@
+"""
+categories: Types,str
+description: repr() may print some non-printable Unicode characters literally instead of as escape sequences
+cause: MicroPython uses a simplified heuristic to determine printable characters, avoiding the need for a full Unicode character database (saves memory). It prints characters >= U+0080 (excluding surrogates) as UTF-8. CPython uses the Unicode database to identify non-printable characters like noncharacters (U+FFFx in each plane).
+workaround: Accept the difference for embedded use cases, or use ascii() or manual escaping if exact control is needed.
+"""
+
+# These are noncharacters that CPython escapes but MicroPython prints
+# showing as hex to avoid display issues in documentation tables
+print("U+FFFF:", repr("\uffff").encode("utf-8").hex())
+print("U+1FFFF:", repr("\U0001ffff").encode("utf-8").hex())

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1137,7 +1137,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
         # Print a note if this looks like it might have been a misfired unittest
         if not uses_unittest and not test_passed:
-            with open(test_file, "r") as f:
+            with open(test_file, "r", encoding="utf-8") as f:
                 if any(re.match("^import.+unittest", l) for l in f.readlines()):
                     print(
                         "NOTE: {} may be a unittest that doesn't run unittest.main()".format(

--- a/tests/unicode/bytes_decode_encoding.py
+++ b/tests/unicode/bytes_decode_encoding.py
@@ -1,0 +1,60 @@
+# Test bytes.decode() and str.encode() with encoding parameter validation
+
+# Check if decode method is available (requires MICROPY_CPYTHON_COMPAT)
+try:
+    b"".decode()
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+# Test valid encodings for bytes.decode()
+# utf-8 (default)
+print(b"hello".decode("utf-8"))
+print(b"hello".decode("utf8"))
+
+# ascii (subset of utf-8)
+print(b"hello".decode("ascii"))
+
+# Test valid encoding for str.encode()
+print("hello".encode("utf-8"))
+print("hello".encode("utf8"))
+print("hello".encode("ascii"))
+
+# Test with bytearray
+print(bytearray(b"test").decode("utf-8"))
+
+# Test that UTF-8 still works correctly with non-ASCII characters
+# © symbol (U+00A9)
+print(b"\xc2\xa9".decode("utf-8"))
+print("©".encode("utf-8"))
+
+# Test emoji 👍 (U+1F44D)
+print(b"\xf0\x9f\x91\x8d".decode("utf-8"))
+print("👍".encode("utf-8"))
+
+# Test invalid decoded code points in repr fallback path.
+print(repr(b"\xf4\x90\x80\x80".decode("utf-8")))
+print(repr(b"\xf5\x80\x80\x80".decode("utf-8")))
+
+# Test invalid encodings for bytes.decode()
+# These should raise LookupError
+invalid_encodings = ["latin-1", "latin1", "utf-16", "utf-32", "iso-8859-1", "cp1252"]
+
+for encoding in invalid_encodings:
+    try:
+        b"hello".decode(encoding)
+        print("UNEXPECTED:", encoding, "should raise LookupError")
+    except LookupError as e:
+        print("LookupError:", encoding)
+
+# Test bytes method accepting bytearray as argument (arg type normalization)
+print(b"hello world".find(bytearray(b"world")))
+print(bytearray(b"hello world").find(bytearray(b"world")))
+
+# Test invalid encodings for str.encode()
+for encoding in invalid_encodings:
+    try:
+        "hello".encode(encoding)
+        print("UNEXPECTED:", encoding, "should raise LookupError")
+    except LookupError as e:
+        print("LookupError:", encoding)

--- a/tests/unicode/bytes_decode_encoding.py.exp
+++ b/tests/unicode/bytes_decode_encoding.py.exp
@@ -1,0 +1,27 @@
+hello
+hello
+hello
+b'hello'
+b'hello'
+b'hello'
+test
+©
+b'\xc2\xa9'
+👍
+b'\xf0\x9f\x91\x8d'
+'\U00110000'
+'\U00140000'
+LookupError: latin-1
+LookupError: latin1
+LookupError: utf-16
+LookupError: utf-32
+LookupError: iso-8859-1
+LookupError: cp1252
+6
+6
+LookupError: latin-1
+LookupError: latin1
+LookupError: utf-16
+LookupError: utf-32
+LookupError: iso-8859-1
+LookupError: cp1252

--- a/tests/unicode/bytes_decode_ignore.py
+++ b/tests/unicode/bytes_decode_ignore.py
@@ -1,0 +1,105 @@
+# Test bytes.decode() with error handler 'ignore'
+
+# Check if decode method is available (requires MICROPY_CPYTHON_COMPAT)
+try:
+    b"".decode()
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+# Check if error handlers are available (requires MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS)
+# When feature is disabled, invalid UTF-8 raises LookupError even with 'ignore'
+# When feature is enabled, invalid UTF-8 with 'ignore' returns a string
+try:
+    result = b"\xff".decode("utf-8", "ignore")
+    # If we get here, feature is available
+except (UnicodeError, LookupError):
+    # Feature not available - 'ignore' was ignored, strict mode was used
+    print("SKIP")
+    raise SystemExit
+
+# Test ignore mode with invalid UTF-8
+print(repr(b"\xff\xfe".decode("utf-8", "ignore")))
+
+# Test strict mode (default) with invalid UTF-8
+try:
+    b"\xff\xfe".decode("utf-8")
+    print("UNEXPECTED")
+except UnicodeError:
+    print("UnicodeError")
+
+# Test strict mode (explicit) with invalid UTF-8
+try:
+    b"\xff\xfe".decode("utf-8", "strict")
+    print("UNEXPECTED")
+except UnicodeError:
+    print("UnicodeError")
+
+# Test with valid UTF-8
+print(repr(b"hello".decode("utf-8", "ignore")))
+
+# Test valid UTF-8 with default mode
+print(repr(b"hello".decode("utf-8")))
+
+# Test mixed valid and invalid UTF-8
+print(repr(b"hello\xffworld".decode("utf-8", "ignore")))
+
+# Test multiple invalid bytes
+print(repr(b"\x80\x81\x82".decode("utf-8", "ignore")))
+
+# Test invalid continuation byte
+print(repr(b"\xc0\x20".decode("utf-8", "ignore")))
+
+# Test incomplete sequence at end
+print(repr(b"hello\xc0".decode("utf-8", "ignore")))
+
+# Test valid multi-byte UTF-8 (© symbol)
+print(repr(b"\xc2\xa9".decode("utf-8", "ignore")))
+
+# Test bytearray support
+print(repr(bytearray(b"\xff\xfe").decode("utf-8", "ignore")))
+
+# Additional tests for continuation byte validation and incomplete sequences
+
+# Test 3-byte UTF-8 sequence - valid (e.g., U+4E00 - 一)
+print(repr(b"\xe4\xb8\x80".decode("utf-8", "ignore")))
+
+# Test 4-byte UTF-8 sequence - valid (e.g., U+1F600 - 😀)
+print(repr(b"\xf0\x9f\x98\x80".decode("utf-8", "ignore")))
+
+# Test incomplete 3-byte sequence (missing 2 continuation bytes)
+print(repr(b"\xe4".decode("utf-8", "ignore")))
+
+# Test incomplete 3-byte sequence (missing 1 continuation byte)
+print(repr(b"\xe4\xb8".decode("utf-8", "ignore")))
+
+# Test incomplete 4-byte sequence (missing 3 continuation bytes)
+print(repr(b"\xf0".decode("utf-8", "ignore")))
+
+# Test incomplete 4-byte sequence (missing 2 continuation bytes)
+print(repr(b"\xf0\x9f".decode("utf-8", "ignore")))
+
+# Test incomplete 4-byte sequence (missing 1 continuation byte)
+print(repr(b"\xf0\x9f\x98".decode("utf-8", "ignore")))
+
+# Test 3-byte sequence with invalid continuation byte (first byte invalid)
+print(repr(b"\xe4\x20\x80".decode("utf-8", "ignore")))
+
+# Test 3-byte sequence with invalid continuation byte (second byte invalid)
+print(repr(b"\xe4\xb8\x20".decode("utf-8", "ignore")))
+
+# Test 4-byte sequence with invalid continuation bytes
+print(repr(b"\xf0\x20\x98\x80".decode("utf-8", "ignore")))
+print(repr(b"\xf0\x9f\x20\x80".decode("utf-8", "ignore")))
+print(repr(b"\xf0\x9f\x98\x20".decode("utf-8", "ignore")))
+
+# Test mixed valid and incomplete sequences
+print(repr(b"hello\xe4world".decode("utf-8", "ignore")))
+print(repr(b"hello\xf0world".decode("utf-8", "ignore")))
+
+# Test valid multi-byte sequence mixed with invalid bytes (exercises got==need path)
+print(repr(b"\xff\xc2\xa9".decode("utf-8", "ignore")))  # © preserved after invalid \xff
+print(repr(b"\xff\xe4\xb8\x80".decode("utf-8", "ignore")))  # 一 preserved after invalid \xff
+
+# Test multiple incomplete sequences in a row
+print(repr(b"\xe4\xf0\xe4".decode("utf-8", "ignore")))

--- a/tests/unicode/bytes_decode_replace.py
+++ b/tests/unicode/bytes_decode_replace.py
@@ -1,0 +1,126 @@
+# Test bytes.decode() with error handler 'replace'
+
+# Check if decode method is available (requires MICROPY_CPYTHON_COMPAT)
+try:
+    b"".decode()
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+# Check if error handlers are available (requires MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS)
+# When feature is disabled, invalid UTF-8 raises UnicodeError even with 'replace'
+# When feature is enabled, invalid UTF-8 with 'replace' returns a string
+try:
+    result = b"\xff".decode("utf-8", "replace")
+    # If we get here, feature is available
+except (UnicodeError, LookupError):
+    # Feature not available - 'replace' was ignored, strict mode was used
+    print("SKIP")
+    raise SystemExit
+
+# Test replace mode with invalid UTF-8
+print(repr(b"\xff\xfe".decode("utf-8", "replace")))
+
+# Test strict mode (default) with invalid UTF-8
+try:
+    b"\xff\xfe".decode("utf-8")
+    print("UNEXPECTED")
+except UnicodeError:
+    print("UnicodeError")
+
+# Test strict mode (explicit) with invalid UTF-8
+try:
+    b"\xff\xfe".decode("utf-8", "strict")
+    print("UNEXPECTED")
+except UnicodeError:
+    print("UnicodeError")
+
+# Test with valid UTF-8
+print(repr(b"hello".decode("utf-8", "replace")))
+
+# Test valid UTF-8 with default mode
+print(repr(b"hello".decode("utf-8")))
+
+# Test mixed valid and invalid UTF-8
+print(repr(b"hello\xffworld".decode("utf-8", "replace")))
+
+# Test multiple invalid bytes
+print(repr(b"\x80\x81\x82".decode("utf-8", "replace")))
+
+# Test invalid continuation byte
+print(repr(b"\xc0\x20".decode("utf-8", "replace")))
+
+# Test incomplete sequence at end
+print(repr(b"hello\xc0".decode("utf-8", "replace")))
+
+# Test valid multi-byte UTF-8 (© symbol)
+print(repr(b"\xc2\xa9".decode("utf-8", "replace")))
+
+# Test bytearray support
+print(repr(bytearray(b"\xff\xfe").decode("utf-8", "replace")))
+
+# Test replace mode - should either work or raise NotImplementedError
+try:
+    result = b"\xff\xfe".decode("utf-8", "replace")
+    print(repr(result))
+except LookupError:
+    print("LookupError")
+
+# Test replace with valid UTF-8
+try:
+    result = b"hello".decode("utf-8", "replace")
+    print(repr(result))
+except LookupError:
+    print("LookupError")
+
+# Test replace with mixed content
+try:
+    result = b"hello\xffworld".decode("utf-8", "replace")
+    print(repr(result))
+except LookupError:
+    print("LookupError")
+
+# Additional tests for continuation byte validation and incomplete sequences
+
+# Test 3-byte UTF-8 sequence - valid (e.g., U+4E00 - 一)
+print(repr(b"\xe4\xb8\x80".decode("utf-8", "replace")))
+
+# Test 4-byte UTF-8 sequence - valid (e.g., U+1F600 - 😀)
+print(repr(b"\xf0\x9f\x98\x80".decode("utf-8", "replace")))
+
+# Test valid multi-byte sequence mixed with invalid bytes (exercises got==need path)
+print(repr(b"\xff\xc2\xa9".decode("utf-8", "replace")))  # \ufffd + © after invalid \xff
+print(repr(b"\xff\xe4\xb8\x80".decode("utf-8", "replace")))  # \ufffd + 一 after invalid \xff
+
+# Test incomplete 3-byte sequence (missing 2 continuation bytes)
+print(repr(b"\xe4".decode("utf-8", "replace")))
+
+# Test incomplete 3-byte sequence (missing 1 continuation byte)
+print(repr(b"\xe4\xb8".decode("utf-8", "replace")))
+
+# Test incomplete 4-byte sequence (missing 3 continuation bytes)
+print(repr(b"\xf0".decode("utf-8", "replace")))
+
+# Test incomplete 4-byte sequence (missing 2 continuation bytes)
+print(repr(b"\xf0\x9f".decode("utf-8", "replace")))
+
+# Test incomplete 4-byte sequence (missing 1 continuation byte)
+print(repr(b"\xf0\x9f\x98".decode("utf-8", "replace")))
+
+# Test 3-byte sequence with invalid continuation byte (first byte invalid)
+print(repr(b"\xe4\x20\x80".decode("utf-8", "replace")))
+
+# Test 3-byte sequence with invalid continuation byte (second byte invalid)
+print(repr(b"\xe4\xb8\x20".decode("utf-8", "replace")))
+
+# Test 4-byte sequence with invalid continuation bytes
+print(repr(b"\xf0\x20\x98\x80".decode("utf-8", "replace")))
+print(repr(b"\xf0\x9f\x20\x80".decode("utf-8", "replace")))
+print(repr(b"\xf0\x9f\x98\x20".decode("utf-8", "replace")))
+
+# Test mixed valid and incomplete sequences
+print(repr(b"hello\xe4world".decode("utf-8", "replace")))
+print(repr(b"hello\xf0world".decode("utf-8", "replace")))
+
+# Test multiple incomplete sequences in a row
+print(repr(b"\xe4\xf0\xe4".decode("utf-8", "replace")))

--- a/tests/unicode/str_center.py
+++ b/tests/unicode/str_center.py
@@ -1,0 +1,36 @@
+# Test str.center() with Unicode characters
+# Issue #17827
+
+try:
+    str.center
+except AttributeError:
+    print("SKIP")
+    raise SystemExit
+
+# ASCII baseline
+print("hello".center(10))
+
+# Latin with accent (é is 2 bytes in UTF-8)
+print("héllo".center(10))
+
+# Chinese (each char is 3 bytes in UTF-8)
+print("你好".center(10))
+
+# Emoji (4 bytes in UTF-8)
+print("🎉".center(5))
+
+# German with umlaut
+print("München".center(15))
+
+# Cyrillic
+print("Москва".center(12))
+
+# Edge cases
+print("test".center(4))  # Exact fit
+print("test".center(3))  # String longer than width
+print("x".center(1))  # Single char, exact fit
+print("".center(5))  # Empty string
+
+# Mixed ASCII and Unicode
+print("café".center(10))
+print("hello世界".center(12))

--- a/tests/unicode/str_from_buffer_errors.py
+++ b/tests/unicode/str_from_buffer_errors.py
@@ -1,0 +1,39 @@
+# str(buffer, encoding, errors) should apply the 'ignore'/'replace' error
+# handlers to any buffer source (array.array, memoryview, ...), the same way it
+# does for bytes and bytearray.  Companion to str_from_buffer_snapshot.py.
+
+try:
+    import array
+
+    memoryview
+except (ImportError, NameError):
+    print("SKIP")
+    raise SystemExit
+
+# Requires the decode error handlers (MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS).
+# When the feature is disabled, invalid UTF-8 raises even with 'replace'.
+try:
+    str(memoryview(b"\xff"), "utf-8", "replace")
+except UnicodeError:
+    print("SKIP")
+    raise SystemExit
+
+# array.array holding invalid UTF-8 bytes (typecode "B" keeps this endian-neutral).
+a = array.array("B", b"a\xffb\x80c")
+print(repr(str(a, "utf-8", "replace")))
+print(repr(str(a, "utf-8", "ignore")))
+
+# A memoryview over invalid UTF-8 (0xc3 0x28 is an invalid 2-byte sequence).
+mv = memoryview(b"x\xc3\x28y")
+print(repr(str(mv, "utf-8", "replace")))
+print(repr(str(mv, "utf-8", "ignore")))
+
+# Strict decoding (the default) must still raise for a buffer source.
+try:
+    str(memoryview(b"a\xffb"), "utf-8")
+    print("UNEXPECTED")
+except UnicodeError:
+    print("UnicodeError")
+
+# A valid-UTF-8 buffer passes through an error handler unchanged ("café").
+print(repr(str(array.array("B", b"caf\xc3\xa9"), "utf-8", "replace")))  # codespell:ignore caf

--- a/tests/unicode/str_from_buffer_snapshot.py
+++ b/tests/unicode/str_from_buffer_snapshot.py
@@ -1,0 +1,30 @@
+# Companion to str_from_bytearray.py: str()/bytes() built from other mutable
+# buffer sources (array.array and a writable memoryview) must also be independent
+# snapshots, not views onto the source buffer.
+try:
+    import array
+
+    memoryview
+except (ImportError, NameError):
+    print("SKIP")
+    raise SystemExit
+
+# Non-interned byte-literal payloads (with raw UTF-8 sequences) avoid relying on
+# str.encode() to build the test data.
+
+# array.array is a mutable buffer source; str()/bytes() must snapshot the data.
+# Content decodes to "array ünicode 🐍 target!".
+a = array.array("B", b"array \xc3\xbcnicode \xf0\x9f\x90\x8d target!")
+s = str(a, "utf-8")
+b = bytes(a)
+a[0] = ord("X")
+print(s)
+print(b)
+
+# A writable memoryview (here over an array) is also a mutable source.
+# Content decodes to "memoryview över 🐍 python!".
+a = array.array("B", b"memoryview \xc3\xb6ver \xf0\x9f\x90\x8d python!")
+mv = memoryview(a)
+s = str(mv, "utf-8")
+a[0] = ord("X")
+print(s)

--- a/tests/unicode/str_from_bytearray.py
+++ b/tests/unicode/str_from_bytearray.py
@@ -1,0 +1,50 @@
+# Test that a str/bytes created from a bytearray is an independent snapshot,
+# and not a view onto the (mutable) bytearray buffer.  Mutating or resizing the
+# source bytearray afterwards must not change the previously created object.
+
+# Skip if needed via `skip_bytearray` logic in run-tests.py
+
+# Non-interned payloads (byte literals) are used so the result isn't returned as
+# an existing qstr.  Every scenario is covered with plain-ASCII data so the core
+# bytearray paths are exercised directly; a couple of cases embed raw UTF-8 byte
+# sequences to also cover multi-byte Unicode decoding, without relying on
+# str.encode() to build the test data.
+
+# str(bytearray, ...) then mutate the source in place.
+ba = bytearray(b"the quick brown fox jumped over!")
+s = str(ba, "utf-8")
+ba[0] = ord("T")
+print(s)
+print(s[0])
+
+# Same, but with multi-byte UTF-8 content: "café naïve 🐍 snapshot!".
+ba = bytearray(b"caf\xc3\xa9 na\xc3\xafve \xf0\x9f\x90\x8d snapshot!")  # codespell:ignore caf
+s = str(ba, "utf-8")
+ba[0] = ord("X")
+print(s)
+
+# Overwriting every byte of the source must not change the str.
+ba = bytearray(b"snapshot test one two three four!")
+s = str(ba, "utf-8")
+for i in range(len(ba)):
+    ba[i] = ord("x")
+print(s)
+
+# Growing the bytearray reallocates its buffer; the str must stay intact.
+ba = bytearray(b"grow test alpha bravo charlie delta!")
+s = str(ba, "utf-8")
+for _ in range(1000):
+    ba.append(ord("Z"))
+print(s)
+
+# bytes(bytearray) is likewise an independent snapshot.
+ba = bytearray(b"bytes snapshot alpha bravo charlie!")
+b = bytes(ba)
+ba[0] = ord("X")
+print(b)
+
+# Same, but with multi-byte UTF-8 content: "bytes ünicode 🐍 snakes!".
+ba = bytearray(b"bytes \xc3\xbcnicode \xf0\x9f\x90\x8d snakes!")
+b = bytes(ba)
+ba[0] = ord("X")
+print(b)

--- a/tests/unicode/unicode.py
+++ b/tests/unicode/unicode.py
@@ -17,11 +17,6 @@ for i in range(-len(s), len(s)):
 enc = s.encode()
 print(enc, enc.decode() == s)
 
-# printing of unicode chars using repr
-# NOTE: for some characters (eg \u10ff) we differ to CPython
-print(repr("a\uffff"))
-print(repr("a\U0001ffff"))
-
 # test invalid escape code
 try:
     eval('"\\U00110000"')

--- a/tests/unicode/unicode.py
+++ b/tests/unicode/unicode.py
@@ -46,3 +46,13 @@ try:
     str(b"\xf0\xe0\xed\xe8", "utf8")
 except UnicodeError:
     print("UnicodeError")
+
+# test surrogate repr uses \uXXXX escape
+print(repr(chr(0xD800)))
+
+# test str() from buffer-protocol object (memoryview)
+print(str(memoryview(b"hello"), "utf-8"))
+try:
+    str(memoryview(b"\xff"), "utf-8")
+except UnicodeError:
+    print("UnicodeError")

--- a/tests/unicode/unicode_char_format.py
+++ b/tests/unicode/unicode_char_format.py
@@ -1,0 +1,58 @@
+# test %c formatting with unicode characters (issue #3364)
+# tests that character codes >= 128 are properly encoded as UTF-8
+
+print("%c%c" % (0x3BC, 0x1F40D))  # Greek letter mu and snake emoji
+
+# ASCII character
+print("%c" % 65)
+
+# 2-byte UTF-8 characters
+print("%c" % 128)
+print("%c" % 169)  # copyright symbol ©
+print("%c" % 255)
+
+# 3-byte UTF-8 character
+print("%c" % 0x4E00)  # CJK ideograph 一
+
+# 4-byte UTF-8 character
+print("%c" % 0x1F600)  # emoji 😀
+
+# test with .format() method
+print("{:c}".format(169))
+print("{:c}".format(0x4E00))
+print("{:c}{:c}".format(0x3BC, 0x1F40D))
+
+# test with f-strings
+c = 169
+print(f"{c:c}")
+c = 0x1F600
+print(f"{c:c}")
+
+# Test boundary values - valid maximum unicode codepoint
+print("%c" % 0x10FFFF)  # Last valid unicode codepoint
+
+# Test invalid codepoint - >= 0x110000 should raise OverflowError
+try:
+    print("%c" % 0x110000)
+    print("UNEXPECTED: should have raised OverflowError")
+except OverflowError:
+    print("OverflowError")
+
+try:
+    print("%c" % 0x110001)
+    print("UNEXPECTED: should have raised OverflowError")
+except OverflowError:
+    print("OverflowError")
+
+# Test format() method with invalid codepoint
+try:
+    print("{:c}".format(0x110000))
+    print("UNEXPECTED: should have raised OverflowError")
+except OverflowError:
+    print("OverflowError")
+
+try:
+    print("{:c}".format(0x200000))
+    print("UNEXPECTED: should have raised OverflowError")
+except OverflowError:
+    print("OverflowError")


### PR DESCRIPTION
### Summary

Improving Unicode support in MicroPython is not just a technical improvement—it's a commitment to global accessibility, educational equity, and inclusive computing. With a limited memory cost of ~0.05%, this enhancement removes barriers for users worldwide and aligns MicroPython with CPython compatibility goals while staying true to its mission of bringing Python to everyone, everywhere. PEP 3131 (2007) established Unicode identifiers as a Python standard, UTF-8 is the universal encoding for modern software development, and MicroPython should support these standards where possible.

This pull request addresses multiple issues related to the handling of Unicode characters and encoding in MicroPython. 
 - Implements validation for the `bytes.decode()` method to ensure only valid encodings are accepted, specifically `utf-8`, `utf8`, and `ascii`. 
 - Introduce support for 'ignore' and 'replace' error handlers in `bytes.decode()`, fixing issues where invalid encodings did not raise appropriate exceptions. The API is now CPython compatible, only not accepting kwargs.
 - Enhances string formatting to correctly handle multi-byte UTF-8 characters, addressing issues where character codes greater than 127 were truncated. 
 - Fixes the `str.center()` method to accurately count Unicode characters instead of bytes, ensuring proper padding for multi-byte characters.

Fixes: #15849
Fixes: #3364
Fixes: #17827

Related PRs:
 - https://github.com/micropython/micropython/pull/18853

This is a re-submit of #18670 which was unrecoverably closed due to user error.

### Testing

Testing has been conducted across various platforms, including ESP32, RP2, and Unix , with all relevant tests passing successfully. This includes new tests for encoding validation, error handling, and Unicode character formatting.

As Unicode offers a very large set of codepoints I have based the testing on Unicode test data in 127 languages and script combinations that are available in [unicode_mpy](https://github.com/Josverl/unicode_mpy)
Using this test set has allowed me to find additional issues that were not yet reported. 

The new tests that have been added to the MicroPython test suite have been based on the examples provided in issues, and on issues found though this test set.

### Trade-offs and Alternatives
- Currently the unicode functionality is enabled progressively based on MICROPY_CONFIG_ROM_LEVEL to reduce memory impact on constrained systems. Perhaps it should be made available on all levels, and only disabled explicitly for the most constrained systems.
-  `bytes.decode()` does not accept kwargs to reduce firmware size. 
-  The `str.center()` method does currently not currently handle the width correctly for multi-byte Unicode characters.
- The current focus is of Left-to-Right (LTR) scripts, Specific functionality for RTL scrips have not been verified.
- There are additional Unicode issues with the MicroPython REPL that are not part of this PR. The handling of characters with differentiated widths requires lookup tables that take about 88kb, which is a significant size. 
- Also the current test tooling is not capable to run tests in the REPL context. 

These issues can be addressed in future PRs.
