### PR TITLE
multiple ports: Standard approach to Makefile C++ support.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -107,9 +107,6 @@ COPT += -Os -DNDEBUG
 LDFLAGS += --gc-sections
 endif
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
-
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=xtensa
 

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -448,15 +448,6 @@ CFLAGS += \
 	-Wfloat-conversion \
 	-Wno-error=unused-parameter
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -std=c99,$(CFLAGS))
-
-# TODO make this common -- shouldn't be using these "private" vars from py.mk
-ifneq ($(SRC_CXX)$(SRC_USERMOD_CXX)$(SRC_USERMOD_LIB_CXX),)
-LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
-LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
-endif
-
 # Configure respective board flash type
 # Add hal/flexspi_nor_flash.h or hal/flexspi_hyper_flash.h respectively
 CFLAGS += -DBOARD_FLASH_OPS_HEADER_H=\"hal/flexspi_$(subst qspi_,,$(FLEXSPI_FLASH_TYPE)).h\"

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -396,7 +396,7 @@ hal/resethandler_MIMXRT10xx.S: $(GEN_FLEXRAM_CONFIG_SRC)
 # =============================================================================
 
 # List of sources for qstr extraction
-SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(GEN_PINS_SRC)
+SRC_QSTR += $(SRC_C) $(SHARED_SRC_C) $(SRC_CXX) $(GEN_PINS_SRC)
 
 # =============================================================================
 # Compiler Flags
@@ -547,6 +547,7 @@ LIBS = $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 OBJ += $(PY_O)
 OBJ += $(addprefix $(BUILD)/, $(LIBM_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(SRC_CXX:.cpp=.o))
 OBJ += $(addprefix $(BUILD)/, $(SHARED_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_S:.s=.o))

--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -217,6 +217,11 @@ void nlr_jump_fail(void *val) {
     }
 }
 
+void abort(void) {
+    for (;;) {
+    }
+}
+
 #ifndef NDEBUG
 void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
     mp_printf(MP_PYTHON_PRINTER, "Assertion '%s' failed, at file %s:%d\n", expr, file, line);

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -47,9 +47,6 @@ CFLAGS += -Os -DNDEBUG
 CFLAGS += -fdata-sections -ffunction-sections
 endif
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -std=c99,$(CFLAGS))
-
 LIBS =
 
 SRC_C = \

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -139,7 +139,7 @@ LDFLAGS += -Wl,--gc-sections
 endif
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
-CFLAGS += $(INC) -Wall -Werror -ansi -std=c11 $(COPT) $(NRF_DEFINES) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Werror -std=c11 $(COPT) $(NRF_DEFINES) $(CFLAGS_EXTRA)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -I$(BOARD_DIR)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -148,15 +148,6 @@ else
 COPT += -Os -DNDEBUG
 endif
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
-
-# TODO make this common -- shouldn't be using these "private" vars from py.mk
-ifneq ($(SRC_CXX)$(SRC_USERMOD_CXX)$(SRC_USERMOD_LIB_CXX),)
-LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
-LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
-endif
-
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=armv7m
 

--- a/ports/rp2/Makefile
+++ b/ports/rp2/Makefile
@@ -56,6 +56,10 @@ ifdef MICROPY_PREVIEW_VERSION_2
 CMAKE_ARGS += -DMICROPY_PREVIEW_VERSION_2=1
 endif
 
+ifdef MICROPY_C_HEAP_SIZE
+CMAKE_ARGS += -DMICROPY_C_HEAP_SIZE=$(MICROPY_C_HEAP_SIZE)
+endif
+
 HELP_PICO_SDK_SUBMODULE ?= "\033[1;31mError: pico-sdk submodule is not initialized.\033[0m Run 'make submodules'"
 HELP_BUILD_ERROR ?= "See \033[1;31mhttps://github.com/micropython/micropython/wiki/Build-Troubleshooting\033[0m"
 

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -108,15 +108,6 @@ ifeq ($(MICROPY_HW_ROMFS_BYTES),0)
 	CFLAGS += -DMICROPY_VFS_ROM=0
 endif
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -std=c99,$(CFLAGS))
-
-# TODO make this common -- shouldn't be using these "private" vars from py.mk
-ifneq ($(SRC_CXX)$(SRC_USERMOD_CXX)$(SRC_USERMOD_LIB_CXX),)
-LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
-LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
-endif
-
 MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH)
 
 SRC_C += \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -189,15 +189,6 @@ endif
 COPT ?= -Os -DNDEBUG
 endif
 
