### PR TITLE
RFC: Embed configuration definitions in debug binary.

### DIFF
--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -241,6 +241,9 @@ ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
 PROG := $(PROG).exe
 endif
 
+DBG_INFO_SECTION=".debug_gdb_scripts"
+DBG_INFO_FILE=$(HEADER_BUILD)/debug_info.bin
+
 all: $(BUILD)/$(PROG)
 
 $(BUILD)/$(PROG): $(OBJ)
@@ -251,6 +254,20 @@ $(BUILD)/$(PROG): $(OBJ)
 ifndef DEBUG
 ifdef STRIP
 	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $@
+endif
+else
+# MinGW requires finding out the end address of the mapped sections block and
+# then set the VMA in order to be placed at the end of the binary once loaded.
+# This hasn't been tested on macOS, so limit the feature to Linux for now.
+ifeq (linux,$(findstring linux,$(COMPILER_TARGET)))
+ifneq (,$(EMBED_DEBUG_INFO))
+	$(ECHO) "GEN $(DBG_INFO_FILE)"
+	$(Q)CPP="$(CPP)" CFLAGS="$(CFLAGS)" $(PYTHON) $(PY_SRC)/writedebuginfo.py > $(DBG_INFO_FILE)
+	$(Q)$(OBJCOPY) \
+		--add-section $(DBG_INFO_SECTION)=$(DBG_INFO_FILE) \
+		--set-section-flags $(DBG_INFO_SECTION)=readonly,merge,strings \
+		$(BUILD)/$(PROG)
+endif
 endif
 endif
 	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $@

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -240,6 +240,9 @@ ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
 PROG := $(PROG).exe
 endif
 
+DBG_INFO_SECTION=".debug_gdb_scripts"
+DBG_INFO_FILE=$(HEADER_BUILD)/debug_info.bin
+
 all: $(BUILD)/$(PROG)
 
 $(BUILD)/$(PROG): $(OBJ)
@@ -250,6 +253,20 @@ $(BUILD)/$(PROG): $(OBJ)
 ifndef DEBUG
 ifdef STRIP
 	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $@
+endif
+else
+# MinGW requires finding out the end address of the mapped sections block and
+# then set the VMA in order to be placed at the end of the binary once loaded.
+# This hasn't been tested on macOS, so limit the feature to Linux for now.
+ifeq (linux,$(findstring linux,$(COMPILER_TARGET)))
+ifneq (,$(EMBED_DEBUG_INFO))
+	$(ECHO) "GEN $(DBG_INFO_FILE)"
+	$(Q)CPP="$(CPP)" CFLAGS="$(CFLAGS)" $(PYTHON) $(PY_SRC)/writedebuginfo.py > $(DBG_INFO_FILE)
+	$(Q)$(OBJCOPY) \
+		--add-section $(DBG_INFO_SECTION)=$(DBG_INFO_FILE) \
+		--set-section-flags $(DBG_INFO_SECTION)=readonly,merge,strings \
+		$(BUILD)/$(PROG)
+endif
 endif
 endif
 	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $@

