### PR TITLE
vfs_blockdev: Use memoryview when available.

### DIFF
--- a/extmod/vfs_blockdev.c
+++ b/extmod/vfs_blockdev.c
@@ -49,7 +49,11 @@ void mp_vfs_blockdev_init(mp_vfs_blockdev_t *self, mp_obj_t bdev) {
 // Helper function to minimise code size of read/write functions
 // note the n_args argument is moved to the end for further code size reduction (args keep same position in caller and callee).
 static int mp_vfs_blockdev_call_rw(mp_obj_t *args, size_t block_num, size_t block_off, size_t len, void *buf, size_t n_args) {
+    #if MICROPY_PY_BUILTINS_MEMORYVIEW
+    mp_obj_array_t ar = {{&mp_type_memoryview}, 'B' | MP_OBJ_ARRAY_TYPECODE_FLAG_RW, 0, len, buf};
+    #else
     mp_obj_array_t ar = {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, len, buf};
+    #endif
     args[2] = MP_OBJ_NEW_SMALL_INT(block_num);
     args[3] = MP_OBJ_FROM_PTR(&ar);
     args[4] = MP_OBJ_NEW_SMALL_INT(block_off); // ignored for n_args == 2

--- a/tests/extmod/vfs_blockdev_invalid2.py
+++ b/tests/extmod/vfs_blockdev_invalid2.py
@@ -1,0 +1,37 @@
+# Tests where the block device returns invalid values
+
+try:
+    import vfs
+
+    vfs.VfsFat
+    memoryview
+except (NameError, ImportError, AttributeError):
+    print("SKIP")
+    raise SystemExit
+
+
+class BadDev:
+    SEC_SIZE = 512
+
+    def __init__(self, blocks):
+        self.blocks = blocks
+
+    def readblocks(self, n, buf):
+        assert len(buf) == self.SEC_SIZE
+        buf[:] = bytearray(self.SEC_SIZE + 1)  # Attempts to enlarge passed-in buf
+
+    def writeblocks(self, n, buf):
+        pass
+
+    def ioctl(self, op, arg):
+        if op == 4:  # MP_BLOCKDEV_IOCTL_BLOCK_COUNT
+            return self.blocks
+        if op == 5:  # MP_BLOCKDEV_IOCTL_BLOCK_SIZE
+            return self.SEC_SIZE
+
+
+bdev = BadDev(512)
+try:
+    vfs.VfsFat.mkfs(bdev)
+except ValueError as e:
+    print("ValueError")

--- a/tests/extmod/vfs_blockdev_invalid2.py.exp
+++ b/tests/extmod/vfs_blockdev_invalid2.py.exp
@@ -1,0 +1,1 @@
+ValueError

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -267,6 +267,7 @@ tests_requiring_slice = (
     "extmod/time_mktime.py",
     "extmod/time_res.py",
     "extmod/tls_sslcontext_ciphers.py",
+    "extmod/vfs_blockdev_invalid2.py",
     "extmod/vfs_fat_fileio1.py",
     "extmod/vfs_fat_finaliser.py",
     "extmod/vfs_fat_more.py",
@@ -873,7 +874,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     def run_one_test(test_file):
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
         # If test_file is one of our own tests always make it relative to our tests/ dir and
-        # otherwise use the abosulte path, irregardless of actual path passed,
+        # otherwise use the absolute path, regardless of actual path passed,
         # such that display and result output is always the same.
         try:
             test_file_relpath = os.path.relpath(test_file, start=base_path())


### PR DESCRIPTION

### Summary

Using memoryview prevents Python code from accidentally performing an operation that resizes the buffer.

However, in the case that the build excludes memoryview, the crash is still possible.

Closes: #17848

### Testing

I added a test for the new code.

### Trade-offs and Alternatives

It's unfortunate that memoryview isn't available everywhere. This means the crash is not fixed for all builds, just builds that include memoryview.

### Generative AI

I did not use generative AI tools when creating this PR.