### PR TITLE
ports/stm32: support more stm32g4 variants.

### DIFF
--- a/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_G474RE/mpconfigboard.h
@@ -16,6 +16,9 @@
 #define MICROPY_HW_CLK_PLLQ         (8)
 #define MICROPY_HW_CLK_PLLR         (2)
 
+// The board has a 32.768 kHz LSE, solder bridge selectable, on by default
+#define MICROPY_HW_RTC_USE_LSE      (1)
+
 #define MICROPY_HW_CLK_USE_HSI48    (1) // for RNG
 
 // 4 wait states

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -537,15 +537,26 @@ MP_WEAK void SystemClock_Config(void) {
         MICROPY_BOARD_FATAL_ERROR("HAL_RCC_ClockConfig");
     }
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_LPUART1
-        | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_ADC12 | RCC_PERIPHCLK_ADC345
+        | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_ADC12
         | RCC_PERIPHCLK_FDCAN | RCC_PERIPHCLK_USB;
+    #if defined(RCC_PERIPHCLK_ADC345)
+    PeriphClkInitStruct.PeriphClockSelection |= RCC_PERIPHCLK_ADC345;
+    PeriphClkInitStruct.Adc345ClockSelection = RCC_ADC345CLKSOURCE_SYSCLK;
+    #endif
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
     PeriphClkInitStruct.Lpuart1ClockSelection = RCC_LPUART1CLKSOURCE_PCLK1;
+    #if MICROPY_HW_CLK_USE_HSI
+    PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
+    #else
     PeriphClkInitStruct.FdcanClockSelection = RCC_FDCANCLKSOURCE_HSE;
+    #endif
     PeriphClkInitStruct.RngClockSelection = RCC_RNGCLKSOURCE_HSI48;
     PeriphClkInitStruct.Adc12ClockSelection = RCC_ADC12CLKSOURCE_SYSCLK;
-    PeriphClkInitStruct.Adc345ClockSelection = RCC_ADC345CLKSOURCE_SYSCLK;
+    #if MICROPY_HW_RTC_USE_LSE
     PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+    #else
+    PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    #endif
     if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK) {
         MICROPY_BOARD_FATAL_ERROR("HAL_RCCEx_PeriphCLKConfig");
     }

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -903,7 +903,7 @@ static const uint32_t tim_instance_table[MICROPY_HW_MAX_TIMER] = {
     #if defined(TIM7)
     #if defined(STM32G0)
     TIM_ENTRY(7, TIM7_LPTIM2_IRQn),
-    #elif defined(STM32G4)
+    #elif defined(STM32G473xx) || defined(STM32G474xx) || defined(STM32G483xx) || defined(STM32G484xx)
     TIM_ENTRY(7, TIM7_DAC_IRQn),
     #else
     TIM_ENTRY(7, TIM7_IRQn),


### PR DESCRIPTION
- `timer.c`
  - `TIM_ENTRY(7, ...)` sets IRQ based on specific STM32G4 part
- `system_stm32.c`
  - Support parts without external clock

### Summary

Building for STM32G4 without external oscillator support required some modifications.
Timer 7 configuration is different for some STM32G4 variants.

### Testing

Testing was done on a custom board with STM32G491 using internal clock.

