### PR TITLE
esp32: Drop support for ESP-IDF <v5.3, fix build on ESP-IDF v5.3

### DIFF
--- a/.github/actions/setup_esp32/action.yml
+++ b/.github/actions/setup_esp32/action.yml
@@ -1,0 +1,41 @@
+name: Setup ESP-IDF for CI
+description: Install ESP-IDF (from cache if necessary) and setup
+inputs:
+  idf_ver:
+    required: true
+    type: string
+  ccache_key:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+
+  steps:
+  - id: python_ver
+    name: Read the Python version
+    run: echo PYTHON_VER=py$(python --version | cut -d' ' -f2) | tee "${GITHUB_OUTPUT}"
+    shell: bash
+
+  - name: Cached ESP-IDF install
+    id: cache_esp_idf
+    uses: actions/cache@v5
+    with:
+      path: |
+        ./esp-idf/
+        ~/.espressif/
+        !~/.espressif/dist/
+        ~/.cache/pip/
+      # Cache is keyed on both IDF version (from the job) and Python version (from the runner)
+      key: esp-idf-${{ inputs.idf_ver }}-${{ steps.python_ver.outputs.PYTHON_VER }}
+
+  - name: Install ESP-IDF packages
+    if: steps.cache_esp_idf.outputs.cache-hit != 'true'
+    run: IDF_VER=${{ inputs.idf_ver }} tools/ci.sh esp32_idf_setup
+    shell: bash
+
+  - name: ccache
+    uses: hendrikmuhs/ccache-action@v1.2
+    with:
+      key: esp32-${{ inputs.ccache_key }}
+

--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -32,28 +32,19 @@ jobs:
     - name: Install packages
       run: tools/ci.sh code_size_setup
 
-    # Needs to be kept in synch with ports_esp32.yml
-    - id: idf_ver
-      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
-      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
-    - name: Cached ESP-IDF install
-      id: cache_esp_idf
-      uses: actions/cache@v5
-      with:
-        path: |
-          ./esp-idf/
-          ~/.espressif/
-          !~/.espressif/dist/
-          ~/.cache/pip/
-        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
-    - name: Install ESP-IDF packages
-      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
-      run: tools/ci.sh esp32_idf_setup
+    - name: Find Latest ESP-IDF version
+      id: idf_ver
+      description: Parses ports_esp32.yml for the highest ESP-IDF version we build in CI.
+      run: |
+          echo "IDF_VER="$(yq .jobs.build_idf.strategy.matrix.idf_ver|sort[-1] \
+            < .github/workflows/ports_esp32.yml) \
+            | tee "${GITHUB_OUTPUT}"
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    - name: Setup ESP-IDF
+      uses: ./.github/actions/setup_esp32
       with:
-        key: code_size
+        idf_ver: ${{ steps.idf_ver.outputs.IDF_VER }}
+        ccache_key: code_size
 
     - name: Build
       run: tools/ci.sh code_size_build

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -26,40 +26,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Build for both oldest and newest supported ESP-IDF versions, as per ports/esp32/README.md
+        # (if updating here, also update "IDF_LATEST_VER" below)
+        idf_ver:
+          - "v5.3"
+          - "v5.5.1"
         ci_func:  # names are functions in ci.sh
           - esp32_build_cmod_spiram_s2
           - esp32_build_s3_c3
           - esp32_build_c2_c5_c6
           - esp32_build_p4
+    env:
+        IDF_LATEST_VER: "v5.5.1"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
 
-    # Needs to be kept in synch with code_size.yml
-    - id: idf_ver
-      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
-      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
+    # Only the latest IDF version will build the ESP-IDF lockfiles correctly,
+    # so we need to disable MICROPY_MAINTAINER_BUILD on older versions.
+    - name: Disable extra checks for older ESP-IDF
+      id: check_latest_ver
+      if: ${{ matrix.idf_ver != env.IDF_LATEST_VER }}
+      run: echo "MICROPY_MAINTAINER_BUILD=0" >> ${GITHUB_ENV}
 
-    - name: Cached ESP-IDF install
-      id: cache_esp_idf
-      uses: actions/cache@v5
+    - name: Setup ESP-IDF
+      uses: ./.github/actions/setup_esp32
       with:
