### PR TITLE
py/builtinimport: Prevent warning when building with compiler disabled.

### DIFF
--- a/py/builtinimport.c
+++ b/py/builtinimport.c
@@ -238,7 +238,9 @@ static void do_load(mp_module_context_t *module_obj, vstr_t *file) {
 
     #endif // MICROPY_MODULE_FROZEN
 
+    #if MICROPY_ENABLE_COMPILER || (MICROPY_PERSISTENT_CODE_LOAD && MICROPY_HAS_FILE_READER)
     qstr file_qstr = qstr_from_str(file_str);
+    #endif
 
     // If we support loading .mpy files then check if the file extension is of
     // the correct format and, if so, load and execute the file.


### PR DESCRIPTION
### Summary

If the compiler and persistent code loading are both disabled then this bit of code is never used, so disable it as well.

### Testing

Tested by building and running the minimal port with `#define MICROPY_ENABLE_COMPILER (0)`.

### Trade-offs and Alternatives

Could add CI to test this build with the compiler disabled.... but I don't think we need more CI at this stage, there's already a lot.

### Generative AI

I did not use generative AI tools when creating this PR.

