### PR TITLE
py: Add a fast version of gc_info.

### DIFF
--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -276,6 +276,28 @@ static mp_obj_t extra_coverage(void) {
 
         // calling gc_nbytes with a non-heap pointer
         mp_printf(&mp_plat_print, "%d\n", (int)gc_nbytes(NULL));
+
+        // test gc_info_fast
+        void *p0 = gc_alloc(4, 0);
+        void *p1 = gc_alloc(4, 0);
+        void *p2 = gc_alloc(4, 0);
+
+        // Create a hole
+        gc_free(p1);
+
+        gc_info_t info_slow;
+        gc_info_t info_fast;
+
+        gc_info(&info_slow);
+        gc_info_fast(&info_fast);
+
+        // Free allocs
+        gc_free(p0);
+        gc_free(p2);
+
+        // Should be equal
+        mp_printf(&mp_plat_print, "%d\n", info_slow.used == info_fast.used);
+        mp_printf(&mp_plat_print, "%d\n", info_slow.free == info_fast.free);
     }
 
     // GC initialisation and allocation stress test, to check the logic behind ALLOC_TABLE_GAP_BYTE

--- a/py/gc.c
+++ b/py/gc.c
@@ -825,6 +825,25 @@ void gc_info(gc_info_t *info) {
     GC_EXIT();
 }
 
+// Fast version of gc_info that only computes total/used/free.
+void gc_info_fast(gc_info_t *info) {
+    GC_ENTER();
+    memset(info, 0, sizeof(*info));
+    const uint8_t lut[16] = {2, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0};
+    for (mp_state_mem_area_t *area = &MP_STATE_MEM(area); area != NULL; area = NEXT_AREA(area)) {
+        size_t free_blocks = 0;
+        info->total += area->gc_pool_end - area->gc_pool_start;
+        for (size_t i = 0; i < area->gc_alloc_table_byte_len; i++) {
+            uint8_t atb = area->gc_alloc_table_start[i];
+            free_blocks += lut[atb & 0xF] + lut[atb >> 4];
+        }
+        info->free += free_blocks;
+    }
+    info->free *= BYTES_PER_BLOCK;
+    info->used = info->total - info->free;
+    GC_EXIT();
+}
+
 #if MICROPY_PY_WEAKREF
 // Mark the GC heap pointer as having a weakref.
 void gc_weakref_mark(void *ptr) {

--- a/py/gc.h
+++ b/py/gc.h
@@ -86,6 +86,7 @@ typedef struct _gc_info_t {
 } gc_info_t;
 
 void gc_info(gc_info_t *info);
+void gc_info_fast(gc_info_t *info);
 void gc_dump_info(const mp_print_t *print);
 void gc_dump_alloc_table(const mp_print_t *print);
 

--- a/tests/ports/unix/extra_coverage.py.exp
+++ b/tests/ports/unix/extra_coverage.py.exp
@@ -33,6 +33,8 @@ abc
 # GC
 0
 0
+1
+1
 # GC part 2
 pass
 # tracked allocation


### PR DESCRIPTION
### Summary

I poll memory stats from multiple heaps, including GC, but gc_info is very slow on large heaps. I've considered just removing it from the stats, but decided to try to add a lightweight gc_info first.. This patch adds a fast version that only computes total/used/free, which can be used for frequent polling. 

### Testing

Working and significantly faster:
```Python
gc_info: 64 ms total=25613952 used=13808 free=25600144
gc_fast: 6 ms total=25613952 used=13808 free=25600144
```

### Trade-offs and Alternatives

- No block counts, but maybe they're not always needed.
- I had an MVE version (64 blocks at a time) but got stuck on popcount (no easy popcount) so I dropped it.

### Generative AI

I did not use generative AI tools when creating this PR.