### PR TITLE
github: Avoid unnecessary failures when Actions run in forks

### DIFF
--- a/.github/workflows/mpremote.yml
+++ b/.github/workflows/mpremote.yml
@@ -20,7 +20,17 @@ jobs:
     - name: Install build tools
       run: pip install build
     - name: Build mpremote wheel
-      run: cd tools/mpremote && python -m build --wheel
+      run: |
+        if ! git rev-parse --verify -q v1.23.0 >/dev/null; then
+          echo "::error::mpremote wheel build requires recent MicroPython version tags in the forked repo."
+          echo ""
+          echo "To fix, push tags from upstream:"
+          echo "  git remote add upstream https://github.com/micropython/micropython.git"
+          echo "  git fetch upstream --tags"
+          echo "  git push origin --tags"
+          exit 1
+        fi
+        cd tools/mpremote && python -m build --wheel
     - name: Archive mpremote wheel
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -95,8 +95,12 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        fail_ci_if_error: true
+        # Only fail the job on error if a token is set, or we're running against upstream repo.
+        # This avoids the annoying situation of the job failing on every push to a fork (if no token is set).
+        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' || github.repository_owner == 'micropython' }}
         verbose: true
+        # note: when a fork opens a PR into MicroPython repo, the pull_request trigger can't access
+        # secrets so this token value will be empty (codecov will do a 'tokenless' upload).
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Print failures
       if: failure()


### PR DESCRIPTION
### Summary

It [came up recently](https://github.com/micropython/micropython/pull/18842#discussion_r2826207917) that if you enable Actions on your fork of MicroPython then it consistently fails the Coverage Upload step (unless you set a codecov token in your fork).

This means you get a failure email each time you push to your own repo, which sucks.

@andrewleech submitted a fix for this in #18861 but it ended up being pulled out.

* This PR submits a new version of the fix that should work as intended.
* I also worked around a less universal problem: if your fork doesn't have recent tags pushed to it, the mpremote build will fail with an obscure error as it can't find a version via the 'vcs' method. Replaced with a more helpful error message (thanks @andrewleech for the suggestion!)

### Testing

* I opened a PR in my own fork: https://github.com/projectgus/micropython/pull/15 and verified it passes. Specifically:
  - Coverage upload step runs with `fail_ci_if_error: false`, doesn't fail any more - https://github.com/projectgus/micropython/actions/runs/23578277216/job/68655578371?pr=15
  - Mpremote build fails with a clear error message: https://github.com/projectgus/micropython/actions/runs/23578278102/job/68655559247?pr=15
* In this PR:
  - Coverage upload step runs with `fail_ci_if_error: true`, same as before this change - https://github.com/micropython/micropython/actions/runs/23578278490/job/68655581062?pr=18998
  - MPremote build succeeds, same as on master - https://github.com/micropython/micropython/actions/runs/23578278499/job/68655560542

### Trade-offs and Alternatives

* We could drop the mpremote change as this failure mode is pretty niche (you have to have created your fork before 2023 to hit this case, so I'm not sure how many "bad" forks are out there). However the error when this fails is pretty vague, it took me a while to figure out it was because of the missing tags. So I think it's a nice "quality of life" helper for anyone who has a long-running personal fork of MicroPython.

### Generative AI

I did not use generative AI tools when creating this PR.
