### PR TITLE
Multiple ports: Don't pass -nostdlib in CFLAGS.

### DIFF
--- a/ports/bare-arm/Makefile
+++ b/ports/bare-arm/Makefile
@@ -14,7 +14,7 @@ PYDFU ?= $(TOP)/tools/pydfu.py
 
 # Set CFLAGS.
 CFLAGS += -I. -I$(TOP) -I$(BUILD)
-CFLAGS += -Wall -Werror -std=c99 -nostdlib
+CFLAGS += -Wall -Werror -std=c99
 CFLAGS += -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float
 CSUPEROPT = -Os # save some code space for performance-critical code
 

--- a/ports/cc3200/Makefile
+++ b/ports/cc3200/Makefile
@@ -22,7 +22,7 @@ include ../../py/mkenv.mk
 CROSS_COMPILE ?= arm-none-eabi-
 
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -march=armv7e-m -mabi=aapcs -mcpu=cortex-m4 -msoft-float -mfloat-abi=soft -fsingle-precision-constant -Wdouble-promotion
-CFLAGS += -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib $(CFLAGS_CORTEX_M4) -Os
+CFLAGS += -Wall -Wpointer-arith -Werror -std=gnu99 $(CFLAGS_CORTEX_M4) -Os
 CFLAGS += -g -ffunction-sections -fdata-sections -fno-common -fsigned-char -mno-unaligned-access
 CFLAGS += -Iboards/$(BOARD)
 

--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -82,7 +82,7 @@ CFLAGS_XTENSA = -fsingle-precision-constant -Wdouble-promotion \
 	-Wl,-EL -mlongcalls -mtext-section-literals -mforce-l32 \
 	-DLWIP_OPEN_SRC
 
-CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -nostdlib -DUART_OS=$(UART_OS) \
+CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -std=gnu99 -DUART_OS=$(UART_OS) \
 	$(CFLAGS_XTENSA) $(COPT) $(CFLAGS_EXTRA) -I$(BOARD_DIR)
 
 LD_FILES ?= boards/esp8266_2m.ld

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -441,7 +441,6 @@ CFLAGS += \
 	-mcpu=cortex-m7 \
 	-mthumb \
 	-mtune=cortex-m7 \
-	-nostdlib \
 	-std=c99 \
 	-Wall \
 	-Wdouble-promotion \
@@ -514,6 +513,7 @@ MPY_CROSS_FLAGS += -march=armv7m
 # =============================================================================
 
 LDFLAGS += \
+	-nostdlib \
 	--cref \
 	--gc-sections \
 	--print-memory-usage \

--- a/ports/minimal/Makefile
+++ b/ports/minimal/Makefile
@@ -23,7 +23,7 @@ ifeq ($(CROSS), 1)
 DFU = $(TOP)/tools/dfu.py
 PYDFU = $(TOP)/tools/pydfu.py
 CFLAGS_CORTEX_M4 = -mthumb -mtune=cortex-m4 -mcpu=cortex-m4 -msoft-float -fsingle-precision-constant -Wdouble-promotion -Wfloat-conversion
-CFLAGS += $(INC) -Wall -Werror -std=c99 -nostdlib $(CFLAGS_CORTEX_M4) $(COPT)
+CFLAGS += $(INC) -Wall -Werror -std=c99 $(CFLAGS_CORTEX_M4) $(COPT)
 LDFLAGS += -nostdlib -T stm32f405.ld -Map=$@.map --cref --gc-sections
 else
 UNAME_S := $(shell uname -s)

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -139,12 +139,12 @@ LDFLAGS += -Wl,--gc-sections
 endif
 
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
-CFLAGS += $(INC) -Wall -Werror -ansi -std=c11 -nostdlib $(COPT) $(NRF_DEFINES) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Werror -ansi -std=c11 $(COPT) $(NRF_DEFINES) $(CFLAGS_EXTRA)
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -I$(BOARD_DIR)
 CFLAGS += -DNRF5_HAL_H='<$(MCU_VARIANT)_hal.h>'
 