-        path: |
-          ./esp-idf/
-          ~/.espressif/
-          !~/.espressif/dist/
-          ~/.cache/pip/
-        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
+        idf_ver: ${{ matrix.idf_ver }}
+        ccache_key: ${{ matrix.ci_func }}
 
-    - name: Install ESP-IDF packages
-      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
-      run: tools/ci.sh esp32_idf_setup
 
-    # Needs to be kept in synch with code_size.yml
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: esp32-${{ matrix.ci_func }}
-
-    - name: Build ci_${{matrix.ci_func }}
+    - name: Build ci_${{matrix.ci_func }} on ESP-IDF ${{ matrix.idf_ver }}
       run: tools/ci.sh ${{ matrix.ci_func }}

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -55,6 +55,9 @@ The ESP-IDF changes quickly and MicroPython only supports certain versions. The
 current recommended version of ESP-IDF for MicroPython is v5.5.1. MicroPython
 also supports v5.3, v5.4, v5.4.1 and v5.4.2.
 
+<!-- Important: If updating the above, also update
+     .github/workflows/port_esp32.yml and the lockfiles/ subdirectory. -->
+
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).
 

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -53,7 +53,7 @@ build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
 current recommended version of ESP-IDF for MicroPython is v5.5.1. MicroPython
-also supports v5.2, v5.2.2, v5.3, v5.4, v5.4.1 and v5.4.2.
+also supports v5.3, v5.4, v5.4.1 and v5.4.2.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -10,7 +10,9 @@ fi
 ulimit -n 1024
 
 # Fail on some things which are warnings otherwise
-export MICROPY_MAINTAINER_BUILD=1
+if [ -z $MICROPY_MAINTAINER_BUILD ]; then
+    export MICROPY_MAINTAINER_BUILD=1
+fi
 
 ########################################################################################
 # general helper functions
@@ -206,20 +208,11 @@ function ci_embedding_build {
 ########################################################################################
 # ports/esp32
 
-# GitHub tag of ESP-IDF to use for CI, extracted from the esp32 dependency lockfile
-# This should end up as a tag name like vX.Y.Z
-# (note: This hacky parsing can be replaced with 'yq' once Ubuntu >=24.04 is in use)
-IDF_VER=v$(grep -A10 "idf:" ports/esp32/lockfiles/dependencies.lock.esp32 | grep "version:" | head -n1 | sed -E 's/ +version: //')
-PYTHON=$(command -v python3 2> /dev/null)
-PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
-
-export IDF_CCACHE_ENABLE=1
-
-function ci_esp32_idf_ver {
-    echo "IDF_VER=${IDF_VER}-py${PYTHON_VER}"
-}
-
 function ci_esp32_idf_setup {
+    if [ -z $IDF_VER ]; then
+        echo "IDF_VER environment variable must be set before running"
+        return 1
+    fi
     echo "Using ESP-IDF version $IDF_VER"
     git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git
     # doing a treeless clone isn't quite as good as --shallow-submodules, but it


### PR DESCRIPTION
### Summary

* We try to support at least some older ESP-IDF versions, so that people making custom MicroPython builds on esp32 aren't always forced to upgrade. Unfortunately we've sometimes merged fixes that break on older ESP-IDF and not noticed until later (recent example: https://github.com/micropython/micropython/pull/18894#issuecomment-4016278894)
* This PR drops support for ESP-IDF v5.2.x, leaving us with three minor versions to support.
* Also applies necessary fixes to build the esp32 port under ESP-IDF v5.3.

### Testing

* Built with ESP-IDF v5.3 and v5.4 locally. Also built with ESP-IDF v5.3 in CI (those changes split off to a new PR, however).

### Trade-offs and Alternatives

* Could more aggressively drop older versions. This makes our lives easier, and is arguably better than the current situation where we "support" older ESP-IDF but the port doesn't actually build. However, having some support for older ESP-IDF seems like a very helpful thing if you're maintaining a custom MicroPython build and want to update MicroPython without always updating ESP-IDF.

### Generative AI

I did not use generative AI tools when creating this PR.