### PR TITLE
boards: Allow overriding USB PID for Arduino boards.

### DIFF
--- a/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_GIGA/mpconfigboard.h
@@ -302,7 +302,9 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_FMC_D15          (pin_D10)
 
 #define MICROPY_HW_USB_VID                      0x2341
+#ifndef MICROPY_HW_USB_PID
 #define MICROPY_HW_USB_PID                      0x0566
+#endif
 #define MICROPY_HW_USB_PID_CDC_MSC              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC_HID              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC                  (MICROPY_HW_USB_PID)

--- a/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_NICLA_VISION/mpconfigboard.h
@@ -227,7 +227,9 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BLE_UART_BAUDRATE_DOWNLOAD_FIRMWARE (3000000)
 
 #define MICROPY_HW_USB_VID                      0x2341
+#ifndef MICROPY_HW_USB_PID
 #define MICROPY_HW_USB_PID                      0x055F
+#endif
 #define MICROPY_HW_USB_PID_CDC_MSC              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC_HID              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC                  (MICROPY_HW_USB_PID)

--- a/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_OPTA/mpconfigboard.h
@@ -212,7 +212,9 @@ extern struct _spi_bdev_t spi_bdev;
 // USB config
 #define MICROPY_HW_USB_FS                       (1)
 #define MICROPY_HW_USB_VID                      0x2341
+#ifndef MICROPY_HW_USB_PID
 #define MICROPY_HW_USB_PID                      0x0564
+#endif
 #define MICROPY_HW_USB_PID_CDC_MSC              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC_HID              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC                  (MICROPY_HW_USB_PID)

--- a/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
+++ b/ports/stm32/boards/ARDUINO_PORTENTA_H7/mpconfigboard.h
@@ -326,7 +326,9 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_ETH_RMII_TXD1    (pin_G12)
 
 #define MICROPY_HW_USB_VID                      0x2341
+#ifndef MICROPY_HW_USB_PID
 #define MICROPY_HW_USB_PID                      0x055B
+#endif
 #define MICROPY_HW_USB_PID_CDC_MSC              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC_HID              (MICROPY_HW_USB_PID)
 #define MICROPY_HW_USB_PID_CDC                  (MICROPY_HW_USB_PID)


### PR DESCRIPTION
### Summary

Arduino boards are assigned different USB PIDs based on the MicroPython "variant" they're running. Enable overriding the USB pid at build time.

See https://github.com/micropython/micropython/issues/18969#issuecomment-4233561256

### Testing

All boards build.

### Generative AI

I did not use generative AI tools when creating this PR.