### PR TITLE
moductypes: Defensiveness in uctypes_struct_agg_size().

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -155,7 +155,7 @@ static inline mp_uint_t uctypes_struct_scalar_size(int val_type) {
 
 // Get size of aggregate type descriptor
 static mp_uint_t uctypes_struct_agg_size(mp_obj_tuple_t *t, int layout_type, mp_uint_t *max_field_size) {
-    if (t->len == 0) {
+    if (t->len < 2) {
         syntax_error();
     }
 


### PR DESCRIPTION
### Summary

Eliminates a read-beyond-end when calling `uctypes_struct_agg_size()` on the length 1 tuple `(uctypes.ARRAY ,)`, discovered when testing my CHERIoT RTOS port.

### Testing

Tested on the `unix` port and my own CHERIoT RTOS port. Minimal change that shouldn't break anything.

### Generative AI

I did not use generative AI tools when creating this PR.