### PR TITLE
rp2/rp2_dma: Reduce footprint of the DMA control fields table.

### DIFF
--- a/ports/rp2/rp2_dma.c
+++ b/ports/rp2/rp2_dma.c
@@ -50,13 +50,14 @@ typedef struct _rp2_dma_obj_t {
 } rp2_dma_obj_t;
 
 typedef struct _rp2_dma_ctrl_field_t {
-    qstr name;
-    uint8_t shift : 5;
-    uint8_t length : 3;
-    uint8_t read_only : 1;
+    qstr_short_t name;
+    uint16_t shift : 5;
+    uint16_t length : 3;
+    uint16_t read_only : 1;
+    // 7 bits available here.
 } rp2_dma_ctrl_field_t;
 
-static rp2_dma_ctrl_field_t rp2_dma_ctrl_fields_table[] = {
+static const rp2_dma_ctrl_field_t rp2_dma_ctrl_fields_table[] = {
     { MP_QSTR_enable, DMA_CH0_CTRL_TRIG_EN_LSB, 1, 0 },
     { MP_QSTR_high_pri, DMA_CH0_CTRL_TRIG_HIGH_PRIORITY_LSB, 1, 0 },
     { MP_QSTR_size, DMA_CH0_CTRL_TRIG_DATA_SIZE_LSB, 2, 0 },


### PR DESCRIPTION
### Summary

This PR shortens the amount of space taken by the DMA control fields table, and explicitly marks it as `const`.

The DMA fields info table used a full-size QSTR index value, and 9 bits of numeric information.  Given that the QSTR index could be converted into a `qstr_short_t`, there is no fields spill outside a machine word boundary - albeit with having 7 unused bits but there isn't much that can be done for that.  The effective structure size for each entry is halved, from 8 bytes down to 4.

Also, the structure is only read from, yet it was not marked as `const`. Marking the structure as constant did not help reduce the final size but at least correctly signals the compiler that no write accesses are possible.

This shrinks the RPI_PICO/RPI_PICO_W build by 56 bytes, with a similar size reduction for RPI_PICO2/RPI_PICO2_W.

### Testing

The `tests/ports/rp2/rp2_dma.py` test was executed successfully on a RP2040.

### Generative AI

I did not use generative AI tools when creating this PR.