### PR TITLE
stm32/rfcore: Add IPCC and HSEM spinlock timeouts.

### DIFF
--- a/ports/stm32/mpnimbleport.c
+++ b/ports/stm32/mpnimbleport.c
@@ -42,6 +42,19 @@
 #include "extmod/nimble/hal/hal_uart.h"
 #include "mpbthciport.h"
 
+#if defined(STM32WB)
+#include "rfcore.h"
+
+// Runs in Thread mode via mp_handle_pending(). Shuts down the entire
+// BLE stack; all Python BLE operations fail with "not active" errors.
+static mp_obj_t rfcore_timeout_shutdown(mp_obj_t arg) {
+    (void)arg;
+    mp_bluetooth_deinit();
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(rfcore_timeout_shutdown_obj, rfcore_timeout_shutdown);
+#endif
+
 // Get any pending data from the UART and send it to NimBLE's HCI buffers.
 // Any further processing by NimBLE will be run via its event queue.
 void mp_bluetooth_hci_poll(void) {
@@ -57,6 +70,19 @@ void mp_bluetooth_hci_poll(void) {
         // Run any remaining events (e.g. if there was no UART data).
         mp_bluetooth_nimble_os_eventq_run_all();
     }
+
+    #if defined(STM32WB)
+    if (rfcore_ipcc_timeout) {
+        // CPU2 unresponsive. Schedule BLE deinit for Thread mode.
+        // mp_sched_schedule is ISR-safe (atomic ring buffer).
+        static bool shutdown_scheduled = false;
+        if (!shutdown_scheduled) {
+            shutdown_scheduled = mp_sched_schedule(
+                MP_OBJ_FROM_PTR(&rfcore_timeout_shutdown_obj), mp_const_none);
+        }
+        return;
+    }
+    #endif
 
     if (mp_bluetooth_nimble_ble_state != MP_BLUETOOTH_NIMBLE_BLE_STATE_OFF) {
         // Call this function again in 128ms to check for new events.

--- a/ports/stm32/rfcore.c
+++ b/ports/stm32/rfcore.c
@@ -90,6 +90,13 @@
 
 #define SYS_ACK_TIMEOUT_MS (250)
 #define BLE_ACK_TIMEOUT_MS (250)
+#define IPCC_CH_MM_TIMEOUT_MS (10)
+#define HSEM_TIMEOUT_MS (500)
+
+// Set when IPCC or HSEM wait times out. Checked by:
+// - rfcore entry points: return early to prevent uninitialized IPCC access
+// - mpnimbleport.c: schedules mp_bluetooth_deinit() and stops re-scheduling polls
+volatile bool rfcore_ipcc_timeout = false;
 
 // AN5185
 #define MAGIC_FUS_ACTIVE 0xA94656B9
@@ -422,7 +429,15 @@ static size_t tl_process_msg(volatile tl_list_node_t *head, unsigned int ch, par
             // Wait for C2 to indicate that it has finished using the free buffer,
             // so that we can link the newly-freed memory in to this buffer.
             // If waiting is needed then it is typically between 5 and 20 microseconds.
+            uint32_t t0 = mp_hal_ticks_ms();
             while (LL_C1_IPCC_IsActiveFlag_CHx(IPCC, IPCC_CH_MM)) {
+                if (mp_hal_ticks_ms() - t0 > IPCC_CH_MM_TIMEOUT_MS) {
+                    rfcore_ipcc_timeout = true;
+                    break;
+                }
+            }
+            if (rfcore_ipcc_timeout) {
+                break;
             }
 
             // Place memory back in free pool.
@@ -536,7 +551,14 @@ void rfcore_init(void) {
 
     // In case we're waking from deepsleep, enforce core synchronisation
     __HAL_RCC_HSEM_CLK_ENABLE();
-    while (LL_HSEM_1StepLock(HSEM, CFG_HW_PWR_STANDBY_SEMID)) {
+    {
+        uint32_t t0 = mp_hal_ticks_ms();
+        while (LL_HSEM_1StepLock(HSEM, CFG_HW_PWR_STANDBY_SEMID)) {
+            if (mp_hal_ticks_ms() - t0 > HSEM_TIMEOUT_MS) {
+                rfcore_ipcc_timeout = true;
+                return;
+            }
+        }
     }
 
     // Set the wakeup source to LSE or fall back to use HSE
@@ -602,6 +624,9 @@ static const struct {
 };
 
 void rfcore_ble_init(void) {
+    if (rfcore_ipcc_timeout) {
+        return;
+    }
     DEBUG_printf("rfcore_ble_init\n");
 
     // Configure and reset the BLE controller.
@@ -637,6 +662,9 @@ bool rfcore_ble_reset(void) {
 }
 
 void rfcore_ble_hci_cmd(size_t len, const uint8_t *src) {
+    if (rfcore_ipcc_timeout) {
+        return;
+    }
     DEBUG_printf("rfcore_ble_hci_cmd\n");
 
     #if HCI_TRACE
@@ -683,6 +711,9 @@ void rfcore_ble_hci_cmd(size_t len, const uint8_t *src) {
 }
 
 size_t rfcore_ble_check_msg(rfcore_ble_msg_callback_t cb, void *env) {
+    if (rfcore_ipcc_timeout) {
+        return 0;
+    }
     parse_hci_info_t parse = { cb, env, false };
     size_t len = tl_check_msg(&ipcc_mem_ble_evt_queue, IPCC_CH_BLE, &parse);
 
@@ -704,6 +735,9 @@ size_t rfcore_ble_check_msg(rfcore_ble_msg_callback_t cb, void *env) {
 
 // "level" is 0x00-0x1f, ranging from -40 dBm to +6 dBm (not linear).
 void rfcore_ble_set_txpower(uint8_t level) {
+    if (rfcore_ipcc_timeout) {
+        return;
+    }
     uint8_t buf[2] = { 0x00, level };
     tl_ble_hci_cmd_resp(HCI_OPCODE(OGF_VENDOR, OCF_SET_TX_POWER), buf, 2);
 }

--- a/ports/stm32/rfcore.h
+++ b/ports/stm32/rfcore.h
@@ -26,7 +26,12 @@
 #ifndef MICROPY_INCLUDED_STM32_RFCORE_H
 #define MICROPY_INCLUDED_STM32_RFCORE_H
 
+#include <stdbool.h>
 #include <stdint.h>
+
+#if defined(STM32WB)
+extern volatile bool rfcore_ipcc_timeout;
+#endif
 
 typedef void (*rfcore_ble_msg_callback_t)(void *, const uint8_t *, size_t);
 


### PR DESCRIPTION
### Summary

On STM32WB55, if CPU2 (the BLE coprocessor) becomes unresponsive, two spinloops in rfcore.c spin forever: the IPCC memory manager channel wait in `tl_process_msg()` and the HSEM power standby semaphore in `rfcore_init()`. In practice this manifests as a hard lockup during BLE operation or on wake from deepsleep — the hardware WDT eventually resets the device, but with no diagnostic information about what stalled.

I've added millisecond timeouts to both spinloops (10ms for IPCC, 500ms for HSEM). When either fires, a `volatile bool rfcore_ipcc_timeout` flag is set. All rfcore entry points (`rfcore_ble_init`, `rfcore_ble_hci_cmd`, `rfcore_ble_check_msg`, `rfcore_ble_set_txpower`) check this flag and return early, preventing further IPCC access on a dead channel.

On the NimBLE side, `mp_bluetooth_hci_poll()` checks the flag and schedules `mp_bluetooth_deinit()` via `mp_sched_schedule()`. This runs in Thread mode (not ISR context), cleanly shutting down the BLE stack so Python-level BLE operations fail with "not active" errors rather than hanging.

```mermaid
sequenceDiagram
    participant App as Python BLE
    participant NimBLE as mp_bluetooth_hci_poll
    participant rfcore as rfcore.c
    participant CPU2 as BLE Coprocessor

    Note over rfcore,CPU2: CPU2 becomes unresponsive
    rfcore->>CPU2: IPCC channel wait (tl_process_msg)
    Note over rfcore: Timeout after 10ms
    rfcore-->>rfcore: rfcore_ipcc_timeout = true

    NimBLE->>rfcore: rfcore_ble_check_msg()
    rfcore-->>NimBLE: returns 0 (timeout flag set)
    NimBLE->>App: mp_sched_schedule(mp_bluetooth_deinit)
    Note over App: BLE ops fail with "not active"
```

### Testing

Tested on STM32WB55 (custom board, FUS v1.2.0 / WS v1.22.0) over several weeks of field operation. Before the change, unresponsive CPU2 caused hard lockups requiring WDT reset with no logs. After the change, the timeout fires, BLE deinits cleanly, and the device continues operating (minus BLE) with diagnostic output.

Not tested on other STM32WB variants (WB35, WB15) but the IPCC/HSEM mechanism is identical across the family.

### Trade-offs and Alternatives

- Adds ~100 bytes of code size for the timeout checks. Acceptable given the alternative is an unrecoverable lockup.
- The 10ms IPCC timeout is generous — the typical wait is 5–20 microseconds. Could be tighter but 10ms avoids false positives on slow paths.
- An alternative would be to use the IPCC interrupt rather than polling, but that would require restructuring the existing synchronous `tl_process_msg()` flow which is shared with the system channel.