### PR TITLE
Add RTOS-like task priority inheritance to asyncio.

### DIFF
--- a/extmod/asyncio/core.py
+++ b/extmod/asyncio/core.py
@@ -116,11 +116,11 @@ class IOQueue:
             # print('poll', s, sm, ev)
             if ev & ~select.POLLOUT and sm[0] is not None:
                 # POLLIN or error
-                _task_queue.push(sm[0])
+                _task_queue.push_raw(sm[0])
                 sm[0] = None
             if ev & ~select.POLLIN and sm[1] is not None:
                 # POLLOUT or error
-                _task_queue.push(sm[1])
+                _task_queue.push_raw(sm[1])
                 sm[1] = None
             if sm[0] is None and sm[1] is None:
                 self._dequeue(s)
@@ -144,7 +144,7 @@ def create_task(coro):
     if not hasattr(coro, "send"):
         raise TypeError("coroutine expected")
     t = Task(coro, globals())
-    _task_queue.push(t)
+    _task_queue.push_raw(t)
     return t
 
 
@@ -216,7 +216,7 @@ def run_until_complete(main_task=None):
                 else:
                     # Schedule any other tasks waiting on the completion of this task.
                     while t.state.peek():
-                        _task_queue.push(t.state.pop())
+                        _task_queue.push_raw(t.state.pop())
                         awaited = True
                     # "False" indicates that the task is complete and has been await'ed on.
                     t.state = False
@@ -224,7 +224,7 @@ def run_until_complete(main_task=None):
                     # An exception ended this detached task, so queue it for later
                     # execution to handle the uncaught exception if no other task retrieves
                     # the exception in the meantime (this is handled by Task.throw).
-                    _task_queue.push(t)
+                    _task_queue.push_raw(t)
                 # Save return value of coro to pass up to caller.
                 t.data = er
             elif t.state is None:
@@ -278,7 +278,7 @@ class Loop:
     def stop():
         global _stop_task
         if _stop_task is not None:
-            _task_queue.push(_stop_task)
+            _task_queue.push_raw(_stop_task)
             # If stop() is called again, do nothing
             _stop_task = None
 

--- a/extmod/asyncio/event.py
+++ b/extmod/asyncio/event.py
@@ -18,7 +18,7 @@ class Event:
         # Note: This must not be called from anything except the thread running
         # the asyncio loop (i.e. neither hard or soft IRQ, or a different thread).
         while self.waiting.peek():
-            core._task_queue.push(self.waiting.pop())
+            core._task_queue.push_raw(self.waiting.pop())
         self.state = True
 
     def clear(self):
@@ -27,10 +27,10 @@ class Event:
     # async
     def wait(self):
         if not self.state:
-            # Event not set, put the calling task on the event's waiting queue
-            self.waiting.push(core.cur_task)
             # Set calling task's data to the event's queue so it can be removed if needed
             core.cur_task.data = self.waiting
+            # Event not set, put the calling task on the event's waiting queue
+            self.waiting.push_raw(core.cur_task)
             yield
         return True
 

--- a/extmod/asyncio/funcs.py
+++ b/extmod/asyncio/funcs.py
@@ -81,7 +81,7 @@ def gather(*aws, return_exceptions=False):
                 # Still some sub-tasks running.
                 return
         # Gather waiting is done, schedule the main gather task.
-        core._task_queue.push(gather_task)
+        core._task_queue.push_raw(gather_task)
 
     # Prepare the sub-tasks for the gather.
     # The `state` variable counts the number of tasks to wait for, and can be negative

--- a/extmod/asyncio/lock.py
+++ b/extmod/asyncio/lock.py
@@ -24,7 +24,7 @@ class Lock:
         if self.waiting.peek():
             # Task(s) waiting on lock, schedule next Task
             self.state = self.waiting.pop()
-            core._task_queue.push(self.state)
+            core._task_queue.push_raw(self.state)
         else:
             # No Task waiting so unlock
             self.state = 0
@@ -33,7 +33,7 @@ class Lock:
     def acquire(self):
         if self.state != 0:
             # Lock unavailable, put the calling Task on the waiting queue
