### PR TITLE
docs/rp2/quickref: add REPL over UART information.

### DIFF
--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -207,10 +207,26 @@ See :ref:`machine.UART <machine.UART>`. ::
     uart1.write('hello')  # write 5 bytes
     uart1.read(5)         # read up to 5 bytes
 
-.. note::
+It is possible to access the REPL over UART, but this is disabled by
+default.  To duplicate the REPL stream over UART, use :func:`os.dupterm`.
+This code should be in ``boot.py`` or ``main.py`` to establish UART on boot.
 
-    REPL over UART is disabled by default. You can see the :ref:`rp2_intro` for
-    details on how to enable REPL over UART.
+.. code-block:: python
+
+    from machine import UART
+    import os
+    uart = UART(0)
+    os.dupterm(uart, 0)
+    uart.irq(os.dupterm_notify, machine.UART.IRQ_RX) # ensure inputs are handled
+
+To use UART for REPL instead of the standard USB interface (for example if you are
+using :mod:`machine.USBDevice`), you will need to :doc:`build MicroPython from source </develop/gettingstarted>`.
+Modify ``ports/rp2/mpconfigport.h``, and change the ``MICROPY_HW_ENABLE_UART_REPL``
+variable to ``1``:
+
+.. code-block:: c
+
+    #define MICROPY_HW_ENABLE_UART_REPL             (1) // useful if there is no USB
 
 
 PWM (pulse width modulation)

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -217,7 +217,7 @@ This code should be in :ref:`boot.py` or :ref:`main.py` to establish UART on boo
     import os
     uart = UART(0)
     os.dupterm(uart, 0)
-    uart.irq(os.dupterm_notify, machine.UART.IRQ_RX) # ensure inputs are handled
+    uart.irq(os.dupterm_notify, UART.IRQ_RXIDLE) # ensure inputs are handled
 
 To use UART for REPL instead of the standard USB interface (for example if you are
 using :mod:`machine.USBDevice`), you will need to :doc:`build MicroPython from source </develop/gettingstarted>`.

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -209,7 +209,7 @@ See :ref:`machine.UART <machine.UART>`. ::
 
 It is possible to access the REPL over UART, but this is disabled by
 default.  To duplicate the REPL stream over UART, use :func:`os.dupterm`.
-This code should be in ``boot.py`` or ``main.py`` to establish UART on boot.
+This code should be in :ref:`boot.py` or :ref:`main.py` to establish UART on boot.
 
 .. code-block:: python
 

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -207,10 +207,26 @@ See :ref:`machine.UART <machine.UART>`. ::
     uart1.write('hello')  # write 5 bytes
     uart1.read(5)         # read up to 5 bytes
 
-.. note::
+It is possible to access the REPL over UART, but this is disabled by
+default.  To duplicate the REPL stream over UART, use :func:`os.dupterm`.
+This code should be in :ref:`boot.py` or :ref:`main.py` to establish UART on boot.
 
-    REPL over UART is disabled by default. You can see the :ref:`rp2_intro` for
-    details on how to enable REPL over UART.
+.. code-block:: python
+
+    from machine import UART
+    import os
+    uart = UART(0)
+    os.dupterm(uart, 0)
+    uart.irq(os.dupterm_notify, UART.IRQ_RXIDLE) # ensure inputs are handled
+
+To use UART for REPL instead of the standard USB interface (for example if you are
+using :mod:`machine.USBDevice`), you will need to :doc:`build MicroPython from source </develop/gettingstarted>`.
+Modify ``ports/rp2/mpconfigport.h``, and change the ``MICROPY_HW_ENABLE_UART_REPL``
+variable to ``1``:
+
+.. code-block:: c
+
+    #define MICROPY_HW_ENABLE_UART_REPL             (1) // useful if there is no USB
 
 
 PWM (pulse width modulation)


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Fixes #18875 by adding information in the RP2 quickref about using the REPL over UART.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

I have built the docs locally, and checked that the links work.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
