### PR TITLE
objint_longlong: Fix signed comparison error.

### DIFF
--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -229,7 +229,7 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
                 // negative shift not allowed
                 mp_raise_ValueError(MP_ERROR_TEXT("negative shift count"));
             }
-            overflow = rhs_val >= (sizeof(long long) * MP_BITS_PER_BYTE)
+            overflow = rhs_val >= (long long)(sizeof(long long) * MP_BITS_PER_BYTE)
                 || lhs_val > (LLONG_MAX >> rhs_val)
                 || lhs_val < (LLONG_MIN >> rhs_val);
             result = (unsigned long long)lhs_val << rhs_val;


### PR DESCRIPTION
### Summary

Under `afl-cc` (acting as a wrapper for clang), the following diagnostic occurs (wrapped for clarity):
```
../../py/objint_longlong.c:232:32: error:
    comparison of integers of different signs:
    'long long' and 'unsigned long' [-Werror,-Wsign-compare]
```

Add a cast to silence it. The value is known statically to fit inside `long long`.

### Testing

This change was previously tested as a part of #17814 

### Generative AI

I did not use generative AI tools when creating this PR.