### PR TITLE
ci/windows: Drop VS 2017, use pre-installed v142 toolset for VS 2019.

### DIFF
--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -25,23 +25,24 @@ jobs:
         platform: [x86, x64]
         configuration: [Debug, Release]
         variant: [dev, standard]
-        visualstudio: ['2017', '2019', '2022']
+        visualstudio: ['2019', '2022']
         include:
-        - visualstudio: '2017'
-          vs_version: '[15, 16)'
-          custom_vs_install: true
         - visualstudio: '2019'
-          vs_version: '[16, 17)'
-          custom_vs_install: true
+          # The v142 toolset (VS 2019 compiler) is pre-installed on
+          # windows-2022 as a component of VS 2022.  Use VS 2022's
+          # MSBuild and select the v142 toolset via PlatformToolset.
+          vs_version: '[17, 18)'
+          platform_toolset: v142
         - visualstudio: '2022'
           vs_version: '[17, 18)'
+          platform_toolset: v143
         # trim down the number of jobs in the matrix
         exclude:
         - variant: standard
           configuration: Debug
         - visualstudio: '2019'
           configuration: Debug
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
     steps:
@@ -51,31 +52,20 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
-    - name: Install Visual Studio ${{ matrix.visualstudio }}
-      if: matrix.custom_vs_install
-      shell: bash
-      # Shell functions in this block are to retry intermittent corrupt
-      # downloads (with a clean download dir) before failing the job outright
-      run: |
-        try () { ($@) || ($@) || ($@) || ($@) }
-        clean_install () ( rm -rf $TEMP/chocolatey; choco install $1 )
-        try clean_install visualstudio${{ matrix.visualstudio }}buildtools
-        try clean_install visualstudio${{ matrix.visualstudio }}-workload-vctools
-        try clean_install windows-sdk-8.1
     - uses: microsoft/setup-msbuild@v2
       with:
         vs-version: ${{ matrix.vs_version }}
     - uses: actions/checkout@v6
     - name: Build mpy-cross.exe
-      run: msbuild mpy-cross\mpy-cross.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }}
+      run: msbuild mpy-cross\mpy-cross.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PlatformToolset=${{ matrix.platform_toolset }}
     - name: Update submodules
       run: git submodule update --init lib/micropython-lib
     - name: Build micropython.exe
-      run: msbuild ports\windows\micropython.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }}
+      run: msbuild ports\windows\micropython.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }}
     - name: Get micropython.exe path
       id: get_path
       run: |
-        $exePath="$(msbuild ports\windows\micropython.vcxproj -nologo -v:m -t:ShowTargetPath -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }})"
+        $exePath="$(msbuild ports\windows\micropython.vcxproj -nologo -v:m -t:ShowTargetPath -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }})"
         echo ("micropython=" + $exePath.Trim()) >> $env:GITHUB_OUTPUT
     - name: Run tests
       id: test


### PR DESCRIPTION
### Summary

The VS 2017 and VS 2019 MSVC CI jobs have been failing intermittently for months due to Chocolatey/Microsoft installer infrastructure issues when downloading old Visual Studio build tools onto `windows-latest` runners. These are not code failures - the build tools installation itself is unreliable (CDN timeouts, corrupt downloads, installer self-update loops).

This removes VS 2017 from the matrix entirely and switches VS 2019 to use the v142 toolset that's already pre-installed on `windows-2022` runners as a component of VS 2022. The PlatformToolset is now passed explicitly to MSBuild for both VS 2019 (v142) and VS 2022 (v143), and the Chocolatey installation step is removed.

VS 2017 reached end-of-life in 2022, and the v141 toolset is no longer reliably installable on GitHub-hosted runners (actions/runner-images#9701, actions/runner-images#12764). The `windows-2019` runner image was removed in June 2025. Docker containers are not supported on Windows runners, and the repo's 10GB Actions cache is already full, so caching the installation isn't feasible either. MSVC v143 is binary-compatible back to v141, so the testing value of v141 was marginal.

The net effect is 16 MSVC jobs (down from 24) with zero installation steps and hopefully no more flaky failures.

### Testing

The workflow change only affects the GitHub Actions matrix configuration. The mingw and Linux cross-build jobs are unchanged. Verified the `windows-2022` runner image includes both `Microsoft.VisualStudio.Component.VC.Tools.x86.x64` (v143) and `Microsoft.VisualStudio.Component.VC.v142.x86.x64` (v142) from the runner image manifest.

### Trade-offs and Alternatives

This drops coverage of the VS 2017 (v141) compiler. If v141 testing is considered essential, the only reliable option would be a self-hosted runner with VS 2017 pre-installed - every approach that installs it at CI time hits the same Microsoft installer flakiness.

An alternative for VS 2019 would be to keep installing it via Chocolatey but with `continue-on-error: true` to make it advisory. The pre-installed v142 toolset approach is simpler and provides identical compiler coverage without any installation step.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.