### PR TITLE
unix: Fix build on GNU/Hurd.

### DIFF
--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -112,6 +112,8 @@
 #define MICROPY_PLATFORM_SYSTEM         "Android"
 #elif defined(__linux)
 #define MICROPY_PLATFORM_SYSTEM         "Linux"
+#elif defined(__GNU__)
+#define MICROPY_PLATFORM_SYSTEM         "GNU"
 #elif defined(__unix__)
 #define MICROPY_PLATFORM_SYSTEM         "Unix"
 #elif defined(__CYGWIN__)

--- a/extmod/vfs_fat.h
+++ b/extmod/vfs_fat.h
@@ -36,7 +36,7 @@ typedef struct _fs_user_mount_t {
     FATFS fatfs;
 } fs_user_mount_t;
 
-extern const byte fresult_to_errno_table[20];
+extern const mp_errno_t fresult_to_errno_table[20];
 extern const mp_obj_type_t mp_fat_vfs_type;
 extern const mp_obj_type_t mp_type_vfs_fat_fileio;
 extern const mp_obj_type_t mp_type_vfs_fat_textio;

--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -36,7 +36,7 @@
 #include "extmod/vfs_fat.h"
 
 // this table converts from FRESULT to POSIX errno
-const byte fresult_to_errno_table[20] = {
+const mp_errno_t fresult_to_errno_table[20] = {
     [FR_OK] = 0,
     [FR_DISK_ERR] = MP_EIO,
     [FR_INT_ERR] = MP_EIO,

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -26,7 +26,11 @@
 
 // options to control how MicroPython is built
 
+#ifdef PATH_MAX
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
+#else
+#define MICROPY_ALLOC_PATH_MAX      (4096)
+#endif
 #define MICROPY_PERSISTENT_CODE_LOAD (0)
 #define MICROPY_PERSISTENT_CODE_LOAD_NATIVE (0)
 #define MICROPY_PERSISTENT_CODE_SAVE (1)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -146,7 +146,11 @@ typedef long mp_off_t;
 #define MICROPY_FATFS_MAX_SS           (4096)
 #define MICROPY_FATFS_LFN_CODE_PAGE    437 /* 1=SFN/ANSI 437=LFN/U.S.(OEM) */
 
+#ifdef PATH_MAX
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
+#else
+#define MICROPY_ALLOC_PATH_MAX      (4096)
+#endif
 
 // Ensure builtinimport.c works with -m.
 #define MICROPY_MODULE_OVERRIDE_MAIN_IMPORT (1)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -45,6 +45,8 @@
 #ifndef MICROPY_PY_SYS_PLATFORM
 #if defined(__APPLE__) && defined(__MACH__)
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
+#elif defined(__GNU__)
+    #define MICROPY_PY_SYS_PLATFORM  "GNU"
 #else
     #define MICROPY_PY_SYS_PLATFORM  "linux"
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -227,6 +227,11 @@ static inline unsigned long mp_random_seed_init(void) {
 #include <stdio.h>
 #endif
 
+#ifdef __GNU__
+// GNU/Hurd uses large error numbers.
+#define MICROPY_ERRNO_POSIX (1)
+#endif
+
 // Configure the implementation of machine.idle().
 #include <sched.h>
 #define MICROPY_UNIX_MACHINE_IDLE sched_yield();

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1185,6 +1185,19 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_USE_INTERNAL_ERRNO (0)
 #endif
 
+// Strictly compliant with POSIX that error values are of type int.  This only
+// needs to be set on systems that disable MICROPY_USE_INTERNAL_ERRNO and have
+// large errno values.
+#ifndef MICROPY_ERRNO_POSIX
+#define MICROPY_ERRNO_POSIX (0)
+#endif
+
+#if MICROPY_ERRNO_POSIX
+typedef int mp_errno_t;
+#else
+typedef char mp_errno_t;
+#endif
+
 // Whether to use internally defined *printf() functions (otherwise external ones)
 #ifndef MICROPY_USE_INTERNAL_PRINTF
 #define MICROPY_USE_INTERNAL_PRINTF (1)


### PR DESCRIPTION
A POSIX compatible system doesn't have to define PATH_MAX if it has no such inherent restriction on path lengths. Thus it fails to build on the GNU Hurd since it does not have such a restriction. Since MicroPython is already memory-aware, we plunge a reasonably large PATH_MAX for this case.