### PR TITLE
Allow mpy-cross to exclude source lines

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -50,6 +50,10 @@ static asm_rv32_backend_options_t rv32_options = { 0 };
 static uint emit_opt = MP_EMIT_OPT_NONE;
 mp_uint_t mp_verbose_flag = 0;
 
+#if MICROPY_ENABLE_SOURCE_LINE
+static bool include_source_lines = true;
+#endif
+
 // Heap size of GC heap (if enabled)
 // Make it larger on a 64 bit machine, because pointers are larger.
 long heap_size = 1024 * 1024 * (sizeof(mp_uint_t) / 4);
@@ -163,6 +167,12 @@ static int usage(char **argv) {
         "  heapsize=<n> -- set the heap size for the GC (default %ld)\n"
         , heap_size);
     impl_opts_cnt++;
+    #if MICROPY_ENABLE_SOURCE_LINE
+    printf(
+        "  source-lines    -- include source line numbers (default)\n"
+        "  no-source-lines -- exclude source line numbers\n");
+    impl_opts_cnt += 2;
+    #endif
 
     if (impl_opts_cnt == 0) {
         printf("  (none)\n");
@@ -186,6 +196,14 @@ static void pre_process_options(int argc, char **argv) {
                     emit_opt = MP_EMIT_OPT_NATIVE_PYTHON;
                 } else if (strcmp(argv[a + 1], "emit=viper") == 0) {
                     emit_opt = MP_EMIT_OPT_VIPER;
+                #if MICROPY_ENABLE_SOURCE_LINE
+                } else if (strcmp(argv[a + 1], "source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = true;
+                } else if (strcmp(argv[a + 1], "no-source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = false;
+                #endif
                 #endif
                 } else if (strncmp(argv[a + 1], "heapsize=", sizeof("heapsize=") - 1) == 0) {
                     char *end;
@@ -303,6 +321,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     MP_STATE_VM(default_emit_opt) = emit_opt;
     #else
     (void)emit_opt;
+    #endif
+
+    #if MICROPY_ENABLE_SOURCE_LINE
+    MP_STATE_VM(include_source_lines) = include_source_lines;
     #endif
 
     // set default compiler configuration

--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -50,6 +50,10 @@ static asm_rv32_backend_options_t rv32_options = { 0 };
 static uint emit_opt = MP_EMIT_OPT_NONE;
 mp_uint_t mp_verbose_flag = 0;
 
+#if MICROPY_ENABLE_SOURCE_LINE
+static bool include_source_lines = true;
+#endif
+
 // Heap size of GC heap (if enabled)
 // Make it larger on a 64 bit machine, because pointers are larger.
 long heap_size = 1024 * 1024 * (sizeof(mp_uint_t) / 4);
@@ -163,6 +167,12 @@ static int usage(char **argv) {
         "  heapsize=<n> -- set the heap size for the GC (default %ld)\n"
         , heap_size);
     impl_opts_cnt++;
+    #if MICROPY_ENABLE_SOURCE_LINE
+    printf(
+        "  source-lines    -- include source line numbers (default)\n"
+        "  no-source-lines -- exclude source line numbers\n");
+    impl_opts_cnt += 2;
+    #endif
 
     if (impl_opts_cnt == 0) {
         printf("  (none)\n");
@@ -186,6 +196,14 @@ static void pre_process_options(int argc, char **argv) {
                     emit_opt = MP_EMIT_OPT_NATIVE_PYTHON;
                 } else if (strcmp(argv[a + 1], "emit=viper") == 0) {
                     emit_opt = MP_EMIT_OPT_VIPER;
+                #endif
+                #if MICROPY_ENABLE_SOURCE_LINE
+                } else if (strcmp(argv[a + 1], "source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = true;
+                } else if (strcmp(argv[a + 1], "no-source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = false;
                 #endif
                 } else if (strncmp(argv[a + 1], "heapsize=", sizeof("heapsize=") - 1) == 0) {
                     char *end;
@@ -311,6 +329,9 @@ MP_NOINLINE int main_(int argc, char **argv) {
     mp_dynamic_compiler.native_arch = MP_NATIVE_ARCH_NONE;
     mp_dynamic_compiler.nlr_buf_num_regs = 0;
     mp_dynamic_compiler.backend_options = NULL;
+    #if MICROPY_ENABLE_SOURCE_LINE
+    mp_dynamic_compiler.include_source_lines = include_source_lines;
+    #endif
 
     const char *input_file = NULL;
     const char *output_file = NULL;

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -430,7 +430,7 @@ void mp_emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
         // If we compile with -O3, don't store line numbers.
         return;
     }
-    if (source_line > emit->last_source_line) {
+    if (MP_STATE_VM(include_source_lines) && source_line > emit->last_source_line) {
         mp_uint_t bytes_to_skip = emit->bytecode_offset - emit->last_source_line_offset;
         mp_uint_t lines_to_skip = source_line - emit->last_source_line;
         emit_write_code_info_bytes_lines(emit, bytes_to_skip, lines_to_skip);

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -430,6 +430,12 @@ void mp_emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
         // If we compile with -O3, don't store line numbers.
         return;
     }
+    #if MICROPY_DYNAMIC_COMPILER
+    if (!mp_dynamic_compiler.include_source_lines) {
+        // Don't store line numbers if explicitly disabled.
+        return;
+    }
+    #endif
     if (source_line > emit->last_source_line) {
         mp_uint_t bytes_to_skip = emit->bytecode_offset - emit->last_source_line_offset;
         mp_uint_t lines_to_skip = source_line - emit->last_source_line;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -231,6 +231,9 @@ typedef struct _mp_state_vm_t {
     #if MICROPY_EMIT_NATIVE
     uint8_t default_emit_opt; // one of MP_EMIT_OPT_xxx
     #endif
+    #if MICROPY_ENABLE_SOURCE_LINE
+    bool include_source_lines;
+    #endif
     #endif
 
     // size of the emergency exception buf, if it's dynamically allocated

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -69,6 +69,9 @@ typedef struct mp_dynamic_compiler_t {
     uint8_t small_int_bits; // must be <= host small_int_bits
     uint8_t native_arch;
     uint8_t nlr_buf_num_regs;
+    #if MICROPY_ENABLE_SOURCE_LINE
+    bool include_source_lines;
+    #endif
 } mp_dynamic_compiler_t;
 extern mp_dynamic_compiler_t mp_dynamic_compiler;
 #endif

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -105,6 +105,9 @@ void mp_init(void) {
     #if MICROPY_EMIT_NATIVE
     MP_STATE_VM(default_emit_opt) = MP_EMIT_OPT_NONE;
     #endif
+    #if MICROPY_ENABLE_SOURCE_LINE
+    MP_STATE_VM(include_source_lines) = true;
+    #endif
     #endif
 
     // init global module dict


### PR DESCRIPTION
This would allow building debug FW without source line data (following #19078).

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Testing

Tested locally with https://github.com/trezor/micropython/pull/29, on x86 emulator & stm32 device.

### Trade-offs and Alternatives

Before this PR, `mpy-cross` needs to be built with `MICROPY_ENABLE_SOURCE_LINE=0` to exclude source line data, since there is no command-line flag (except `-O3` which also disables all debug-related features).

### Generative AI

I did not use generative AI tools when creating this PR.
