### PR TITLE
qemu: Enable support for C++ usermodules.

### DIFF
--- a/ports/qemu/mcu/arm/imx6.ld
+++ b/ports/qemu/mcu/arm/imx6.ld
@@ -28,6 +28,13 @@ SECTIONS
         *(.text*)
         *(.rodata*)
         . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnulinkonce.armextab.*)
+        . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
         _etext = .;
         _sidata = _etext;
     } > RAM

--- a/ports/qemu/mcu/arm/mps2.ld
+++ b/ports/qemu/mcu/arm/mps2.ld
@@ -23,6 +23,9 @@ SECTIONS
 
     .ARM.exidx : AT ( _etext ) {
         . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        . = ALIGN(4);
         __exidx_start = .;
         *(.ARM.exidx*)
         *(.gnu.linkonce.armexidx.*)

--- a/ports/qemu/mcu/arm/mps3.ld
+++ b/ports/qemu/mcu/arm/mps3.ld
@@ -22,7 +22,13 @@ SECTIONS
         *(.text*)
         *(.rodata*)
         . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+        __exidx_start = .;
         *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
         . = ALIGN(4);
         _etext = .;
         _sidata = _etext;

--- a/ports/qemu/mcu/arm/nrf51.ld
+++ b/ports/qemu/mcu/arm/nrf51.ld
@@ -19,6 +19,14 @@ SECTIONS
         *(.text*)
         *(.rodata*)
         . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
         _etext = .;
         _sidata = _etext;
     } > ROM

--- a/ports/qemu/mcu/arm/startup.c
+++ b/ports/qemu/mcu/arm/startup.c
@@ -139,6 +139,12 @@ void exit(int status) {
     }
 }
 
+void abort(void) {
+    for (;;) {
+    }
+    MP_UNREACHABLE;
+}
+
 #ifndef NDEBUG
 void __assert_func(const char *file, int line, const char *func, const char *expr) {
     (void)func;

--- a/ports/qemu/mcu/arm/stm32.ld
+++ b/ports/qemu/mcu/arm/stm32.ld
@@ -19,6 +19,13 @@ SECTIONS
         *(.text*)
         *(.rodata*)
         . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
         _etext = .;
         _sidata = _etext;
     } > ROM

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -406,7 +406,7 @@ function ci_qemu_build_arm_sabrelite {
 
 function ci_qemu_build_arm_thumb_softfp {
     ci_qemu_build_arm_prepare
-    make BOARD=MPS2_AN385 ${MAKEOPTS} -C ports/qemu test_full
+    make BOARD=MPS2_AN385 ${MAKEOPTS} -C ports/qemu USER_C_MODULES=../../examples/usercmodule test_full
 
     # Test building native .mpy with ARM-M softfp architectures.
     ci_native_mpy_modules_build armv6m


### PR DESCRIPTION
### Summary

This PR brings the QEMU port almost in line with the rest of the embedded targets as far as user module linking CI tests go.  This is done just for one board (`MPS_AN385`) to not impact too much on CI build times.

To get there, however, a few issues with C++ code linking had to be sorted out.  Unfortunately this only applies to Arm-based boards, since the toolchain provided by the Linux distribution in use by the CI image is incomplete as far as RISC-V goes (as in, only the C part of picolibc is provided).

Maybe when the CI image will be updated to Ubuntu 26.04 things would have improved on that front.  On my Arch Linux machine `VIRT_RV32` does not need any changes when built using GCC 15 provided by the Arch Linux folks themselves as the `riscv64-elf-gcc` package, whilst `VIRT_RV64` needs some tweaking w.r.t. libgcc support.  I'll leave the latter for later.

### Testing

All boards in question were built with GCC 13 provided by Ubuntu 24.04 adding the example C/C++ user module as part of the build.  The same process was then attempted again but with GCC 14 provided by Arch Linux.

The `NETDUINO2` board variant was built after manually merging #19099 - unfortunately it wouldn't save it from running out of RAM when built with GCC 14 though.

### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

I believe there's an opportunity here to refactor both Arm and RISC-V linkerscripts, since most sections are more or less the same across variants of the same architecture (or with very little differences that can be easily sorted out).  Could be an interesting task for a first time contributor though!