### PR TITLE
various: Avoid `qstr_str` calls.

### DIFF
--- a/ports/mimxrt/machine_pin.c
+++ b/ports/mimxrt/machine_pin.c
@@ -329,7 +329,7 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
 static void machine_pin_obj_print(const mp_print_t *print, mp_obj_t o, mp_print_kind_t kind) {
     (void)kind;
     const machine_pin_obj_t *self = MP_OBJ_TO_PTR(o);
-    mp_printf(print, "Pin(%s)", qstr_str(self->name));
+    mp_printf(print, "Pin(%q)", (qstr)self->name);
 }
 
 // pin(id, mode, pull, ...)

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -1583,10 +1583,10 @@ MP_DEFINE_CONST_OBJ_TYPE(
 static void pyb_timer_channel_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     pyb_timer_channel_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    mp_printf(print, "TimerChannel(timer=%u, channel=%u, mode=%s)",
+    mp_printf(print, "TimerChannel(timer=%u, channel=%u, mode=%q)",
         self->timer->tim_id,
         self->channel,
-        qstr_str(channel_mode_info[self->mode].name));
+        (qstr)channel_mode_info[self->mode].name);
 }
 
 /// \method capture([value])

--- a/ports/unix/modjni.c
+++ b/ports/unix/modjni.c
@@ -357,7 +357,7 @@ static void jmethod_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
     (void)kind;
     mp_obj_jmethod_t *self = MP_OBJ_TO_PTR(self_in);
     // Variable value printed as cast to int
