### PR TITLE
py/mpconfig: Automatically configure thumb2 and float emitter features.

### DIFF
--- a/ports/alif/mpconfigport.h
+++ b/ports/alif/mpconfigport.h
@@ -87,9 +87,7 @@
 // MicroPython emitters
 #define MICROPY_PERSISTENT_CODE_LOAD            (1)
 #define MICROPY_EMIT_THUMB                      (1)
-#define MICROPY_EMIT_THUMB_ARMV7M               (1)
 #define MICROPY_EMIT_INLINE_THUMB               (1)
-#define MICROPY_EMIT_INLINE_THUMB_FLOAT         (1)
 
 // Optimisations
 #define MICROPY_OPT_COMPUTED_GOTO               (1)

--- a/ports/rp2/mpconfigport.h
+++ b/ports/rp2/mpconfigport.h
@@ -103,10 +103,6 @@
 #if PICO_ARM
 #define MICROPY_EMIT_THUMB                      (1)
 #define MICROPY_EMIT_INLINE_THUMB               (1)
-#if PICO_RP2040
-#define MICROPY_EMIT_THUMB_ARMV7M               (0)
-#define MICROPY_EMIT_INLINE_THUMB_FLOAT         (0)
-#endif
 #elif PICO_RISCV
 #define MICROPY_EMIT_RV32                       (1)
 #define MICROPY_EMIT_RV32_ZBA                   (1)

--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -6,7 +6,6 @@
 // MicroPython emitters
 #define MICROPY_EMIT_THUMB              (SAMD21_EXTRA_FEATURES)
 #define MICROPY_EMIT_INLINE_THUMB       (SAMD21_EXTRA_FEATURES)
-#define MICROPY_EMIT_THUMB_ARMV7M       (0)
 #define MICROPY_MODULE_BUILTIN_INIT     (1)
 
 // Selected extensions beyond the basic features set.

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -464,7 +464,11 @@ typedef uint64_t mp_uint_t;
 
 // Whether to emit ARMv7-M instruction support in thumb native code
 #ifndef MICROPY_EMIT_THUMB_ARMV7M
+#if defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH_ISA_THUMB == 2
 #define MICROPY_EMIT_THUMB_ARMV7M (1)
+#else
+#define MICROPY_EMIT_THUMB_ARMV7M (0)
+#endif
 #endif
 
 // Whether to enable the thumb inline assembler
@@ -474,7 +478,11 @@ typedef uint64_t mp_uint_t;
 
 // Whether to enable float support in the Thumb2 inline assembler
 #ifndef MICROPY_EMIT_INLINE_THUMB_FLOAT
+#if defined(__ARM_ARCH_ISA_THUMB) && __ARM_ARCH_ISA_THUMB == 2 && defined(__ARM_FP)
 #define MICROPY_EMIT_INLINE_THUMB_FLOAT (1)
+#else
+#define MICROPY_EMIT_INLINE_THUMB_FLOAT (0)
+#endif
 #endif
 
 // Whether to emit ARM native code


### PR DESCRIPTION
### Summary

Prior to this commit a port would need to manually configure the `MICROPY_EMIT_THUMB_ARMV7M` and `MICROPY_EMIT_INLINE_THUMB_FLOAT` options, based on whether the CPU is Thumb2 and whether it has hardware floating point support (eg Cortex-M0+ vs Cortex-M3 vs Cortex-M4).

This is error prone, for example on stm32:
- `NUCLEO_G0B1RE` (a Cortex-M0+ MCU) had both enabled even though neither options work on that target.
- `NUCLEO_L152RE` (a Cortex-M3 MCU) had both enabled but this target does not support hardware floating point.

The change here automatically enables the two options based on build-in compiler macros.  These macros -- `__thumb2__` and `__ARM_FP` -- are the same macros used to configure `MPY_FEATURE_ARCH` so should be correct.

### Testing

This change is tested on the following boards:
- alif ALIF_ENSEMBLE: both enabled
- rp2 RPI_PICO: both disabled
- rp2 RPI_PICO2: both enabled
- samd SAMD21_XPLAINED_PRO: both disabled
- samd SAMD_GENERIC_D51X20: both enabled
- stm32 NUCLEO_G0B1RE: both disabled
- stm32 NUCLEO_L152RE: only MICROPY_EMIT_THUMB_ARMV7M enabled
- stm32 PYBD_SF6: both enabled
- stm32 PYBV10: both enabled

### Generative AI

I did not use generative AI tools when creating this PR.