### PR TITLE
shared, stm32: Network init improvements for USB networking support.

### DIFF
--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -8,8 +8,6 @@
 #define LWIP_LOOPIF_MULTICAST           1
 #define LWIP_LOOPBACK_MAX_PBUFS         8
 
-#define LWIP_IPV6                       0
-
 #define LWIP_RAND() rng_get()
 
 // Increase memory for lwIP to get better performance.
@@ -22,8 +20,12 @@
 #define MEMP_NUM_TCP_SEG                (64)
 #endif
 
-// Include common lwIP configuration.
+// Include common lwIP configuration (also mpconfig.h).
 #include "extmod/lwip-include/lwipopts_common.h"
+
+#ifndef LWIP_IPV6
+#define LWIP_IPV6                       0
+#endif
 
 extern uint32_t rng_get(void);
 

--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -8,8 +8,6 @@
 #define LWIP_LOOPIF_MULTICAST           1
 #define LWIP_LOOPBACK_MAX_PBUFS         8
 
-#define LWIP_IPV6                       0
-
 #define LWIP_RAND() rng_get()
 
 // Increase memory for lwIP to get better performance.
@@ -22,7 +20,7 @@
 #define MEMP_NUM_TCP_SEG                (64)
 #endif
 
-// Include common lwIP configuration.
+// Include common lwIP configuration (also mpconfig.h).
 #include "extmod/lwip-include/lwipopts_common.h"
 
 extern uint32_t rng_get(void);

--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -608,6 +608,10 @@ soft_reset:
     extint_init0();
     timer_init0();
 
+    #if MICROPY_PY_NETWORK
+    mod_network_init();
+    #endif
+
     #if MICROPY_HW_ENABLE_CAN
     pyb_can_init0();
     #endif
@@ -697,10 +701,6 @@ soft_reset:
 
     #if MICROPY_HW_ENABLE_SERVO
     servo_init();
-    #endif
-
-    #if MICROPY_PY_NETWORK
-    mod_network_init();
     #endif
 
     // At this point everything is fully configured and initialised.

--- a/shared/libc/string0.c
+++ b/shared/libc/string0.c
@@ -259,3 +259,13 @@ size_t strcspn(const char *s, const char *reject) {
     }
     return s - ss;
 }
+
+// Decimal-only, non-negative integers; no leading whitespace handling.
+// Marked weak so a libc-provided atoi() takes precedence if available.
+__attribute__((weak)) int atoi(const char *num) {
+    int value = 0;
+    while (*num >= '0' && *num <= '9') {
+        value = value * 10 + (*num++ - '0');
+    }
+    return value;
+}

--- a/shared/netutils/dhcpserver.c
+++ b/shared/netutils/dhcpserver.c
@@ -280,7 +280,9 @@ static void dhcp_server_process(void *arg, struct udp_pcb *upcb, struct pbuf *p,
 
     opt_write_n(&opt, DHCP_OPT_SERVER_ID, 4, &ip_2_ip4(&d->ip)->addr);
     opt_write_n(&opt, DHCP_OPT_SUBNET_MASK, 4, &ip_2_ip4(&d->nm)->addr);
-    opt_write_n(&opt, DHCP_OPT_ROUTER, 4, &ip_2_ip4(&d->ip)->addr); // aka gateway; can have multiple addresses
+    if (d->send_router) {
+        opt_write_n(&opt, DHCP_OPT_ROUTER, 4, &ip_2_ip4(&d->ip)->addr); // aka gateway; can have multiple addresses
+    }
     opt_write_n(&opt, DHCP_OPT_DNS, 4, &ip_2_ip4(&d->ip)->addr);
     opt_write_u32(&opt, DHCP_OPT_IP_LEASE_TIME, DEFAULT_LEASE_TIME_S);
     *opt++ = DHCP_OPT_END;
@@ -295,6 +297,7 @@ void dhcp_server_init(dhcp_server_t *d, ip_addr_t *ip, ip_addr_t *nm) {
     ip_addr_copy(d->ip, *ip);
     ip_addr_copy(d->nm, *nm);
     memset(d->lease, 0, sizeof(d->lease));
+    d->send_router = true;
     if (dhcp_socket_new_dgram(&d->udp, d, dhcp_server_process) != 0) {
         return;
     }

--- a/shared/netutils/dhcpserver.h
+++ b/shared/netutils/dhcpserver.h
@@ -41,6 +41,7 @@ typedef struct _dhcp_server_t {
     ip_addr_t nm;
     dhcp_server_lease_t lease[DHCPS_MAX_IP];
     struct udp_pcb *udp;
+    bool send_router; // advertise server IP as default gateway
 } dhcp_server_t;
 
 void dhcp_server_init(dhcp_server_t *d, ip_addr_t *ip, ip_addr_t *nm);


### PR DESCRIPTION
### Summary

Prep work for the USB NCM network driver (separate PR). Moves network stack initialisation earlier so USB network interfaces can be configured in boot.py, and adds a few helpers needed by the NCM driver.

- `mod_network_init()` now runs before boot.py rather than after, so boot.py can call `network.USB_NET()` without hitting an uninitialised stack.
- Adds `send_router` flag to the DHCP server so point-to-point USB links don't advertise a default gateway (which would hijack the host's internet).
- Makes `LWIP_IPV6` configurable in stm32 lwipopts rather than hardcoded off.
- Adds a minimal `atoi()` implementation in modlwip needed by `netif_find()`.

### Testing

Tested on NUCLEO_WB55 (stm32) with TinyUSB and NCM enabled. Network stack init order verified by configuring USB_NET in boot.py. DHCP server `send_router=false` confirmed via Wireshark - host default route is no longer clobbered.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.