### PR TITLE
esp32/network_lan: Make EMAC RMII pins configurable on ESP32-P4.

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -54,6 +54,16 @@ typedef struct _lan_if_obj_t {
     bool initialized;
     int8_t mdc_pin;
     int8_t mdio_pin;
+    #if CONFIG_IDF_TARGET_ESP32P4
+    int8_t crs_dv_pin;
+    int8_t rxd0_pin;
+    int8_t rxd1_pin;
+    int8_t tx_en_pin;
+    int8_t txd0_pin;
+    int8_t txd1_pin;
+    int8_t clk_in_pin;
+    int8_t clk_out_pin;
+    #endif
     int8_t phy_reset_pin;
     int8_t phy_power_pin;
     int8_t phy_cs_pin;
@@ -115,7 +125,12 @@ static mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     }
 
     enum { ARG_id, ARG_mdc, ARG_mdio, ARG_reset, ARG_power, ARG_phy_addr, ARG_phy_type,
-           ARG_spi, ARG_cs, ARG_int, ARG_ref_clk_mode, ARG_ref_clk };
+           ARG_spi, ARG_cs, ARG_int, ARG_ref_clk_mode, ARG_ref_clk,
+           #if CONFIG_IDF_TARGET_ESP32P4
+           ARG_crs_dv, ARG_rxd0, ARG_rxd1, ARG_tx_en,
+           ARG_txd0, ARG_txd1, ARG_clk_in, ARG_clk_out,
+           #endif
+    };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_id,           MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_mdc,          MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
@@ -129,6 +144,16 @@ static mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         { MP_QSTR_int,          MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_ref_clk_mode, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1} },
         { MP_QSTR_ref_clk,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        #if CONFIG_IDF_TARGET_ESP32P4
+        { MP_QSTR_crs_dv,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_rxd0,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_rxd1,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_tx_en,        MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_txd0,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_txd1,         MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_clk_in,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        { MP_QSTR_clk_out,      MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
+        #endif
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -148,6 +173,16 @@ static mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     self->phy_power_pin = GET_PIN(ARG_power);
     self->phy_cs_pin = GET_PIN(ARG_cs);
     self->phy_int_pin = GET_PIN(ARG_int);
+    #if CONFIG_IDF_TARGET_ESP32P4
+    self->crs_dv_pin = GET_PIN(ARG_crs_dv);
+    self->rxd0_pin = GET_PIN(ARG_rxd0);
+    self->rxd1_pin = GET_PIN(ARG_rxd1);
+    self->tx_en_pin = GET_PIN(ARG_tx_en);
+    self->txd0_pin = GET_PIN(ARG_txd0);
+    self->txd1_pin = GET_PIN(ARG_txd1);
+    self->clk_in_pin = GET_PIN(ARG_clk_in);
+    self->clk_out_pin = GET_PIN(ARG_clk_out);
+    #endif
 
     if (args[ARG_phy_addr].u_int < 0x00 || args[ARG_phy_addr].u_int > 0x1f) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid phy address"));
@@ -293,6 +328,40 @@ static mp_obj_t get_lan(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
         }
         esp32_config.smi_mdc_gpio_num = self->mdc_pin;
         esp32_config.smi_mdio_gpio_num = self->mdio_pin;
+
+        #if CONFIG_IDF_TARGET_ESP32P4
+        if (self->crs_dv_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.crs_dv_num = self->crs_dv_pin;
+        }
+        if (self->rxd0_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.rxd0_num = self->rxd0_pin;
+        }
+        if (self->rxd1_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.rxd1_num = self->rxd1_pin;
+        }
+        if (self->tx_en_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.tx_en_num = self->tx_en_pin;
+        }
+        if (self->txd0_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.txd0_num = self->txd0_pin;
+        }
+        if (self->txd1_pin != -1) {
+            esp32_config.emac_dataif_gpio.rmii.txd1_num = self->txd1_pin;
+        }
+        if (self->clk_out_pin != -1) {
+            if (self->clk_in_pin == -1) {
+                mp_raise_ValueError(MP_ERROR_TEXT("clk_in must be specified if clk_out is specified"));
+            }
+            esp32_config.clock_config.rmii.clock_mode = EMAC_CLK_OUT;
+            esp32_config.clock_config.rmii.clock_gpio = (emac_rmii_clock_gpio_t)self->clk_out_pin;
+            esp32_config.clock_config_out_in.rmii.clock_mode = EMAC_CLK_EXT_IN;
+            esp32_config.clock_config_out_in.rmii.clock_gpio = (emac_rmii_clock_gpio_t)self->clk_in_pin;
+        } else if (self->clk_in_pin != -1) {
+            esp32_config.clock_config.rmii.clock_mode = EMAC_CLK_EXT_IN;
+            esp32_config.clock_config.rmii.clock_gpio = (emac_rmii_clock_gpio_t)self->clk_in_pin;
+        }
+        #endif
+
         mac = esp_eth_mac_new_esp32(&esp32_config, &mac_config);
     }
     #endif


### PR DESCRIPTION
### Summary

Fixes #19035.

Example usage with [Espressif's ESP32-P4-Function-EV-Board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/user_guide.html):

```
import network
lan = network.LAN(phy_addr=1, phy_type=network.PHY_IP101, mdc=31, mdio=52,
    crs_dv=28, rxd0=29, rxd1=30, tx_en=49, txd0=34, txd1=35, clk_in=50, # All of these are optional
    # clk_out=23, # Also optional, but not used on Espressif's dev board, so must be omitted in this case
)
```

See [here](https://docs.espressif.com/projects/esp-idf/en/v5.5.3/esp32p4/api-reference/network/esp_eth.html#configure-mac-and-phy) for valid pin choices.

### Testing

Tested on a couple ESP32-P4 dev boards (one is ESP32-P4-Function-EV-Board, other is from a third party vendor) with PHY chips on different pins.

Before this PR, the Espressif board worked fine, but the PHY was unusable on the other board. After this change, both boards work (have to specify the RMII pins on the third party board when calling `network.LAN()`).

For Espressif's dev board, the RMII pins can be omitted when calling `network.LAN()`, and the same default pins are used. Would be good to make the default pins configurable per board, but will save that for a future PR.

### Trade-offs and Alternatives

This PR addresses the RMII pins, but not the MII pins. I don't know of any dev boards using an MII interface, so I've opted to omit that feature for now. If desired, this could be modified to also allow an interface selection (MII or RMII) and the additional pins required for MII.

### Generative AI

I did not use generative AI tools when creating this PR.
