### PR TITLE
esp32/sdcard: Add support for SDMMC power control with internal LDO.

### DIFF
--- a/docs/library/machine.SDCard.rst
+++ b/docs/library/machine.SDCard.rst
@@ -24,7 +24,7 @@ or a non-standard pin assignment. The exact subset of arguments supported will
 vary from platform to platform.
 
 .. class:: SDCard(slot=1, width=1, cd=None, wp=None, sck=None, miso=None, mosi=None,
-                  cs=None, cmd=None, data=None, freq=20000000)
+                  cs=None, cmd=None, data=None, ldo=None, freq=20000000)
 
     This class provides access to SD or MMC storage cards using either
     a dedicated SD/MMC interface hardware or through an SPI channel.
@@ -59,6 +59,9 @@ vary from platform to platform.
 
      - *data* can be used to specify a list or tuple of SD data bus pins
        (ESP32-S3 only).
+
+     - *ldo* can be used to specify the internal LDO channel used for SD
+       card logic level for SDIO 3.0 (ESP32-P4 only).
 
      - *freq* selects the SD/MMC interface frequency in Hz.
 
@@ -187,6 +190,16 @@ parameters ``sck``, ``cs``, ``miso``, ``mosi`` as needed to assign pins.
 
 In either mode the ``cd`` and ``wp`` pins default to disabled, unless set in the
 constructor.
+
+ESP32-P4
+~~~~~~~~
+
+The ESP32-P4 has multiple internal adjustable LDO regulators, and some boards use
+one of LDOs to control the SD card logic level required by SDIO 3.0. Most boards
+will automatically select the correct LDO channel, but it may be necessary to
+manually specify the ``ldo`` parameter as an integer (1 through 4). For example::
+
+    sd = SDCard(ldo=4)
 
 Other ESP32 chips
 ~~~~~~~~~~~~~~~~~

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -12,6 +12,7 @@
 #define MICROPY_PY_ESPNOW                (0)
 
 #define MICROPY_HW_ENABLE_SDCARD            (1)
+#define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -35,7 +35,7 @@
 
 #if SOC_SDMMC_HOST_SUPPORTED
 #include "driver/sdmmc_host.h"
-#if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
+#if SOC_SDMMC_IO_POWER_EXTERNAL
 #include "sd_pwr_ctrl_by_on_chip_ldo.h"
 #endif
 #endif
@@ -212,6 +212,9 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         ARG_cmd,
         ARG_data,
         #endif
+        #if SOC_SDMMC_IO_POWER_EXTERNAL
+        ARG_ldo,
+        #endif
         ARG_freq,
     };
     #if SOC_SDMMC_HOST_SUPPORTED
@@ -233,6 +236,13 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         #if SOC_SDMMC_USE_GPIO_MATRIX
         { MP_QSTR_cmd,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_data,     MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        #endif
+        #if SOC_SDMMC_IO_POWER_EXTERNAL
+        #ifdef MICROPY_HW_SDMMC_LDO_CHAN_ID
+        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_SDMMC_LDO_CHAN_ID} },
+        #else
+        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        #endif
         #endif
         // freq is valid for both SPI and SDMMC interfaces
         { MP_QSTR_freq,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 20000000} },
@@ -313,13 +323,15 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         self->host = _temp_host;
     }
     #endif
-    #if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
-    sd_pwr_ctrl_ldo_config_t ldo_config = {
-        .ldo_chan_id = MICROPY_HW_SDMMC_LDO_CHAN_ID,
-    };
-    sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
-    check_esp_err(sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle));
-    self->host.pwr_ctrl_handle = pwr_ctrl_handle;
+    #if SOC_SDMMC_IO_POWER_EXTERNAL
+    if (arg_vals[ARG_ldo].u_int != -1) {
+        sd_pwr_ctrl_ldo_config_t ldo_config = {
+            .ldo_chan_id = arg_vals[ARG_ldo].u_int,
+        };
+        sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
+        check_esp_err(sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle));
+        self->host.pwr_ctrl_handle = pwr_ctrl_handle;
+    }
     #endif
 
     DEBUG_printf("  Calling host.init()");
@@ -442,7 +454,7 @@ static mp_obj_t sd_deinit(mp_obj_t self_in) {
             // SD card used a (dedicated) SPI bus, so free that SPI bus.
             spi_bus_free(self->host.slot);
         }
