### PR TITLE
stm32: Fix mboot build with TinyUSB-enabled boards.

### DIFF
--- a/ports/stm32/mpconfigboard_common.h
+++ b/ports/stm32/mpconfigboard_common.h
@@ -262,6 +262,7 @@
 #ifndef MICROPY_HW_ENABLE_USBDEV
 #define MICROPY_HW_ENABLE_USBDEV (1)
 #define MICROPY_HW_TINYUSB_LL_INIT mp_usbd_ll_init
+void mp_usbd_ll_init(void);
 #endif
 
 #ifndef MICROPY_HW_USB_CDC

--- a/ports/stm32/usbd_conf.c
+++ b/ports/stm32/usbd_conf.c
@@ -32,7 +32,9 @@
 #include "usbd_core.h"
 #include "py/obj.h"
 #include "py/mphal.h"
+#if !BUILDING_MBOOT
 #include "shared/tinyusb/mp_usbd.h"
+#endif
 #include "irq.h"
 #include "usb.h"
 


### PR DESCRIPTION
### Summary

Mboot builds fail on boards with TinyUSB enabled because `usbd_conf.c` unconditionally includes `shared/tinyusb/mp_usbd.h` which pulls in `tusb.h`. The `BUILDING_MBOOT` guard that disables TinyUSB comes after the include so the header isn't found.

This guards the include with `!BUILDING_MBOOT` and adds a forward declaration of `mp_usbd_ll_init()` in `mpconfigboard_common.h` next to the `MICROPY_HW_TINYUSB_LL_INIT` macro, since the function is used in an inline function in `mp_usbd.h` but only declared in the port-specific `usbd_conf.h`.

### Testing

Build-tested mboot for NUCLEO_WB55 and PYBD_SF6 (both TinyUSB-enabled). Verified the main firmware still builds and runs correctly on NUCLEO_WB55.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.