### PR TITLE
esp32/adc: Raise error if ADC read result is invalid.

### DIFF
--- a/ports/esp32/adc.c
+++ b/ports/esp32/adc.c
@@ -54,7 +54,7 @@ mp_int_t madcblock_read_helper(machine_adc_block_obj_t *self, adc_channel_t chan
     adc_is_init_guard(self);
 
     int reading = 0;
-    adc_oneshot_read(self->handle, channel_id, &reading);
+    check_esp_err(adc_oneshot_read(self->handle, channel_id, &reading));
     return reading;
 }
 


### PR DESCRIPTION
### Summary

The `adc_oneshot_read()` function returns a status indicating whether the value was read correctly ([documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/api-reference/peripherals/adc/adc_oneshot.html#_CPPv416adc_oneshot_read25adc_oneshot_unit_handle_t13adc_channel_tPi)), but we weren't checking it.

### Generative AI

I did not use generative AI tools when creating this PR.