### PR TITLE
extmod/machine_i2c: Add a deinit method to machine.I2C.

### DIFF
--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -101,8 +101,6 @@ General Methods
 
    Turn off the I2C bus.
 
-   Availability: WiPy.
-
 .. method:: I2C.scan()
 
    Scan all I2C addresses between 0x08 and 0x77 inclusive and return a list of

--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -319,6 +319,16 @@ static mp_obj_t machine_i2c_init(size_t n_args, const mp_obj_t *args, mp_map_t *
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(machine_i2c_init_obj, 1, machine_i2c_init);
 
+static mp_obj_t machine_i2c_deinit(mp_obj_t self_in) {
+    mp_obj_base_t *self = (mp_obj_base_t *)MP_OBJ_TO_PTR(self_in);
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)MP_OBJ_TYPE_GET_SLOT(self->type, protocol);
+    if (i2c_p->deinit != NULL) {
+        i2c_p->deinit(self);
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(machine_i2c_deinit_obj, machine_i2c_deinit);
+
 static mp_obj_t machine_i2c_scan(mp_obj_t self_in) {
     mp_obj_base_t *self = MP_OBJ_TO_PTR(self_in);
     mp_obj_t list = mp_obj_new_list(0, NULL);
@@ -633,6 +643,7 @@ static MP_DEFINE_CONST_FUN_OBJ_KW(machine_i2c_writeto_mem_obj, 1, machine_i2c_wr
 
 static const mp_rom_map_elem_t machine_i2c_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_i2c_init_obj) },
+    { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_i2c_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&machine_i2c_scan_obj) },
 
     // primitive I2C operations
@@ -724,6 +735,7 @@ int mp_machine_soft_i2c_write(mp_obj_base_t *self_in, const uint8_t *src, size_t
 
 static const mp_machine_i2c_p_t mp_machine_soft_i2c_p = {
     .init = mp_machine_soft_i2c_init,
+    .deinit = NULL,
     .start = (int (*)(mp_obj_base_t *))mp_hal_i2c_start,
     .stop = (int (*)(mp_obj_base_t *))mp_hal_i2c_stop,
     .read = mp_machine_soft_i2c_read,

--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -157,6 +157,7 @@ typedef struct _mp_machine_i2c_p_t {
     bool transfer_supports_write1;
     #endif
     void (*init)(mp_obj_base_t *obj, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
+    void (*deinit)(mp_obj_base_t *obj); // can be NULL
     int (*start)(mp_obj_base_t *obj);
     int (*stop)(mp_obj_base_t *obj);
     int (*read)(mp_obj_base_t *obj, uint8_t *dest, size_t len, bool nack);


### PR DESCRIPTION
### Summary

This PR adds the `.deinit()` method to the `machine.I2C` class, bringing it in line with both the target I2C class variant and the rest of the peripheral classes.

Ports that want to allocate I²C bus entries dynamically can implement the `self.deinit()` method to add deallocation/cleanup code, that can be especially useful on low-memory targets (64KiB or less), otherwise this method is entirely optional to have.

If no method is found in the port-provided object structure then calling `deinit()` on the object will do nothing, following what the `machine.SPI` object does.

This addresses #19096.

### Testing

This change, by design, is not meant to change anything on the current ports' implementation.

However, a custom build of the `rp2` port was made with an extra protocol handler for the `deinit` method.  Then it was checked whether calling `.deinit()` on a `machine.I2C` instance would invoke the callback.

The same was done with no extra handler to also make sure the call to `.deinit()` is actually ignored.

### Trade-offs and Alternatives

This comes with a modest size increase across the board except for ports that do not provide I2C support or the `cc3200` port, as the latter already provides its own `.deinit()` method.

### Generative AI

I did not use generative AI tools when creating this PR.