### PR TITLE
esp32: Only check the lockfile currently used by the build.

### DIFF
--- a/ports/esp32/CMakeLists.txt
+++ b/ports/esp32/CMakeLists.txt
@@ -63,19 +63,20 @@ set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 # Generate individual dependencies.lock files based on chip target
-idf_build_set_property(DEPENDENCIES_LOCK lockfiles/dependencies.lock.${IDF_TARGET})
+set(LOCKFILE_PATH lockfiles/dependencies.lock.${IDF_TARGET})
+idf_build_set_property(DEPENDENCIES_LOCK ${LOCKFILE_PATH})
 
 # Define the project.
 project(micropython)
 
 # Check for lockfile changes and either warn or error depending on build type
 message("Checking lockfile contents...")
-execute_process(COMMAND git diff --exit-code lockfiles/ WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+execute_process(COMMAND git diff --exit-code ${LOCKFILE_PATH} WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     RESULT_VARIABLE RES)
 if (RES)
     # Maintainer builds (CI or autobuild runs) should fail if this has happened
     if($ENV{MICROPY_MAINTAINER_BUILD})
-        message(FATAL_ERROR "Failing build as lockfiles are dirty (see above). Check that ESP-IDF versions match.")
+        message(FATAL_ERROR "Failing build as lockfile is dirty (see above). Check that ESP-IDF versions match.")
     else()
         message(WARNING "Component lockfile contents have changed (see above). This may be due to building with a different ESP-IDF version. Please mention this output if reporting an issue with MicroPython.")
     endif()


### PR DESCRIPTION
### Summary

Small tweak to avoid changes in other targets' lockfiles from printing warnings when building esp32 port.

Spun out from #18915.

*This work was funded through GitHub Sponsors.*

### Generative AI

I did not use generative AI tools when creating this PR.
