### PR TITLE
io: Error on over-long read()/write().

### DIFF
--- a/py/modio.c
+++ b/py/modio.c
@@ -63,6 +63,10 @@ static mp_uint_t iobase_read_write(mp_obj_t obj, void *buf, mp_uint_t size, int 
     }
     mp_int_t ret = mp_obj_get_int(ret_obj);
     if (ret >= 0) {
+        if ((mp_uint_t)ret > size) {
+            *errcode = MP_EIO;
+            return MP_STREAM_ERROR;
+        }
         return ret;
     } else {
         *errcode = -ret;

--- a/tests/micropython/io_badlength.py
+++ b/tests/micropython/io_badlength.py
@@ -1,0 +1,35 @@
+# Test when a use IOBase class has write/readinto which returns more data than
+# requested (https://github.com/micropython/micropython/issues/18845)
+
+try:
+    import io, json
+except:
+    print("SKIP")
+    raise SystemExit
+
+
+class S(io.IOBase):
+    def write(self, buf):
+        assert len(buf) >= 0
+        return 2
+
+    def ioctl(self, cmd, arg):
+        return 0
+
+    def readinto(self, buf):
+        assert len(buf) >= 0
+        return 3
+
+
+try:
+    print("abc", file=S())
+    print("write OK")
+except OSError as e:
+    print("write failed, errno", e.errno)
+
+buf = bytearray(1)
+try:
+    json.load(S())
+    print("readinto OK")
+except OSError as e:
+    print("read failed, errno", e.errno)

--- a/tests/micropython/io_badlength.py.exp
+++ b/tests/micropython/io_badlength.py.exp
@@ -1,0 +1,2 @@
+write failed, errno 5
+read failed, errno 5


### PR DESCRIPTION
### Summary

It is a mistake in Python code if the result of readinto()/write() is more bytes than requested. Before this PR, incorrect values would lead to misbehavior as reported in #18845 if this invariant is not respected.

CPython appears to largely ignore the values returned from readinto()/write(), at least from `print()` & `json.load()`. Consequently, an expected output file is needed for the new test.

Closes: #18845

### Testing

I implemented a new test and ran it on the unix coverage build.

### Trade-offs and Alternatives

It seemed possible that this could go down in mp_stream_rw instead, but any core implementations of stream can be assumed well-behaved. It seemed better to keep the check closest to where the wrong value could be returned from user-controlled code.

### Generative AI

I did not use generative AI tools when creating this PR.