### PR TITLE
stm32/boards: Extend RAM section by 192K on STM32H723.

### DIFF
--- a/ports/stm32/boards/stm32h723.ld
+++ b/ports/stm32/boards/stm32h723.ld
@@ -9,8 +9,10 @@ MEMORY
     FLASH_APP  (rx) : ORIGIN = 0x08020000, LENGTH = 640K    /* sectors 1-5 */
     FLASH_FS (r)    : ORIGIN = 0x080c0000, LENGTH = 256K    /* sectors 6-7 */
     DTCM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K    /* Used for FS storage cache */
-    RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 128K    /* AXI SRAM (could extend +192K from ITCM) */
+    RAM (xrw)       : ORIGIN = 0x24000000, LENGTH = 320K    /* AXI SRAM (128k) + ITCM/AXI SRAM (192k) */
     RAM_SRAM1 (xrw) : ORIGIN = 0x30000000, LENGTH = 16K     /* SRAM1 */
+    RAM_SRAM2 (xrw) : ORIGIN = 0x30004000, LENGTH = 16K     /* SRAM2 */
+    RAM_SRAM4 (xrw) : ORIGIN = 0x38000000, LENGTH = 16K     /* SRAM4 */
 }
 
 /* produce a link error if there is not this amount of RAM for these sections */


### PR DESCRIPTION
### Summary

This extends the RAM section into the adjacent ITCM RAM block, increasing the total GC heap size by the same amount (because the GC heap uses all available remaining RAM).

Also defined the additional SRAMx regions for possible future use.

This affects only the NUCLEO_H723ZG board, bringing available GC heap from 73984 to 266048 bytes.

### Testing

Tested on NUCLEO_H723ZG, the GC heap increased.  Ran the test suite as well and there are no regressions (and now certain tests like `extmod/deflate_decompress.py` that require more RAM can pass).

### Generative AI

I did not use generative AI tools when creating this PR.