### PR TITLE
objtemplate: Correctly cast qstr literals.

### DIFF
--- a/py/objtemplate.c
+++ b/py/objtemplate.c
@@ -152,9 +152,9 @@ static mp_obj_t mp_obj_template_make_new(const mp_obj_type_t *type, size_t n_arg
 static void mp_obj_template_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_template_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "%q(%q=", MP_QSTR_Template, MP_QSTR_strings);
+    mp_printf(print, "%q(%q=", (qstr)MP_QSTR_Template, (qstr)MP_QSTR_strings);
     mp_obj_print_helper(print, self->strings, PRINT_REPR);
-    mp_printf(print, ", %q=", MP_QSTR_interpolations);
+    mp_printf(print, ", %q=", (qstr)MP_QSTR_interpolations);
     mp_obj_print_helper(print, self->interpolations, PRINT_REPR);
     mp_print_str(print, ")");
 }
@@ -346,7 +346,7 @@ static mp_obj_t mp_obj_interpolation_make_new(const mp_obj_type_t *type, size_t 
 static void mp_obj_interpolation_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     mp_obj_interpolation_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_printf(print, "%q(", MP_QSTR_Interpolation);
+    mp_printf(print, "%q(", (qstr)MP_QSTR_Interpolation);
     mp_obj_print_helper(print, self->value, PRINT_REPR);
     mp_print_str(print, ", ");
     mp_obj_print_helper(print, self->expression, PRINT_REPR);


### PR DESCRIPTION
### Summary

qstr literals are of type qstr_short_t, aka uint16_t. for efficiency, but when the type is passed to `mp_printf` it must be cast explicitly to type `qstr`.

These locations were found using an experimental gcc plugin for `mp_printf` error checking (#17556)

### Testing

I built and tested t-strings locally in the Unix coverage build, which was one of the builds that encountered an error using the plugin.

### Generative AI

I did not use generative AI tools when creating this PR.