-    mp_printf(print, "<jmethod '%s'>", qstr_str(self->name));
+    mp_printf(print, "<jmethod '%q'>", (qstr)self->name);
 }
 
 #define IMATCH(s, static) ((!strncmp(s, static, sizeof(static) - 1)) && (s += sizeof(static) - 1))

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -134,7 +134,7 @@ static void asm_debug_reg_imm(asm_debug_t *as, const char *op, int reg, int imm)
 
 #if !MICROPY_PERSISTENT_CODE_SAVE
 static void asm_debug_reg_qstr(asm_debug_t *as, const char *op, int reg, int qst) {
-    asm_debug_printf(as, "%s(%s, %s)\n", op, reg_name_table[reg], qstr_str(qst));
+    asm_debug_printf(as, "%s(%s, %q)\n", op, reg_name_table[reg], (qstr)qst);
 }
 #endif
 

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -165,7 +165,7 @@ void mp_obj_exception_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kin
     mp_print_kind_t k = kind & ~PRINT_EXC_SUBCLASS;
     bool is_subclass = kind & PRINT_EXC_SUBCLASS;
     if (!is_subclass && (k == PRINT_REPR || k == PRINT_EXC)) {
-        mp_print_str(print, qstr_str(o->base.type->name));
+        mp_print_str(print, mp_obj_get_type_str(o_in));
     }
 
     if (k == PRINT_EXC) {

--- a/py/parse.c
+++ b/py/parse.c
@@ -491,10 +491,10 @@ void mp_parse_node_print(const mp_print_t *print, mp_parse_node_t pn, size_t ind
         uintptr_t arg = MP_PARSE_NODE_LEAF_ARG(pn);
         switch (MP_PARSE_NODE_LEAF_KIND(pn)) {
             case MP_PARSE_NODE_ID:
-                mp_printf(print, "id(%s)\n", qstr_str(arg));
+                mp_printf(print, "id(%q)\n", (qstr)arg);
                 break;
             case MP_PARSE_NODE_STRING:
-                mp_printf(print, "str(%s)\n", qstr_str(arg));
+                mp_printf(print, "str(%q)\n", (qstr)arg);
                 break;
             default:
                 assert(MP_PARSE_NODE_LEAF_KIND(pn) == MP_PARSE_NODE_TOKEN);

--- a/py/showbc.c
+++ b/py/showbc.c
@@ -99,8 +99,8 @@ void mp_bytecode_print(const mp_print_t *print, const mp_raw_code_t *rc, size_t 
     #else
     qstr source_file = cm->source_file;
     #endif
-    mp_printf(print, "File %s, code block '%s' (descriptor: %p, bytecode @%p %u bytes)\n",
-        qstr_str(source_file), qstr_str(block_name), rc, ip_start, (unsigned)fun_data_len);
+    mp_printf(print, "File %q, code block '%q' (descriptor: %p, bytecode @%p %u bytes)\n",
+        source_file, block_name, rc, ip_start, (unsigned)fun_data_len);
 
     // raw bytecode dump
     size_t prelude_size = ip - ip_start + n_info + n_cell;
@@ -121,7 +121,7 @@ void mp_bytecode_print(const mp_print_t *print, const mp_raw_code_t *rc, size_t 
         #if MICROPY_EMIT_BYTECODE_USES_QSTR_TABLE
         qst = cm->qstr_table[qst];
         #endif
-        mp_printf(print, " %s", qstr_str(qst));
+        mp_printf(print, " %q", qst);
     }
     mp_printf(print, "\n");
 
@@ -189,7 +189,7 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
 
         case MP_BC_LOAD_CONST_STRING:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_CONST_STRING '%s'", qstr_str(qst));
+            mp_printf(print, "LOAD_CONST_STRING '%q'", qst);
             break;
 
         case MP_BC_LOAD_CONST_OBJ:
@@ -214,27 +214,27 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
 
         case MP_BC_LOAD_NAME:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_NAME %s", qstr_str(qst));
+            mp_printf(print, "LOAD_NAME %q", qst);
             break;
 
         case MP_BC_LOAD_GLOBAL:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_GLOBAL %s", qstr_str(qst));
+            mp_printf(print, "LOAD_GLOBAL %q", qst);
             break;
 
         case MP_BC_LOAD_ATTR:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_ATTR %s", qstr_str(qst));
+            mp_printf(print, "LOAD_ATTR %q", qst);
             break;
 
         case MP_BC_LOAD_METHOD:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_METHOD %s", qstr_str(qst));
+            mp_printf(print, "LOAD_METHOD %q", qst);
             break;
 
         case MP_BC_LOAD_SUPER_METHOD:
             DECODE_QSTR;
-            mp_printf(print, "LOAD_SUPER_METHOD %s", qstr_str(qst));
+            mp_printf(print, "LOAD_SUPER_METHOD %q", qst);
             break;
 
         case MP_BC_LOAD_BUILD_CLASS:
@@ -257,17 +257,17 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
 
         case MP_BC_STORE_NAME:
             DECODE_QSTR;
-            mp_printf(print, "STORE_NAME %s", qstr_str(qst));
+            mp_printf(print, "STORE_NAME %q", qst);
             break;
 
         case MP_BC_STORE_GLOBAL:
             DECODE_QSTR;
-            mp_printf(print, "STORE_GLOBAL %s", qstr_str(qst));
+            mp_printf(print, "STORE_GLOBAL %q", qst);
             break;
 
         case MP_BC_STORE_ATTR:
             DECODE_QSTR;
-            mp_printf(print, "STORE_ATTR %s", qstr_str(qst));
+            mp_printf(print, "STORE_ATTR %q", qst);
             break;
 
         case MP_BC_STORE_SUBSCR:
@@ -286,12 +286,12 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
 
         case MP_BC_DELETE_NAME:
             DECODE_QSTR;
-            mp_printf(print, "DELETE_NAME %s", qstr_str(qst));
+            mp_printf(print, "DELETE_NAME %q", qst);
             break;
 
         case MP_BC_DELETE_GLOBAL:
             DECODE_QSTR;
-            mp_printf(print, "DELETE_GLOBAL %s", qstr_str(qst));
+            mp_printf(print, "DELETE_GLOBAL %q", qst);
             break;
 
         case MP_BC_DUP_TOP:
@@ -506,12 +506,12 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
 
         case MP_BC_IMPORT_NAME:
             DECODE_QSTR;
-            mp_printf(print, "IMPORT_NAME '%s'", qstr_str(qst));
+            mp_printf(print, "IMPORT_NAME '%q'", qst);
             break;
 
         case MP_BC_IMPORT_FROM:
             DECODE_QSTR;
-            mp_printf(print, "IMPORT_FROM '%s'", qstr_str(qst));
+            mp_printf(print, "IMPORT_FROM '%q'", qst);
             break;
 
         case MP_BC_IMPORT_STAR:
@@ -527,10 +527,10 @@ const byte *mp_bytecode_print_str(const mp_print_t *print, const byte *ip_start,
                 mp_printf(print, "STORE_FAST " UINT_FMT, (mp_uint_t)ip[-1] - MP_BC_STORE_FAST_MULTI);
             } else if (ip[-1] < MP_BC_UNARY_OP_MULTI + MP_UNARY_OP_NUM_BYTECODE) {
                 mp_uint_t op = ip[-1] - MP_BC_UNARY_OP_MULTI;
-                mp_printf(print, "UNARY_OP " UINT_FMT " %s", op, qstr_str(mp_unary_op_method_name[op]));
+                mp_printf(print, "UNARY_OP " UINT_FMT " %q", op, (qstr)mp_unary_op_method_name[op]);
             } else if (ip[-1] < MP_BC_BINARY_OP_MULTI + MP_BINARY_OP_NUM_BYTECODE) {
                 mp_uint_t op = ip[-1] - MP_BC_BINARY_OP_MULTI;
-                mp_printf(print, "BINARY_OP " UINT_FMT " %s", op, qstr_str(mp_binary_op_method_name[op]));
+                mp_printf(print, "BINARY_OP " UINT_FMT " %q", op, (qstr)mp_binary_op_method_name[op]);
             } else {
                 mp_printf(print, "code %p, byte code 0x%02x not implemented\n", ip - 1, ip[-1]);
                 assert(0);


### PR DESCRIPTION
### Summary

The `%q` formatter of mp_printf can be used instead, and may save a small amount of code.

### Testing

I built the Unix port coverage build with the compile-time format checker (#17556).

### Generative AI

I did not use generative AI tools when creating this PR.