### PR TITLE
esp32: Drop support for ESP-IDF <v5.3, fix build on ESP-IDF v5.3

### DIFF
--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -53,7 +53,7 @@ build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
 current recommended version of ESP-IDF for MicroPython is v5.5.1. MicroPython
-also supports v5.2, v5.2.2, v5.3, v5.4, v5.4.1 and v5.4.2.
+also supports v5.3, v5.4, v5.4.1 and v5.4.2.
 
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -277,14 +277,6 @@ target_compile_options(${MICROPY_TARGET} PUBLIC
 target_include_directories(${MICROPY_TARGET} PUBLIC
     ${IDF_PATH}/components/bt/host/nimble/nimble
 )
-if (IDF_VERSION VERSION_LESS "5.3")
-# Additional include directories needed for private RMT header.
-#  IDF 5.x versions before 5.3.1
-  message(STATUS "Using private rmt headers for ${IDF_VERSION}")
-  target_include_directories(${MICROPY_TARGET} PRIVATE
-    ${IDF_PATH}/components/driver/rmt
-  )
-endif()
 
 # Add additional extmod and usermod components.
 if (MICROPY_PY_BTREE)

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -169,7 +169,6 @@ list(APPEND IDF_COMPONENTS
     esp_app_format
     esp_mm
     esp_common
-    esp_driver_touch_sens
     esp_eth
     esp_event
     esp_hw_support
@@ -197,6 +196,11 @@ list(APPEND IDF_COMPONENTS
     usb
     vfs
 )
+
+if($ENV{IDF_VERSION} VERSION_GREATER_EQUAL "5.4")
+    list(APPEND IDF_COMPONENTS
+        esp_driver_touch_sens)
+endif()
 
 # Provide the default LD fragment if not set
 if (MICROPY_USER_LDFRAGMENTS)

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -30,6 +30,6 @@ direct_dependencies:
 - espressif/lan867x
 - espressif/mdns
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32c2
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32c3
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32c5
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32c6
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -88,6 +88,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32p4
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -32,6 +32,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32s2
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -32,6 +32,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 482087bc40f0e187795a9ef9ad08ef15a585b4cdabc296c715a9d19284622150
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
 target: esp32s3
 version: 2.0.0

--- a/ports/esp32/machine_bitstream.c
+++ b/ports/esp32/machine_bitstream.c
@@ -95,9 +95,6 @@ static void IRAM_ATTR machine_bitstream_high_low_bitbang(mp_hal_pin_obj_t pin, u
 /******************************************************************************/
 // RMT implementation
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
-#include "rmt_private.h"
-#endif
 #include "driver/rmt_tx.h"
 #include "driver/rmt_encoder.h"
 
@@ -159,11 +156,7 @@ static bool machine_bitstream_high_low_rmt(mp_hal_pin_obj_t pin, uint32_t *timin
     // Disable and release channel.
     check_esp_err(rmt_del_encoder(encoder));
     rmt_disable(channel);
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
-    channel->del(channel);
-    #else
     rmt_del_channel(channel);
-    #endif
 
     // Cancel RMT output to GPIO pin.
     esp_rom_gpio_connect_out_signal(pin, SIG_GPIO_OUT_IDX, false, false);

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -183,7 +183,15 @@ void machine_timer_enable(machine_timer_obj_t *self) {
     }
 
     timer_ll_enable_counter(self->hal_context.dev, self->index, false);
+
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     esp_clk_tree_enable_src(TIMER_CLK_SRC, true);
+    #elif TIMER_CLK_SRC != SOC_MOD_CLK_APB
+    // esp_clk_tree_enable_src() is only required on some newer chips where timer
+    // source clock may not be enabled by default
+    #error "This chip requires ESP-IDF v5.4 or newer for working Timer."
+    #endif
+
     #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     timer_ll_set_clock_source(self->hal_context.dev, self->index, TIMER_CLK_SRC);
     timer_ll_enable_clock(self->hal_context.dev, self->index, true);

--- a/ports/esp32/machine_touchpad.c
+++ b/ports/esp32/machine_touchpad.c
@@ -31,14 +31,6 @@
 
 #if SOC_TOUCH_SENSOR_SUPPORTED
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
-#if SOC_TOUCH_VERSION_1
-#define SOC_TOUCH_SENSOR_VERSION (1)
-#elif SOC_TOUCH_VERSION_2
-#define SOC_TOUCH_SENSOR_VERSION (2)
-#endif
-#endif
-
 #if SOC_TOUCH_SENSOR_VERSION == 1 // ESP32 only
 #include "driver/touch_pad.h"
 #elif SOC_TOUCH_SENSOR_VERSION == 2 // most ESP32

--- a/ports/esp32/main/idf_component.yml
+++ b/ports/esp32/main/idf_component.yml
@@ -19,6 +19,5 @@ dependencies:
     version: "~1.0.0"
     rules:
       - if: "target == esp32"
-      - if: "idf_version >=5.3"
   idf:
-    version: ">=5.2.0"
+    version: ">=5.3.0"

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -29,8 +29,8 @@
 #include "esp_wifi_types.h"
 #include "esp_netif.h"
 
-// lan867x component requires newer IDF version
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0) && CONFIG_IDF_TARGET_ESP32
+// lan867x component requires Original ESP32
+#if CONFIG_IDF_TARGET_ESP32
 #define PHY_LAN867X_ENABLED (1)
 #else
 #define PHY_LAN867X_ENABLED (0)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -140,8 +140,8 @@
 #define MICROPY_PY_MACHINE_I2C              (1)
 #define MICROPY_PY_MACHINE_I2C_TRANSFER_WRITE1 (1)
 #ifndef MICROPY_PY_MACHINE_I2C_TARGET
-// I2C target hardware is limited on ESP32 (eg read event comes after the read) so we only support newer SoCs.
-#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32)
+// I2C target hardware is limited on ESP32 (eg read event comes after the read) so we only support newer SoCs & ESP-IDF v5.4 or newer
+#define MICROPY_PY_MACHINE_I2C_TARGET       (SOC_I2C_SUPPORT_SLAVE && !CONFIG_IDF_TARGET_ESP32 && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0))
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/esp32/machine_i2c_target.c"
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX   (2)
 #endif

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -769,9 +769,7 @@ static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_ENT_192), MP_ROM_INT(WIFI_AUTH_WPA3_ENT_192) },
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK) },
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_EXT_PSK_MIXED_MODE), MP_ROM_INT(WIFI_AUTH_WPA3_EXT_PSK_MIXED_MODE) },
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     { MP_ROM_QSTR(MP_QSTR_SEC_DPP), MP_ROM_INT(WIFI_AUTH_DPP) },
-    #endif
     #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA3_ENT), MP_ROM_INT(WIFI_AUTH_WPA3_ENTERPRISE) },
     { MP_ROM_QSTR(MP_QSTR_SEC_WPA2_WPA3_ENT), MP_ROM_INT(WIFI_AUTH_WPA2_WPA3_ENTERPRISE) },
