### PR TITLE
alif/tinyusb_port: Fix _xfer_trb cache alignment.

### DIFF
--- a/ports/alif/tinyusb_port/tusb_alif_dcd.c
+++ b/ports/alif/tinyusb_port/tusb_alif_dcd.c
@@ -52,7 +52,7 @@ static uint32_t  _evnt_buf[1024] CFG_TUSB_MEM_SECTION __attribute__((aligned(409
 static volatile uint32_t* _evnt_tail;
 
 static uint8_t  _ctrl_buf[64] CFG_TUSB_MEM_SECTION __attribute__((aligned(32))); // [TODO] runtime alloc
-static uint32_t _xfer_trb[8][4] CFG_TUSB_MEM_SECTION __attribute__((aligned(32))); // [TODO] runtime alloc
+static uint32_t _xfer_trb[8][8] CFG_TUSB_MEM_SECTION __attribute__((aligned(32))); // [TODO] runtime alloc
 static uint16_t _xfer_bytes[8];
 static bool     _ctrl_long_data = false;
 static bool     _xfer_cfgd = false;


### PR DESCRIPTION
TRB buffers, which are the target of cache clean/invalidate actions, were not cache-aligned between buffers. Reported the problem to Alif, and adding padding to them is the proper fix. Appears to work without any other changes in device behavior.