### PR TITLE
github: Revert "Run esp32&zephyr daily to keep mstr branch caches hot".

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -12,10 +12,6 @@ on:
       - 'lib/**'
       - 'drivers/**'
       - 'ports/esp32/**'
-  schedule:
-     # Scheduled run exists to keep master branch ESP-IDF cache entry hot
-     # and prevent creating many redundant per-branch cache entries instead.
-     - cron: "20 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -12,10 +12,6 @@ on:
       - 'lib/**'
       - 'ports/zephyr/**'
       - 'tests/**'
-  schedule:
-     # Scheduled run exists to keep master branch Zephyr cache entry hot
-     # and prevent creating many redundant per-branch cache entries instead.
-     - cron: "40 4 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Summary

This reverts commit 046013a1ffbeccb971b6067ff389ebd0350b9e9c (#18130).

Looks like since the latest round of GitHub Actions updates, the Cache LRU algorithm is working as designed again.

*This work was funded through GitHub Sponsors.*

### Generative AI

I did not use generative AI tools when creating this PR.
