### PR TITLE
py/persistentcode: Use MP_ENCODE_UINT_MAX_BYTES instead of custom macro.

### DIFF
--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -558,9 +558,8 @@ static void mp_print_bytes(mp_print_t *print, const byte *data, size_t len) {
     print->print_strn(print->data, (const char *)data, len);
 }
 
-#define BYTES_FOR_INT ((MP_BYTES_PER_OBJ_WORD * 8 + 6) / 7)
 static void mp_print_uint(mp_print_t *print, size_t n) {
-    byte buf[BYTES_FOR_INT];
+    byte buf[MP_ENCODE_UINT_MAX_BYTES];
     byte *p = buf + sizeof(buf);
     *--p = n & 0x7f;
     n >>= 7;


### PR DESCRIPTION
### Summary

MP_ENCODE_UINT_MAX_BYTES has an equivalent value to BYTES_FOR_INT and the former is used in other locations to encode variable (u)int values.

### Testing

To be tested by CI.

### Generative AI

I did not use generative AI tools when creating this PR.