### PR TITLE
stm32: Fix printing value of pyb.CAN auto_restart on FDCAN hardware.

### DIFF
--- a/ports/stm32/pyb_can.c
+++ b/ports/stm32/pyb_can.c
@@ -140,7 +140,7 @@ static void pyb_can_print(const mp_print_t *print, mp_obj_t self_in, mp_print_ki
             self->can_id,
             mode,
             #if MICROPY_HW_ENABLE_FDCAN
-            (self->can.Instance->CCCR & FDCAN_CCCR_DAR) ? MP_QSTR_True : MP_QSTR_False
+            MP_QSTR_False // auto_restart not supported on FDCAN hardware
             #else
                 (self->can.Instance->MCR & CAN_MCR_ABOM) ? MP_QSTR_True : MP_QSTR_False
             #endif


### PR DESCRIPTION
### Summary

As pointed out in https://github.com/micropython/micropython/pull/18572#issuecomment-4047198140. The DAR register field is for disabling auto-retransmit, FDCAN hardware doesn't support automatic restart to clear Bus Off.

*This work was funded through GitHub Sponsors.*

### Testing

Manually built a NUCLEO_G474RE board and ran the `pyb_can.py` unit test.

### Generative AI

I did not use generative AI tools when creating this PR.