--- a/py/writedebuginfo.py
+++ b/py/writedebuginfo.py
@@ -1,0 +1,98 @@
+# This file is part of the MicroPython project, http://micropython.org/
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2026 Alessandro Gatti
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Encode to STDOUT some configuration information used to build the binary.
+
+The output is meant to be embedded in the final ELF binary (or platform-specific
+equivalent), to be used by GDB.  Platform build scripts will take this output
+and perform the actual binary merge operation.
+
+More documentation on how this works can be found here:
+https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html
+"""
+
+import io
+import os
+import shlex
+import subprocess
+import sys
+
+
+DEBUG_INFO_TEMPLATE = """
+#include "mpconfigport.h"
+#include "../../py/mpconfig.h"
+
+MPY_DEBUG_INFO_START
+repr({
+  "float_impl": MICROPY_FLOAT_IMPL,
+  "longint_impl": MICROPY_LONGINT_IMPL,
+  "mpz_dig_size": MPZ_DIG_SIZE,
+  "obj_immediate_objs": MICROPY_OBJ_IMMEDIATE_OBJS,
+  "obj_repr": MICROPY_OBJ_REPR,
+  "timestamp_impl": MICROPY_TIMESTAMP_IMPL,
+})
+"""
+
+
+def preprocess(source):
+    preprocessor = os.environ.get("CPP", None)
+    if not preprocessor:
+        raise Exception("no preprocessor specified")
+    cpp, *flags = shlex.split(preprocessor)
+    command_line = [cpp]
+    if flags:
+        command_line.extend(flags)
+    command_line.extend(shlex.split(os.environ.get("CFLAGS", "")))
+    command_line.append("-")
+    with subprocess.Popen(command_line, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as process:
+        process.stdin.write(DEBUG_INFO_TEMPLATE.encode())
+        process.stdin.close()
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+    if stderr:
+        raise Exception("preprocessing failed", stderr)
+    debug_info = stdout.decode("utf-8")
+    cut_index = debug_info.find("MPY_DEBUG_INFO_START")
+    if cut_index == -1:
+        raise Exception("incomplete debug info")
+    debug_info = [line for line in debug_info[cut_index:].splitlines()[1:] if line]
+    return "\n".join(debug_info).strip()
+
+
+def main():
+    # The C preprocessor won't remove extra brackets or evaluate expressions in
+    # the first pass.  However the output should be "python-like" enough for
+    # eval() to clean up.
+
+    preprocessed = preprocess(DEBUG_INFO_TEMPLATE)
+    debug_info = eval(preprocessed).strip()
+    sys.stdout.write(f'\x04"gdb.inlinedscript"\nMPY_BINARY_DEBUG_INFO={debug_info}\x00')
+
+
+if __name__ == "__main__":
+    main()

--- a/py/writedebuginfo.py
+++ b/py/writedebuginfo.py
@@ -1,0 +1,133 @@
+# This file is part of the MicroPython project, http://micropython.org/
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2026 Alessandro Gatti
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Encode to STDOUT some configuration information used to build the binary.
+
+The output is meant to be embedded in the final ELF binary (or platform-specific
+equivalent), to be used by GDB.  Platform build scripts will take this output
+and perform the actual binary merge operation.
+
+More documentation on how this works can be found here:
+https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html
+"""
+
+import io
+import os
+import shlex
+import subprocess
+import sys
+
+
+DEBUG_INFO_TEMPLATE = """
+#include "mpconfigport.h"
+#include "../../py/mpconfig.h"
+#include "../../py/nlr.h"
+
+MPY_DEBUG_INFO_START
+repr({
+  "float_impl": MICROPY_FLOAT_IMPL,
+  "longint_impl": MICROPY_LONGINT_IMPL,
+  "mpz_dig_size": MPZ_DIG_SIZE,
+#ifdef MICROPY_NLR_NUM_REGS
+  "nlr_num_regs": MICROPY_NLR_NUM_REGS,
+#else
+  "nlr_num_regs": 0,
+#endif
+#if MICROPY_NLR_X86
+  "nlr_platform": "x86",
+#elif MICROPY_NLR_X64 && MICROPY_NLR_OS_WINDOWS
+  "nlr_platform": "x64-win",
+#elif MICROPY_NLR_X64 && !MICROPY_NLR_OS_WINDOWS
+  "nlr_platform": "x64",
+#elif MICROPY_NLR_THUMB && defined(__SOFTFP__)
+  "nlr_platform": "aarch32-softfp",
+#elif MICROPY_NLR_THUMB && !defined(__SOFTFP__)
+  "nlr_platform": "aarch32-hardfp",
+#elif MICROPY_NLR_AARCH64
+  "nlr_platform": "aarch64",
+#elif MICROPY_NLR_XTENSA
+  "nlr_platform": "xtensa",
+#elif MICROPY_NLR_POWERPC
+  "nlr_platform": "powerpc",
+#elif MICROPY_NLR_MIPS
+  "nlr_platform": "mips",
+#elif MICROPY_NLR_RV32I
+  "nlr_platform": "rv32",
+#elif MICROPY_NLR_RV64I
+  "nlr_platform": "rv64",
+#elif MICROPY_NLR_LOONG64
+  "nlr_platform": "loongarch64",
+#elif MICROPY_NLR_SETJMP
+  "nlr_platform": "setjmp",
+#else
+  "nlr_platform": None,
+#endif
+  "obj_immediate_objs": MICROPY_OBJ_IMMEDIATE_OBJS,
+  "obj_repr": MICROPY_OBJ_REPR,
+  "timestamp_impl": MICROPY_TIMESTAMP_IMPL,
+})
+"""
+
+
+def preprocess(source):
+    preprocessor = os.environ.get("CPP", None)
+    if not preprocessor:
+        raise Exception("no preprocessor specified")
+    cpp, *flags = shlex.split(preprocessor)
+    command_line = [cpp]
+    if flags:
+        command_line.extend(flags)
+    command_line.extend(shlex.split(os.environ.get("CFLAGS", "")))
+    command_line.append("-")
+    with subprocess.Popen(command_line, stdin=subprocess.PIPE, stdout=subprocess.PIPE) as process:
+        process.stdin.write(DEBUG_INFO_TEMPLATE.encode())
+        process.stdin.close()
+        try:
+            stdout, stderr = process.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            stdout, stderr = process.communicate()
+    if stderr:
+        raise Exception("preprocessing failed", stderr)
+    debug_info = stdout.decode("utf-8")
+    cut_index = debug_info.find("MPY_DEBUG_INFO_START")
+    if cut_index == -1:
+        raise Exception("incomplete debug info")
+    debug_info = [line for line in debug_info[cut_index:].splitlines()[1:] if line]
+    return "\n".join(debug_info).strip()
+
+
+def main():
+    # The C preprocessor won't remove extra brackets or evaluate expressions in
+    # the first pass.  However the output should be "python-like" enough for
+    # eval() to clean up.
+
+    preprocessed = preprocess(DEBUG_INFO_TEMPLATE)
+    debug_info = eval(preprocessed).strip()
+    sys.stdout.write(f'\x04"gdb.inlinedscript"\nMPY_BINARY_DEBUG_INFO={debug_info}\x00')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This PR introduces the ability to record selected configuration settings used to build the binary in debug mode, and embed the encoded representation of said information in the produced executable binary itself.