-# Flags for optional C++ source code
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS))
-
-# TODO make this common -- shouldn't be using these "private" vars from py.mk
-ifneq ($(SRC_CXX)$(SRC_USERMOD_CXX)$(SRC_USERMOD_LIB_CXX),)
-LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
-LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
-endif
-
 # Options for mpy-cross
 MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH_$(MCU_SERIES))
 

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -239,8 +239,6 @@ ifneq ($(FROZEN_MANIFEST),)
 CFLAGS += -DMPZ_DIG_SIZE=16 # force 16 bits to work on both 32 and 64 bit archs
 endif
 
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99,$(CFLAGS) $(CXXFLAGS_MOD))
-
 ifeq ($(MICROPY_FORCE_32BIT),1)
 RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags='-march=x86'
 endif

--- a/ports/windows/Makefile
+++ b/ports/windows/Makefile
@@ -104,8 +104,6 @@ ifeq ($(shell $(CC) -dumpmachine),i686-w64-mingw32)
 CFLAGS += -msse -mfpmath=sse -march=pentium4
 endif
 
-CXXFLAGS += $(filter-out -std=gnu99,$(CFLAGS))
-
 include $(TOP)/py/mkrules.mk
 
 .PHONY: test test_full

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -38,6 +38,18 @@ CFLAGS += -DMICROPY_BOARD_BUILD_NAME=\"$(BOARD)-$(BOARD_VARIANT)\"
 endif
 endif
 
+# Add default C++ compiler flags based on CFLAGS. For use with C++ user modules.
+CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99 -std=c99,$(CFLAGS) $(CXXFLAGS_MOD))
+
+# Add LDFLAGS to link libstdc++ on bare metal ports. Added only if a port has
+# -nostdlib in LDFLAGS and C++ source files are provided.
+ifneq ($(findstring nostdlib,"$(LDFLAGS)"),)
+ifneq ($(SRC_CXX)$(SRC_USERMOD_CXX)$(SRC_USERMOD_LIB_CXX),)
+LIBSTDCPP_FILE_NAME = "$(shell $(CXX) $(CXXFLAGS) -print-file-name=libstdc++.a)"
+LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
+endif
+endif
+
 # QSTR generation uses the same CFLAGS, with these modifications.
 QSTR_GEN_FLAGS = -DNO_QSTR
 # Note: := to force evaluation immediately.

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -39,7 +39,7 @@ endif
 endif
 
 # Add default C++ compiler flags based on CFLAGS. For use with C++ user modules.
-CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99 -std=c99,$(CFLAGS) $(CXXFLAGS_MOD))
+CXXFLAGS += $(filter-out -Wmissing-prototypes -Wold-style-definition -std=gnu99 -std=c99 -std=c11,$(CFLAGS) $(CXXFLAGS_MOD))
 
 # Add LDFLAGS to link libstdc++ on bare metal ports. Added only if a port has
 # -nostdlib in LDFLAGS and C++ source files are provided.

--- a/tests/misc/cexample_subclass.py
+++ b/tests/misc/cexample_subclass.py
@@ -2,6 +2,7 @@
 
 try:
     from cexample import AdvancedTimer
