### PR TITLE
tests/run-tests.py: Update the list of tests requiring floats.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -240,6 +240,8 @@ tests_requiring_float = (
     "extmod/uctypes_le_float.py",
     "extmod/uctypes_native_float.py",
     "extmod/uctypes_sizeof_float.py",
+    "extmod/vfs_rom.py",
+    "micropython/const_float.py",
     "misc/rge_sm.py",
     "ports/unix/ffi_float.py",
     "ports/unix/ffi_float2.py",


### PR DESCRIPTION
### Summary

This PR updates the list of the tests that must be skipped when the suite is executed on a target that does not have floating point support.

Two more tests, namely `extmod/vfs_rom.py` and
`micropython/const_float.py` have been added to the list, since they both rely on floating point support being there.

There may be more of them but the test suite execution on my device reported these two - among other issues that maybe are in my code.  The first test being skipped is quite unfortunate, since I just finished adding VFS support and turns out I had to patch the test bytecode too only to find out it was skipped :)

### Testing

I've tested this with a port for CH32V microcontrollers I'm developing, but this can be replicated with any port with floats disabled.

### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

There are a few tests that still expect higher ROM levels but do not get skipped if they cannot run (eg. `micropython/emg_exc.py` requiring tracebacks, and see also #17707).

I got bitten by `unittest` not running on a port configured with `MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES` and just enough to get by (eg. `gc`, `io`, `sys`, longint, compiler), due to a syntax error I have to track down, and that is probably hiding more issues.

I know I can add a new platform exclusion list, but I tried to see how much effort it'd take to make the test suite more resilient too.