### PR TITLE
mimxrt: Convert port to use new event waiting functions.

### DIFF
--- a/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
+++ b/ports/mimxrt/boards/MIMXRT1170_EVK/mpconfigboard.h
@@ -3,10 +3,8 @@
 
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-1070evk"
 
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-    } while (0);
+// Do not use WFE when waiting for an event.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS)
 
 // MIMXRT1170_EVK has 2 user LEDs
 #define MICROPY_HW_LED1_PIN (pin_GPIO_AD_04)

--- a/ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.h
+++ b/ports/mimxrt/boards/PHYBOARD_RT1170/mpconfigboard.h
@@ -3,10 +3,8 @@
 
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-phyboard"
 
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-    } while (0);
+// Do not use WFE when waiting for an event.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS)
 
 // phyBOARD-RT1170 SoM onboard LEDs (red and green from phyCORE SoM)
 // Carrier board provides additional RGB LEDs via GPIO

--- a/ports/mimxrt/machine_i2c.c
+++ b/ports/mimxrt/machine_i2c.c
@@ -170,7 +170,7 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     }
     //  Wait for the transfer to complete
     while (self->transfer_busy) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 
     // Transfer will not send a stop in case of errors like NAK. So it's done here.

--- a/ports/mimxrt/machine_uart.c
+++ b/ports/mimxrt/machine_uart.c
@@ -527,7 +527,7 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
                     return received;
                 }
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         // Get as many bytes as possible to meet the need.
         nget = avail < (size - received) ? avail : size - received;
@@ -558,7 +558,7 @@ static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_
             *errcode = MP_ETIMEDOUT;
             return MP_STREAM_ERROR;
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 
     // Check if the first part has to be sent semi-blocking.
@@ -581,7 +581,7 @@ static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_
                     return size - self->handle.txDataSize;
                 }
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         remaining = self->txbuf_len;
     } else {
@@ -627,7 +627,7 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
             if (mp_machine_uart_txdone(self)) {
                 return 0;
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         } while (ticks_us64() < timeout);
 
         *errcode = MP_ETIMEDOUT;

--- a/ports/mimxrt/modmachine.c
+++ b/ports/mimxrt/modmachine.c
@@ -133,7 +133,7 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
 }
 
 static void mp_machine_idle(void) {
-    MICROPY_EVENT_POLL_HOOK;
+    mp_event_wait_ms(1);
 }
 
 static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {

--- a/ports/mimxrt/mpconfigport.h
+++ b/ports/mimxrt/mpconfigport.h
@@ -223,14 +223,6 @@ extern const struct _mp_obj_type_t network_lan_type;
 #define MICROPY_HW_USB_PID (0x9802)
 #endif
 
-#ifndef  MICROPY_EVENT_POLL_HOOK
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-        __WFE(); \
-    } while (0);
-#endif
-
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MP_HAL_CLEANINVALIDATE_DCACHE(addr, size) \

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -71,7 +71,7 @@ int mp_hal_stdin_rx_chr(void) {
             return dupterm_c;
         }
         #endif
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_indefinite();
     }
 }
 

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -50,6 +50,11 @@
 #define MICROPY_PY_LWIP_REENTER MICROPY_PY_PENDSV_REENTER
 #define MICROPY_PY_LWIP_EXIT    MICROPY_PY_PENDSV_EXIT
 
+// Port level Wait-for-Event macro.
+#ifndef MICROPY_INTERNAL_WFE
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFE()
+#endif
+
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT   (500)
 
 #define MP_HAL_PIN_FMT                  "%q"

--- a/ports/mimxrt/sdio.c
+++ b/ports/mimxrt/sdio.c
@@ -259,7 +259,7 @@ static status_t sdio_transfer_dma(USDHC_Type *base,
     while ((sdmmc.xfer_flags != xfer_flags) &&
            !(sdmmc.xfer_flags & SDIO_TRANSFER_ERROR) &&
            (mp_hal_ticks_ms() - start) < timeout_ms) {
-        MICROPY_EVENT_POLL_HOOK;
+        mp_event_wait_ms(1);
     }
 
     if (sdmmc.xfer_flags == 0) {

--- a/ports/mimxrt/ticks.c
+++ b/ports/mimxrt/ticks.c
@@ -136,7 +136,7 @@ void ticks_delay_us64(uint64_t us) {
         }
         ticks_wake_after_us32((uint32_t)dt);
         if (dt > 50) {
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
     }
 }


### PR DESCRIPTION
### Summary

Convert the mimxrt port from the old `MICROPY_EVENT_POLL_HOOK` macro to use the new `mp_event_wait_xxx()` functions in conjunction with `MICROPY_INTERNAL_WFE`.

This change should be functionally equivalent to the existing behaivour because `mp_event_wait_ms()` and `mp_event_wait_indefinite()` are equal to `mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); __WFE()`, which is what `MICROPY_EVENT_POLL_HOOK` was.

### Testing

Tested on TEENSY40, running the full test suite.

### Generative AI

I did not use generative AI tools when creating this PR.
