### PR TITLE
py/objstr: Return 0 from str.count when end precedes start.

### DIFF
--- a/py/objstr.c
+++ b/py/objstr.c
@@ -1799,6 +1799,10 @@ static mp_obj_t str_count(size_t n_args, const mp_obj_t *args) {
         end = str_index_to_ptr(self_type, haystack, haystack_len, args[3], true);
     }
 
+    if (end < start) {
+        return MP_OBJ_NEW_SMALL_INT(0);
+    }
+
     // if needle_len is zero then we count each gap between characters as an occurrence
     if (needle_len == 0) {
         return MP_OBJ_NEW_SMALL_INT(utf8_charlen(start, end - start) + 1);

--- a/tests/basics/bytes_count.py
+++ b/tests/basics/bytes_count.py
@@ -48,6 +48,10 @@ print(b"aaaa".count(b'a', 1, 5))
 print(b"aaaa".count(b'a', -1, 5))
 print(b"abbabba".count(b"abba"))
 
+# start > end: count must be 0 (CPython); empty needle hit buggy utf8 path.
+print(b"abc".count(b"", 2, 1))
+print(b"abc".count(b"a", 2, 1))
+
 print(b'\xaa \xaa'.count(b'\xaa'))
 print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'))
 print(b'\xaa \xaa \xaa \xaa'.count(b'\xaa'), 1)

--- a/tests/basics/string_count.py
+++ b/tests/basics/string_count.py
@@ -48,6 +48,10 @@ print("aaaa".count('a', 1, 5))
 print("aaaa".count('a', -1, 5))
 print("abbabba".count("abba"))
 
+# start > end: count must be 0 (CPython); empty needle hit buggy utf8 path.
+print("abc".count("", 2, 1))
+print("abc".count("a", 2, 1))
+
 def t():
     return True
 


### PR DESCRIPTION
## Summary

- `str_count`: if the slice resolves so that `end < start`, return `0` (same as CPython).
- Fixes the empty-needle case where `utf8_charlen` was called with an inverted byte span.
- Adds matching `str` / `bytes` regression lines in `tests/basics/string_count.py` and `bytes_count.py` (expected output from CPython via `run-tests.py`).