### PR TITLE
ci,esp32: Build oldest & newest ESP-IDF versions in CI.

### DIFF
--- a/.github/actions/setup_esp32/action.yml
+++ b/.github/actions/setup_esp32/action.yml
@@ -1,0 +1,47 @@
+name: Setup ESP-IDF for CI
+description: Install ESP-IDF
+inputs:
+  idf_ver:
+    required: true
+    type: string
+  ccache_key:
+    required: true
+    type: string
+
+runs:
+  using: "composite"
+
+  steps:
+  - id: python_ver
+    name: Read the Python version
+    run: echo PYTHON_VER=py$(python --version | cut -d' ' -f2) | tee "${GITHUB_OUTPUT}"
+    shell: bash
+
+  - name: Cached ESP-IDF install
+    id: cache_esp_idf
+    uses: actions/cache@v5
+    with:
+      path: |
+        ./esp-idf/
+        ~/.espressif/
+        !~/.espressif/dist/
+        ~/.cache/pip/
+      # Cache is keyed on both IDF version (from the job) and Python version (from the runner)
+      key: esp-idf-${{ inputs.idf_ver }}-${{ steps.python_ver.outputs.PYTHON_VER }}
+
+  - name: Install ESP-IDF packages
+    if: steps.cache_esp_idf.outputs.cache-hit != 'true'
+    env:
+       IDF_VER: ${{ inputs.idf_ver }}
+    run: tools/ci.sh esp32_idf_setup
+    shell: bash
+
+  - name: ccache
+    uses: hendrikmuhs/ccache-action@v1.2
+    with:
+      key: esp32-${{ inputs.idf_ver }}-${{ inputs.ccache_key }}
+
+  - name: Enable CCache for ESP-IDF
+    run: echo "IDF_CCACHE_ENABLE=1" >> ${GITHUB_ENV}
+    shell: bash
+

--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -32,28 +32,17 @@ jobs:
     - name: Install packages
       run: tools/ci.sh code_size_setup
 
-    # Needs to be kept in synch with ports_esp32.yml
-    - id: idf_ver
-      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
-      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
-    - name: Cached ESP-IDF install
-      id: cache_esp_idf
-      uses: actions/cache@v5
-      with:
-        path: |
-          ./esp-idf/
-          ~/.espressif/
-          !~/.espressif/dist/
-          ~/.cache/pip/
-        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
-    - name: Install ESP-IDF packages
-      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
-      run: tools/ci.sh esp32_idf_setup
+    - name: Find IDF_NEWEST_VER
+      id: idf_ver
+      run: |
+          echo "IDF_VER="$(yq .env.IDF_NEWEST_VER < .github/workflows/ports_esp32.yml) \
+          | tee "${GITHUB_OUTPUT}"
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    - name: Setup ESP-IDF
+      uses: ./.github/actions/setup_esp32
       with:
-        key: code_size
+        idf_ver: ${{ steps.idf_ver.outputs.IDF_VER }}
+        ccache_key: code_size
 
     - name: Build
       run: tools/ci.sh code_size_build

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -17,45 +17,47 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+   # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
+   IDF_OLDEST_VER: &oldest "v5.3"
+   IDF_NEWEST_VER: &newest "v5.5.1"
+
 jobs:
   build_idf:
     strategy:
       fail-fast: false
       matrix:
+        idf_ver:
+          - *oldest
+          - *newest
         ci_func:  # names are functions in ci.sh
           - esp32_build_cmod_spiram_s2
           - esp32_build_s3_c3
           - esp32_build_c2_c5_c6
           - esp32_build_p4
+        exclude:
+          # Exclude some jobs on the oldest IDF version, to save resources
+          - idf_ver: *oldest
+            ci_func: esp32_build_c2_c5_c6
+          - idf_ver: *oldest
+            ci_func: esp32_build_p4
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
 
-    # Needs to be kept in synch with code_size.yml
-    - id: idf_ver
-      name: Read the ESP-IDF version (including Python version) and set outputs.IDF_VER
-      run: tools/ci.sh esp32_idf_ver | tee "${GITHUB_OUTPUT}"
+    # Only the newest IDF version will build the ESP-IDF lockfiles correctly,
+    # so we need to disable MICROPY_MAINTAINER_BUILD on older versions.
+    - name: Disable extra checks for older ESP-IDF
+      id: check_newest_ver
+      if: ${{ matrix.idf_ver != env.IDF_NEWEST_VER }}
+      run: echo "MICROPY_MAINTAINER_BUILD=0" >> ${GITHUB_ENV}
 
