### PR TITLE
tests/cpydiff: Add str return type and subclass preservation differences.

### DIFF
--- a/tests/cpydiff/core_class_strrettype.py
+++ b/tests/cpydiff/core_class_strrettype.py
@@ -1,0 +1,14 @@
+"""
+categories: Core,Classes
+description: ``__str__`` returning non-string type does not raise TypeError
+cause: MicroPython's instance_print does not validate that ``__str__`` or ``__repr__`` return a str or its subclass
+workaround: Ensure ``__str__`` and ``__repr__`` always return a str instance or its subclass
+"""
+
+
+class Foo:
+    def __str__(self):
+        return True
+
+
+print(str(Foo()))

--- a/tests/cpydiff/core_class_subclassret.py
+++ b/tests/cpydiff/core_class_subclassret.py
@@ -1,0 +1,19 @@
+"""
+categories: Core,Classes
+description: str() does not preserve str subclass type from ``__str__`` or ``__repr__`` return value
+cause: Implementation discards str subclass type returned by ``__str__`` or ``__repr__`` and always returns a plain str instance from str().
+workaround: Do not rely on str() preserving str subclass types
+"""
+
+
+class MyStr(str):
+    pass
+
+
+class Foo:
+    def __str__(self):
+        return MyStr("abc")
+
+
+result = str(Foo())
+print(type(result))


### PR DESCRIPTION
### Summary

Document two `str()`-related CPython compatibility differences in `tests/cpydiff/`:

1. **`types_str_strrettype.py`**: `__str__`/`__repr__` returning a non-string type does not raise `TypeError`. MicroPython silently converts and prints the value.
Relates to #18941.

2. **`types_str_subclassret.py`**: `str()` does not preserve `str` subclass type from `__str__`/`__repr__` return value. MicroPython always returns a plain `str` instance.
Relates to #18942.

### Testing

Verified that each test produces different output between CPython and MicroPython:

- `types_str_strrettype.py`: CPython raises `TypeError`, MicroPython prints `True`.
- `types_str_subclassret.py`: CPython prints `<class '__main__.MyStr'>`, MicroPython prints `<class 'str'>`.

Tested on unix port, Linux.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.