### PR TITLE
compile: Reject annotation of non-id expressions.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -2028,14 +2028,15 @@ static void compile_expr_stmt(compiler_t *comp, mp_parse_node_struct_t *pns) {
         int kind = MP_PARSE_NODE_STRUCT_KIND(pns1);
         if (kind == PN_annassign) {
             // the annotation is in pns1->nodes[0] and is ignored
+            if (!MP_PARSE_NODE_IS_ID(pns->nodes[0])) {
+                compile_syntax_error(comp, pns->nodes[0], MP_ERROR_TEXT("illegal target for annotation"));
+            }
             if (MP_PARSE_NODE_IS_NULL(pns1->nodes[1])) {
                 // an annotation of the form "x: y"
                 // inside a function this declares "x" as a local
+                qstr lhs = MP_PARSE_NODE_LEAF_ARG(pns->nodes[0]);
                 if (comp->scope_cur->kind == SCOPE_FUNCTION) {
-                    if (MP_PARSE_NODE_IS_ID(pns->nodes[0])) {
-                        qstr lhs = MP_PARSE_NODE_LEAF_ARG(pns->nodes[0]);
-                        scope_find_or_add_id(comp->scope_cur, lhs, ID_INFO_KIND_LOCAL);
-                    }
+                    scope_find_or_add_id(comp->scope_cur, lhs, ID_INFO_KIND_LOCAL);
                 }
             } else {
                 // an assigned annotation of the form "x: y = z"

--- a/tests/basics/annotate_var.py
+++ b/tests/basics/annotate_var.py
@@ -18,8 +18,11 @@ def f():
         print("NameError")
 f()
 
-# here, "x" should remain a global
-def f():
-    x.y: int
-    print(x)
-f()
+# An annotation like `f(): int` is correctly rejected
+try:
+    eval("def f():\n    f(): int")
+    print("OK")
+except SyntaxError as e:
+    print("SyntaxError")
+
+# Note: Annotations like `x.y: int` are not tested here, see cpydiff/syntax_annotation_expression.py

--- a/tests/cpydiff/syntax_annotation_expression.py
+++ b/tests/cpydiff/syntax_annotation_expression.py
@@ -1,0 +1,23 @@
+"""
+categories: Syntax,Annotations
+description: Type annotations allowed only on identifiers
+cause: Micropython disallows annotating certain expressions that CPython allows. These disallowed annotations are rejected as invalid by common type checkers.
+workaround: Remove the annotation.
+"""
+
+
+def test(expr):
+    code = f"def f():\n    {expr}: int"
+    print(code)
+    try:
+        exec(code)
+        print("OK")
+    except SyntaxError as e:
+        print("SyntaxError")
+    print()
+
+
+test("x.y")
+test("x.y.z")
+test("x[1]")
+test("x[1].y")


### PR DESCRIPTION
This rejects some annotations not allowed by CPython but previously accepted by micropython (e.g., `f(): int` or `x, y: int`) as well as some expressions allowed by CPython but rejected by all common type checkers (e.g., `x.y: int` or `x[1]: int`)

Closes: #19031

### Summary

MicroPython accepts some statements as type annotations, which are rejected by CPython, such as:
```py
f(): int
[x, y]: int
```

The present PR rejects a type annotation on anything that is not a simple identifier, in the interests of keeping the code simple. This also includes rejecting type annotations like the following, which are accepted by CPython but treated as meaningless or as errors by all the common type checkers:
```py
x.y: int
x[0]: int
```
### Testing

The testsuite now checks for rejection of annotations on a complex expression. Additionally, cpydiff tests the cases I know of where micropython & CPython deliberately differ.

### Trade-offs and Alternatives

The main trade-off is to do nothing. After all, this change will turn some code into no-longer-accepted code.

A second possibility is to make this a MicroPython 2-gated incompatible change.

Of course, it could be possible to fully implement whatever the CPython rule is.

### Generative AI

I did not use generative AI tools when creating this PR.