### PR TITLE
tests: Use a unique domain name for tests/multi_wlan/getaddrinfo.

### DIFF
--- a/tests/multi_wlan/getaddrinfo.py
+++ b/tests/multi_wlan/getaddrinfo.py
@@ -20,8 +20,11 @@ def instance0():
 
     multitest.next()
 
+    # Note: Lookup domain for this test doesn't need to exist, as the board
+    # isn't internet connected. It also shouldn't exist, so a cached result is
+    # never returned!
     try:
-        socket.getaddrinfo("micropython.org", 80)
+        socket.getaddrinfo("doesnotexist.example.com", 80)
     except OSError as er:
         print(
             "active(0) failed"
@@ -30,7 +33,7 @@ def instance0():
     wlan.active(1)
 
     try:
-        socket.getaddrinfo("micropython.org", 80)
+        socket.getaddrinfo("doesnotexist.example.com", 80)
     except OSError as er:
         print(
             "active(1) failed", er.errno in (-2, -202)


### PR DESCRIPTION
### Summary

Otherwise this test can fail if the "should fail" lookup is resolved from a cached result.

### Testing

Ran updated test on an ESP32-C6 board, it still passes.

### Generative AI

I did not use generative AI tools when creating this PR.
