### PR TITLE
zephyr/machine_uart: ignore return value of uart_irq_update

### DIFF
--- a/ports/zephyr/machine_uart.c
+++ b/ports/zephyr/machine_uart.c
@@ -265,7 +265,7 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
 static void uart_interrupt_handler(const struct device *dev, void *user_data) {
     machine_uart_obj_t *self = (machine_uart_obj_t *)user_data;
 
-    while (uart_irq_update(dev) && uart_irq_is_pending(dev)) {
+    while (uart_irq_update(dev), uart_irq_is_pending(dev)) {
         if (uart_irq_rx_ready(dev)) {
             uint8_t _rx_buffer[32];
             size_t _free_space = MIN(ringbuf_free(&self->rx_ringbuffer), sizeof(_rx_buffer));


### PR DESCRIPTION
### Summary

For uart_irq_update() the allowed return values
are a negative errno or 1. 0 is not allowd.
Therefore ignore the return value.
Also the return type might soon be changed to void.
see https://github.com/zephyrproject-rtos/zephyr/pull/105231

### Testing

NA

### Trade-offs and Alternatives

NA

### Generative AI

I did not use generative AI tools when creating this PR.

