### PR TITLE
esp32/machine_uart: Allow passing -1 to specify pin will be unused.

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -372,21 +372,12 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
     }
     check_esp_err(uart_get_baudrate(self->uart_num, &baudrate));
 
-    if (args[ARG_tx].u_obj != MP_OBJ_NULL) {
-        self->tx = machine_pin_get_id(args[ARG_tx].u_obj);
-    }
-
-    if (args[ARG_rx].u_obj != MP_OBJ_NULL) {
-        self->rx = machine_pin_get_id(args[ARG_rx].u_obj);
-    }
-
-    if (args[ARG_rts].u_obj != MP_OBJ_NULL) {
-        self->rts = machine_pin_get_id(args[ARG_rts].u_obj);
-    }
-
-    if (args[ARG_cts].u_obj != MP_OBJ_NULL) {
-        self->cts = machine_pin_get_id(args[ARG_cts].u_obj);
-    }
+    // set pins
+    #define SET_PIN(prop, arg) if (arg != MP_OBJ_NULL) prop = mp_obj_is_int(arg) && mp_obj_get_int(arg) == -1 ? UART_PIN_NO_CHANGE : machine_pin_get_id(arg);
+    SET_PIN(self->tx, args[ARG_tx].u_obj);
+    SET_PIN(self->rx, args[ARG_rx].u_obj);
+    SET_PIN(self->rts, args[ARG_rts].u_obj);
+    SET_PIN(self->cts, args[ARG_cts].u_obj);
     check_esp_err(uart_set_pin(self->uart_num, self->tx, self->rx, self->rts, self->cts));
 
     // set data bits


### PR DESCRIPTION
### Summary

The UART constructor previously required you to pass a TX and RX pin, else it would use the default pin numbers.

However, sometimes you don't want to allocate a pin for one of these functions, for example when you have a read-only or write-only UART. The workaround would be to pass an unused pin for the unused function, or to let some pin first be claimed by the UART and then steal it away for some other function.

The ESP-IDF supports leaving a pin unused by passing `UART_PIN_NO_CHANGE` (which equal -1) as the pin number.

`machine_pin_get_id` doesn't consider -1 a valid pin number (rightly so). So I used a small macro, inspired by the one used in `machine_lan.c`, that passes through a -1 as `UART_PIN_NO_CHANGE`.

(The RTS and CTS pins already default to UART_PIN_NO_CHANGE, so they were only changed for consistency with the other pin assignments.)

### Testing

Tested it on a few ESP32-based boards where I have a read-only UART and no other free pins. When passing `tx=-1` everything works as expected: The UART functions as normal, without trying to configure a pin for the TX function.

### Generative AI

I did not use generative AI tools when creating this PR.