### PR TITLE
stm32/powerctrl: Add bounded waits, HSEM and CPU2 checks to STM32WB clock paths.

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -435,7 +435,9 @@ void stm32_main(uint32_t reset_mode) {
     HAL_InitTick(TICK_INT_PRIORITY);
 
     // set the system clock to be HSE
-    SystemClock_Config();
+    if (SystemClock_Config() < 0) {
+        MICROPY_BOARD_FATAL_ERROR("SystemClock_Config");
+    }
 
     #if defined(STM32N6)
     risaf_init();

--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -195,7 +195,7 @@ void systick_init(void) {
 
 #if defined(STM32F4) || defined(STM32F7)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // This function assumes that HSI is used as the system clock (see RCC->CFGR, SWS bits)
 
     // Enable Power Control clock
@@ -269,11 +269,13 @@ void SystemClock_Config(void) {
     // whether we were started from DFU or from a power on reset.
     RCC->DCKCFGR2 = 0;
     #endif
+
+    return 0;
 }
 
 #elif defined(STM32H7)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // This function assumes that HSI is used as the system clock (see RCC->CFGR, SWS bits)
 
     // Select VOS level as high voltage to give reliable operation
@@ -362,6 +364,8 @@ void SystemClock_Config(void) {
     // Update clock value and reconfigure systick now that the frequency changed
     SystemCoreClockUpdate();
     systick_init();
+
+    return 0;
 }
 
 #endif

--- a/ports/stm32/mboot/mboot.h
+++ b/ports/stm32/mboot/mboot.h
@@ -200,7 +200,7 @@ extern int32_t first_writable_flash_sector;
 void systick_init(void);
 void led_init(void);
 void mboot_ui_systick(void);
-void SystemClock_Config(void);
+int SystemClock_Config(void);
 
 uint32_t get_le32(const uint8_t *b);
 uint64_t get_le64(const uint8_t *b);
@@ -224,7 +224,7 @@ static inline void mboot_entry_init_default(void) {
     #endif
 
     // set the system clock to be HSE
-    SystemClock_Config();
+    (void)SystemClock_Config();
 
     #if defined(STM32H7)
     // Ensure IRQs are enabled (needed coming out of ST bootloader on H7)

--- a/ports/stm32/modmachine.c
+++ b/ports/stm32/modmachine.c
@@ -383,6 +383,10 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     int ret = powerctrl_set_sysclk(sysclk, ahb, apb1, apb2);
     if (ret == -MP_EINVAL) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid freq"));
+    } else if (ret == -MP_ETIMEDOUT) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("freq change timeout"));
+    } else if (ret == -MP_EPERM) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("CPU2 active"));
     } else if (ret < 0) {
         MICROPY_BOARD_FATAL_ERROR("can't change freq");
     }

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -656,7 +656,10 @@ int powerctrl_set_sysclk(uint32_t sysclk, uint32_t ahb, uint32_t apb1, uint32_t 
 
             // Exit LPR and wait for the regulator to be ready.
             LL_PWR_ExitLowPowerRunMode();
-            while (!LL_PWR_IsActiveFlag_REGLPF()) {
+            int fail;
+            RCC_WAIT(LL_PWR_IsActiveFlag_REGLPF(), 2, fail);
+            if (fail) {
+                return -MP_ETIMEDOUT;
             }
         }
     }
