### PR TITLE
py/obj: Add assert that float isn't used with mp_obj_is_type.

### DIFF
--- a/ports/renesas-ra/timer.c
+++ b/ports/renesas-ra/timer.c
@@ -339,7 +339,7 @@ static mp_obj_t pyb_timer_freq(size_t n_args, const mp_obj_t *args) {
         uint32_t freq;
         if (0) {
         #if MICROPY_PY_BUILTINS_FLOAT
-        } else if (mp_obj_is_type(args[1], &mp_type_float)) {
+        } else if (mp_obj_is_float(args[1])) {
             freq = (int)mp_obj_get_float(args[1]);
         #endif
         } else {

--- a/ports/stm32/timer.c
+++ b/ports/stm32/timer.c
@@ -450,7 +450,7 @@ static uint32_t compute_prescaler_period_from_freq(pyb_timer_obj_t *self, mp_obj
     uint32_t period;
     if (0) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (mp_obj_is_type(freq_in, &mp_type_float)) {
+    } else if (mp_obj_is_float(freq_in)) {
         float freq = mp_obj_get_float_to_f(freq_in);
         if (freq <= 0) {
             goto bad_freq;
@@ -545,7 +545,7 @@ static uint32_t compute_pwm_value_from_percent(uint32_t period, mp_obj_t percent
     uint32_t cmp;
     if (0) {
     #if MICROPY_PY_BUILTINS_FLOAT
-    } else if (mp_obj_is_type(percent_in, &mp_type_float)) {
+    } else if (mp_obj_is_float(percent_in)) {
         mp_float_t percent = mp_obj_get_float(percent_in);
         if (percent <= 0.0) {
             cmp = 0;

--- a/py/obj.h
+++ b/py/obj.h
@@ -117,7 +117,7 @@ extern const struct _mp_obj_float_t mp_const_float_inf_obj;
 extern const struct _mp_obj_float_t mp_const_float_nan_obj;
 #endif
 
-#define mp_obj_is_float(o) mp_obj_is_type((o), &mp_type_float)
+#define mp_obj_is_float(o) mp_obj_is_exact_type((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
 #endif
@@ -162,7 +162,7 @@ extern const struct _mp_obj_float_t mp_const_float_inf_obj;
 extern const struct _mp_obj_float_t mp_const_float_nan_obj;
 #endif
 
-#define mp_obj_is_float(o) mp_obj_is_type((o), &mp_type_float)
+#define mp_obj_is_float(o) mp_obj_is_exact_type((o), &mp_type_float)
 mp_float_t mp_obj_float_get(mp_obj_t self_in);
 mp_obj_t mp_obj_new_float(mp_float_t value);
 #endif
@@ -986,8 +986,13 @@ void *mp_obj_malloc_with_finaliser_helper(size_t num_bytes, const mp_obj_type_t 
     MP_STATIC_ASSERT_NONCONSTEXPR((t) != &mp_type_str), assert((t) != &mp_type_str),           \
     MP_STATIC_ASSERT_NONCONSTEXPR((t) != &mp_type_NoneType), assert((t) != &mp_type_NoneType), \
     1)
+#if MICROPY_PY_BUILTINS_FLOAT
+#define mp_type_assert_not_float(t) (MP_STATIC_ASSERT_NONCONSTEXPR((t) != &mp_type_float), assert((t) != &mp_type_float), 1)
+#else
+#define mp_type_assert_not_float(t) (1)
+#endif
 
-#define mp_obj_is_type(o, t) (mp_type_assert_not_bool_int_str_nonetype(t) && mp_obj_is_exact_type(o, t))
+#define mp_obj_is_type(o, t) (mp_type_assert_not_bool_int_str_nonetype(t) && mp_type_assert_not_float(t) && mp_obj_is_exact_type(o, t))
 #if MICROPY_OBJ_IMMEDIATE_OBJS
 // bool's are immediates, not real objects, so test for the 2 possible values.
 #define mp_obj_is_bool(o) ((o) == mp_const_false || (o) == mp_const_true)


### PR DESCRIPTION
### Summary

Some object representations have floats as literal objects (ie not heap allocated) and in such a case using `mp_obj_is_type(t, &mp_type_float)` will always return false.  So add a compile-time assertion to force the correct usage.

And fixed three cases that this new assert picks up.

### Testing

Tested on OPENMV_N6 which uses object representation C and would previously fail when passing in a float to `pyb.Timer.freq()`.  It now works.

### Generative AI

I did not use generative AI tools when creating this PR.
