### PR TITLE
zephyr: Add mp_hal_get_random.

### DIFF
--- a/ports/zephyr/mpconfigport.h
+++ b/ports/zephyr/mpconfigport.h
@@ -112,6 +112,9 @@
 #define MICROPY_PY_BINASCII         (1)
 #define MICROPY_PY_HASHLIB          (1)
 #define MICROPY_PY_OS               (1)
+#if CONFIG_HARDWARE_DEVICE_CS_GENERATOR || CONFIG_PSA_CSPRNG_GENERATOR
+#define MICROPY_PY_OS_URANDOM       (1)
+#endif
 #define MICROPY_PY_TIME_TIME_TIME_NS (1)
 #define MICROPY_PY_TIME_INCLUDEFILE "ports/zephyr/modtime.c"
 #define MICROPY_PY_ZEPHYR           (1)

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -1,5 +1,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/random/random.h>
 #include "shared/runtime/interrupt_char.h"
 
 #define MICROPY_BEGIN_ATOMIC_SECTION irq_lock
@@ -93,3 +94,9 @@ static inline void mp_hal_pin_od_low(mp_hal_pin_obj_t pin) {
 static inline void mp_hal_pin_od_high(mp_hal_pin_obj_t pin) {
     (void)gpio_pin_set_raw(pin->port, pin->pin, 1);
 }
+
+#if CONFIG_HARDWARE_DEVICE_CS_GENERATOR || CONFIG_PSA_CSPRNG_GENERATOR
+static inline void mp_hal_get_random(size_t n, uint8_t *buf) {
+    sys_csrand_get(buf, n);
+}
+#endif


### PR DESCRIPTION
### Summary

Zephyr port does not support a random number generator function - while Zephyr itself does have functions for that. I've implemented a a very simple `mp_hal_get_random` leveraging cryptographically secure RNG, if available.

It is also very easy to extend this PR and cater for non CS random sources, if required.

### Testing

I've tested the patch on an nrf52840 board, and `os.urandom()` works as expected. To test it, the following is needed:
- define `MICROPY_PY_OS_URANDOM=1`
- configure Zephyr with `CONFIG_HARDWARE_DEVICE_CS_GENERATOR=y` or `CONFIG_PSA_CSPRNG_GENERATOR=y`

The board devicetree should enumerate a RNG source, of course. For mine, the following snippet was already in place:

```
    chosen {
        ...
        zephyr,entropy = &rng;
        ...
    };

   soc {
        ...
        rng: random@4000d000 {
            compatible = "nordic,nrf-rng";
            reg = < 0x4000d000 0x1000 >;
            interrupts = < 0xd 0x1 >;
            status = "okay";
        };
       ...
   };
```

### Generative AI

I did not use generative AI tools when creating this PR.

