### PR TITLE
stm32/tinyusb: Add High-Speed USB support and fix CDC/VBUS issues.

### DIFF
--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -28,7 +28,7 @@
 
 #if MICROPY_HW_ENABLE_USB_RUNTIME_DEVICE
 
-#include "mp_usbd.h"
+#include "shared/tinyusb/mp_usbd.h"
 #include "py/mperrno.h"
 #include "py/objstr.h"
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -111,6 +111,7 @@ INC += -I$(STM32LIB_HAL_ABS)/Inc
 INC += -I$(USBDEV_DIR)/core/inc -I$(USBDEV_DIR)/class/inc
 #INC += -I$(USBHOST_DIR)
 INC += -I$(TOP)/lib/tinyusb/src
+INC += -Itinyusb_port
 INC += -I$(TOP)/shared/tinyusb/
 INC += -Ilwip_inc
 

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -112,7 +112,6 @@ INC += -I$(USBDEV_DIR)/core/inc -I$(USBDEV_DIR)/class/inc
 #INC += -I$(USBHOST_DIR)
 INC += -I$(TOP)/lib/tinyusb/src
 INC += -Itinyusb_port
-INC += -I$(TOP)/shared/tinyusb/
 INC += -Ilwip_inc
 
 CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 $(CFLAGS_EXTRA)

--- a/ports/stm32/factoryreset.c
+++ b/ports/stm32/factoryreset.c
@@ -44,8 +44,14 @@ static const char fresh_boot_py[] =
     "import pyb\r\n"
     "#pyb.main('main.py') # main script to run after this one\r\n"
 #if MICROPY_HW_ENABLE_USB
+#if MICROPY_HW_TINYUSB_STACK
+    "#usb = machine.USBDevice()\r\n"
+    "#usb.builtin_driver = machine.USBDevice.BUILTIN_DEFAULT  # CDC + MSC\r\n"
+    "#usb.active(True)\r\n"
+#else
     "#pyb.usb_mode('VCP+MSC') # act as a serial and a storage device\r\n"
     "#pyb.usb_mode('VCP+HID') # act as a serial device and a mouse\r\n"
