### PR TITLE
esp32/machine_pin: Make all pins on ESP32-P4 output capable.

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -55,8 +55,6 @@
 #define GPIO_FIRST_NON_OUTPUT (34)
 #elif CONFIG_IDF_TARGET_ESP32S2
 #define GPIO_FIRST_NON_OUTPUT (46)
-#elif CONFIG_IDF_TARGET_ESP32P4
-#define GPIO_FIRST_NON_OUTPUT (54)
 #endif
 
 // Return the gpio_num_t index for a given machine_pin_obj_t pointer.


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

All GPIO pins on the ESP32-P4 are output capable, so there is no need to define `GPIO_FIRST_NON_OUTPUT`.

Also fixes #18982, since `GPIO_FIRST_NON_OUTPUT` was incorrectly set to `54`, preventing that pin from being configured as an output.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Tested on an ESP32-P4 board. Before this change, pin 54 could not be configured as an output. After this change, it can. Tested with an LED to verify it toggles correctly.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
