### PR TITLE
nlrx86: Fix for Clang 19.

### DIFF
--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -39,24 +39,37 @@ unsigned int nlr_push_tail(nlr_buf_t *nlr) asm ("nlr_push_tail");
 __attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
 #endif
 
+
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 8
-// Since gcc 8.0 the naked attribute is supported
-#define USE_NAKED (1)
-#define UNDO_PRELUDE (0)
+// Since gcc 8.0 the naked and no-sanitize attributes are supported
+    #define NLR_PUSH_ATTRIBUTE __attribute__((naked, no_sanitize("unreachable")))
+    #define UNDO_PRELUDE (0)
+    #define ARG_USED(x) (void)x;
+    #define NLR_UNREACHABLE __builtin_unreachable();
 #elif defined(__ZEPHYR__) || defined(__ANDROID__)
 // Zephyr and Android use a different calling convention by default
-#define USE_NAKED (0)
-#define UNDO_PRELUDE (0)
+    #define NLR_PUSH_ATTRIBUTE /* NOTHING */
+    #define UNDO_PRELUDE (0)
+    #define ARG_USED(x) (void)x;
+    #define NLR_UNREACHABLE return 0;
+#elif defined(__clang__)
+// clang on Ubuntu 24.04 enables -fsanitize=unreachable by default, but this
+// destroys the content of the ebx register.
+    #define NLR_PUSH_ATTRIBUTE __attribute__((naked, no_sanitize("unreachable")))
+    #define UNDO_PRELUDE (0)
+    #define ARG_USED(x) /* NOTHING */
+    #define NLR_UNREACHABLE /* NOTHING */
 #else
-#define USE_NAKED (0)
-#define UNDO_PRELUDE (1)
+// gcc before 8 unavoidably emits a 'push %ebp' prologue instruction
+    #define NLR_PUSH_ATTRIBUTE /* NOTHING */
+    #define UNDO_PRELUDE (1)
+    #define ARG_USED(x) (void)x;
+    #define NLR_UNREACHABLE return 0;
 #endif
 
-#if USE_NAKED
-__attribute__((naked))
-#endif
+NLR_PUSH_ATTRIBUTE
 unsigned int nlr_push(nlr_buf_t *nlr) {
-    (void)nlr;
+    ARG_USED(nlr)
 
     __asm volatile (
         #if UNDO_PRELUDE
@@ -73,9 +86,7 @@ unsigned int nlr_push(nlr_buf_t *nlr) {
         "jmp    nlr_push_tail       \n" // do the rest in C
         );
 
-    #if !USE_NAKED
-    return 0; // needed to silence compiler warning
-    #endif
+    NLR_UNREACHABLE
 }
 
 MP_NORETURN void nlr_jump(void *val) {


### PR DESCRIPTION
### Summary

This version is believed to work from Clang 3.0 to 22.1.0 (all versions on godbolt at the time of writing).

Clang rejects the `(void)x;` notation for a used variable in a naked asm function, so do this only conditionally.

Introduces use of `__builtin_unreachable()` with gcc. This saves 1 byte by causing gcc not to emit an `ud2` opcode at the end. Clang does not accept `__builtin_unreachable` or `return 0;` here, so it must emit nothing.

Closes: #19117

### Testing

Locally, I ran `make clean && make CC="clang -m32 -g" -j12 test//basic test//native` in ports/unix.

### Trade-offs and Alternatives

This combination is not ci-tested. A ci-time test could be added, perhaps nanbox or just a dupe of something else like standard.

### Generative AI

I did not use generative AI tools when creating this PR.