GDB can parse special sections as containers for either references to external debug scripts or as embedded python/scheme code.  Since there are some configuration settings that are not persisted in the MicroPython binary, GDB helper scripts would have to either guess the values of some configuration definitions or prompt the user for the values themselves.  For example, the chosen object representation scheme is not tracked anywhere in the binary for space reasons, and the value of the appropriate preprocessor definition is lost once the build process ends.

The changes in this PR encode a few definitions used by GDB helper scripts into a dictionary called "MPY_BINARY_DEBUG_INFO", which can be queried from a GDB session via GDB's Python API.

GDB doesn't load the encoded contents unless it is explicitly configured to either ignore any safeguards regarding foreign scripts, or if the currently debugged executable is in the "safe" script sources.

GDB documents this facility here: https://sourceware.org/gdb/current/onlinedocs/gdb.html/dotdebug_005fgdb_005fscripts-section.html

Right now this is used by the Unix port and the debug information gets embedded only for debug builds if the "EMBED_DEBUG_INFO" variable is set in the make command line.

<hr>

This came up during a discussion between @AJMansfield and I - as we both wrote our own GDB helper scripts/printers to decode container objects, QSTRs, raw `mp_obj_t` payloads and so on - and we both ended up having the same pain points regarding how to find out configuration settings that were lost in the build process (like the chosen object representation).

Even though this PR does not embed configuration information on anything but the Unix port when compiled for Linux, this method is also safe for embedded targets.  Board deployment programs/flashers/etc already ignore non-relevant sections, so an ELF size increase does not correspond to an on-flash size increase.

The configuration encoding mechanism can also be changed to also be available for non-debug builds, but the main use case is to augment GDB helper scripts - which greatly benefit from having debug symbols in.

That said, this can also be the starting point for an official GDB printers/helpers script that could be either provided in a separate repo or shipped with MicroPython itself (like other projects do, including CPython).

### Testing

Debug information was retrieved from a GDB session with this commands sequence:

```
$ make -C ports/unix DEBUG=1 EMBED_DEBUG_INFO=1
$ gdb \
	-q \
	-iex "set auto-load safe-path $(pwd)/ports/unix/build-standard/micropython" \
	ports/unix/build-standard/micropython

Reading symbols from ports/unix/build-standard/micropython...
(gdb) python print(MPY_BINARY_DEBUG_INFO)
{'float_impl': 2, 'longint_impl': 2, 'mpz_dig_size': 16, 'obj_immediate_objs': True, 'obj_repr': 0, 'timestamp_impl': 2}
(gdb)
```

### Trade-offs and Alternatives

There may be some security concerns related to the mechanisms used to generate and load the encoded data.

For data generation, since these changes interact directly with the preprocessor and use Python's `eval` to clean data up, this functionality is enabled only in response to explicit user input, at which point an eventual attacker already has full control of the execution environment.

Data consumption events only occur in rather specialised situations and they also require an explicit configuration from the user or a general misconfiguration of the GDB installation.  In the latter case, literally any other malicious binary would already have exploited all that's available to exploit.

An alternative could be to generate a json/yaml/etc. version of the collected debug information and store it in the build directory, however that's one more file to keep track of when having to debug certain issues reported by third parties - where an ELF file is usually provided but not even core files are a given.

### Generative AI

I did not use generative AI tools when creating this PR.