### PR TITLE
stm32/boards/OPENMV_N6: Update TinyUSB CDC buffers to 4KB size.

### DIFF
--- a/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
+++ b/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
@@ -155,6 +155,11 @@
 #define MICROPY_HW_BLE_UART_BAUDRATE_SECONDARY  (3000000)
 #define MICROPY_HW_BLE_UART_BAUDRATE_DOWNLOAD_FIRMWARE (3000000)
 
+// USB CDC config
+#define CFG_TUD_CDC_EP_BUFSIZE  (4096)
+#define CFG_TUD_CDC_RX_BUFSIZE  (4096)
+#define CFG_TUD_CDC_TX_BUFSIZE  (4096)
+
 /******************************************************************************/
 // Bootloader configuration
 


### PR DESCRIPTION
### Summary

4KB CDC buffers max out USB packet movement performance with HS USB. Same as on the AE3 and RT1062, which have HS USB.

### Testing

Verified on the OpenMV N6 with Tiny USB streaming GENX320 video to PC. 

### Generative AI

I did not use generative AI tools when creating this PR.