### PR TITLE
py/emitglue: Fix macro logic that selects cache flushing code.

### DIFF
--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -107,17 +107,17 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, cons
     // Some architectures require flushing/invalidation of the I/D caches,
     // so that the generated native code which was created in data RAM will
     // be available for execution from instruction RAM.
-    #if MICROPY_EMIT_THUMB || MICROPY_EMIT_INLINE_THUMB || (MP_NATIVE_ARCH_ARMV6M <= MPY_FEATURE_ARCH && MPY_FEATURE_ARCH <= MP_NATIVE_ARCH_ARMV7EMDP)
+    #if defined(__thumb__) || defined(__thumb2__)
     #if __ICACHE_PRESENT == 1
     // Flush D-cache, so the code emitted is stored in RAM.
     MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
     // Invalidate I-cache, so the newly-created code is reloaded from RAM.
     SCB_InvalidateICache();
     #endif
-    #elif MICROPY_EMIT_ARM || (MPY_FEATURE_ARCH == MP_NATIVE_ARCH_ARMV6)
+    #elif defined(__arm__)
     #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
     __builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len);
-    #elif defined(__arm__)
+    #else
     // Flush I-cache and D-cache.
     asm volatile (
         "0:"
@@ -127,7 +127,7 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, cons
         "mcr p15, 0, r0, c7, c7, 0\n" // invalidate I-cache and D-cache
         : : : "r0", "cc");
     #endif
-    #elif (MICROPY_EMIT_RV32 || MICROPY_EMIT_INLINE_RV32 || (MPY_FEATURE_ARCH == MP_NATIVE_ARCH_RV32IMC)) && defined(MP_HAL_CLEAN_DCACHE)
+    #elif defined(__riscv) && defined(MP_HAL_CLEAN_DCACHE)
     // Flush the D-cache.
     MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
     #endif


### PR DESCRIPTION
### Summary

This fixes a regression made by 9e9da6cb0d794e85dbafcabd39972528afc15474 (bug found by `git bisect` between v1.27.0 and current master, running `tests/feature_check/native.py` on an ESP32-P4).

There are two issues here:

1. `MPY_FEATURE_ARCH` and `MP_NATIVE_ARCH_xxx` are not visible in this file because `py/persistentcode.h` is not included.

2. Even if they were visible the macro logic will not work because `MP_NATIVE_ARCH_xxx` are enum values and cannot be used in #if logic.

What this means is that the first `#if` is always true, so there is no cache flushing on ARM (non-Thumb) or RISC-V targets.  This breaks native code on, eg, ESP32-P4.

The fix here aims to simplify the logic by using built-in compiler defines to select the target:

- On an ARM Thumb target with `__ICACHE_PRESENT` enabled, it will flush the cache.

- On an ARM (non-Thumb) target, it will prefer `__builtin___clear_cache()` if possible, otherwise it will use inline assembler.

- On a RISC-V target, it will use `MP_HAL_CLEAN_DCACHE()` if that macro is defined (that's only on ESP32-P4 at the moment).

The logic should be the same as before, except for the cases where an emitter is enabled on a mismatching architecture.  For example, if `MICROPY_EMIT_THUMB` and/or `MICROPY_EMIT_INLINE_THUMB` were enabled on a non-Thumb target, previously that will try to generate code to flush caches (which doesn't really make sense), but now it will not.  This actually happened for `mpy-cross` which does enable all the emitters, and prior to this fix would follow the Thumb path, but not generate any code because `__ICACHE_PRESENT` is disabled (at least when building `mpy-cross` on x86).

### Testing

Tested on an ESP32-P4 board, running:
```
$ ./run-tests.py -t a0 --via-mpy --emit native
```
Without the fix here that fails immediately.  With this PR all tests pass.

Also tested on PYBD_SF6 running the same command.  Tests still pass (they also pass prior to the change here, as expected).

### Trade-offs and Alternatives

An alternative would be to include `py/persistentcode.h` and change all the `MP_NATIVE_ARCH_xxx` from an enum to `#define`'s.  But that's a much bigger change.  I've aimed here for simplicity.

Also, eventually we should make this cache logic even simpler, something like:
```c
#ifdef MP_HAL_CLEAN_DCACHE
MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
#endif
#ifdef MP_HAL_INVALIDATE_ICACHE
MP_HAL_INVALIDATE_ICACHE();
#endif
```
which would cover all architectures.  But that's a bigger change.  I needed something minimal because this bug is blocking the v1.28.0 release.

### Generative AI

I did not use generative AI tools when creating this PR.