### PR TITLE
esp32: Make default SDMMC slot configurable.

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -214,7 +214,7 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         ARG_freq,
     };
     #if SOC_SDMMC_HOST_SUPPORTED
-    static const int DEFAULT_SLOT = 1;
+    static const int DEFAULT_SLOT = MICROPY_HW_SDMMC_DEFAULT_SLOT;
     #else
     static const int DEFAULT_SLOT = SD_SLOT_MAX;
     #endif

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -195,6 +195,13 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#if CONFIG_IDF_TARGET_ESP32P4
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#else
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #ifndef MICROPY_HW_ESP_NEW_I2C_DRIVER


### PR DESCRIPTION
### Summary

Resolves part of #18984 (see https://github.com/micropython/micropython/issues/18984#issuecomment-4144620980).

Adds new `MICROPY_HW_SDMMC_DEFAULT_SLOT` that defaults to `1` for most ESP32 variants, but defaults to `0` on ESP32-P4 because slot 0 supports SDIO 3.0, and is likely the default for most ESP32-P4 boards. `MICROPY_HW_SDMMC_DEFAULT_SLOT` can be set in `mpconfigboard.h` to change the default slot.

This change makes it so `slot` does not need to be specified when calling `machine.SDCard()` if `MICROPY_HW_SDMMC_DEFAULT_SLOT` is set correctly.

### Testing

Tested with [ESP32-P4-Function-EV-Board v1.5.2](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/user_guide.html) with the following test code:

```
import esp32, machine, network
wlan = network.WLAN()
ldo = esp32.LDO(4, 3300, adjustable=True)
vfs.mount(machine.SDCard(), '/sd')
wlan.active(True)
```

Before this PR, the code would crash when the last line is called, unless `slot=0` was explicitly specified. After this PR, the code executes just fine without specifying `slot=0`.

### Generative AI

I did not use generative AI tools when creating this PR.