@@ -797,8 +795,6 @@ _Static_assert(WIFI_AUTH_MAX == 17, "Synchronize WIFI_AUTH_XXX constants with th
 _Static_assert(WIFI_AUTH_MAX == 16, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types_generic.h");
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 _Static_assert(WIFI_AUTH_MAX == 14, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types_generic.h");
-#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-_Static_assert(WIFI_AUTH_MAX == 13, "Synchronize WIFI_AUTH_XXX constants with the ESP-IDF. Look at esp-idf/components/esp_wifi/include/esp_wifi_types.h");
 #else
 #error "Error in macro logic, all supported versions should be covered."
 #endif

--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -36,9 +36,7 @@
 #include "freertos/portmacro.h"
 
 // Number of bytes in the input buffer, and number of bytes for output chunking.
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)
-#endif
 
 static DRAM_ATTR portMUX_TYPE rx_mux = portMUX_INITIALIZER_UNLOCKED;
 static uint8_t rx_buf[USB_SERIAL_JTAG_PACKET_SZ_BYTES];


### PR DESCRIPTION
### Summary

* We try to support at least some older ESP-IDF versions, so that people making custom MicroPython builds on esp32 aren't always forced to upgrade. Unfortunately we've sometimes merged fixes that break on older ESP-IDF and not noticed until later (recent example: https://github.com/micropython/micropython/pull/18894#issuecomment-4016278894)
* This PR drops support for ESP-IDF v5.2.x, leaving us with three minor versions to support.
* Also applies necessary fixes to build the esp32 port under ESP-IDF v5.3.

### Testing

* Built with ESP-IDF v5.3 and v5.4 locally. Also built with ESP-IDF v5.3 in CI (those changes split off to #18919, however).

### Trade-offs and Alternatives

* Could more aggressively drop older versions. This makes our lives easier, and is arguably better than the current situation where we "support" older ESP-IDF but the port doesn't actually build. However, having some support for older ESP-IDF seems like a very helpful thing if you're maintaining a custom MicroPython build and want to update MicroPython without always updating ESP-IDF.

### Generative AI

I did not use generative AI tools when creating this PR.