### PR TITLE
tools/mpy-tool.py: Clean up escaped compiled module name.

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1507,6 +1507,8 @@ def read_raw_code(reader, parent_name, qstr_table, obj_table, segments):
 
 
 def read_mpy(filename):
+    import re
+
     with open(filename, "rb") as fileobj:
         reader = MPYReader(filename, fileobj)
         segments = []
@@ -1551,7 +1553,10 @@ def read_mpy(filename):
             obj_table.append(read_obj(reader, segments))
 
         # Compute the compiled-module escaped name.
-        cm_escaped_name = qstr_table[0].str.replace("/", "_")[:-3]
+        module_name = qstr_table[0].str
+        if not all(0x7F >= ord(codepoint) >= 0x20 for codepoint in module_name):
+            raise MPYReadError(filename, "cannot have unicode characters in module name")
+        cm_escaped_name = re.sub("[^a-zA-Z0-9_]", "_", "_".join(module_name.split(".")[:-1]))
 
         # Read the outer raw code, which will in turn read all its children.
         raw_code_file_offset = reader.tell()
@@ -1732,7 +1737,7 @@ def freeze_mpy(firmware_qstr_idents, compiled_modules):
         if module_name.endswith("/__init__.py"):
             short_name = module_name[: -len("/__init__.py")]
         else:
-            short_name = module_name[: -len(".py")]
+            short_name = ".".join(module_name.split(".")[:-1])
         print('MICROPY_FROZEN_LIST_ITEM("%s", "%s")' % (short_name, module_name))
     print("#endif")
 


### PR DESCRIPTION
### Summary

This PR lets "mpy-tool.py" filter unwanted characters that may end up in the compiled module name, even after the first encoding pass.

Certain characters are already ASCII-safe but cannot appear in a C identifier (eg. dots, dashes, etc.).  Those characters, when appearing in a module name, won't be escaped and will be placed in the output C source code template when freezing files - leading to an invalid source file.

Now the code, after the first character encoding pass, will pre-process the compiled module name to use when filling out the C source code template.  Every character that is not expected to be part of a C identifier will be replaced with an underscore.

This closes #3445.

### Testing

A Python file was frozen with a custom module name containing characters that cannot be part of a C identifier, and the generated C file was compiled to make sure all generated identifiers are compliant:

```
$ cd ports/unix
$ make
$ printf "class Hello:\n  def __init__(self):\n    pass\n" > test.py
$ ../../mpy-cross/build/mpy-cross -o test.mpy -s "test.mpy" test.py
$ ../../tools/mpy-tool.py -f -q build-standard/genhdr/qstrdefs.preprocessed.h test.mpy > frozen.c
$ gcc -I. -I../.. -Ivariants/standard -Ibuild-standard -DMPZ_DIG_SIZE=16 -c frozen.c
$ size frozen.o
   text    data     bss     dec     hex filename
    155     176       0     331     14b frozen.o
```

### Trade-offs and Alternatives

This PR does not help recovering from cases where the module gets named with incompatible names (eg. starting with a digit), but that wouldn't have worked in the first place.

### Generative AI

I did not use generative AI tools when creating this PR.