### PR TITLE
stm32/make-pins.py: Fix GPIO AF constant for FDCAN peripherals.

### DIFF
--- a/ports/stm32/boards/make-pins.py
+++ b/ports/stm32/boards/make-pins.py
@@ -319,8 +319,10 @@ class Stm32PinGenerator(boardgen.PinGenerator):
                     "    #if defined({:s})".format(CONDITIONAL_VAR[af_fn].format(num=af_unit)),
                     file=out_af_const,
                 )
+            # For CAN, use FDCAN in the GPIO constant name (for STM32G0/etc compat).
+            gpio_name = name.replace("_CAN", "_FDCAN")
             print(
-                "    {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_INT(GPIO_{:s}) }},".format(name, name),
+                "    {{ MP_ROM_QSTR(MP_QSTR_{:s}), MP_ROM_INT(GPIO_{:s}) }},".format(name, gpio_name),
                 file=out_af_const,
             )
             if af_fn in CONDITIONAL_VAR:


### PR DESCRIPTION
This PR fixes the build failure on NUCLEO_G0B1RE (and other STM32G0 boards) when CAN is enabled.

## Problem

The STM32G0 series uses FDCAN instead of the older bxCAN. The `make-pins.py` script correctly maps "FDCAN" to "CAN" for the MicroPython API naming, but was incorrectly generating `GPIO_AFx_CANx` instead of `GPIO_AFx_FDCANx` for the underlying HAL GPIO constant.

This caused build failures when `MICROPY_HW_CAN1_TX` was defined:
```
error: 'GPIO_AF3_CAN1' undeclared here
```

## Solution

Map "CAN" back to "FDCAN" when generating the GPIO constant name in `print_af_const()`.

Before:
```c
{ MP_ROM_QSTR(MP_QSTR_AF3_CAN1), MP_ROM_INT(GPIO_AF3_CAN1) },  // Wrong - fails on G0
```

After:
```c
{ MP_ROM_QSTR(MP_QSTR_AF3_CAN1), MP_ROM_INT(GPIO_AF3_FDCAN1) },  // Correct
```

The MicroPython API name (`AF3_CAN1`) remains unchanged for compatibility.

Fixes #18312