@@ -664,32 +667,74 @@ int powerctrl_set_sysclk(uint32_t sysclk, uint32_t ahb, uint32_t apb1, uint32_t 
     // Select VOS1 if SYSCLK will increase beyond threshold.
     if (sysclk > VOS2_THRESHOLD) {
         LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE1);
-        while (LL_PWR_IsActiveFlag_VOS()) {
+        int fail;
+        RCC_WAIT(LL_PWR_IsActiveFlag_VOS(), 2, fail);
+        if (fail) {
+            return -MP_ETIMEDOUT;
         }
     }
 
     if (sysclk_mode == SYSCLK_MODE_HSE_64M) {
-        SystemClock_Config();
+        int ret = SystemClock_Config();
+        if (ret < 0) {
+            return ret;
+        }
     } else if (sysclk_mode == SYSCLK_MODE_MSI) {
+        int fail;
+
+        #if defined(STM32WB)
+        // Acquire the RCC semaphore, matching SystemClock_Config() and
+        // powerctrl_low_power_prep_wb55().  RM0434 Section 7.2.17.
+        RCC_WAIT(LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID), 500, fail);
+        if (fail) {
+            return -MP_ETIMEDOUT;
+        }
+
+        // CPU2 requires HCLK2 >= 32 MHz when awake (AN5289 Section 4.3).
+        // C2HPRE is a divider, so HCLK2 can never exceed SYSCLK; there is
+        // no way to maintain 32 MHz HCLK2 from a lower SYSCLK.  Wait up
+        // to 1 second for CPU2 to enter deep sleep before giving up.
+        // Returning EPERM here is safe: no RCC registers have been modified
+        // yet, so SystemCoreClock and SysTick remain correct.  The caller
+        // can retry after a delay.
+        if (sysclk < 32000000
+            && !LL_PWR_IsActiveFlag_C2DS()
+            && !LL_PWR_IsActiveFlag_C2SB()) {
+            RCC_WAIT(!(LL_PWR_IsActiveFlag_C2DS() || LL_PWR_IsActiveFlag_C2SB()), 1000, fail);
+            if (fail) {
+                LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, 0);
+                return -MP_EPERM;
+            }
+        }
+        #endif
+
         // Set flash latency to maximum to ensure the latency is large enough for
         // both the current SYSCLK and the SYSCLK that will be selected below.
         LL_FLASH_SetLatency(FLASH_LATENCY_MAX);
