### PR TITLE
qemu/boards/NETDUINO2: Change heap size to 114k.

### DIFF
--- a/ports/qemu/boards/NETDUINO2/mpconfigboard.mk
+++ b/ports/qemu/boards/NETDUINO2/mpconfigboard.mk
@@ -9,4 +9,7 @@ LDSCRIPT = mcu/arm/stm32.ld
 
 SRC_BOARD_O = shared/runtime/gchelper_native.o shared/runtime/gchelper_thumb2.o
 
+# 114k heap, because this board only has 128k RAM and the stack needs 10k.
+MICROPY_HEAP_SIZE ?= 116736
+
 MPY_CROSS_FLAGS += -march=armv7m


### PR DESCRIPTION
### Summary

This board has 128k RAM, and its heap was originally 120k but commit e84c9abfc21f57fe93b4d9a05c1d123e3f333880 changed that to 140k which will not fit.

This commit reduces the heap down to 116k which allows enough room for the remaining data/bss, a 10k heap and about 1k spare.

### Testing

Built and ran test suite on NETDUINO2.  The test suite run as `make BOARD=NETDUINO2 test` passes.

### Generative AI

I did not use generative AI tools when creating this PR.