-            self.waiting.push(core.cur_task)
+            self.waiting.push_raw(core.cur_task)
             # Set calling task's data to the lock's queue so it can be removed if needed
             core.cur_task.data = self.waiting
             try:

--- a/extmod/asyncio/task.py
+++ b/extmod/asyncio/task.py
@@ -100,10 +100,19 @@ class TaskQueue:
         return self.heap
 
     def push(self, v, key=None):
+        v.ph_key = key
+        self.push_raw(v)
+
+    def push_raw(self, v):
         assert v.ph_child is None
         assert v.ph_next is None
         v.data = None
-        v.ph_key = key if key is not None else core.ticks()
+        if v.ph_key is None:
+            if isinstance(v.state, TaskQueue):
+                # RTOS-like priority inheritance
+                v.ph_key = v.state.peek().ph_key
+            else:
+                v.ph_key = core.ticks()
         self.heap = ph_meld(v, self.heap)
 
     def pop(self):
@@ -111,10 +120,12 @@ class TaskQueue:
         assert v.ph_next is None
         self.heap = ph_pairing(v.ph_child)
         v.ph_child = None
+        v.ph_key = None
         return v
 
     def remove(self, v):
         self.heap = ph_delete(self.heap, v)
+        v.ph_key = None
 
 
 # Task class representing a coroutine, can be waited on and cancelled.
@@ -123,7 +134,7 @@ class Task:
         self.coro = coro  # Coroutine of this Task
         self.data = None  # General data for queue it is waiting on
         self.state = True  # None, False, True, a callable, or a TaskQueue instance
-        self.ph_key = 0  # Pairing heap
+        self.ph_key = None  # Pairing heap
         self.ph_child = None  # Paring heap
         self.ph_child_last = None  # Paring heap
         self.ph_next = None  # Paring heap
@@ -147,7 +158,7 @@ class Task:
             raise self.data
         else:
             # Put calling task on waiting queue.
-            self.state.push(core.cur_task)
+            self.state.push_raw(core.cur_task)
             # Set calling task's data to this task that it waits on, to double-link it.
             core.cur_task.data = self
 
@@ -175,3 +186,23 @@ class Task:
             core._task_queue.push(self)
         self.data = core.CancelledError
         return True
+
+    def prioritize(self, relative=0):
+        # set this tasks's queue priority
+        return self.prioritize_raw(core.ticks_add(core.ticks(), relative))
+
+    def prioritize_raw(self, ph_key):
+        if not self.state:
+            return False
+
+        if self.ph_key is None or core.ticks_diff(ph_key, self.ph_key) < 0:
+            self.ph_key = ph_key
+
+            if isinstance(self.data, Task):
+                # waiting on another task, bump that task's priority forward
+                return self.data.prioritize_raw(ph_key)
+
+            elif isinstance(self.data, TaskQueue):
+                # waiting in a queue, bump ourselves forward in that queue
+                self.data.remove(self)
+                self.data.push_raw(self)

--- a/extmod/modasyncio.c
+++ b/extmod/modasyncio.c
@@ -62,6 +62,8 @@ static const mp_obj_type_t task_queue_type;
 static const mp_obj_type_t task_type;
 
 static mp_obj_t task_queue_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args);
+static mp_obj_t task_queue_push_raw(mp_obj_t self_in, mp_obj_t task_in);
+static mp_obj_t task_prioritize_raw(mp_obj_t self_in, mp_obj_t ph_key);
 
 /******************************************************************************/
 // Ticks for task ordering in pairing heap
