### PR TITLE
mimxrt: clean up unused systick code, and fix `mp_hal_delay_ms(0)`

### DIFF
--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -123,6 +123,9 @@ static inline mp_uint_t mp_hal_ticks_us(void) {
 }
 
 static inline void mp_hal_delay_ms(mp_uint_t ms) {
+    // This function must run events at least once, so do that now.
+    mp_event_handle_nowait();
+
     uint64_t us = (uint64_t)ms * 1000;
     ticks_delay_us64(us);
 }

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -80,10 +80,6 @@
 extern int mp_interrupt_char;
 extern ringbuf_t stdin_ringbuf;
 
-// Define an alias for systick_ms, because the shared softtimer.c uses
-// the symbol uwTick for the systick ms counter.
-#define uwTick systick_ms
-
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
 #define mp_hal_get_pin_obj(o)   pin_find(o)
 #define mp_hal_pin_name(p)      ((p)->name)

--- a/ports/mimxrt/pendsv.h
+++ b/ports/mimxrt/pendsv.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_MIMXRT_PENDSV_H
 #define MICROPY_INCLUDED_MIMXRT_PENDSV_H
 
+#include "py/mpconfig.h"
+
 enum {
     PENDSV_DISPATCH_SOFT_TIMER,  // For later & for having at least one entry
     #if MICROPY_PY_NETWORK && MICROPY_PY_LWIP

--- a/ports/mimxrt/systick.c
+++ b/ports/mimxrt/systick.c
@@ -24,10 +24,7 @@
  * THE SOFTWARE.
  */
 
-#include "py/runtime.h"
-#include "py/mphal.h"
 #include "systick.h"
-
 #include "pendsv.h"
 #include "shared/runtime/softtimer.h"
 

--- a/ports/mimxrt/systick.c
+++ b/ports/mimxrt/systick.c
@@ -36,9 +36,7 @@ volatile uint32_t systick_ms = 0;
 systick_dispatch_t systick_dispatch_table[SYSTICK_DISPATCH_NUM_SLOTS];
 
 void SysTick_Handler(void) {
-    // Instead of calling HAL_IncTick we do the increment here of the counter.
-    // This is purely for efficiency, since SysTick is called 1000 times per
-    // second at the highest interrupt priority.
+    // Increment the systick millisecond counter.
     uint32_t uw_tick = systick_ms + 1;
     systick_ms = uw_tick;
 
@@ -50,18 +48,5 @@ void SysTick_Handler(void) {
 
     if (soft_timer_next == uw_tick) {
         pendsv_schedule_dispatch(PENDSV_DISPATCH_SOFT_TIMER, soft_timer_handler);
-    }
-}
-
-bool systick_has_passed(uint32_t start_tick, uint32_t delay_ms) {
-    return systick_ms - start_tick >= delay_ms;
-}
-
-// waits until at least delay_ms milliseconds have passed from the sampling of
-// startTick. Handles overflow properly. Assumes stc was taken from
-// HAL_GetTick() some time before calling this function.
-void systick_wait_at_least(uint32_t start_tick, uint32_t delay_ms) {
-    while (!systick_has_passed(start_tick, delay_ms)) {
-        __WFI(); // enter sleep mode, waiting for interrupt
     }
 }

--- a/ports/mimxrt/systick.h
+++ b/ports/mimxrt/systick.h
@@ -26,6 +26,8 @@
 #ifndef MICROPY_INCLUDED_MIMXRT_SYSTICK_H
 #define MICROPY_INCLUDED_MIMXRT_SYSTICK_H
 
+#include "py/mpconfig.h"
+
 // Works for x between 0 and 16 inclusive
 #define POW2_CEIL(x) ((((x) - 1) | ((x) - 1) >> 1 | ((x) - 1) >> 2 | ((x) - 1) >> 3) + 1)
 

--- a/ports/mimxrt/systick.h
+++ b/ports/mimxrt/systick.h
@@ -54,7 +54,4 @@ static inline void systick_disable_dispatch(size_t slot) {
     systick_dispatch_table[slot] = NULL;
 }
 
-void systick_wait_at_least(uint32_t stc, uint32_t delay_ms);
-bool systick_has_passed(uint32_t stc, uint32_t delay_ms);
-
 #endif // MICROPY_INCLUDED_MIMXRT_SYSTICK_H


### PR DESCRIPTION
### Summary

This PR cleans up and improves mimxrt's systick component:
1. remove unused functions and macro (which were copied from stm32 and never used)
2. ~~use the SysTick 1ms counter to implement `mp_hal_ticks_ms()`; this counter already exists and is much more efficient than `ticks_ms32()` which needs to convert a 64-bit microsecond counter to milliseconds~~
3. fix `mp_hal_delay_ms(0)` so it runs the scheduler

~~Point 2 addresses #19076, providing a fast `mp_hal_ticks_ms()`.~~

Edit: as discussed further in #19076, there's no need to change how ticks-ms works, so that's been reverted.

### Testing

Tested on TEENSY40, running the test suite in standard mode, and with `--via-mpy --emit native`.  With the native emitter `tests/micropython/schedule_sleep.py` would lock up prior to the fix in this PR.  Now it passes, as do all other tests (except `socket_badconstructor.py` which is fixed by a different PR).

### Trade-offs and Alternatives

~~Note that `systick_ms` will stop counting if IRQs are disabled.  That's also partly true of the existing ticks based on a GPT, due to the handling of the overflow in an IRQ, although there the overflow happens every 71 minutes, rather than every millisecond.~~

~~This also makes `ticks_ms32()` unused, so it could be removed.  But probably best to keep it in case it's needed again.~~

Alternatively, could provide a config option to select the `mp_hal_ticks_ms()` implementation: systick vs microsecond GPT.  Another alternative would be to provide a `mp_hal_ticks_ms_fast()` which uses systick, and keep `mp_hal_ticks_ms()` using the GPT.

### Generative AI

I did not use generative AI tools when creating this PR.