+#endif
 #endif
 #if MICROPY_PY_NETWORK
     "#import network\r\n"

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -384,7 +384,7 @@ void USB1_OTG_HS_IRQHandler(void) {
 void OTG_HS_IRQHandler(void) {
     IRQ_ENTER(OTG_HS_IRQn);
     #if MICROPY_HW_TINYUSB_STACK
-    tud_int_handler(0);
+    tud_int_handler(1); // OTG_HS is always RHPORT1 on F4/F7/H7 (not N6, which uses USB1_OTG_HS_IRQHandler)
     #else
     HAL_PCD_IRQHandler(&pcd_hs_handle);
     #endif

--- a/ports/stm32/tinyusb_port/tusb_config.h
+++ b/ports/stm32/tinyusb_port/tusb_config.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Andrew Leech
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_STM32_TINYUSB_PORT_TUSB_CONFIG_H
+#define MICROPY_INCLUDED_STM32_TINYUSB_PORT_TUSB_CONFIG_H
+
+#include "py/mpconfig.h"
+
+// STM32F4/F7/H7 boards with USB_HS use OTG_HS on RHPORT1, not RHPORT0.
+// Disable RHPORT0 and put RHPORT1 in device mode (HS, or FS when the
+// HS controller uses the internal FS PHY via MICROPY_HW_USB_HS_IN_FS).
+// Other configs are handled either by the board (e.g. N6 sets RHPORT0
+// to HS in mpconfigboard_common.h) or by the shared default in
+// shared/tinyusb/tusb_config.h (RHPORT0 in FS device mode).
+
+// These families place OTG_HS on RHPORT1. Extend the list if a new family
+// also uses OTG_HS on RHPORT1 rather than RHPORT0.
+#if MICROPY_HW_USB_HS && (defined(STM32F4) || defined(STM32F7) || defined(STM32H7))
+#define CFG_TUSB_RHPORT0_MODE (OPT_MODE_NONE)
+#if MICROPY_HW_USB_HS_IN_FS
+#define CFG_TUSB_RHPORT1_MODE (OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED)
+#else
+#define CFG_TUSB_RHPORT1_MODE (OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED)
+#endif
+#endif
+
+#include "shared/tinyusb/tusb_config.h"
+
+#endif // MICROPY_INCLUDED_STM32_TINYUSB_PORT_TUSB_CONFIG_H

--- a/ports/stm32/usbd.c
+++ b/ports/stm32/usbd.c
@@ -29,7 +29,7 @@
 #if MICROPY_HW_ENABLE_USBDEV && MICROPY_HW_TINYUSB_STACK
 
 #include <string.h>
-#include "mp_usbd.h"
+#include "shared/tinyusb/mp_usbd.h"
 #include "mphalport.h"
 
 void mp_usbd_port_get_serial_number(char *serial_buf) {

--- a/ports/stm32/usbd.c
+++ b/ports/stm32/usbd.c
@@ -28,15 +28,25 @@
 
 #if MICROPY_HW_ENABLE_USBDEV && MICROPY_HW_TINYUSB_STACK
 
+#include <string.h>
 #include "mp_usbd.h"
-#include "py/mpconfig.h"
-#include "string.h"
 #include "mphalport.h"
 
 void mp_usbd_port_get_serial_number(char *serial_buf) {
+    // Use the same algorithm as the ST DFU bootloader so that the serial
+    // number is consistent across all USB modes.
+    MP_STATIC_ASSERT(12 <= MICROPY_HW_USB_DESC_STR_MAX); // 6 derived bytes x 2 hex digits + NUL
+    static const char hexdig[] = "0123456789ABCDEF";
     uint8_t *id = (uint8_t *)MP_HAL_UNIQUE_ID_ADDRESS;
-    MP_STATIC_ASSERT(12 * 2 <= MICROPY_HW_USB_DESC_STR_MAX);
-    mp_usbd_hex_str(serial_buf, id, 12);
+    uint8_t bytes[] = {
+        id[11], (uint8_t)(id[10] + id[2]), id[9],
+        (uint8_t)(id[8] + id[0]), id[7], id[6],
+    };
+    for (int i = 0; i < 6; i++) {
+        serial_buf[i * 2] = hexdig[bytes[i] >> 4];
+        serial_buf[i * 2 + 1] = hexdig[bytes[i] & 0x0f];
+    }
+    serial_buf[12] = '\0';
 }
 
 #endif

--- a/shared/tinyusb/mp_usbd_cdc.c
+++ b/shared/tinyusb/mp_usbd_cdc.c
@@ -34,6 +34,11 @@
 
 #if MICROPY_HW_USB_CDC && MICROPY_HW_ENABLE_USBDEV && !MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC
 
+// TinyUSB has no public API for endpoint stall detection/clearing; this
+// private header is the intended interface for class drivers (all built-in
+// TinyUSB class drivers include it for the same purpose).
+#include "device/usbd_pvt.h"
+
 static uint8_t cdc_itf_pending; // keep track of cdc interfaces which need attention to poll
 static int8_t cdc_connected_flush_delay = 0;
 
@@ -176,10 +181,18 @@ void MICROPY_WRAP_TUD_CDC_LINE_STATE_CB(tud_cdc_line_state_cb)(uint8_t itf, bool
     #if MICROPY_HW_USB_CDC && !MICROPY_EXCLUDE_SHARED_TINYUSB_USBD_CDC
     if (dtr) {
         // A host application has started to open the cdc serial port.
+        // USBD_CDC_EP_IN is the IN endpoint for itf 0; only clear stall for itf 0.
+        if (itf == 0 && usbd_edpt_stalled(TUD_OPT_RHPORT, USBD_CDC_EP_IN)) {
+            usbd_edpt_clear_stall(TUD_OPT_RHPORT, USBD_CDC_EP_IN);
+        }
         // Wait a few ms for host to be ready then send tx buffer.
         // High speed connection SOF fires at 125us, full speed at 1ms.
         cdc_connected_flush_delay = (tud_speed_get() == TUSB_SPEED_HIGH) ? 128 : 16;
         tud_sof_cb_enable(true);
+    } else {
+        // Host has closed the cdc serial port. Discard pending TX data to
+        // avoid a full FIFO blocking writes on the next connection.
+        tud_cdc_n_write_clear(itf);
     }
     #endif
     #if MICROPY_HW_USB_CDC_DTR_RTS_BOOTLOADER


### PR DESCRIPTION
### Summary

The STM32 port's TinyUSB integration only supports the FS controller. Boards with a HS controller (PYBD_SF6, STM32F429DISC, OLIMEX_H407, or ULPI-based designs) cannot use TinyUSB — the RHPORT configuration is hardcoded to RHPORT 0 / full-speed only.

This PR adds proper RHPORT mode selection in `tusb_config.h` based on `MICROPY_HW_USB_HS` and `MICROPY_HW_USB_HS_IN_FS` board config, routes HS IRQ handlers to the correct RHPORT (including STM32N6 which maps HS to RHPORT 0), and adds VBUS sensing configuration for the HS-in-FS path on STM32F4/F7 (mirroring the existing FS path, with support for both VBDEN and legacy NOVBUSSENS register variants).

Additional issues found and fixed during testing (each is a separate commit and can be split into its own PR if preferred):

- **CDC reconnect stall**: When a host closes and reopens the CDC serial port (e.g. repeated mpremote connect/disconnect cycles), the IN endpoint can remain stalled from a prior runtime USB disconnect. The device becomes unresponsive until reset. Fixed by clearing endpoint stall on DTR high. Additionally, on DTR low (host close) the TX FIFO is now flushed so stale data from a previous session does not accumulate and block writes on the next connection.

- **DFU bootloader serial number mismatch**: The TinyUSB serial descriptor uses a raw hex dump of all 12 UID bytes (24-char lowercase), while the legacy USB stack and ST's onboard DFU bootloader use a condensed algorithm that selects 6 bytes with two additions (12-char uppercase). This causes the device to report a different serial number depending on which USB stack is active, breaking tools that identify devices by serial (udev rules, mpremote, dfu-util). Fixed by using the ST DFU bootloader algorithm.

- **TinyUSB-specific boot.py template**: The factory reset boot.py template references `pyb.usb_mode()` which does not exist on the TinyUSB stack. A TinyUSB-specific template is added that uses `machine.USBDevice` with `BUILTIN_DEFAULT`.

### Testing

Built with `CFLAGS_EXTRA=-DMICROPY_HW_TINYUSB_STACK=1` for:
- PYBD_SF6 (F7, HS-in-FS) — flashed and verified CDC serial, `machine.USBDevice` API, filesystem access
- OPENMV_N6 (N6, HS-in-FS) — flashed and verified CDC serial, `machine.USBDevice` API, filesystem access
- STM32F429DISC (F4, HS-in-FS) — build only
- OLIMEX_H407 (F4, HS-in-FS) — build only
- NUCLEO_H563ZI (H5, FS only) — build only, regression check

ULPI boards (STM32H747I_DISCO) are tested on hardware as part of the original development in #18303 — this branch is split out from that work.

#### CDC serial throughput (OPENMV_N6, HS link at 480 Mbit/s)

Compared TinyUSB vs legacy USB stack using `tests/serial_test.py` methodology.

**Read (device → host):**

| bufsize | TinyUSB KB/s | Legacy KB/s | Ratio |
|---------|-------------|-------------|-------|
| 256 | 5198 | 816 | 6.4x |
| 512 | 5490 | 817 | 6.7x |
| 1024 | 6050 | 811 | 7.5x |
| 2048 | 7560 | 817 | 9.3x |
| 4096 | 9448 | 811 | 11.6x |
| 8192 | 8422 | 815 | 10.3x |
| 16384 | 8086 | 787 | 10.3x |

**Write (host → device):**

| bufsize | TinyUSB KB/s | Legacy KB/s | Ratio |
|---------|-------------|-------------|-------|
| 256 | 186 | 464 | 0.4x |
| 512 | 218 | 592 | 0.4x |
| 1024 | 193 | 671 | 0.3x |
| 2048 | 185 | 733 | 0.3x |
| 4096 | 184 | 763 | 0.2x |
| 8192 | 178 | 786 | 0.2x |
| 16384 | 179 | 800 | 0.2x |

TinyUSB read is 6-12x faster. Write is 2.5-4.5x slower due to a pre-existing limitation in the TinyUSB CDC stdin path — `mp_hal_stdin_rx_chr()` reads byte-by-byte through a 512-byte ringbuffer, causing backpressure on the USB OUT endpoint. This affects all TinyUSB ports, not just HS, and is being tracked separately.

### Trade-offs and Alternatives

The RHPORT configuration uses `#ifndef` guards so boards like STM32N6 that pre-define `CFG_TUSB_RHPORT0_MODE` in `mpconfigboard_common.h` pass through unchanged. This avoids needing per-family `#if` chains but means any future HS-capable family (e.g. STM32U5) needs its own board-level override.