-LDFLAGS += $(CFLAGS)
+LDFLAGS += $(CFLAGS) -nostdlib
 LDFLAGS += -Xlinker -Map=$(@:.elf=.map)
 LDFLAGS += -mthumb -mabi=aapcs $(addprefix -T,$(LD_FILES)) -L boards/
 

--- a/ports/powerpc/Makefile
+++ b/ports/powerpc/Makefile
@@ -22,7 +22,7 @@ INC += -I$(TOP)
 INC += -I$(BUILD)
 
 CFLAGS += $(INC) -g -Wall -Wdouble-promotion -Wfloat-conversion -std=c99 $(COPT)
-CFLAGS += -mno-string -mno-multiple -mno-vsx -mno-altivec -nostdlib
+CFLAGS += -mno-string -mno-multiple -mno-vsx -mno-altivec
 CFLAGS += -mlittle-endian -mstrict-align -msoft-float
 CFLAGS += -Os
 CFLAGS += -fdata-sections -ffunction-sections -fno-stack-protector -ffreestanding

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -110,7 +110,7 @@ CFLAGS_MCU_RA6M2 = $(CFLAGS_CORTEX_M) -mtune=cortex-m4 -mcpu=cortex-m4
 CFLAGS_MCU_RA6M5 = $(CFLAGS_CORTEX_M) -mtune=cortex-m33 -mcpu=cortex-m33
 
 ASFLAGS += $(CFLAGS_CORTEX_M) -mcpu=cortex-$(MCU_SERIES)
-CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 -nostdlib $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 $(CFLAGS_EXTRA)
 #CFLAGS += -D$(CMSIS_MCU)
 CFLAGS += $(CFLAGS_MCU_$(CMSIS_MCU))
 CFLAGS += $(COPT)

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -82,7 +82,7 @@ AF_FILE = mcu/$(MCU_SERIES_LOWER)/pin-af-table.csv
 GEN_PINS_SRC = $(BUILD)/pins_$(BOARD).c
 GEN_PINS_HDR = $(HEADER_BUILD)/pins.h
 
-CFLAGS += $(INC) -Wall -Werror -std=c99 -nostdlib -mthumb $(CFLAGS_MCU) -fsingle-precision-constant -Wdouble-promotion
+CFLAGS += $(INC) -Wall -Werror -std=c99 -mthumb $(CFLAGS_MCU) -fsingle-precision-constant -Wdouble-promotion
 CFLAGS += -DMCU_$(MCU_SERIES) -D__$(CMSIS_MCU)__
 CFLAGS += $(CFLAGS_EXTRA)
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -114,7 +114,7 @@ INC += -I$(TOP)/lib/tinyusb/src
 INC += -I$(TOP)/shared/tinyusb/
 INC += -Ilwip_inc
 
-CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 -nostdlib $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU) -DUSE_FULL_LL_DRIVER
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
 CFLAGS += $(COPT)

--- a/ports/stm32/mboot/Makefile
+++ b/ports/stm32/mboot/Makefile
@@ -73,7 +73,7 @@ INC += -I../$(USBDEV_DIR)/core/inc -I../$(USBDEV_DIR)/class/inc
 # the compiler does not optimise these functions in terms of themselves.
 CFLAGS_BUILTIN ?= -ffreestanding -fno-builtin -fno-lto
 
-CFLAGS += $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Werror -std=gnu99 -nostdlib $(CFLAGS_EXTRA)
+CFLAGS += $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -Werror -std=gnu99 $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU)
 CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
 CFLAGS += $(COPT)


### PR DESCRIPTION
### Summary

While working on #18885 I noticed that `-nostdlib` had been copied into the CFLAGS of many ports.

This is a linker option, so provided it's added to LDFLAGS then it can be dropped from CFLAGS without changing the compiler behaviour.

*This work was funded through GitHub Sponsors.*

### Testing

I built many ports with this change while working on the other PR, but I think all of these will be built in CI.
