### PR TITLE
esp32/esp32_common.cmake: Add missing C flags to user C module sources.

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -277,6 +277,11 @@ target_compile_options(${MICROPY_TARGET} PUBLIC
     -Wno-missing-field-initializers
 )
 
+# User C modules don't pick up certain compile options set by the IDF, most
+# importantly the optimisation level.  So set them here.
+idf_build_get_property(idf_compile_options COMPILE_OPTIONS)
+target_compile_options(usermod INTERFACE ${idf_compile_options})
+
 # Additional include directories needed for private NimBLE headers.
 target_include_directories(${MICROPY_TARGET} PUBLIC
     ${IDF_PATH}/components/bt/host/nimble/nimble


### PR DESCRIPTION
### Summary

On esp32 when adding a user C module, the source code for the user C module is missing a lot of C flags when it's compiled.  Notably the optimisation flag.

This PR fixes that by explicitly adding the missing C flags to the compilation of user C modules.

The missing flags were the following, which are now included when building user C modules (found by inspecting the generated CMake files when building with ulab):
```
-ffunction-sections
-fdata-sections
-Wall
-Werror=all
-Wno-error=unused-function
-Wno-error=unused-variable
-Wno-error=unused-but-set-variable
-Wno-error=deprecated-declarations
-Wextra
-Wno-error=extra
-Wno-unused-parameter
-Wno-sign-compare
-Wno-enum-conversion
-gdwarf-4
-ggdb
-mdisable-hardware-atomics
-O2
-fmacro-prefix-map=micropython/ports/esp32=.
-fmacro-prefix-map=espressif/esp-idf=/IDF
-fstrict-volatile-bitfields
-fno-jump-tables
-fno-tree-switch-conversion
```

Fixes issue #18880.

Done in collaboration with @andrewleech .

### Testing

Tested by building various esp32 boards with ulab as the user C module.  Without the fix here ulab would be 1.3MiB!  With the fix it's about 200kb.

### Trade-offs and Alternatives

This is a "quick fix" that seems to work reasonably well.  There are probably better/proper fixes, but likely they involve changing how user C modules are defined in `micropython.cmake` files, eg changing them from an INTERFACE to something else.  That would be a very big breaking change because all user C module components (eg ulab) would need to change their `micropython.cmake` file.

Note that the rp2 (which also uses cmake) doesn't have this problem, so it's specific to the esp32 port / IDF.