@@ -113,14 +115,32 @@ static mp_obj_t task_queue_peek(mp_obj_t self_in) {
 static MP_DEFINE_CONST_FUN_OBJ_1(task_queue_peek_obj, task_queue_peek);
 
 static mp_obj_t task_queue_push(size_t n_args, const mp_obj_t *args) {
-    mp_obj_task_queue_t *self = MP_OBJ_TO_PTR(args[0]);
     mp_obj_task_t *task = MP_OBJ_TO_PTR(args[1]);
-    task->data = mp_const_none;
-    if (n_args == 2) {
-        task->ph_key = ticks();
-    } else {
+    if (n_args >= 3) {
         assert(mp_obj_is_small_int(args[2]));
         task->ph_key = args[2];
+    }
+    return task_queue_push_raw(args[0], args[1]);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(task_queue_push_obj, 2, 3, task_queue_push);
+
+static mp_obj_t task_queue_push_raw(mp_obj_t self_in, mp_obj_t task_in) {
+    mp_obj_task_queue_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_obj_task_t *task = MP_OBJ_TO_PTR(task_in);
+    task->data = mp_const_none;
+    // if v.ph_key is None:
+    if (task->ph_key == mp_const_none) {
+        if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(mp_obj_get_type(task->state)), MP_OBJ_FROM_PTR(&task_queue_type))) {
+            mp_obj_task_queue_t *waiting_queue = MP_OBJ_TO_PTR(task->state);
+            mp_obj_task_t *waiting_task = (mp_obj_task_t *)mp_pairheap_peek(task_lt, TASK_PAIRHEAP(waiting_queue->heap));
+            if (waiting_task != NULL) {
+                task->ph_key = waiting_task->ph_key;
+            } else {
+                task->ph_key = ticks();
+            }
+        } else {
+            task->ph_key = ticks();
+        }
     }
     self->heap = (mp_obj_task_t *)mp_pairheap_push(task_lt, TASK_PAIRHEAP(self->heap), TASK_PAIRHEAP(task));
     #if MICROPY_PY_ASYNCIO_TASK_QUEUE_PUSH_CALLBACK
@@ -130,7 +150,7 @@ static mp_obj_t task_queue_push(size_t n_args, const mp_obj_t *args) {
     #endif
     return mp_const_none;
 }
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(task_queue_push_obj, 2, 3, task_queue_push);
+static MP_DEFINE_CONST_FUN_OBJ_2(task_queue_push_raw_obj, task_queue_push_raw);
 
 static mp_obj_t task_queue_pop(mp_obj_t self_in) {
     mp_obj_task_queue_t *self = MP_OBJ_TO_PTR(self_in);
@@ -139,6 +159,7 @@ static mp_obj_t task_queue_pop(mp_obj_t self_in) {
         mp_raise_msg(&mp_type_IndexError, MP_ERROR_TEXT("empty heap"));
     }
     self->heap = (mp_obj_task_t *)mp_pairheap_pop(task_lt, &self->heap->pairheap);
+    head->ph_key = mp_const_none;
     return MP_OBJ_FROM_PTR(head);
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(task_queue_pop_obj, task_queue_pop);
@@ -147,6 +168,7 @@ static mp_obj_t task_queue_remove(mp_obj_t self_in, mp_obj_t task_in) {
     mp_obj_task_queue_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_task_t *task = MP_OBJ_TO_PTR(task_in);
     self->heap = (mp_obj_task_t *)mp_pairheap_delete(task_lt, &self->heap->pairheap, &task->pairheap);
+    task->ph_key = mp_const_none;
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(task_queue_remove_obj, task_queue_remove);
@@ -154,6 +176,7 @@ static MP_DEFINE_CONST_FUN_OBJ_2(task_queue_remove_obj, task_queue_remove);
 static const mp_rom_map_elem_t task_queue_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_peek), MP_ROM_PTR(&task_queue_peek_obj) },
     { MP_ROM_QSTR(MP_QSTR_push), MP_ROM_PTR(&task_queue_push_obj) },
+    { MP_ROM_QSTR(MP_QSTR_push_raw), MP_ROM_PTR(&task_queue_push_raw_obj) },
     { MP_ROM_QSTR(MP_QSTR_pop), MP_ROM_PTR(&task_queue_pop_obj) },
     { MP_ROM_QSTR(MP_QSTR_remove), MP_ROM_PTR(&task_queue_remove_obj) },
 };
@@ -181,7 +204,7 @@ static mp_obj_t task_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     self->coro = args[0];
     self->data = mp_const_none;
     self->state = TASK_STATE_RUNNING_NOT_WAITED_ON;
-    self->ph_key = MP_OBJ_NEW_SMALL_INT(0);
+    self->ph_key = mp_const_none;
     if (n_args == 2) {
         mp_asyncio_context = args[1];
     }
@@ -220,17 +243,13 @@ static mp_obj_t task_cancel(mp_obj_t self_in) {
         dest[2] = MP_OBJ_FROM_PTR(self);
         mp_call_method_n_kw(1, 0, dest);
         // _task_queue.push(self)
-        dest[0] = _task_queue;
-        dest[1] = MP_OBJ_FROM_PTR(self);
-        task_queue_push(2, dest);
+        task_queue_push_raw(_task_queue, MP_OBJ_FROM_PTR(self));
     } else if (ticks_diff(self->ph_key, ticks()) > 0) {
         // On the main running queue but scheduled in the future, so bring it forward to now.
         // _task_queue.remove(self)
         task_queue_remove(_task_queue, MP_OBJ_FROM_PTR(self));
         // _task_queue.push(self)
-        dest[0] = _task_queue;
-        dest[1] = MP_OBJ_FROM_PTR(self);
-        task_queue_push(2, dest);
+        task_queue_push_raw(_task_queue, MP_OBJ_FROM_PTR(self));
     }
 
     self->data = mp_obj_dict_get(mp_asyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR_CancelledError));
