### PR TITLE
ports: Consolidate TinyUSB source includes across build systems.

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -177,14 +177,9 @@ DRIVERS_SRC_C += $(addprefix drivers/,\
 	dht/dht.c \
 	)
 
-TINYUSB_SRC_C += \
-	lib/tinyusb/src/tusb.c \
-	lib/tinyusb/src/class/cdc/cdc_device.c \
-	lib/tinyusb/src/class/msc/msc_device.c \
-	lib/tinyusb/src/common/tusb_fifo.c \
-	lib/tinyusb/src/device/usbd.c \
-	lib/tinyusb/src/device/usbd_control.c \
-	tinyusb_port/tusb_alif_dcd.c \
+-include $(TOP)/lib/tinyusb/src/tinyusb.mk
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, $(TINYUSB_SRC_C)))
+TINYUSB_SRC_C += tinyusb_port/tusb_alif_dcd.c
 
 ALIF_SRC_C += $(addprefix $(ALIF_DFP_REL_TOP)/,\
 	Device/common/source/clk.c \

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -93,19 +93,11 @@ endif
 # =============================================================================
 
 # TinyUSB Stack source
-SRC_TINYUSB_C += \
-	lib/tinyusb/src/class/cdc/cdc_device.c \
-	lib/tinyusb/src/class/dfu/dfu_rt_device.c \
-	lib/tinyusb/src/class/hid/hid_device.c \
-	lib/tinyusb/src/class/midi/midi_device.c \
-	lib/tinyusb/src/class/msc/msc_device.c \
-	lib/tinyusb/src/class/usbtmc/usbtmc_device.c \
-	lib/tinyusb/src/class/vendor/vendor_device.c \
-	lib/tinyusb/src/common/tusb_fifo.c \
-	lib/tinyusb/src/device/usbd.c \
-	lib/tinyusb/src/device/usbd_control.c \
-	lib/tinyusb/src/portable/chipidea/ci_hs/dcd_ci_hs.c \
-	lib/tinyusb/src/tusb.c
+-include $(TOP)/lib/tinyusb/src/tinyusb.mk
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
+	$(TINYUSB_SRC_C) \
+	src/portable/chipidea/ci_hs/dcd_ci_hs.c \
+	))
 
 # All settings for Ethernet support are controller by the value of MICROPY_PY_LWIP
 ifeq ($(MICROPY_PY_LWIP),1)
@@ -543,7 +535,7 @@ OBJ += $(addprefix $(BUILD)/, $(SHARED_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_S:.s=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_SS:.S=.o))
-OBJ += $(addprefix $(BUILD)/, $(SRC_TINYUSB_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(TINYUSB_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_HAL_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_HAL_IMX_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_ETH_C:.c=.o))

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -252,14 +252,12 @@ endif
 
 SRC_C += drivers/usb/usb_cdc.c
 
-SRC_C += $(addprefix lib/tinyusb/src/,\
-	common/tusb_fifo.c \
-	device/usbd.c \
-	device/usbd_control.c \
-	class/cdc/cdc_device.c \
-	tusb.c \
-	portable/nordic/nrf5x/dcd_nrf5x.c \
-	)
+# TinyUSB Stack source
+-include $(TOP)/lib/tinyusb/src/tinyusb.mk
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
+	$(TINYUSB_SRC_C) \
+	src/portable/nordic/nrf5x/dcd_nrf5x.c \
+	))
 
 endif
 
@@ -306,6 +304,7 @@ OBJ += $(addprefix $(BUILD)/, $(DRIVERS_SRC_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SYSTEM_C_SRC:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_LIB_C:.c=.o))
 OBJ += $(addprefix $(BUILD)/, $(SRC_SHARED_C:.c=.o))
+OBJ += $(addprefix $(BUILD)/, $(TINYUSB_SRC_C:.c=.o))
 OBJ += $(GEN_PINS_SRC:.c=.o)
 
 $(BUILD)/$(OOFATFS_DIR)/ff.o: COPT += -Os

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -171,22 +171,13 @@ SHARED_SRC_C += $(addprefix shared/,\
 	)
 
 # TinyUSB Stack source
-TINYUSB_SRC_C += $(addprefix lib/tinyusb/,\
-	src/class/cdc/cdc_device.c \
-	src/class/dfu/dfu_rt_device.c \
-	src/class/hid/hid_device.c \
-	src/class/midi/midi_device.c \
-	src/class/msc/msc_device.c \
-	src/class/usbtmc/usbtmc_device.c \
-	src/class/vendor/vendor_device.c \
-	src/common/tusb_fifo.c \
-	src/device/usbd.c \
-	src/device/usbd_control.c \
+-include $(TOP)/lib/tinyusb/src/tinyusb.mk
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
+	$(TINYUSB_SRC_C) \
 	src/portable/renesas/rusb2/dcd_rusb2.c \
 	src/portable/renesas/rusb2/hcd_rusb2.c \
 	src/portable/renesas/rusb2/rusb2_common.c \
-	src/tusb.c \
-	)
+	))
 
 ifeq ($(MICROPY_FLOAT_IMPL),double)
 LIBM_SRC_C += $(SRC_LIB_LIBM_DBL_C)

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -158,14 +158,12 @@ ASF4_SRC_C += $(addprefix lib/asf4/$(MCU_SERIES_LOWER)/,\
 LIBM_SRC_C += $(SRC_LIB_LIBM_C)
 LIBM_SRC_C += $(SRC_LIB_LIBM_SQRT_SW_C)
 
-TINYUSB_SRC_C += $(addprefix lib/tinyusb/src/,\
-	class/cdc/cdc_device.c \
-	common/tusb_fifo.c \
-	device/usbd.c \
-	device/usbd_control.c \
-	portable/microchip/samd/dcd_samd.c \
-	tusb.c \
-	)
+# TinyUSB Stack source
+-include $(TOP)/lib/tinyusb/src/tinyusb.mk
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
+	$(TINYUSB_SRC_C) \
+	src/portable/microchip/samd/dcd_samd.c \
+	))
 
 DRIVERS_SRC_C += \
 	drivers/bus/softspi.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -461,13 +461,13 @@ USBDEV_SRC_C += $(addprefix $(USBDEV_DIR)/,\
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
-TINYUSB_SRC_C := $(addprefix lib/tinyusb/, \
+TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c \
 	src/portable/synopsys/dwc2/dcd_dwc2.c \
 	src/portable/synopsys/dwc2/dwc2_common.c \
 	src/portable/synopsys/dwc2/hcd_dwc2.c \
-	)
+	))
 
 ifeq ($(MICROPY_SSL_MBEDTLS),1)
 LIB_SRC_C += mbedtls/mbedtls_port.c


### PR DESCRIPTION
### Summary

Several ports (alif, mimxrt, renesas-ra, samd) had their own copy-pasted lists of TinyUSB source files in their Makefiles. This replaces them with a single `-include $(TOP)/lib/tinyusb/src/tinyusb.mk` and uses `$(sort ...)` to deduplicate any overlapping entries. Keeps things in sync as TinyUSB upstream adds or renames files.

### Testing

Build-tested on mimxrt (SEEED_ARCH_MIX) and samd (SEEED_WIO_TERMINAL). The generated object lists are identical before and after the change.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.