-        #if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
+        #if SOC_SDMMC_IO_POWER_EXTERNAL
         if (self->host.pwr_ctrl_handle) {
             check_esp_err(sd_pwr_ctrl_del_on_chip_ldo(self->host.pwr_ctrl_handle));
         }

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -35,6 +35,9 @@
 
 #if SOC_SDMMC_HOST_SUPPORTED
 #include "driver/sdmmc_host.h"
+#if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
+#include "sd_pwr_ctrl_by_on_chip_ldo.h"
+#endif
 #endif
 #include "driver/sdspi_host.h"
 #include "sdmmc_cmd.h"
@@ -310,6 +313,14 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         self->host = _temp_host;
     }
     #endif
+    #if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
+    sd_pwr_ctrl_ldo_config_t ldo_config = {
+        .ldo_chan_id = MICROPY_HW_SDMMC_LDO_CHAN_ID,
+    };
+    sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
+    check_esp_err(sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle));
+    self->host.pwr_ctrl_handle = pwr_ctrl_handle;
+    #endif
 
     DEBUG_printf("  Calling host.init()");
 
@@ -431,6 +442,11 @@ static mp_obj_t sd_deinit(mp_obj_t self_in) {
             // SD card used a (dedicated) SPI bus, so free that SPI bus.
             spi_bus_free(self->host.slot);
         }
+        #if SOC_SDMMC_IO_POWER_EXTERNAL && defined(MICROPY_HW_SDMMC_LDO_CHAN_ID)
+        if (self->host.pwr_ctrl_handle) {
+            check_esp_err(sd_pwr_ctrl_del_on_chip_ldo(self->host.pwr_ctrl_handle));
+        }
+        #endif
         self->flags &= ~SDCARD_CARD_FLAGS_HOST_INIT_DONE;
     }
 

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -239,9 +239,9 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         #endif
         #if SOC_SDMMC_IO_POWER_EXTERNAL
         #ifdef MICROPY_HW_SDMMC_LDO_CHAN_ID
-        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_SDMMC_LDO_CHAN_ID} },
+        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(MICROPY_HW_SDMMC_LDO_CHAN_ID)} },
         #else
-        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
+        { MP_QSTR_ldo,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         #endif
         #endif
         // freq is valid for both SPI and SDMMC interfaces
@@ -324,9 +324,9 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
     }
     #endif
     #if SOC_SDMMC_IO_POWER_EXTERNAL
-    if (arg_vals[ARG_ldo].u_int != -1) {
+    if (arg_vals[ARG_ldo].u_obj != mp_const_none) {
         sd_pwr_ctrl_ldo_config_t ldo_config = {
-            .ldo_chan_id = arg_vals[ARG_ldo].u_int,
+            .ldo_chan_id = mp_obj_get_int(arg_vals[ARG_ldo].u_obj),
         };
         sd_pwr_ctrl_handle_t pwr_ctrl_handle = NULL;
         check_esp_err(sd_pwr_ctrl_new_on_chip_ldo(&ldo_config, &pwr_ctrl_handle));


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Fixes #18984.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Before this change, the following error was thrown when trying to mount an SD card:

```
>>> import machine
>>> vfs.mount(machine.SDCard(), "/sd")
E (11418) sdmmc_common: sdmmc_init_ocr: send_op_cond (1) returned 0x107
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: 16
```

After this change, the SD card mounts just fine:

```
>>> import machine, os
>>> vfs.mount(machine.SDCard(), "/sd")
>>> os.listdir()
['sd', 'boot.py']
```

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

This PR changes `ESP32_GENERIC_P4` to assume LDO 4 is used for powering the SD card, which may not be true for all boards. This board definition is meant to be generic, so I can see arguments for not doing this. However without this change, an SD card cannot be used with the ESP32-P4-Function-EV-Board at all. Since the ESP32-P4-Function-EV-Board is what's depicted on the [MicroPython download page](https://micropython.org/download/ESP32_GENERIC_P4/), I would argue in favor of keeping this change.

A possible alternative is for the LDO to be specified as an argument in `machine.SDCard()` instead of the board definition. However for a given board, the LDO is a fixed parameter, so IMO it really should live in the board definition to avoid extra tedium with manually specifying the LDO in user code; I see the generic board definition as an exception.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