@@ -238,6 +257,49 @@ static mp_obj_t task_cancel(mp_obj_t self_in) {
     return mp_const_true;
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(task_cancel_obj, task_cancel);
+
+static mp_obj_t task_prioritize(size_t n_args, const mp_obj_t *args) {
+    mp_int_t prio_time = mp_hal_ticks_ms();
+    if (n_args >= 2) {
+        prio_time += mp_obj_int_get_checked(args[1]);
+    }
+    return task_prioritize_raw(args[0], MP_OBJ_NEW_SMALL_INT(prio_time & (MICROPY_PY_TIME_TICKS_PERIOD - 1)));
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(task_prioritize_obj, 1, 2, task_prioritize);
+
+static mp_obj_t task_prioritize_raw(mp_obj_t self_in, mp_obj_t ph_key) {
+    mp_obj_task_t *self = MP_OBJ_TO_PTR(self_in);
+
+    // if not self.state:
+    if (TASK_IS_DONE(self)) {
+        // return False
+        return mp_const_false;
+    }
+
+    // if self.ph_key is None or core.ticks_diff(ph_key, self.ph_key) < 0:
+    if (self->ph_key == mp_const_none || ticks_diff(ph_key, self->ph_key) < 0) {
+        // self.ph_key = ph_key
+        self->ph_key = ph_key;
+
+        // if isinstance(self.data, Task):
+        if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(mp_obj_get_type(self->data)), MP_OBJ_FROM_PTR(&task_type))) {
+            // # waiting on another task, bump that task's priority forward
+            // return self.data.prioritize_raw(ph_key)
+            return task_prioritize_raw(self->data, ph_key); // i.e. tail call recursion
+        }
+        // elif isinstance(self.data, TaskQueue):
+        if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(mp_obj_get_type(self->data)), MP_OBJ_FROM_PTR(&task_queue_type))) {
+            // # waiting in a queue, bump ourselves forward in that queue
+            // self.data.remove(self)
+            task_queue_remove(self->data, self_in);
+            // self.data.push_raw(self)
+            task_queue_push_raw(self->data, self_in);
+        }
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_2(task_prioritize_raw_obj, task_prioritize_raw);
+
 
 static void task_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     mp_obj_task_t *self = MP_OBJ_TO_PTR(self_in);
