### PR TITLE
unix: Improve support for FreeBSD.

### DIFF
--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -103,6 +103,9 @@
 #elif defined(__ANDROID__)
 #define MICROPY_PLATFORM_LIBC_LIB       "bionic"
 #define MICROPY_PLATFORM_LIBC_VER       MP_STRINGIFY(__ANDROID_API__)
+#elif defined(__FreeBSD__)
+#define MICROPY_PLATFORM_LIBC_LIB       "libc"
+#define MICROPY_PLATFORM_LIBC_VER       ""
 #else
 #define MICROPY_PLATFORM_LIBC_LIB       ""
 #define MICROPY_PLATFORM_LIBC_VER       ""
@@ -112,6 +115,8 @@
 #define MICROPY_PLATFORM_SYSTEM         "Android"
 #elif defined(__linux)
 #define MICROPY_PLATFORM_SYSTEM         "Linux"
+#elif defined(__FreeBSD__)
+#define MICROPY_PLATFORM_SYSTEM         "FreeBSD"
 #elif defined(__unix__)
 #define MICROPY_PLATFORM_SYSTEM         "Unix"
 #elif defined(__CYGWIN__)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -51,7 +51,12 @@
 #endif
 
 #ifndef MICROPY_PY_SYS_PATH_DEFAULT
-#define MICROPY_PY_SYS_PATH_DEFAULT ".frozen:~/.micropython/lib:/usr/lib/micropython"
+#if defined(__FreeBSD__)
+#define SYSTEM_LIB_PATH "/usr/local/lib/micropython"
+#else
+#define SYSTEM_LIB_PATH "/usr/lib/micropython"
+#endif
+#define MICROPY_PY_SYS_PATH_DEFAULT ".frozen:~/.micropython/lib:" SYSTEM_LIB_PATH
 #endif
 
 #define MP_STATE_PORT MP_STATE_VM

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -45,6 +45,8 @@
 #ifndef MICROPY_PY_SYS_PLATFORM
 #if defined(__APPLE__) && defined(__MACH__)
     #define MICROPY_PY_SYS_PLATFORM  "darwin"
+#elif defined(__FreeBSD__)
+    #define MICROPY_PY_SYS_PLATFORM  "freebsd"
 #else
     #define MICROPY_PY_SYS_PLATFORM  "linux"
 #endif

--- a/tests/extmod/select_poll_fd.py
+++ b/tests/extmod/select_poll_fd.py
@@ -1,10 +1,18 @@
 # Test select.poll in combination with file descriptors.
 
 try:
-    import select, errno
+    import sys, select, errno
 
     select.poll  # Raises AttributeError for CPython implementations without poll()
 except (ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+# FreeBSD allows to have up to ~120k file descriptor by default, so this test
+# will fail on such a system.  Since there's no provision to query sysctl
+# values or an easy way to parse the output of `ulimit -n` the test is just
+# skipped on FreeBSD.
+if sys.platform == "freebsd":
     print("SKIP")
     raise SystemExit
 

--- a/tests/ports/unix/ffi_callback.py
+++ b/tests/ports/unix/ffi_callback.py
@@ -16,7 +16,7 @@ def ffi_open(names):
     raise err
 
 
-libc = ffi_open(("libc.so", "libc.so.0", "libc.so.6", "libc.dylib"))
+libc = ffi_open(("libc.so", "libc.so.0", "libc.so.6", "libc.so.7", "libc.dylib"))
 
 qsort = libc.func("v", "qsort", "piip")
 

--- a/tests/ports/unix/ffi_float.py
+++ b/tests/ports/unix/ffi_float.py
@@ -17,7 +17,7 @@ def ffi_open(names):
     raise err
 
 
-libc = ffi_open(("libc.so", "libc.so.0", "libc.so.6", "libc.dylib"))
+libc = ffi_open(("libc.so", "libc.so.0", "libc.so.6", "libc.so.7", "libc.dylib"))
 
 try:
     strtof = libc.func("f", "strtof", "sp")
@@ -33,7 +33,9 @@ strtod = libc.func("d", "strtod", "sp")
 print("%.6f" % strtod("1.23", None))
 
 # test passing double and float args
-libm = ffi_open(("libm.so", "libm.so.6", "libc.so.0", "libc.so.6", "libc.dylib"))
+libm = ffi_open(
+    ("libm.so", "libm.so.5", "libm.so.6", "libc.so.0", "libc.so.6", "libc.so.7", "libc.dylib")
+)
 tgamma = libm.func("d", "tgamma", "d")
 for fun_name in ("tgamma",):
     fun = globals()[fun_name]


### PR DESCRIPTION
### Summary

This PR addresses a few minor issues related to MicroPython on the FreeBSD platform:

* FFI tests tried to open a now missing libc library version (`libc.so.6` is no longer there, now it's called `libc.so.7`)
* The system-wide entry in `sys.path` for the standard library pointed to `/usr/lib/micropyhon`, but on FreeBSD anything outside the base system files has to reside elsewhere; the usual root under `/usr` for third party packages is `/usr/local`
* `sys.platform` now reports it's running on FreeBSD instead of Linux
* The interpreter banner recognises FreeBSD as a separate platform and sets the correct libc name
* `platform.platform` now reports FreeBSD as the operating system
* The EDEADLK result code returned on failed lock acquisition is handled, aliased to EBUSY at the moment
* The `extmod/select_poll_fd` test is skipped on FreeBSD

<hr>

This is technically the continuation of https://github.com/micropython/micropython-lib/pull/1099, as it fixes FFI support on recent FreeBSD versions in `micropython/micropython-lib`.

### Testing

The test suite was executed in a FreeBSD 15.0-RELEASE x64 virtual machine, with no FFI-related test failures.  `thread/thread_heap_lock`, and `thread/thread_lock5` were failing before these changes as well.  I haven't yet looked into those two tests.

### Trade-offs and Alternatives

The changes in this PR should affect MicroPython's behaviour exclusively when built on FreeBSD.  FFI and `sys.path` changes might also apply to OpenBSD, NetBSD, and their derivatives, but they weren't tested on those OSes.

### Generative AI

I did not use generative AI tools when creating this PR.