### PR TITLE
stm32/mpthreadport: Increase minimum thread stack size to 2.5k.

### DIFF
--- a/ports/stm32/mpthreadport.c
+++ b/ports/stm32/mpthreadport.c
@@ -61,8 +61,8 @@ mp_uint_t mp_thread_get_id(void) {
 mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size) {
     if (*stack_size == 0) {
         *stack_size = 4096; // default stack size
-    } else if (*stack_size < 2048) {
-        *stack_size = 2048; // minimum stack size
+    } else if (*stack_size < 2560) {
+        *stack_size = 2560; // minimum stack size
     }
 
     // round stack size to a multiple of the word size


### PR DESCRIPTION
### Summary

2.25k Seems necessary so it doesn't crash `thread/thread_stacksize1.py`. But 2.5k gives a little extra headroom to make that test actually pass.

### Testing

Tested on PYBV10 using `make BOARD_VARIANT=THREAD` and `./run-tests.py -t a0 -d thread`:
- prior to the fix here, `tests/thread/thread_stacksize1.py` would consistently hard-crash the board
- with the fix, it passes every time

### Generative AI

I did not use generative AI tools when creating this PR.