-    - name: Cached ESP-IDF install
-      id: cache_esp_idf
-      uses: actions/cache@v5
+    - name: Setup ESP-IDF
+      uses: ./.github/actions/setup_esp32
       with:
-        path: |
-          ./esp-idf/
-          ~/.espressif/
-          !~/.espressif/dist/
-          ~/.cache/pip/
-        key: esp-idf-${{ steps.idf_ver.outputs.IDF_VER }}
+        idf_ver: ${{ matrix.idf_ver }}
+        ccache_key: ${{ matrix.ci_func }}
 
-    - name: Install ESP-IDF packages
-      if: steps.cache_esp_idf.outputs.cache-hit != 'true'
-      run: tools/ci.sh esp32_idf_setup
 
-    # Needs to be kept in synch with code_size.yml
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: esp32-${{ matrix.ci_func }}
-
-    - name: Build ci_${{matrix.ci_func }}
+    - name: Build ci_${{matrix.ci_func }} on ESP-IDF ${{ matrix.idf_ver }}
       run: tools/ci.sh ${{ matrix.ci_func }}

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -55,6 +55,12 @@ The ESP-IDF changes quickly and MicroPython only supports certain versions. The
 current recommended version of ESP-IDF for MicroPython is v5.5.1. MicroPython
 also supports v5.3, v5.4, v5.4.1 and v5.4.2.
 
+<!-- Important: If updating the above, please also update:
+     * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml
+     * minimum version at bottom of main/idf_component.yml
+     * the lockfiles/ subdirectory.
+-->
+
 To install the ESP-IDF the full instructions can be found at the
 [Espressif Getting Started guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#installation-step-by-step).
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -10,7 +10,9 @@ fi
 ulimit -n 1024
 
 # Fail on some things which are warnings otherwise
-export MICROPY_MAINTAINER_BUILD=1
+if [ -z "$MICROPY_MAINTAINER_BUILD" ]; then
+    export MICROPY_MAINTAINER_BUILD=1
+fi
 
 ########################################################################################
 # general helper functions
@@ -206,20 +208,11 @@ function ci_embedding_build {
 ########################################################################################
 # ports/esp32
 
-# GitHub tag of ESP-IDF to use for CI, extracted from the esp32 dependency lockfile
-# This should end up as a tag name like vX.Y.Z
-# (note: This hacky parsing can be replaced with 'yq' once Ubuntu >=24.04 is in use)
-IDF_VER=v$(grep -A10 "idf:" ports/esp32/lockfiles/dependencies.lock.esp32 | grep "version:" | head -n1 | sed -E 's/ +version: //')
-PYTHON=$(command -v python3 2> /dev/null)
-PYTHON_VER=$(${PYTHON:-python} --version | cut -d' ' -f2)
-
-export IDF_CCACHE_ENABLE=1
-
-function ci_esp32_idf_ver {
-    echo "IDF_VER=${IDF_VER}-py${PYTHON_VER}"
-}
-
 function ci_esp32_idf_setup {
+    if [ -z "$IDF_VER" ]; then
+        echo "IDF_VER environment variable must be set before running"
+        return 1
+    fi
     echo "Using ESP-IDF version $IDF_VER"
     git clone --depth 1 --branch $IDF_VER https://github.com/espressif/esp-idf.git
     # doing a treeless clone isn't quite as good as --shallow-submodules, but it


### PR DESCRIPTION
### Summary

Intended to catch problems where new features don't build in old ESP-IDF. This PR has been split off from fixes applied in #18918, it will fail the v5.3 build until that PR is merged and this is rebased on top. (Edit: now rebased!)

Includes major refactor to the GitHub Actions Workflow for esp32 port, including making a reusable workflow for both Code Size and ESP32 build jobs.

*This work was funded through GitHub Sponsors.*

### Testing

* Testing was mostly building the changes from #18918 in my own fork, and verifying they build OK in CI.
* Checked the caching was working and that the ccache stats looked healthy.
* Checked the build still breaks if the component manifest changes due to a different ESP-IDF version.

### Trade-offs and Alternatives

* The trade-off is we're adding two more CI build jobs. They run in parallel with the others, but due to resource limits from GitHub this will make CI a little slower.
* On the plus side this should prevent the need for catch-up fix PRs like #18918.

### Generative AI

I did not use generative AI tools when creating this PR.