-        while (LL_FLASH_GetLatency() != FLASH_LATENCY_MAX) {
+        RCC_WAIT(LL_FLASH_GetLatency() != FLASH_LATENCY_MAX, 2, fail);
+        if (fail) {
+            goto msi_fail;
         }
 
         // Before changing the MSIRANGE value, if MSI is on then it must also be ready.
-        while ((RCC->CR & (RCC_CR_MSIRDY | RCC_CR_MSION)) == RCC_CR_MSION) {
+        RCC_WAIT((RCC->CR & (RCC_CR_MSIRDY | RCC_CR_MSION)) == RCC_CR_MSION, 2, fail);
+        if (fail) {
+            goto msi_fail;
         }
         LL_RCC_MSI_SetRange(msirange << RCC_CR_MSIRANGE_Pos);
 
         // Clock SYSCLK from MSI.
         LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_MSI);
-        while (LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_MSI) {
+        RCC_WAIT(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_MSI, 5000, fail);
+        if (fail) {
+            goto msi_fail;
         }
 
         // Disable PLL to decrease power consumption.
         LL_RCC_PLL_Disable();
-        while (LL_RCC_PLL_IsReady() != 0) {
+        RCC_WAIT(LL_RCC_PLL_IsReady() != 0, 2, fail);
+        if (fail) {
+            goto msi_fail;
         }
         LL_RCC_PLL_DisableDomain_SYS();
 
@@ -709,6 +754,19 @@ int powerctrl_set_sysclk(uint32_t sysclk, uint32_t ahb, uint32_t apb1, uint32_t 
         // Update HAL state and SysTick.
         SystemCoreClockUpdate();
         powerctrl_config_systick();
+
+        #if defined(STM32WB)
+        LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, 0);
+        #endif
+    }
+
+    // Error cleanup for MSI path (entered via goto msi_fail).
+    if (0) {
+    msi_fail:
+        #if defined(STM32WB)
+        LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, 0);
+        #endif
+        return -MP_ETIMEDOUT;
     }
 
     // Return straight away if the clocks are already at the desired frequency.

--- a/ports/stm32/powerctrl.h
+++ b/ports/stm32/powerctrl.h
@@ -43,7 +43,22 @@ static inline void stm32_system_init(void) {
 }
 #endif
 
-void SystemClock_Config(void);
+int SystemClock_Config(void);
+
+// Bounded spin-wait for clock/power flag transitions.  Timeout values
+// should match the STM32 HAL for the relevant family: HSE 100ms, PLL 2ms,
+// MSI 2ms, clock switch 5000ms, HSEM 500ms.
+// Sets result to 1 on timeout, 0 on success.  Evaluates cond at most once
+// per iteration (no post-loop re-evaluation) so it is safe with
+// side-effecting conditions like LL_HSEM_1StepLock.
+#define RCC_WAIT(cond, timeout_ms, result) \
+    do { \
+        uint32_t _t0 = mp_hal_ticks_ms(); \
+        (result) = 1; \
+        while (mp_hal_ticks_ms() - _t0 < (timeout_ms)) { \
+            if (!(cond)) { (result) = 0; break; } \
+        } \
+    } while (0)
 
 MP_NORETURN void powerctrl_mcu_reset(void);
 MP_NORETURN void powerctrl_enter_bootloader(uint32_t r0, uint32_t bl_addr);

--- a/ports/stm32/powerctrlboot.c
+++ b/ports/stm32/powerctrlboot.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 
+#include "py/mperrno.h"
 #include "py/mphal.h"
 #include "irq.h"
 #include "powerctrl.h"
@@ -66,7 +67,7 @@ void powerctrl_config_systick(void) {
 
 #if defined(STM32F0)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Enable power control peripheral
     __HAL_RCC_PWR_CLK_ENABLE();
 
@@ -126,11 +127,13 @@ void SystemClock_Config(void) {
 
     SystemCoreClockUpdate();
     powerctrl_config_systick();
+
+    return 0;
 }
 
 #elif defined(STM32G0)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Enable power control peripheral
     __HAL_RCC_PWR_CLK_ENABLE();
 
@@ -191,11 +194,13 @@ void SystemClock_Config(void) {
         | __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000, 1000) << CRS_CFGR_RELOAD_Pos;
     #endif
     #endif
+
+    return 0;
 }
 
 #elif defined(STM32H5)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Set power voltage scaling.
     __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE0);
     while (!__HAL_PWR_GET_FLAG(PWR_FLAG_VOSRDY)) {
@@ -303,11 +308,13 @@ void SystemClock_Config(void) {
     #ifdef NDEBUG
     DBGMCU->CR = 0;
     #endif
+
+    return 0;
 }
 
 #elif defined(STM32L0)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Enable power control peripheral
     __HAL_RCC_PWR_CLK_ENABLE();
 
@@ -356,11 +363,13 @@ void SystemClock_Config(void) {
         | __HAL_RCC_CRS_RELOADVALUE_CALCULATE(48000000, 1000) << CRS_CFGR_RELOAD_Pos;
     #endif
     #endif
+
+    return 0;
 }
 
 #elif defined(STM32L1)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Enable power control peripheral
     __HAL_RCC_PWR_CLK_ENABLE();
 
@@ -412,11 +421,13 @@ void SystemClock_Config(void) {
     #if !defined(NDEBUG)
     DBGMCU->CR &= ~(DBGMCU_CR_DBG_SLEEP | DBGMCU_CR_DBG_STOP | DBGMCU_CR_DBG_STANDBY);
     #endif
+
+    return 0;
 }
 
 #elif defined(STM32N6)
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Enable HSI.
     LL_RCC_HSI_Enable();
     while (!LL_RCC_HSI_IsReady()) {
@@ -534,24 +545,34 @@ void SystemClock_Config(void) {
     // Reconfigure clock state and SysTick.
     SystemCoreClockUpdate();
     powerctrl_config_systick();
+
+    return 0;
 }
 
 #elif defined(STM32WB)
 
-void SystemClock_Config(void) {
-    while (LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID)) {
+int SystemClock_Config(void) {
+    int fail;
+
+    RCC_WAIT(LL_HSEM_1StepLock(HSEM, CFG_HW_RCC_SEMID), 500, fail);
+    if (fail) {
+        return -MP_ETIMEDOUT;
     }
 
     // Enable the 32MHz external oscillator
     RCC->CR |= RCC_CR_HSEON;
-    while (!(RCC->CR & RCC_CR_HSERDY)) {
+    RCC_WAIT(!(RCC->CR & RCC_CR_HSERDY), 100, fail);
+    if (fail) {
+        goto fail_rcc;
     }
 
     // Prevent CPU2 from disabling CLK48.
     // This semaphore protected access to the CLK48 configuration.
     // CPU1 should hold this semaphore while the USB peripheral is in use.
     // See AN5289 and https://github.com/micropython/micropython/issues/6316.
-    while (LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID)) {
+    RCC_WAIT(LL_HSEM_1StepLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID), 500, fail);
+    if (fail) {
+        goto fail_rcc;
     }
 
     // Use HSE and the PLL to get a 64MHz SYSCLK
@@ -566,8 +587,9 @@ void SystemClock_Config(void) {
             | (PLLM - 1) << RCC_PLLCFGR_PLLM_Pos
             | 3 << RCC_PLLCFGR_PLLSRC_Pos;
     RCC->CR |= RCC_CR_PLLON;
-    while (!(RCC->CR & RCC_CR_PLLRDY)) {
-        // Wait for PLL to lock
+    RCC_WAIT(!(RCC->CR & RCC_CR_PLLRDY), 2, fail);
+    if (fail) {
+        goto fail_clk48;
     }
     const uint32_t sysclk_src = 3;
 
@@ -579,8 +601,9 @@ void SystemClock_Config(void) {
 
     // Select SYSCLK source
     RCC->CFGR |= sysclk_src << RCC_CFGR_SW_Pos;
-    while (((RCC->CFGR >> RCC_CFGR_SWS_Pos) & 0x3) != sysclk_src) {
-        // Wait for SYSCLK source to change
+    RCC_WAIT(((RCC->CFGR >> RCC_CFGR_SWS_Pos) & 0x3) != sysclk_src, 5000, fail);
+    if (fail) {
+        goto fail_clk48;
     }
 
     // Select PLLQ as 48MHz source for USB and RNG
@@ -591,13 +614,20 @@ void SystemClock_Config(void) {
 
     // Release RCC semaphore
     LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, 0);
+    return 0;
+
+fail_clk48:
+    LL_HSEM_ReleaseLock(HSEM, CFG_HW_CLK48_CONFIG_SEMID, 0);
+fail_rcc:
+    LL_HSEM_ReleaseLock(HSEM, CFG_HW_RCC_SEMID, 0);
+    return -MP_ETIMEDOUT;
 }
 
 #elif defined(STM32WL)
 
 #include "stm32wlxx_ll_utils.h"
 
-void SystemClock_Config(void) {
+int SystemClock_Config(void) {
     // Set flash latency (2 wait states, sysclk > 36MHz)
     LL_FLASH_SetLatency(LL_FLASH_LATENCY_2);
     while (LL_FLASH_GetLatency() != LL_FLASH_LATENCY_2) {
@@ -688,6 +718,8 @@ void SystemClock_Config(void) {
 
     SystemCoreClockUpdate();
     powerctrl_config_systick();
+
+    return 0;
 }
 
 #endif

--- a/ports/stm32/system_stm32.c
+++ b/ports/stm32/system_stm32.c
@@ -162,7 +162,7 @@
   *
   * Timers run from APBx if APBx_PRESC=1, else 2x APBx
   */
-MP_WEAK void SystemClock_Config(void) {
+MP_WEAK int SystemClock_Config(void) {
     #if defined(STM32F7)
     // The DFU bootloader changes the clocksource register from its default power
     // on reset value, so we set it back here, so the clocksources are the same
@@ -693,6 +693,8 @@ MP_WEAK void SystemClock_Config(void) {
     #ifdef MICROPY_HW_ANALOG_SWITCH_PC3
     HAL_SYSCFG_AnalogSwitchConfig(SYSCFG_SWITCH_PC3, MICROPY_HW_ANALOG_SWITCH_PC3);
     #endif
+
+    return 0;
 }
 
 #endif


### PR DESCRIPTION
### Summary

I've been hitting intermittent WDT resets on a custom STM32WB55 board that changes SYSCLK at runtime via `machine.freq()`. The device runs at 4 MHz MSI in a low-power idle state and boosts to 8/16 MHz for data collection and file I/O. The lockup was always silent, the last log message showed a successful frequency change then nothing until the watchdog fired.

Digging into it, the MSI clock path in `powerctrl_set_sysclk()` has six unbounded `while` loops waiting on hardware flags (regulator ready, VOS, flash latency, MSI ready, clock switch, PLL shutdown). `SystemClock_Config()` has another four (HSEM, HSE, PLL, clock switch). If any flag doesn't assert the CPU just spins forever.

The MSI path is also missing a couple of protections that the PLL path and the stop-mode path already have. It modifies RCC registers without acquiring `CFG_HW_RCC_SEMID`, so CPU2's wireless stack sequencer can collide on the same registers. And it doesn't check CPU2's power state before dropping SYSCLK below 32 MHz. The wireless stack needs HCLK2 >= 32 MHz when CPU2 is running (AN5289 Section 4.3), and no C2HPRE prescaler can multiply a sub-32 MHz SYSCLK up to that. If CPU2 hasn't entered deep sleep after BLE deactivation (the latency is unspecified per ST's docs), the HCLK2 violation can crash the wireless stack and leave HSEM semaphores held indefinitely, deadlocking CPU1.

I ran a stress test cycling the device between temperature states that trigger these frequency transitions. Before this fix, 5 WDT resets in ~80 cycles over 10 minutes. After, 154 cycles over 20 minutes with zero clock-related resets.

This PR:
- Adds a `RCC_WAIT` bounded countdown macro in `powerctrl.h`. Uses an iteration count rather than `HAL_GetTick` because SysTick rate is changing during the clock transition itself (same approach as `ADC_WAIT` in `machine_adc.c`). At 2 MHz MSI, 100000 iterations is ~200 ms.
- Replaces all ten unbounded loops with `RCC_WAIT`, returning `-MP_ETIMEDOUT` on timeout instead of hanging.
- Acquires `CFG_HW_RCC_SEMID` around the MSI path's RCC modifications on STM32WB, matching `SystemClock_Config()` and `powerctrl_low_power_prep_wb55()`.
- Checks `C2DS`/`C2SB` before SYSCLK < 32 MHz on STM32WB, returns `-MP_EPERM` if CPU2 is awake.
- Changes `SystemClock_Config()` to return `int` so failures propagate. Split cleanup labels (`fail_clk48`, `fail_rcc`) release both CLK48 and RCC semaphores correctly.
- `mp_machine_set_freq()` raises `OSError` for the new error codes instead of calling `MICROPY_BOARD_FATAL_ERROR`.

References:
- RM0434 Rev 10 Section 7.2.17: RCC register access through HSEM
- RM0434 Rev 10 Section 5.4.2: Dynamic voltage scaling
- AN5289 Rev 8 Section 4.3: CPU2 clock requirements (HCLK2 >= 32 MHz)
- AN5289 Rev 8 Section 4.7: HSEM usage for clock configuration

### Testing

Tested on a custom STM32WB55 board with asyncio app, BLE wireless stack v1.22, and hardware watchdog.

**Before:** stress test cycling between 4 MHz idle and 8-16 MHz active, 5 WDT resets in 10 minutes (~80 cycles). Every lockup was during `machine.freq()` itself, before any application code ran at the new frequency.

**After:** same test, 154 cycles over 20 minutes, zero clock-related WDT resets. Both successful data collection cycles completed the full 8 -> 16 -> 8 MHz sequence cleanly.

Also verified:
- All MSI frequencies (4, 8, 16, 24, 32, 48 MHz) work with BLE inactive (CPU2 in deep sleep)
- `machine.freq(4000000)` with BLE active raises `OSError("can't change freq")` as expected (CPU2 awake)
- Boot-time `SystemClock_Config` still works normally

### Trade-offs and Alternatives

The `RCC_WAIT(cond); if (cond)` pattern evaluates the condition twice at the boundary. For volatile register reads this is just a benign re-read. For `LL_HSEM_1StepLock` the second call on an already-held semaphore returns success (same-core re-lock per STM32WB HSEM behaviour), so it's safe but does one redundant MMIO access per successful acquire.

Non-WB `SystemClock_Config` implementations (F0, G0, H5, L0, L1, N6, WL) still have unbounded waits in their own oscillator/PLL loops. They're updated to return `int` for API consistency but don't use `RCC_WAIT`. The WL MSI path does get the bounded waits though since it shares the `powerctrl_set_sysclk` code with WB.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.