### PR TITLE
lib/littlefs: Update LittleFS to v2.11.3.

### DIFF
--- a/lib/littlefs/lfs2.c
+++ b/lib/littlefs/lfs2.c
@@ -258,7 +258,7 @@ static int lfs2_bd_prog(lfs2_t *lfs2,
             continue;
         }
 
-        // pcache must have been flushed, either by programming and
+        // pcache must have been flushed, either by programming an
         // entire block or manually flushing the pcache
         LFS2_ASSERT(pcache->block == LFS2_BLOCK_NULL);
 
@@ -286,7 +286,7 @@ static int lfs2_bd_erase(lfs2_t *lfs2, lfs2_block_t block) {
 
 // some operations on paths
 static inline lfs2_size_t lfs2_path_namelen(const char *path) {
-    return strcspn(path, "/");
+    return (lfs2_size_t)strcspn(path, "/");
 }
 
 static inline bool lfs2_path_islast(const char *path) {
@@ -1291,6 +1291,7 @@ static lfs2_stag_t lfs2_dir_fetchmatch(lfs2_t *lfs2,
 
             // found a match for our fetcher?
             if ((fmask & tag) == (fmask & ftag)) {
+                LFS2_ASSERT(cb != NULL);
                 int res = cb(data, tag, &(struct lfs2_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {
@@ -1501,7 +1502,7 @@ nextname:
         if (lfs2_tag_type3(tag) == LFS2_TYPE_DIR) {
             name += strspn(name, "/");
         }
-        lfs2_size_t namelen = strcspn(name, "/");
+        lfs2_size_t namelen = (lfs2_size_t)strcspn(name, "/");
 
         // skip '.'
         if (namelen == 1 && memcmp(name, ".", 1) == 0) {
@@ -1520,7 +1521,7 @@ nextname:
         int depth = 1;
         while (true) {
             suffix += strspn(suffix, "/");
-            sufflen = strcspn(suffix, "/");
+            sufflen = (lfs2_size_t)strcspn(suffix, "/");
             if (sufflen == 0) {
                 break;
             }
@@ -1761,7 +1762,7 @@ static int lfs2_dir_commitcrc(lfs2_t *lfs2, struct lfs2_commit *commit) {
 
         commit->off = noff;
         // perturb valid bit?
-        commit->ptag = ntag ^ ((0x80UL & ~eperturb) << 24);
+        commit->ptag = ntag ^ ((lfs2_tag_t)(0x80 & ~eperturb) << 24);
         // reset crc for next commit
         commit->crc = 0xffffffff;
 
@@ -3244,10 +3245,12 @@ static int lfs2_file_open_(lfs2_t *lfs2, lfs2_file_t *file,
 #endif
 
 static int lfs2_file_close_(lfs2_t *lfs2, lfs2_file_t *file) {
-#ifndef LFS2_READONLY
-    int err = lfs2_file_sync_(lfs2, file);
-#else
     int err = 0;
+#ifndef LFS2_READONLY
+    // it's not safe to do anything if our file errored
+    if (!(file->flags & LFS2_F_ERRED)) {
+        err = lfs2_file_sync_(lfs2, file);
+    }
 #endif
 
     // remove from list of mdirs
@@ -3429,17 +3432,11 @@ relocate:
 
 #ifndef LFS2_READONLY
 static int lfs2_file_sync_(lfs2_t *lfs2, lfs2_file_t *file) {
-    if (file->flags & LFS2_F_ERRED) {
-        // it's not safe to do anything if our file errored
-        return 0;
-    }
-
     int err = lfs2_file_flush(lfs2, file);
     if (err) {
         file->flags |= LFS2_F_ERRED;
         return err;
     }
-
 
     if ((file->flags & LFS2_F_DIRTY) &&
             !lfs2_pair_isnull(file->m.pair)) {
@@ -3485,6 +3482,17 @@ static int lfs2_file_sync_(lfs2_t *lfs2, lfs2_file_t *file) {
         file->flags &= ~LFS2_F_DIRTY;
     }
 
+    // mark any other file handles as dirty + desync
+    for (lfs2_file_t *f = (lfs2_file_t*)lfs2->mlist; f; f = f->next) {
+        if (file != f
+                && f->type == LFS2_TYPE_REG
+                && lfs2_pair_cmp(f->m.pair, file->m.pair) == 0
+                && f->id == file->id) {
+            f->flags |= LFS2_F_DUSTY;
+        }
+    }
+
+    file->flags &= ~LFS2_F_ERRED & ~LFS2_F_DUSTY;
     return 0;
 }
 #endif
@@ -3692,7 +3700,7 @@ static lfs2_ssize_t lfs2_file_write_(lfs2_t *lfs2, lfs2_file_t *file,
         return nsize;
     }
 
-    file->flags &= ~LFS2_F_ERRED;
+    file->flags &= ~LFS2_F_ERRED & ~LFS2_F_DUSTY;
     return nsize;
 }
 #endif
@@ -4771,7 +4779,8 @@ int lfs2_fs_traverse_(lfs2_t *lfs2,
             continue;
         }
 
-        if ((f->flags & LFS2_F_DIRTY) && !(f->flags & LFS2_F_INLINE)) {
+        if (((f->flags & LFS2_F_DIRTY) || (f->flags & LFS2_F_DUSTY))
+                && !(f->flags & LFS2_F_INLINE)) {
             int err = lfs2_ctz_traverse(lfs2, &f->cache, &lfs2->rcache,
                     f->ctz.head, f->ctz.size, cb, data);
             if (err) {

--- a/lib/littlefs/lfs2.h
+++ b/lib/littlefs/lfs2.h
@@ -135,14 +135,15 @@ enum lfs2_open_flags {
 
     // internally used flags
 #ifndef LFS2_READONLY
-    LFS2_F_DIRTY   = 0x010000, // File does not match storage
-    LFS2_F_WRITING = 0x020000, // File has been written since last flush
+    LFS2_F_DIRTY   = 0x00010000, // File does not match storage due to write
+    LFS2_F_DUSTY   = 0x00020000, // File does not match storage due to desync
+    LFS2_F_WRITING = 0x00040000, // File has been written since last flush
 #endif
-    LFS2_F_READING = 0x040000, // File has been read since last flush
+    LFS2_F_READING = 0x00080000, // File has been read since last flush
 #ifndef LFS2_READONLY
-    LFS2_F_ERRED   = 0x080000, // An error occurred during write
+    LFS2_F_ERRED   = 0x00100000, // An error occurred during write
 #endif
-    LFS2_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS2_F_INLINE  = 0x01000000, // Currently inlined in directory entry
 };
 
 // File seek flags


### PR DESCRIPTION
### Summary

Updates LittleFS to v2.11.3 ([changelog](https://github.com/littlefs-project/littlefs/releases/tag/v2.11.3)).

Most noteworthy is a fix for a potential corruption issue when writing to multiple handles for the same file.

### Testing

~I'm running this on a few different ESP32 boards, no regressions so far. But marking this PR as draft so I can run some longer tests first.~

EDIT: I've been running it for almost a month now without noticing any problems over a large number of reads and writes on various boards. Marking as ready.

### Generative AI

I did not use generative AI tools when creating this PR.