### PR TITLE
tests/extmod: Don't require constructor to raise for bad socket type.

### DIFF
--- a/tests/extmod/socket_badconstructor.py
+++ b/tests/extmod/socket_badconstructor.py
@@ -16,10 +16,12 @@ try:
 except TypeError:
     print("TypeError")
 
+# This may or may not raise an exception, depending on the socket implementation.
+# The test is here for coverage.
 try:
     s = socket.socket(socket.AF_INET, 123456)
 except OSError:
-    print("OSError")
+    pass
 
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_RAW, None)


### PR DESCRIPTION
### Summary

Some socket implementations (eg `extmod/modsocket.c`) don't (and can't easily) raise an exception for an invalid socket type.  So just test that passing such a value doesn't crash the device.

### Testing

Tested on:
- TEENSY40 (uses `modsocket.c`)
- PYBD_SF6 (uses `modlwip.c`)
- unix

The test passes.

### Generative AI

I did not use generative AI tools when creating this PR.
