### PR TITLE
esp32/modules: Use "from machine import *" instead of __getattr__.

### DIFF
--- a/ports/esp32/modules/machine.py
+++ b/ports/esp32/modules/machine.py
@@ -3,7 +3,7 @@ import sys
 _path = sys.path
 sys.path = ()
 try:
-    import machine as _machine
+    from machine import *
 finally:
     sys.path = _path
     del _path
@@ -185,8 +185,3 @@ if hasattr(esp32, "PCNT"):
 
 
 del esp32
-
-
-# Delegate to built-in machine module.
-def __getattr__(attr):
-    return getattr(_machine, attr)


### PR DESCRIPTION
### Summary

The esp32 port has the machine Counter and Encoder classes implemented in Python, requiring a `machine.py` that extends the built-in machine module.

That previously used `__getattr__()` to delegate lookups to the built-in, but that means any failed lookup raises an `AttributeError` instead of an `ImportError`.  This means (among other things) that certain tests like CAN and I2CTarget would fail because they couldn't skip the test correctly.

This commit improves the situation by using `from machine import *` instead of `__getattr__()`, which puts all the built-in functions/classes/constants directly in the `machine.py` global namespace.  That means an `ImportError` is now correctly raised for attributes that don't exist.

Although this takes up a bit more RAM, it's now a lot faster to import from the machine module: what used to take around 100us to lookup a name now takes only 5us.

### Testing

Tested with ESP32_GENERIC firmware.  Prior to this change running the `tests/extmod_hardware/*.py` tests would fail on CAN and I2CTarget tests, simply because the test could not be properly skipped.  Now, those tests are skipped correctly.

Ran the full test suite against ESP32_GENERIC and there are no regressions.

### Trade-offs and Alternatives

As noted above, this takes up more RAM for the `machine.py` globals dict (around 500 bytes).  OTOH it's much faster to import things, eg `machine.Pin` is about 20 times faster.

An alternative would be to do:
```py
# Delegate to built-in machine module.
def __getattr__(attr):
    try:
        return getattr(_machine, attr)
    except AttributeError:
        raise ImportError(attr)
```
but that will make importing even slower (due to the try-except).

Eventually it would be good to rewrite Counter and Encoder in C (using a common set of bindings) but that's a lot more work.

### Generative AI

I did not use generative AI tools when creating this PR.
