### PR TITLE
qemu/Makefile: Do not mount ROMFS partition on non-test targets.

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -224,13 +224,12 @@ endif
 
 ROMFS_TEST_IMAGE = assets/random_romfs.bin
 
+# Mount the ROMFS test image specifically for test runs (if there is a slot 0).
 ifneq ($(MICROPY_HW_ROMFS_PART0_START),)
-ifeq ($(QEMU_ROMFS_IMG0),)
-QEMU_ARGS += -device loader,file=$(ROMFS_TEST_IMAGE),addr=$(MICROPY_HW_ROMFS_PART0_START),force-raw=on
-endif
+QEMU_TEST_ARGS = -device loader,file=$(ROMFS_TEST_IMAGE),addr=$(MICROPY_HW_ROMFS_PART0_START),force-raw=on
 endif
 
-RUN_TESTS_FULL_ARGS = -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../ports/qemu/$<" $(RUN_TESTS_ARGS)
+RUN_TESTS_FULL_ARGS = -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) $(QEMU_TEST_ARGS) -serial pty -kernel ../ports/qemu/$<" $(RUN_TESTS_ARGS)
 
 ################################################################################
 # Source files and libraries


### PR DESCRIPTION
### Summary

This commit fixes a mistake introduced in #19051, where the test ROMFS partition would get mounted even on targets that do not need it to function (ie. `repl`).

Now the ROMFS image is mounted only for test targets: `test`, `test_full`, and `test_natmod`, and only if there's no explicit ROMFS partition being chosen to be mounted via the command line.

### Testing

The interpreter for the `VIRT_RV32` board was built and executed both for Make targets that require ROMFS and targets that don't, making sure the process would proceed as expected.

This was done using the version of Make that comes with Ubuntu 24.04, so hopefully this should work on the CI machine.

### Generative AI

I did not use generative AI tools when creating this PR.