### PR TITLE
re: Must check stack during compilecode()

### DIFF
--- a/lib/re1.5/compilecode.c
+++ b/lib/re1.5/compilecode.c
@@ -29,6 +29,8 @@ static const char *_compilecode(const char *re, ByteProg *prog, int sizecode)
     int term = PC;
     int alt_label = 0;
 
+    re1_5_stack_chk();
+
     for (; *re && *re != ')'; re++) {
         switch (*re) {
         case '\\':

--- a/tests/extmod/re_stack_overflow2.py
+++ b/tests/extmod/re_stack_overflow2.py
@@ -1,0 +1,25 @@
+# Test overflow in re.compile output code.
+
+try:
+    import re
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+def test_re(r):
+    try:
+        re.compile(r)
+    except:
+        print("Error")
+
+
+try:
+    r = "(" * 65536 + ")" * 65536
+except MemoryError:
+    print("SKIP")
+    raise SystemExit
+
+# This happens to trigger RecursionError on current versions of CPython
+# (tested with 3.13.5) as well, so no .exp file is needed.
+test_re(r)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -178,6 +178,7 @@ platform_tests_to_skip = {
         "extmod/binascii_a2b_base64.py",
         "extmod/deflate_compress_memory_error.py",  # tries to allocate unlimited memory
         "extmod/re_stack_overflow.py",
+        "extmod/re_stack_overflow2.py",
         "extmod/time_res.py",
         "extmod/vfs_posix.py",
         "extmod/vfs_posix_enoent.py",

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -873,7 +873,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
     def run_one_test(test_file):
         test_file_abspath = os.path.abspath(test_file).replace("\\", "/")
         # If test_file is one of our own tests always make it relative to our tests/ dir and
-        # otherwise use the abosulte path, irregardless of actual path passed,
+        # otherwise use the absolute path, regardless of actual path passed,
         # such that display and result output is always the same.
         try:
             test_file_relpath = os.path.relpath(test_file, start=base_path())


### PR DESCRIPTION
### Summary

Aa very deeply nested regular expression like
```
re.compile("(" * 65536)
```
can exhaust the host stack during the compile phase. This turns that into a `RuntimeError: maximum recursion depth exceeded` instead.

This crash was found via fuzzing.

### Testing

I added a new test for this condition.

### Trade-offs and Alternatives

None identified.

### Generative AI

I did not use generative AI tools when creating this PR.