+    import time  # used to skip this test on minimal unix variant
 except ImportError:
     print("SKIP")
     raise SystemExit

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -287,7 +287,7 @@ function ci_esp8266_build {
     make ${MAKEOPTS} -C ports/esp8266 submodules
     make ${MAKEOPTS} -C ports/esp8266 BOARD=ESP8266_GENERIC
     make ${MAKEOPTS} -C ports/esp8266 BOARD=ESP8266_GENERIC BOARD_VARIANT=FLASH_512K
-    make ${MAKEOPTS} -C ports/esp8266 BOARD=ESP8266_GENERIC BOARD_VARIANT=FLASH_1M
+    make ${MAKEOPTS} -C ports/esp8266 BOARD=ESP8266_GENERIC BOARD_VARIANT=FLASH_1M USER_C_MODULES=../../examples/usercmodule
 
     # Test building native .mpy with xtensa architecture.
     ci_native_mpy_modules_build xtensa
@@ -324,7 +324,7 @@ function ci_mimxrt_build {
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1020_EVK submodules
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1020_EVK
     make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40 submodules
-    make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40
+    make ${MAKEOPTS} -C ports/mimxrt BOARD=TEENSY40 USER_C_MODULES=../../examples/usercmodule
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1060_EVK submodules
     make ${MAKEOPTS} -C ports/mimxrt BOARD=MIMXRT1060_EVK CFLAGS_EXTRA=-DMICROPY_HW_USB_MSC=1
 }
@@ -462,7 +462,7 @@ function ci_renesas_ra_board_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/renesas-ra submodules
     make ${MAKEOPTS} -C ports/renesas-ra BOARD=RA4M1_CLICKER
-    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M2
+    make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M2 USER_C_MODULES=../../examples/usercmodule
     make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA6M1
     make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4M1
     make ${MAKEOPTS} -C ports/renesas-ra BOARD=EK_RA4W1
@@ -729,6 +729,7 @@ function ci_unix_coverage_setup {
 }
 
 function ci_unix_coverage_build {
+    # note: the coverage variant incorporates ../../examples/usercmodule, set in mpconfigvariant.mk
     ci_unix_build_helper VARIANT=coverage
     ci_unix_build_ffi_lib_helper gcc
 }
@@ -987,13 +988,13 @@ function ci_unix_repr_b_run_tests {
 
 function ci_windows_setup {
     sudo apt-get update
-    sudo apt-get install gcc-mingw-w64
+    sudo apt-get install gcc-mingw-w64 g++-mingw-w64
 }
 
 function ci_windows_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/windows submodules
-    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32-
+    make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=i686-w64-mingw32- USER_C_MODULES=../../examples/usercmodule
     make ${MAKEOPTS} -C ports/windows CROSS_COMPILE=x86_64-w64-mingw32- BUILD=build-standard-w64
 }
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -341,7 +341,7 @@ function ci_nrf_build {
     make ${MAKEOPTS} -C mpy-cross
     make ${MAKEOPTS} -C ports/nrf submodules
     make ${MAKEOPTS} -C ports/nrf BOARD=PCA10040
-    make ${MAKEOPTS} -C ports/nrf BOARD=MICROBIT
+    make ${MAKEOPTS} -C ports/nrf BOARD=MICROBIT USER_C_MODULES=../../examples/usercmodule
     make ${MAKEOPTS} -C ports/nrf BOARD=PCA10056 SD=s140
     make ${MAKEOPTS} -C ports/nrf BOARD=PCA10090
 }


### PR DESCRIPTION
### Summary

The goal of this PR is to standardise the approach to building C++ sources in MicroPython ports that use simple Makefiles (esp8266, minimal, mimxrt, renesas-ra, samd, stm32, unix, windows with mingw). This removes a TODO that had been copied into the Makefile of all the bare metal (`-nostdlib`) ports over the years.

Partially resolves the issues reported in #18351.

Also:

* Adds CI coverage for the example user C modules to esp8266, nrf, mimxrt, renesas-ra & windows mingw ports, meaning all of the ports mentioned above now have CI coverage for building C++ sources. (Except minimal, which isn't built in CI as far as I can tell).
* Fixes C++ compilation on the nrf port.
* Adds a default `abort()` implementation to mimxrt port, copied from other ports. This allows the default cppexample module to build.
* ~~Explains the libstdc++ dynamic allocation and standard library situation in the docs~~ (Docs expanded and submitted as #19021 instead).

### Testing

Built with `USER_C_MODULES=../../examples/usercmodule` and verified the example `cppexample` module was functional on:

* stm32 port (`BOARD=PYBD_SF2`)
* samd port (`BOARD=SEEED_WIO_TERMINAL`)
* unix port (standard variant)

Also built but didn't have hardware to test, but verified the `cppfunc` symbol appeared in the map file:

* mimxrt port (`BOARD=TEENSY40`)
* renesas-ra port (`BOARD=EK_RA6M2`)
* nrf port

CI should also now build at least one board/variants from each of these ports with the usercmodule modules.

### Trade-offs and Alternatives

* `py/mkrules.mk` is the most appropriate *existing* common Makefile I could find for the C++ support, but it doesn't feel 100% right in there to me. We could instead add a `py/flags.mk` or similar and put it there (possibly along with some other things which are the same on all Makefile ports.)