@@ -254,6 +316,12 @@ static void task_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
             dest[1] = self_in;
         } else if (attr == MP_QSTR_cancel) {
             dest[0] = MP_OBJ_FROM_PTR(&task_cancel_obj);
+            dest[1] = self_in;
+        } else if (attr == MP_QSTR_prioritize) {
+            dest[0] = MP_OBJ_FROM_PTR(&task_prioritize_obj);
+            dest[1] = self_in;
+        } else if (attr == MP_QSTR_prioritize_raw) {
+            dest[0] = MP_OBJ_FROM_PTR(&task_prioritize_raw_obj);
             dest[1] = self_in;
         } else if (attr == MP_QSTR_ph_key) {
             dest[0] = self->ph_key;
@@ -294,8 +362,7 @@ static mp_obj_t task_iternext(mp_obj_t self_in) {
     } else {
         // Put calling task on waiting queue.
         mp_obj_t cur_task = mp_obj_dict_get(mp_asyncio_context, MP_OBJ_NEW_QSTR(MP_QSTR_cur_task));
-        mp_obj_t args[2] = { self->state, cur_task };
-        task_queue_push(2, args);
+        task_queue_push_raw(self->state, cur_task);
         // Set calling task's data to this task that it waits on, to double-link it.
         ((mp_obj_task_t *)MP_OBJ_TO_PTR(cur_task))->data = self_in;
     }


### PR DESCRIPTION
### Summary

- `TaskQueue.push_raw(task)`, is a new interface for other code to push tasks with their `ph_key` values already set.
- `Task.ph_key` is now `None` by default, indicating that `push_raw` should set `ph_key` to a default value.
- `TaskQueue.push` and `push_raw` now check for the existence of a queue of other tasks waiting on it, and if it exists will inherit the tasks priority from the earliest-priority element of that queue.
- `Task.prioritize` allows for a caller to mark a task (often asyncio.core.cur_task, but could be another) to be prioritized based on the moment that _that_ function is called, rather than the moment that task becomes ready to be reinserted into a task queue.
- `Task.prioritize_raw` allows re-prioritizing a task to a new earlier-priority value (i.e. to back the more user-facing `prioritize` function that calls it with a relative offset from the current moment). This function then recursively updates any other tasks that the task being prioritized is awaiting on, to update them with their own new lower inherited priorities as appropriate.

This specific approach also leaves scheduling priority something that can be set at a granular await-by-await level, with priority automatically cleared when the task resumes.

```py
while True:
    asyncio.cur_task.prioritize()
    await high_priority_response_thing()
    # priority is automatically reset when the task resumes
    await low_priority_response_thing()
```

Note that inherited priority is an important feature of RTOS scheduling, that ensures that in a scenario with a high-priority task blocked on some other task, that the blocking task doesn't need to be rewritten to still have its own priority bumped ahead to match the earliest-priority task waiting on it:

```py
async def buf_task_fn():
    buf.append(await next_chunk())
    buf_has_next.set()

async def use_buf_lowlatency():
    buf_task.prioritize()
    await buf_has_next.wait()
    low_latency_thing(buf)

async def process_other_stream_maybe_background():
    maybe_background = asyncio.wait_for(other_next_chunk())
    if await other_thing_needs_low_latency():
        asyncio.cur_task.prioritize()
    maybe_background_operation(await maybe_background)
```

See also:
- #18816
- #18826
- #18828

Thanks to @peterhinch and @projectgus for their own work in this space trying to find ways to better manage asyncio latency.

### Testing
TBD! Mostly looking for comments on the overall approach.

### Trade-offs and Alternatives
Priority scheduling is _always_ a foot-gun regardless of how well or poorly it's implemented; though the priority that this concept offers as its own _default_ higher priority (no-args `Task.prioritize()`) is still ultimately a reasonably-well-behaved round-robin policy, just basing the round-robin position on when each task declared priority or _started_ sleeping, rather than on becoming ready to resume. (Though for use-cases that do require even earlier priorities, and an engineer willing to take responsibility for it, `Task.prioritize(-1000)` will still _let_ you break it all.)

-priority default (i.e. substituting "prioritize based on when we started waiting" as a replacement for "prioritize based on when the task became ready to resume") is still a _reasonably_-safe default.

Beyond that, as currently implemented, re-prioritizing a parent task will also silently truncate the duration of an ongoing `await asyncio.sleep(5)` in any task blocking its priority await. For a child that's polling in a loop, that's 's not as much a problem, as subsequent sleeps will still be correct --- and if necessary, that could be fixed for _all_ async sleeps by reimplementing sleep using its own polling loop that just sleeps again if it was woken early. 

The additions proposed here also represents a deviation from the otherwise-CPython-like API for Task objects. I'm of the opinion though, that that's a worthwhile deviation for the sake of being able to extend MicroPython's "direct access to the physical world" ideal to async code by giving async code at least a way to approximate RTOS-like scheduling.

### Generative AI
I did not use generative AI tools when creating this PR.

