### PR TITLE
extmod/modtls_mbedtls: Factor out mbedtls_hardware_poll().

### DIFF
--- a/extmod/mbedtls/mbedtls_alt.c
+++ b/extmod/mbedtls/mbedtls_alt.c
@@ -86,3 +86,20 @@ int __wrap_mbedtls_ecdsa_write_signature(mbedtls_ecdsa_context *ctx,
     return ret;
 }
 #endif
+
+#include "py/mpconfig.h"
+
+#if MICROPY_PY_SSL && MICROPY_SSL_MBEDTLS
+#include "mbedtls/mbedtls_config_port.h"
+
+#if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
+#include "py/mphal.h"
+
+int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
+    *olen = len;
+    mp_hal_get_random(len, output);
+    return 0;
+}
+#endif
+
+#endif

--- a/ports/alif/mbedtls/mbedtls_port.c
+++ b/ports/alif/mbedtls/mbedtls_port.c
@@ -28,22 +28,6 @@
 #include "se_services.h"
 #include "mbedtls_config_port.h"
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    uint32_t val = 0;
-    int n = 0;
-    *olen = len;
-    while (len--) {
-        if (!n) {
-            val = se_services_rand64();
-            n = 4;
-        }
-        *output++ = val;
-        val >>= 8;
-        --n;
-    }
-    return 0;
-}
-
 #if defined(MBEDTLS_HAVE_TIME)
 
 time_t alif_mbedtls_time(time_t *timer) {

--- a/ports/mimxrt/mbedtls/mbedtls_port.c
+++ b/ports/mimxrt/mbedtls/mbedtls_port.c
@@ -36,13 +36,6 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    *olen = len;
-    mp_hal_get_random(len, output);
-
-    return 0;
-}
-
 #if defined(MBEDTLS_HAVE_TIME)
 time_t mimxrt_rtctime_seconds(time_t *timer) {
     // Get date and date in CPython order.

--- a/ports/renesas-ra/mbedtls/mbedtls_port.c
+++ b/ports/renesas-ra/mbedtls/mbedtls_port.c
@@ -33,22 +33,6 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    uint32_t val = 0;
-    int n = 0;
-    *olen = len;
-    while (len--) {
-        if (!n) {
-            val = rng_read();
-            n = 4;
-        }
-        *output++ = val;
-        val >>= 8;
-        --n;
-    }
-    return 0;
-}
-
 #if defined(MBEDTLS_HAVE_TIME)
 time_t ra_rtctime_seconds(time_t *timer) {
     rtc_init_finalise();

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -477,6 +477,10 @@ if (MICROPY_PY_NETWORK_WIZNET5K)
     )
 endif()
 
+list(APPEND MICROPY_SOURCE_EXTMOD
+    ${MICROPY_EXTMOD_DIR}/mbedtls/mbedtls_alt.c
+)
+
 # Add qstr sources for extmod and usermod, in case they are modified by components above.
 list(APPEND MICROPY_SOURCE_QSTR
     ${MICROPY_SOURCE_EXTMOD}

--- a/ports/rp2/mbedtls/mbedtls_port.c
+++ b/ports/rp2/mbedtls/mbedtls_port.c
@@ -35,17 +35,6 @@
 #include "mbedtls/platform_time.h"
 #include "pico/aon_timer.h"
 
-#include "pico/rand.h"
-
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    *olen = len;
-    for (size_t i = 0; i < len; i += 8) {
-        uint64_t rand64 = get_rand_64();
-        memcpy(output + i, &rand64, MIN(len - i, 8));
-    }
-    return 0;
-}
-
 time_t rp2_rtctime_seconds(time_t *timer) {
     struct timespec ts;
     aon_timer_get_time(&ts);

--- a/ports/stm32/mbedtls/mbedtls_port.c
+++ b/ports/stm32/mbedtls/mbedtls_port.c
@@ -33,22 +33,6 @@
 #include "mbedtls/platform_time.h"
 #endif
 
-int mbedtls_hardware_poll(void *data, unsigned char *output, size_t len, size_t *olen) {
-    uint32_t val = 0;
-    int n = 0;
-    *olen = len;
-    while (len--) {
-        if (!n) {
-            val = rng_get();
-            n = 4;
-        }
-        *output++ = val;
-        val >>= 8;
-        --n;
-    }
-    return 0;
-}
-
 #if defined(MBEDTLS_HAVE_TIME)
 time_t stm32_rtctime_seconds(time_t *timer) {
     rtc_init_finalise();


### PR DESCRIPTION
### Summary

Factor out mbedtls_hardware_poll() using the common function mp_hal_get_random().

### Testing

The ports alif, mimxrt, renesas-ra, rp2 and stm32 are addresses by this change. For each port a board's firmware which use mbedtls was built successfully. The firmware was tested with PYBD_SF6, Teensy 4.1 and RP2 Pico W using tests/net_inet and tests/net_hosted and showed the same coverage with and without this PR, although RP2 PIco W failed/skipped all tests from tests/net_inet.
