### PR TITLE
cpydiff: Add file for annotation expressions.

### DIFF
--- a/tests/cpydiff/syntax_annotation_expression.py
+++ b/tests/cpydiff/syntax_annotation_expression.py
@@ -1,0 +1,24 @@
+"""
+categories: Syntax,Annotations
+description: MicroPython accepts type annotations on expressions where CPython forbids them.
+cause: To reduce code size, MicroPython does not check the form of expressions with type annotations applied.
+workaround: Always check for valid Python code using a linting tool.
+
+The expressions themselves are not evaluated.
+"""
+
+
+def test(expr):
+    code = f"def f():\n    {expr}: int"
+    print(code)
+    try:
+        exec(code)
+        print("OK")
+    except SyntaxError as e:
+        print("SyntaxError")
+    print()
+
+
+test("print('test')")
+test("[x,y]")
+test("x,y")


### PR DESCRIPTION
### Summary

Document the behavior on expression annotations rejected by CPython but accepted by MicroPython.

Closes: #19031 

### Testing

I ran `make cpydiff` locally and looked at the output.

### Trade-offs and Alternatives

I tried to "fix" this in #19038 with small code size growth but it turned out to reject things that need to be allowed.

### Generative AI

I did not use generative AI tools when creating this PR.