### PR TITLE
esp32/network_wlan: Look up IP addresses for the stations list.

### DIFF
--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -37,11 +37,15 @@
 #include "py/runtime.h"
 #include "py/mphal.h"
 #include "extmod/modnetwork.h"
+#include "shared/netutils/netutils.h"
 #include "modnetwork.h"
 
 #include "esp_wifi.h"
 #include "esp_log.h"
 #include "esp_psram.h"
+#if !CONFIG_ESP_HOSTED_ENABLED
+#include "esp_wifi_ap_get_sta_list.h"
+#endif
 
 #ifndef NO_QSTR
 #include "mdns.h"
@@ -409,11 +413,28 @@ static mp_obj_t network_wlan_status(size_t n_args, const mp_obj_t *args) {
             require_if(args[0], ESP_IF_WIFI_AP);
             wifi_sta_list_t station_list;
             esp_exceptions(esp_wifi_ap_get_sta_list(&station_list));
-            wifi_sta_info_t *stations = (wifi_sta_info_t *)station_list.sta;
+            #if !CONFIG_ESP_HOSTED_ENABLED
+            wifi_sta_mac_ip_list_t mac_ip_list;
+            esp_exceptions(esp_wifi_ap_get_sta_list_with_ip(&station_list, &mac_ip_list));
+            #endif
             mp_obj_t list = mp_obj_new_list(0, NULL);
-            for (int i = 0; i < station_list.num; ++i) {
+            #if CONFIG_ESP_HOSTED_ENABLED
+            int count = station_list.num;
+            wifi_sta_info_t *source = (wifi_sta_info_t *)station_list.sta;
+            #else
+            int count = mac_ip_list.num;
+            esp_netif_pair_mac_ip_t *source = (esp_netif_pair_mac_ip_t *)mac_ip_list.sta;
+            #endif
+            for (int i = 0; i < count; ++i) {
+                #if CONFIG_ESP_HOSTED_ENABLED
                 mp_obj_tuple_t *t = mp_obj_new_tuple(1, NULL);
-                t->items[0] = mp_obj_new_bytes(stations[i].mac, sizeof(stations[i].mac));
+                #else
+                mp_obj_tuple_t *t = mp_obj_new_tuple(2, NULL);
+                #endif
+                t->items[0] = mp_obj_new_bytes(source[i].mac, sizeof(source[i].mac));
+                #if !CONFIG_ESP_HOSTED_ENABLED
+                t->items[1] = source[i].ip.addr != 0 ? netutils_format_ipv4_addr((uint8_t *)(&source[i].ip), NETUTILS_BIG) : mp_const_none;
+                #endif
                 mp_obj_list_append(list, t);
             }
             return list;


### PR DESCRIPTION
### Summary

This PR extends the output of `WLAN.status('stations')` to also include the IP address of WiFi stations connected to the device if in AP mode.

The ESP32 port is brought up to parity with most ports in this regard (primarily with the ESP8266).  This functionality depends on the DHCP server provided by ESP-IDF, which is automatically run on the WiFi interface if the device is put in AP mode.  Currently the ESP32 port cannot run with said DHCP server disabled, so if a device does not request a static IP it may either have the wrong IP address returned (since the DHCP server assigned an address which is then discarded by the client), or it won't have any (ie. "0.0.0.0").  In the latter case `None` will be returned as the station's address instead.

This implements #9203.

<hr>

ESP-IDF was probably always able to pull this off by performing the manual MAC→IP match via LWIP's DHCPS functions, but I guess that was not done to save on code space.

ESP-IDF 5.0 introduced a function that performs just that with little code (`esp_wifi_ap_get_sta_list_with_ip`), so now this can be safely added.

### Testing

This was tested on an ESP32C3 running on git master and ESP-IDF 5.5.1, by connecting and disconnecting several devices to the device put in AP mode beforehand.

The original behaviour (returning a tuple with just the MAC address) is preserved for boards that use WiFi hosted mode (namely the ESP32P4).  I do not have one of those boards myself so I wasn't able to test that specific use case, although the ifdef guards seem to be properly placed at least.

### Trade-offs and Alternatives

There is currently no provision for the ESP32 port to run without DHCPS on the WiFi interface when put in AP mode, so I have no idea on the effective behaviour of a client connection without a DHCP server being present.

### Generative AI

I did not use generative AI tools when creating this PR.