### PR TITLE
docs/reference/speed_python: Update native emitter limitations.

### DIFF
--- a/docs/reference/speed_python.rst
+++ b/docs/reference/speed_python.rst
@@ -243,12 +243,10 @@ no adaptation (but see below). It is invoked by means of a function decorator:
 
 There are certain limitations in the current implementation of the native code emitter.
 
-* Context managers are not supported (the ``with`` statement).
-* Generators are not supported.
 * If ``raise`` is used an argument must be supplied.
 * The background scheduler (see `micropython.schedule`) is not run during
   execution of native code.
-* On targets with thrteading and the GIL, the GIL is not released during
+* On targets with threading and the GIL, the GIL is not released during
   execution of native code.
 
 To mitigate the last two points, long running native functions should call


### PR DESCRIPTION
### Summary

This PR updates the listed limitations of the native emitter in the documentation related to how to increase speed of python code.

Context managers are supported, as in functions marked as native can use the `with` statement in regular code.  Generators can be used in native functions both on the emitting (ie. `yield <whatever>`) and on the receiving end.

<hr>

This should address the remarks mentioned in #10476.

### Testing

Documentation was built successfully, and the limitations removed from the document have been verified to be actually working with some simple tests on Linux/x64.

### Generative AI

I did not use generative AI tools when creating this PR.