### PR TITLE
compile: Reject *arg after keyword argument.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -2421,6 +2421,14 @@ static void compile_trailer_paren_helper(compiler_t *comp, mp_parse_node_t pn_ar
                     compile_syntax_error(comp, (mp_parse_node_t)pns_arg, MP_ERROR_TEXT("* arg after **"));
                     return;
                 }
+                if (n_keyword) {
+                    // Support for *arg after kwarg is a CPython feature omitted
+                    // from MicroPython in order to reduce code size. See
+                    // https://github.com/micropython/micropython/issues/11439 for
+                    // more info.
+                    compile_syntax_error(comp, (mp_parse_node_t)pns_arg, MP_ERROR_TEXT("* arg after kwarg"));
+                    return;
+                }
                 #if MICROPY_DYNAMIC_COMPILER
                 if (i >= (size_t)mp_dynamic_compiler.small_int_bits - 1)
                 #else

--- a/tests/basics/fun_callstar_kwarg.py
+++ b/tests/basics/fun_callstar_kwarg.py
@@ -1,0 +1,8 @@
+# A CPython syntax feature not supported by MicroPython. For more information
+# see `this issue <https://github.com/micropython/micropython/issues/11439>`_.
+# and tests/cpydiff/core_function_star.py
+
+try:
+    exec("f(y=1, *(3,))")
+except SyntaxError as e:
+    print("SyntaxError")

--- a/tests/basics/fun_callstar_kwarg.py.exp
+++ b/tests/basics/fun_callstar_kwarg.py.exp
@@ -1,0 +1,1 @@
+SyntaxError

--- a/tests/cpydiff/core_function_star.py
+++ b/tests/cpydiff/core_function_star.py
@@ -1,0 +1,16 @@
+"""
+categories: Core,Functions
+description: ``*args`` cannot follow a keyword argument
+cause: MicroPython is optimised for code space. For more information see `this issue <https://github.com/micropython/micropython/issues/11439>`_.
+workaround: Re-order the arguments
+"""
+
+
+def f(x, y):
+    return x + y
+
+
+try:
+    print(f(y=1, *(3,)))
+except Exception as e:
+    print(e)


### PR DESCRIPTION
### Summary

Reject a `*arg` after a keyword argument in function calls, and document this in cpydiff.

As discussed in #11441, the code growth from handling this case seems to outweigh the benefit of implementing it properly.

Closes: #11439

### Testing

I ran the tests locally and manually ran the cpydiff code.

### Trade-offs and Alternatives

#11441 does properly implement this language feature instead. It added +132 to the minimal ARM build.

### Generative AI

I did not use generative AI tools when creating this PR.