### PR TITLE
stm32/make-stmconst.py: Point periph reg defns to S/NS addresses on Cortex-M33/Cortex-M55.

### DIFF
--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -720,7 +720,7 @@ $(GEN_PLLI2STABLE_HDR): $(PLLI2SVALUES) | $(HEADER_BUILD)/qstr.i.last
 $(BUILD)/modstm.o: $(GEN_STMCONST_HDR)
 $(HEADER_BUILD)/modstm_const.h: $(CMSIS_MCU_HDR) make-stmconst.py | $(HEADER_BUILD)
 	$(ECHO) "GEN stmconst $@"
-	$(Q)$(PYTHON) make-stmconst.py --mpz $(GEN_STMCONST_MPZ) $(CMSIS_MCU_HDR) > $(GEN_STMCONST_HDR)
+	$(Q)$(PYTHON) make-stmconst.py --mpz $(GEN_STMCONST_MPZ) $(CMSIS_MCU_HDR) $(CFLAGS_MCU) > $(GEN_STMCONST_HDR)
 
 $(GEN_CDCINF_HEADER): $(GEN_CDCINF_FILE) $(FILE2H) | $(HEADER_BUILD)
 	$(ECHO) "GEN $@"

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -116,7 +116,7 @@ INC += -Ilwip_inc
 
 CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU) -DUSE_FULL_LL_DRIVER
-CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
+CFLAGS += $(CFLAGS_MCU)
 CFLAGS += $(COPT)
 CFLAGS += -I$(BOARD_DIR)
 CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
@@ -130,7 +130,7 @@ endif
 # as doesn't recognise -mcpu=cortex-m55
 AFLAGS += -march=armv8.1-m.main
 else
-AFLAGS += $(filter -mcpu=%,$(CFLAGS_MCU_$(MCU_SERIES)))
+AFLAGS += $(filter -mcpu=%,$(CFLAGS_MCU))
 endif
 
 # Configure for nan-boxing object model if requested
@@ -199,7 +199,7 @@ LDFLAGS += -L"$(shell dirname $(LIBSTDCPP_FILE_NAME))"
 endif
 
 # Options for mpy-cross
-MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH_$(MCU_SERIES))
+MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH)
 
 SHARED_SRC_C += $(addprefix shared/,\
 	libc/string0.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -116,7 +116,7 @@ INC += -Ilwip_inc
 
 CFLAGS += $(INC) -Wall -Wpointer-arith -Werror -Wdouble-promotion -Wfloat-conversion -std=gnu99 $(CFLAGS_EXTRA)
 CFLAGS += -D$(CMSIS_MCU) -DUSE_FULL_LL_DRIVER
-CFLAGS += $(CFLAGS_MCU_$(MCU_SERIES))
+CFLAGS += $(CFLAGS_MCU)
 CFLAGS += $(COPT)
 CFLAGS += -I$(BOARD_DIR)
 CFLAGS += -DSTM32_HAL_H='<stm32$(MCU_SERIES)xx_hal.h>'
@@ -130,7 +130,7 @@ endif
 # as doesn't recognise -mcpu=cortex-m55
 AFLAGS += -march=armv8.1-m.main
 else
-AFLAGS += $(filter -mcpu=%,$(CFLAGS_MCU_$(MCU_SERIES)))
+AFLAGS += $(filter -mcpu=%,$(CFLAGS_MCU))
 endif
 
 # Configure for nan-boxing object model if requested
@@ -190,7 +190,7 @@ COPT ?= -Os -DNDEBUG
 endif
 
 # Options for mpy-cross
-MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH_$(MCU_SERIES))
+MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH)
 
 SHARED_SRC_C += $(addprefix shared/,\
 	libc/string0.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -711,7 +711,7 @@ $(GEN_PLLI2STABLE_HDR): $(PLLI2SVALUES) | $(HEADER_BUILD)/qstr.i.last
 $(BUILD)/modstm.o: $(GEN_STMCONST_HDR)
 $(HEADER_BUILD)/modstm_const.h: $(CMSIS_MCU_HDR) make-stmconst.py | $(HEADER_BUILD)
 	$(ECHO) "GEN stmconst $@"
-	$(Q)$(PYTHON) make-stmconst.py --mpz $(GEN_STMCONST_MPZ) $(CMSIS_MCU_HDR) > $(GEN_STMCONST_HDR)
+	$(Q)$(PYTHON) make-stmconst.py --mpz $(GEN_STMCONST_MPZ) $(CMSIS_MCU_HDR) $(CFLAGS_MCU) > $(GEN_STMCONST_HDR)
 
 $(GEN_CDCINF_HEADER): $(GEN_CDCINF_FILE) $(FILE2H) | $(HEADER_BUILD)
 	$(ECHO) "GEN $@"

--- a/ports/stm32/make-stmconst.py
+++ b/ports/stm32/make-stmconst.py
@@ -119,12 +119,25 @@ def parse_file(filename):
         m = lexer.next_match()
         if m[0] == "EOF":
             break
-        elif m[0] == "#define hex":
+
+        # If the CPU is secure, skip definitions for opposite security mode.
+        if m[0].startswith("#define"):
+            id_lhs = m[1]["id"]
+            if (
+                security_mode
+                and id_lhs.endswith(("_NS", "_S"))
+                and not id_lhs.endswith(security_mode)
+            ):
+                continue
+
+        if m[0] == "#define hex":
             d = m[1].groupdict()
             consts[d["id"]] = int(d["hex"], base=16)
         elif m[0] == "#define X":
             d = m[1].groupdict()
             if d["id2"] in consts:
+                if d["id"] in consts:
+                    raise Exception(f"macro {d['id']} redefined")
                 consts[d["id"]] = consts[d["id2"]]
         elif m[0] == "#define X+hex":
             d = m[1].groupdict()
@@ -133,7 +146,11 @@ def parse_file(filename):
         elif m[0] == "#define typedef":
             d = m[1].groupdict()
             if d["id2"] in consts:
-                periphs.append((d["id"], consts[d["id2"]]))
+                periph_reg = d["id"]
+                if security_mode:
+                    # Make, eg, "RTC_S"/"RTC_NS" available as "RTC".
+                    periph_reg = periph_reg.removesuffix(security_mode)
+                periphs.append((periph_reg, consts[d["id2"]]))
         elif m[0] == "typedef struct":
             lexer.must_match("{")
             m = lexer.next_match()
@@ -230,7 +247,20 @@ const mp_obj_module_t stm_%s_obj = {
 
 
 def main():
+    global security_mode
+
     cmd_parser = argparse.ArgumentParser(description="Extract ST constants from a C header file.")
+
+    # Options used by gcc to control CPU architecture.
+    cmd_parser.add_argument("-mcmse", action="store_true")
+    cmd_parser.add_argument("-mcpu")
+    cmd_parser.add_argument("-mfloat-abi")
+    cmd_parser.add_argument("-mfp16-format")
+    cmd_parser.add_argument("-mfpu")
+    cmd_parser.add_argument("-msoft-float", action="store_true")
+    cmd_parser.add_argument("-mthumb", action="store_true")
+    cmd_parser.add_argument("-mtune")
+
     cmd_parser.add_argument("file", nargs=1, help="input file")
     cmd_parser.add_argument(
         "--mpz",
@@ -240,6 +270,16 @@ def main():
     )
     args = cmd_parser.parse_args()
 
+    # Determine the security mode of the CPU.
+    if args.mcpu in ("cortex-m33", "cortex-m55"):
+        if args.mcmse:
+            security_mode = "_S"
+        else:
+            security_mode = "_NS"
+    else:
+        security_mode = None
+
+    # Parse the input CMSIS file with the register definitions.
     periphs, reg_defs = parse_file(args.file[0])
 
     # add legacy GPIO constants that were removed when upgrading CMSIS

--- a/ports/stm32/stm32.mk
+++ b/ports/stm32/stm32.mk
@@ -86,6 +86,10 @@ MPY_CROSS_MCU_ARCH_u5 = armv7m
 MPY_CROSS_MCU_ARCH_wb = armv7m
 MPY_CROSS_MCU_ARCH_wl = armv7m
 
+# Select the correct flags for the given MCU series.
+CFLAGS_MCU = $(CFLAGS_MCU_$(MCU_SERIES))
+MPY_CROSS_MCU_ARCH = $(MPY_CROSS_MCU_ARCH_$(MCU_SERIES))
+
 # gcc up to 14.2.0 have a known loop-optimisation bug:
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116799
 # This bug manifests for Cortex M55 targets, so require a newer compiler on such targets.


### PR DESCRIPTION
### Summary

Cortex-M33 and Cortex-M55 CPUs have both secure and non-secure addresses for most peripherals.  Prior to this commit, the `stm` module was not taking this into account and instead of providing standard constants like `stm.RTC` it was providing both the _S and _NS set of peripherals, like `stm.RTC_S` and `stm.RTC_NS`.

This makes it hard to write portable code which expectes things like `stm.RTC` to exist.  Furthermore, Python code doesn't really have a way to know whether it's running in secure or non-secure mode, so doesn't know which peripheral registers to use (either _S or _NS).

This commit addresses this issue by removing the constants ending in _S and _NS, and providing standard peripheral constants without any suffix.  The address of the peripheral is chosen as the _S or _NS peripheral address depending on whether the firmware is built in secure or non-secure mode, respectively.  The information about secure/non-secure mode is provide to `make-stmconst.py` by passing through the MCU CFLAGS.
### Testing

Tested on STM32H573I_DK (Cortex-M33 in non-secure mode) and OPENMV_N6 (Cortex-M55 in secure mode).  Prior to this fix they would both fail `tests/ports/stm32/modstm.py` and `tests/ports/stm32/rtc.py`.  With the fix those tests pass on both boards.  (Those tests use constants from the `stm` module.)

I also tested generating the `build/genhdr/modstm_consts.h` file on the following boards, comparing them with their contents prior to the change in this PR:
- PYBV10: no change
- PYBD_SF6: no change
- NUCLEO_H563ZI: all _S and _NS constants removed, replaced by standard constant names pointing to the non-secure addresses
- NUCLEO_H723ZG: no change
- NUCLEO_U5A5ZJ_Q: same as NUCLEO_H563ZI
- STM32H573I_DK: same as NUCLEO_H563ZI
- OPENMV_N6: all _S and _NS constants removed, replaced by standard constant names pointing to the secure addresses


### Trade-offs and Alternatives

This removes the _S and _NS constants, so is a breaking change.  But since boards with CM33/CM55 are relatively new, I doubt anyone ever used these constants.

If needed we could retain the _S and _NS and add the non-suffix versions as well, but it's a lot of extra constants (and hence extra code size) and has very little advantage.  If users really need to know the secure and/or non-secure address, it's pretty easy to get it from the other one (the high nibble of the address is 4 for non-secure, 5 for secure).

### Generative AI

I did not use generative AI tools when creating this PR.