### PR TITLE
samd: Convert port to use new event waiting functions.

### DIFF
--- a/ports/samd/machine_i2c.c
+++ b/ports/samd/machine_i2c.c
@@ -224,7 +224,7 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     self->buf = buf;
     // Wait a while if the bus is busy
     while (IS_BUS_BUSY && self->timer) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
         if (--self->timer == 0) {
             return -MP_ETIMEDOUT;
         }
@@ -240,7 +240,7 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     self->timer = self->timeout;
     while (self->state == state_busy && self->timer) {
         self->timer--;
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
     i2c->I2CM.INTENCLR.reg = SERCOM_I2CM_INTENSET_MB | SERCOM_I2CM_INTENSET_SB | SERCOM_I2CM_INTENSET_ERROR;
 

--- a/ports/samd/machine_pwm.c
+++ b/ports/samd/machine_pwm.c
@@ -287,7 +287,7 @@ static void wait_for_register_update(Tcc *tcc) {
         if (tcc->INTFLAG.reg & TCC_INTFLAG_OVF) {
             break;
         }
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
     // Clear the flag, telling that a cycle has been handled.
     tcc->INTFLAG.reg = TCC_INTFLAG_OVF;

--- a/ports/samd/machine_spi.c
+++ b/ports/samd/machine_spi.c
@@ -328,7 +328,7 @@ static void machine_spi_transfer(mp_obj_base_t *self_in, size_t len, const uint8
         int32_t timeout = 1000;
         while (self->rxlen > 0 && timeout) {
             timeout--;
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         spi->SPI.INTENCLR.reg = SERCOM_SPI_INTENCLR_RXC;
     } else {

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -581,7 +581,7 @@ static void mp_machine_uart_sendbreak(machine_uart_obj_t *self) {
     // Wait for the tx buffer to drain.
     #if MICROPY_HW_UART_TXBUF
     while (ringbuf_avail(&self->write_buffer) > 0) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
     #endif
     // Wait for the TX queue & register to clear
@@ -699,7 +699,7 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
                     return i;
                 }
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         *dest++ = ringbuf_get(&(self->read_buffer));
         i++;
@@ -751,7 +751,7 @@ static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_
                     return i;
                 }
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         if (bits >= 9) {
             mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
@@ -778,7 +778,7 @@ static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf_in, mp_
                     return i;
                 }
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         }
         if (self->bits > 8 && i < (size - 1)) {
             uart->USART.DATA.bit.DATA = *(uint16_t *)src;
@@ -822,7 +822,7 @@ static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uint
             if (mp_machine_uart_txdone(self)) {
                 return 0;
             }
-            MICROPY_EVENT_POLL_HOOK
+            mp_event_wait_ms(1);
         } while (mp_hal_ticks_ms_64() < timeout);
         *errcode = MP_ETIMEDOUT;
         ret = MP_STREAM_ERROR;

--- a/ports/samd/modmachine.c
+++ b/ports/samd/modmachine.c
@@ -99,7 +99,7 @@ static mp_obj_t mp_machine_unique_id(void) {
 }
 
 static void mp_machine_idle(void) {
-    MICROPY_EVENT_POLL_HOOK;
+    mp_event_wait_ms(1);
 }
 
 static mp_int_t mp_machine_reset_cause(void) {

--- a/ports/samd/mpconfigport.h
+++ b/ports/samd/mpconfigport.h
@@ -168,12 +168,6 @@
 
 // Miscellaneous settings
 
-#define MICROPY_EVENT_POLL_HOOK \
-    do { \
-        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); \
-        __WFE(); \
-    } while (0);
-
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p) | 1))
 
 #define MP_SSIZE_MAX (0x7fffffff)

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -48,7 +48,7 @@ ringbuf_t stdin_ringbuf = { stdin_ringbuf_array, sizeof(stdin_ringbuf_array), 0,
 // interrupt handler) and there is in/out data pending on the USB CDC interface.
 #define MICROPY_EVENT_POLL_HOOK_WITH_USB \
     do { \
-        MICROPY_EVENT_POLL_HOOK; \
+        mp_event_wait_ms(1); \
         mp_usbd_task(); \
     } while (0)
 
@@ -71,7 +71,7 @@ void mp_hal_clr_pin_mux(mp_hal_pin_obj_t pin) {
 void mp_hal_delay_ms(mp_uint_t ms) {
     uint32_t t0 = systick_ms;
     while (systick_ms - t0 < ms) {
-        MICROPY_EVENT_POLL_HOOK
+        mp_event_wait_ms(1);
     }
 }
 

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -41,6 +41,9 @@
 #define MICROPY_PY_PENDSV_ENTER   uint32_t atomic_state = raise_irq_pri(IRQ_PRI_PENDSV)
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state)
 
+// Port level Wait-for-Event macro.
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFE()
+
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 
 extern int mp_interrupt_char;


### PR DESCRIPTION
### Summary

Convert the samd port from the old `MICROPY_EVENT_POLL_HOOK` macro to use the new `mp_event_wait_xxx()` functions in conjunction with `MICROPY_INTERNAL_WFE`.

This change should be functionally equivalent to the existing behaivour because `mp_event_wait_ms()` is equal to
`mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS); __WFE()`, which is what `MICROPY_EVENT_POLL_HOOK` was.

(See very similar change to mimxrt port in #19054.)

### Testing

Tested on ADAFRUIT_ITSYBITSY_M0_EXPRESS running `./run-tests.py -t a0`.  There were no regressions that I saw (although not all the tests pass... that's a separate set of PRs).

### Generative AI

I did not use generative AI tools when creating this PR.