### PR TITLE
stm32/boards/PYBD_SF2: Free up some space in internal flash.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
+++ b/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
@@ -50,6 +50,7 @@ SECTIONS
     .text_ext :
     {
         . = ALIGN(4);
+        *py/emit*(.text.emit_inline_thumb_* .rodata.emit_inline_thumb_*)
         *lib/btstack/*(.text* .rodata*)
         *lib/mbedtls/*(.text* .rodata*)
         *lib/mynewt-nimble/*(.text* .rodata*)


### PR DESCRIPTION
### Summary

With the recent addition of `machine.PWM` and `machine.CAN` to the stm32 port, the internal flash of PYBD_SF3 overflows by about 300 bytes.

This commit moves the inline assembler compiler functions from internal to external QSPI flash, for both PYBD_SF2 and PYBD_SF3 (which are essentially the same thing, the SF3 just has high-speed USB).  That frees up about 3k internal flash, and shouldn't affect performance.

### Testing

Tested on PYBD_SF2.  The standard test suite passes.

### Trade-offs and Alternatives

I tried enabling LTO but that's tricky because these boards use linker commands to place specific code in external flash, and they no longer work when LTO is enabled (because they specify the code by file name, which gets removed with LTO).

### Generative AI

I did not use generative AI tools when creating this PR.
