### PR TITLE
Add coverage_sjlj variant, fix (some) setjmp-related problems.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -55,6 +55,18 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
+  sjlj:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build
+      run: tools/ci.sh unix_sjlj_build
+    - name: Run main test suite
+      run: tools/ci.sh unix_sjlj_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
   standard_v2:
     runs-on: ubuntu-latest
     steps:

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -143,8 +143,8 @@ static int usage(char **argv) {
         "Target specific options:\n"
         "-msmall-int-bits=number : set the maximum bits used to encode a small-int\n"
         "-march=<arch> : set architecture for native emitter;\n"
-        "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp,\n"
-        "                armv7emdp, xtensa, xtensawin, rv32imc, rv64imc, host, debug\n"
+        "                x86, x64, x64-linux-sjlj, armv6, armv6m, armv7m, armv7em, armv7emsp,\n"
+        "                armv7emdp, xtensa, xtensawin, rv32imc, rv64imc, host, debug, debug-sjlj\n"
         "-march-flags=<flags> : set architecture-specific flags (can be either a dec/hex/bin value or a comma-separated flags string)\n"
         "                       supported flags for rv32imc: zba, zcmp\n"
         "\n"
@@ -367,6 +367,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 } else if (strcmp(arch, "x64") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_X64;
                     mp_dynamic_compiler.nlr_buf_num_regs = MAX(MICROPY_NLR_NUM_REGS_X64, MICROPY_NLR_NUM_REGS_X64_WIN);
+                } else if (strcmp(arch, "x64-linux-sjlj") == 0) {
+                    mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_X64;
+                    mp_dynamic_compiler.nlr_buf_num_regs = MAX(MICROPY_NLR_NUM_REGS_X64, MICROPY_NLR_NUM_REGS_X64_WIN);
+                    mp_dynamic_compiler.nlr_setjmp = 1;
+                    mp_dynamic_compiler.local_idx_exc_handler_pc = (2 + 0);
                 } else if (strcmp(arch, "armv6") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_ARMV6;
                     mp_dynamic_compiler.nlr_buf_num_regs = MICROPY_NLR_NUM_REGS_ARM_THUMB_FP;
@@ -401,6 +406,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 } else if (strcmp(arch, "debug") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_DEBUG;
                     mp_dynamic_compiler.nlr_buf_num_regs = 0;
+                } else if (strcmp(arch, "debug-sjlj") == 0) {
+                    mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_DEBUG;
+                    mp_dynamic_compiler.nlr_buf_num_regs = 1;
+                    mp_dynamic_compiler.nlr_setjmp = 1;
+                    mp_dynamic_compiler.local_idx_exc_handler_pc = (2 + 0);
                 } else if (strcmp(arch, "host") == 0) {
                     #if defined(__i386__) || defined(_M_IX86)
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_X86;

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -310,6 +310,8 @@ MP_NOINLINE int main_(int argc, char **argv) {
     // don't support native emitter unless -march is specified
     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_NONE;
     mp_dynamic_compiler.nlr_buf_num_regs = 0;
+    mp_dynamic_compiler.nlr_setjmp = 0;
+    mp_dynamic_compiler.local_idx_exc_handler_pc = -1;
     mp_dynamic_compiler.backend_options = NULL;
 
     const char *input_file = NULL;
@@ -389,6 +391,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 } else if (strcmp(arch, "xtensawin") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_XTENSAWIN;
                     mp_dynamic_compiler.nlr_buf_num_regs = MICROPY_NLR_NUM_REGS_XTENSAWIN;
+                    mp_dynamic_compiler.nlr_setjmp = 1;
                 } else if (strcmp(arch, "rv32imc") == 0) {
                     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_RV32IMC;
                     mp_dynamic_compiler.nlr_buf_num_regs = MICROPY_NLR_NUM_REGS_RV32I;

--- a/ports/unix/variants/sjlj/manifest.py
+++ b/ports/unix/variants/sjlj/manifest.py
@@ -1,0 +1,1 @@
+../standard/manifest.py

--- a/ports/unix/variants/sjlj/mpconfigvariant.h
+++ b/ports/unix/variants/sjlj/mpconfigvariant.h
@@ -1,0 +1,16 @@
+#include "../standard/mpconfigvariant.h"
+
+#define MICROPY_NLR_SETJMP (1)
+
+// This value is appropriate for x86_64 glibc on linux but is likely incorrect
+// on other systems.
+#ifdef __linux__
+#include <features.h>
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 0)
+#define NLR_BUF_IDX_LOCAL_1 (2 + 0) // rbx in glibc 2.41 jmpbuf-offsets.h
+#endif
+#endif
+
+#ifndef NLR_BUF_IDX_LOCAL_1
+#error Need definition of NLR_BUF_IDX_LOCAL_1 for this environment
+#endif

--- a/ports/unix/variants/sjlj/mpconfigvariant.mk
+++ b/ports/unix/variants/sjlj/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+include variants/standard/mpconfigvariant.mk
+
+RUN_TESTS_MPY_CROSS_FLAGS = --mpy-cross-flags=-march=x64-linux-sjlj

--- a/py/emitnarm.c
+++ b/py/emitnarm.c
@@ -8,8 +8,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmarm.h"
 
+#if defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (3) // r4
+#endif
 
 #define N_ARM (1)
 #define EXPORT_FUN(name) emit_native_arm_##name

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -61,6 +61,10 @@
 // wrapper around everything in this file
 #if N_X64 || N_X86 || N_THUMB || N_ARM || N_XTENSA || N_XTENSAWIN || N_RV32 || N_DEBUG
 
+#if !defined(N_NLR_SETJMP)
+#define N_NLR_SETJMP (MICROPY_NLR_SETJMP)
+#endif
+
 // C stack layout for native functions:
 //  0:                          nlr_buf_t [optional]
 //                              return_value [optional word]

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -61,10 +61,6 @@
 // wrapper around everything in this file
 #if N_X64 || N_X86 || N_THUMB || N_ARM || N_XTENSA || N_XTENSAWIN || N_RV32 || N_DEBUG
 
-#if !defined(N_NLR_SETJMP)
-#define N_NLR_SETJMP (MICROPY_NLR_SETJMP)
-#endif
-
 // C stack layout for native functions:
 //  0:                          nlr_buf_t [optional]
 //                              return_value [optional word]
@@ -92,10 +88,12 @@
 //                              locals (reversed, L0 at end)    |
 //                              (L0-L2 may be in regs instead)
 
-// Native emitter needs to know the following sizes and offsets of C structs (on the target):
+// Native emitter needs to know the following flags, sizes and offsets of C structs (on the target):
 #if MICROPY_DYNAMIC_COMPILER
+#define EMIT_NLR_SETJMP (mp_dynamic_compiler.nlr_setjmp)
 #define SIZEOF_NLR_BUF (2 + mp_dynamic_compiler.nlr_buf_num_regs + 1) // the +1 is conservative in case MICROPY_ENABLE_PYSTACK enabled
 #else
+#define EMIT_NLR_SETJMP (N_NLR_SETJMP)
 #define SIZEOF_NLR_BUF (sizeof(nlr_buf_t) / sizeof(uintptr_t))
 #endif
 #define SIZEOF_CODE_STATE (sizeof(mp_code_state_native_t) / sizeof(uintptr_t))
@@ -142,7 +140,11 @@
 
 // Indices within the local C stack for various variables
 #define LOCAL_IDX_EXC_VAL(emit) (NLR_BUF_IDX_RET_VAL)
+#if MICROPY_DYNAMIC_COMPILER
+#define LOCAL_IDX_EXC_HANDLER_PC(emit) (mp_dynamic_compiler.local_idx_exc_handler_pc == -1 ? NLR_BUF_IDX_LOCAL_1 : mp_dynamic_compiler.local_idx_exc_handler_pc)
+#else
 #define LOCAL_IDX_EXC_HANDLER_PC(emit) (NLR_BUF_IDX_LOCAL_1)
+#endif
 #define LOCAL_IDX_EXC_HANDLER_UNWIND(emit) (SIZEOF_NLR_BUF + 1) // this needs a dedicated variable outside nlr_buf_t
 #define LOCAL_IDX_THROW_VAL(emit) (SIZEOF_NLR_BUF + 2) // needs a dedicated variable outside nlr_buf_t, following inject_exc in py/vm.c
 #define LOCAL_IDX_RET_VAL(emit) (SIZEOF_NLR_BUF) // needed when NEED_GLOBAL_EXC_HANDLER is true
@@ -1235,10 +1237,10 @@ static void emit_native_global_exc_entry(emit_t *emit) {
             // Wrap everything in an nlr context
             ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 0);
             emit_call(emit, MP_F_NLR_PUSH);
-            #if N_NLR_SETJMP
-            ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 2);
-            emit_call(emit, MP_F_SETJMP);
-            #endif
+            if (EMIT_NLR_SETJMP) {
+                ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 2);
+                emit_call(emit, MP_F_SETJMP);
+            }
             ASM_JUMP_IF_REG_ZERO(emit->as, REG_RET, start_label, true);
         } else {
             // Clear the unwind state
@@ -1255,10 +1257,10 @@ static void emit_native_global_exc_entry(emit_t *emit) {
             emit_native_label_assign(emit, nlr_label);
             ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 0);
             emit_call(emit, MP_F_NLR_PUSH);
-            #if N_NLR_SETJMP
-            ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 2);
-            emit_call(emit, MP_F_SETJMP);
-            #endif
+            if (EMIT_NLR_SETJMP) {
+                ASM_MOV_REG_LOCAL_ADDR(emit->as, REG_ARG_1, 2);
+                emit_call(emit, MP_F_SETJMP);
+            }
             ASM_JUMP_IF_REG_NONZERO(emit->as, REG_RET, global_except_label, true);
 
             // Clear PC of current code block, and jump there to resume execution

--- a/py/emitndebug.c
+++ b/py/emitndebug.c
@@ -277,6 +277,8 @@ static void asm_debug_setcc_reg_reg_reg(asm_debug_t *as, int op, int reg1, int r
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (5) // rbx
 
+#define N_NLR_SETJMP (0)
+
 #define N_DEBUG (1)
 #define EXPORT_FUN(name) emit_native_debug_##name
 #include "py/emitnative.c"

--- a/py/emitnrv32.c
+++ b/py/emitnrv32.c
@@ -34,8 +34,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmrv32.h"
 
+#if defined(__riscv) && __riscv_xlen == 32
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (6) // S3
+#endif
 
 #define N_RV32 (1)
 #define EXPORT_FUN(name) emit_native_rv32_##name

--- a/py/emitnthumb.c
+++ b/py/emitnthumb.c
@@ -8,8 +8,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmthumb.h"
 
+#if defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (3) // r4
+#endif
 
 #define N_THUMB (1)
 #define EXPORT_FUN(name) emit_native_thumb_##name

--- a/py/emitnx64.c
+++ b/py/emitnx64.c
@@ -8,8 +8,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmx64.h"
 
+#if defined(__x86_64__)
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
 // Word indices of REG_LOCAL_x in nlr_buf_t
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 #define NLR_BUF_IDX_LOCAL_1 (5) // rbx
+#endif
 
 #define N_X64 (1)
 #define EXPORT_FUN(name) emit_native_x64_##name

--- a/py/emitnx86.c
+++ b/py/emitnx86.c
@@ -9,8 +9,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmx86.h"
 
+#if defined(__i386__)
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (5) // ebx
+#endif
 
 // x86 needs a table to know how many args a given function has
 static byte mp_f_n_args[MP_F_NUMBER_OF] = {

--- a/py/emitnxtensa.c
+++ b/py/emitnxtensa.c
@@ -8,8 +8,21 @@
 #define GENERIC_ASM_API (1)
 #include "py/asmxtensa.h"
 
+#if defined(__xtensa__)
+#if MICROPY_NLR_SETJMP
+#define N_NLR_SETJMP (1)
+#else
+#define N_NLR_SETJMP (0)
+#endif
+#endif
+
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#if N_NLR_SETJMP
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (8) // a12
+#endif
 
 #define N_XTENSA (1)
 #define EXPORT_FUN(name) emit_native_xtensa_##name

--- a/py/emitnxtensawin.c
+++ b/py/emitnxtensawin.c
@@ -9,8 +9,14 @@
 #define GENERIC_ASM_API_WIN (1)
 #include "py/asmxtensa.h"
 
+#if MICROPY_NLR_SETJMP
+#if !defined(NLR_BUF_IDX_LOCAL_1)
+#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
+#endif
+#else
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (2 + 4) // a4
+#endif
 
 #define N_NLR_SETJMP (1)
 #define N_XTENSAWIN (1)

--- a/py/emitnxtensawin.c
+++ b/py/emitnxtensawin.c
@@ -9,14 +9,8 @@
 #define GENERIC_ASM_API_WIN (1)
 #include "py/asmxtensa.h"
 
-#if MICROPY_NLR_SETJMP
-#if !defined(NLR_BUF_IDX_LOCAL_1)
-#error Must define NLR_BUF_IDX_LOCAL_1 (depends on layout of jmp_buf)
-#endif
-#else
 // Word indices of REG_LOCAL_x in nlr_buf_t
 #define NLR_BUF_IDX_LOCAL_1 (2 + 4) // a4
-#endif
 
 #define N_NLR_SETJMP (1)
 #define N_XTENSAWIN (1)

--- a/py/modweakref.c
+++ b/py/modweakref.c
@@ -77,6 +77,24 @@ void gc_weakref_about_to_be_freed(void *ptr) {
     }
 }
 
+static void call_callbacks(mp_obj_ref_t *ref) {
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        if (ref->base.type == &mp_type_ref) {
+            // weakref.ref() type.
+            mp_call_function_1(ref->callback, MP_OBJ_FROM_PTR(ref));
+        } else {
+            // weakref.finalize() type.
+            mp_obj_finalize_t *fin = (mp_obj_finalize_t *)ref;
+            mp_call_function_n_kw(fin->base.callback, fin->n_args, fin->n_kw, fin->args);
+        }
+        nlr_pop();
+    } else {
+        mp_printf(MICROPY_ERROR_PRINTER, "Unhandled exception in weakref callback:\n");
+        mp_obj_print_exception(MICROPY_ERROR_PRINTER, MP_OBJ_FROM_PTR(nlr.ret_val));
+    }
+}
+
 void gc_weakref_sweep(void) {
     mp_map_t *map = &MP_STATE_VM(mp_weakref_map);
     for (size_t i = 0; i < map->alloc; i++) {
@@ -87,27 +105,14 @@ void gc_weakref_sweep(void) {
             mp_obj_ref_t *ref = REF_FIN_LIST_OBJ_TO_PTR(map->table[i].value);
             map->table[i].value = MP_OBJ_NULL;
             while (ref != NULL) {
+
                 // Invalidate the weak reference.
                 assert(ref->obj_weak_ref != mp_const_none);
                 ref->obj_weak_ref = mp_const_none;
 
                 // Call any registered callbacks.
                 if (ref->callback != mp_const_none) {
-                    nlr_buf_t nlr;
-                    if (nlr_push(&nlr) == 0) {
-                        if (ref->base.type == &mp_type_ref) {
-                            // weakref.ref() type.
-                            mp_call_function_1(ref->callback, MP_OBJ_FROM_PTR(ref));
-                        } else {
-                            // weakref.finalize() type.
-                            mp_obj_finalize_t *fin = (mp_obj_finalize_t *)ref;
-                            mp_call_function_n_kw(fin->base.callback, fin->n_args, fin->n_kw, fin->args);
-                        }
-                        nlr_pop();
-                    } else {
-                        mp_printf(MICROPY_ERROR_PRINTER, "Unhandled exception in weakref callback:\n");
-                        mp_obj_print_exception(MICROPY_ERROR_PRINTER, MP_OBJ_FROM_PTR(nlr.ret_val));
-                    }
+                    call_callbacks(ref);
                 }
 
                 // Unlink the node.

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -69,6 +69,8 @@ typedef struct mp_dynamic_compiler_t {
     uint8_t small_int_bits; // must be <= host small_int_bits
     uint8_t native_arch;
     uint8_t nlr_buf_num_regs;
+    uint8_t nlr_setjmp;
+    int8_t local_idx_exc_handler_pc;
 } mp_dynamic_compiler_t;
 extern mp_dynamic_compiler_t mp_dynamic_compiler;
 #endif

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -199,10 +199,11 @@ static bool mp_native_yield_from(mp_obj_t gen, mp_obj_t send_value, mp_obj_t *re
     nlr_buf_t nlr_buf;
     mp_obj_t throw_value = *ret_value;
     if (nlr_push(&nlr_buf) == 0) {
+        mp_obj_t to_send = send_value;
         if (throw_value != MP_OBJ_NULL) {
-            send_value = MP_OBJ_NULL;
+            to_send = MP_OBJ_NULL;
         }
-        ret_kind = mp_resume(gen, send_value, throw_value, ret_value);
+        ret_kind = mp_resume(gen, to_send, throw_value, ret_value);
         nlr_pop();
     } else {
         ret_kind = MP_VM_RETURN_EXCEPTION;

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -702,6 +702,15 @@ function ci_unix_minimal_run_tests {
     make -C ports/unix VARIANT=minimal test
 }
 
+function ci_unix_sjlj_build {
+    ci_unix_build_helper VARIANT=sjlj
+    ci_unix_build_ffi_lib_helper gcc
+}
+
+function ci_unix_sjlj_run_tests {
+    ci_unix_run_tests_full_helper sjlj
+}
+
 function ci_unix_standard_build {
     ci_unix_build_helper VARIANT=standard
     ci_unix_build_ffi_lib_helper gcc


### PR DESCRIPTION
### Summary

Back in #17415 I reported that a Unix build using setjmp/longjmp for exception handling encountered crashes in the testsuite when using the native and viper code emitters.

More recently, this issue drew interest when @agatti reported similar problems on RV32 with MICROPY_NLR_SETJMP.
Independently, we each noticed that value NLR_BUF_IDX_LOCAL_1 (the location of the "local 1" address with an nlr_buf, used to store the exception handler PC) was hard coded for the native nlr implementation, and did not match the setjmp implementation.

This insight led fairly directly to the present fix, but there's also a lot of tidying needed:
 * The dynamic compiler can select whether to use setjmp, and the offset of NLR_BUF_IDX_LOCAL_1
 * for most native emitters, you get an error if you turn on SETJMP but do not set NLR_BUF_IDX_LOCAL_1 explicitly (the exception is xtensa non-windowed, which already uses setjmp).
 * mpy-cross now knows two new `-march=` values, x64-linux-sjlj and debug-sjlj, and more can be added
 * however there are not mpy file magic numbers allocated for this, so you can load an incompatible mpy file

### Testing

I ran "make test VARIANT=coverage_sjlj" locally.

### Trade-offs and Alternatives

I'm not sure at what "level" the layout of jmp_buf is set. It looks like musl and bionic both follow glibc on x86_64 so it may be universal. However, I coded it as linux glibc only.

I offer this PR as a way to find out whether it's worth pursuing this further. I was doing this only for the abstract reason of covering a major configuration that was not tested during CI. However, @agatti has actual uses for the setjmp implementation, "adding MicroPython scripting to a RV32 project that is using a RTOS that is not currently supported (RT-Thread)". Note that this PR doesn't actually add support for this specific RV32 RTOS but it should allow it to be added simply by mpconfig settings.

### Generative AI

I did not use generative AI tools when creating this PR.
