### PR TITLE
ports/esp32: Add ESP32-S3 digital signature support.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -205,6 +205,57 @@ Constants
     Used in `idf_heap_info`.
 
 
+.. _esp32.DS:
+
+DS
+--
+
+This class provides access to the ESP32-S3 digital signature peripheral.
+
+.. note:: This is only available in custom builds with ``MICROPY_PY_ESP32_DS=1``.
+   For example, build the board with ``make BOARD=ESP32_GENERIC_S3 CMAKE_ARGS='-DMICROPY_PY_ESP32_DS=1'``.
+
+.. class:: DS()
+
+    Create a digital signature helper object.
+
+.. method:: DS.sign(message, data, key_id)
+
+    Sign *message* using the digital signature peripheral and return the
+    signature as a ``bytes`` object.
+
+    *message* must be a read-only buffer containing the preformatted message to
+    sign. Its length must match the RSA size encoded by *data*.
+
+    *data* must be a read-only buffer containing the provisioned
+    ``esp_ds_data_t`` structure required by ESP-IDF.
+
+    *key_id* selects the HMAC key slot to use. It must be one of the
+    ``KEY0`` to ``KEY5`` constants, or ``KEY_KM`` when that key is available.
+
+    A ``ValueError`` is raised if the length of *message* or *data* is invalid,
+    or if *key_id* is not a supported key slot. Other failures from the
+    underlying ESP-IDF digital signature API raise ``OSError``.
+
+    .. note:: This peripheral requires device provisioning outside MicroPython.
+       The contents of *data* and the selected key slot must be prepared using
+       the appropriate ESP-IDF provisioning flow.
+
+.. data:: DS.KEY_MAX
+          DS.KEY0
+          DS.KEY1
+          DS.KEY2
+          DS.KEY3
+          DS.KEY4
+          DS.KEY5
+          DS.KEY_KM
+
+    Integer constants for the available HMAC key slots.
+
+    ``KEY_KM`` is only available on targets that support the key manager HMAC
+    deploy key.
+
+
 .. _esp32.PCNT:
 
 PCNT

--- a/ports/esp32/boards/ESP32_GENERIC_S3/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_S3/mpconfigboard.cmake
@@ -6,3 +6,9 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.spiram_sx
     boards/ESP32_GENERIC_S3/sdkconfig.board
 )
+
+if(MICROPY_PY_ESP32_DS)
+    list(APPEND MICROPY_DEF_BOARD
+        MICROPY_PY_ESP32_DS=1
+    )
+endif()

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -139,6 +139,7 @@ list(APPEND MICROPY_SOURCE_PORT
     esp32_rmt.c
     esp32_ulp.c
     esp32_ldo.c
+    esp32_ds.c
     modesp32.c
     machine_hw_spi.c
     mpthreadport.c

--- a/ports/esp32/esp32_ds.c
+++ b/ports/esp32/esp32_ds.c
@@ -1,0 +1,77 @@
+#include "py/runtime.h"
+#include "py/objstr.h"
+#include "mphalport.h"
+#include "modesp32.h"
+
+#if MICROPY_PY_ESP32_DS
+
+#include "esp_ds.h"
+#include "hal/hmac_types.h"
+
+typedef struct _esp32_ds_obj_t {
+    mp_obj_base_t base;
+} esp32_ds_obj_t;
+
+static mp_obj_t esp32_ds_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    mp_arg_check_num(n_args, n_kw, 0, 0, false);
+    return mp_obj_malloc(esp32_ds_obj_t, type);
+}
+
+static mp_obj_t esp32_ds_sign(size_t n_args, const mp_obj_t *args) {
+    (void)n_args;
+    mp_buffer_info_t message_info;
+    mp_buffer_info_t data_info;
+    mp_get_buffer_raise(args[1], &message_info, MP_BUFFER_READ);
+    mp_get_buffer_raise(args[2], &data_info, MP_BUFFER_READ);
+
+    if (data_info.len != sizeof(esp_ds_data_t)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid DS data length"));
+    }
+
+    const esp_ds_data_t *data = (const esp_ds_data_t *)data_info.buf;
+    size_t rsa_bytes = (data->rsa_length + 1) * sizeof(uint32_t);
+    if (message_info.len != rsa_bytes) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid message length"));
+    }
+
+    mp_int_t key_id = mp_obj_get_int(args[3]);
+    if (key_id < 0 || key_id >= HMAC_KEY_MAX || key_id == 6) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid HMAC key id"));
+    }
+
+    vstr_t vstr;
+    vstr_init_len(&vstr, rsa_bytes);
+    esp_err_t err = esp_ds_sign(message_info.buf, data, (hmac_key_id_t)key_id, vstr.buf);
+    if (err != ESP_OK) {
+        vstr_clear(&vstr);
+        check_esp_err(err);
+    }
+    return mp_obj_new_bytes_from_vstr(&vstr);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp32_ds_sign_obj, 4, 4, esp32_ds_sign);
+
+static const mp_rom_map_elem_t esp32_ds_locals_dict_table[] = {
+    { MP_ROM_QSTR(MP_QSTR_sign), MP_ROM_PTR(&esp32_ds_sign_obj) },
+    { MP_ROM_QSTR(MP_QSTR_KEY_MAX), MP_ROM_INT(HMAC_KEY_MAX) },
+    { MP_ROM_QSTR(MP_QSTR_KEY0), MP_ROM_INT(HMAC_KEY0) },
+    { MP_ROM_QSTR(MP_QSTR_KEY1), MP_ROM_INT(HMAC_KEY1) },
+    { MP_ROM_QSTR(MP_QSTR_KEY2), MP_ROM_INT(HMAC_KEY2) },
+    { MP_ROM_QSTR(MP_QSTR_KEY3), MP_ROM_INT(HMAC_KEY3) },
+    { MP_ROM_QSTR(MP_QSTR_KEY4), MP_ROM_INT(HMAC_KEY4) },
+    { MP_ROM_QSTR(MP_QSTR_KEY5), MP_ROM_INT(HMAC_KEY5) },
+    #if SOC_KEY_MANAGER_HMAC_KEY_DEPLOY
+    { MP_ROM_QSTR(MP_QSTR_KEY_KM), MP_ROM_INT(HMAC_KEY_KM) },
+    #endif
+};
+
+static MP_DEFINE_CONST_DICT(esp32_ds_locals_dict, esp32_ds_locals_dict_table);
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    esp32_ds_type,
+    MP_QSTR_DS,
+    MP_TYPE_FLAG_NONE,
+    make_new, esp32_ds_make_new,
+    locals_dict, &esp32_ds_locals_dict
+    );
+
+#endif

--- a/ports/esp32/modesp32.c
+++ b/ports/esp32/modesp32.c
@@ -346,6 +346,9 @@ static const mp_rom_map_elem_t esp32_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_NVS), MP_ROM_PTR(&esp32_nvs_type) },
     { MP_ROM_QSTR(MP_QSTR_Partition), MP_ROM_PTR(&esp32_partition_type) },
+    #if MICROPY_PY_ESP32_DS
+    { MP_ROM_QSTR(MP_QSTR_DS), MP_ROM_PTR(&esp32_ds_type) },
+    #endif
     #if MICROPY_PY_ESP32_PCNT
     { MP_ROM_QSTR(MP_QSTR_PCNT), MP_ROM_PTR(&esp32_pcnt_type) },
     #endif

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -84,6 +84,10 @@ extern const mp_obj_type_t esp32_rmt_type;
 extern const mp_obj_type_t esp32_ulp_type;
 extern const mp_obj_type_t esp32_ldo_type;
 
+#if MICROPY_PY_ESP32_DS
+extern const mp_obj_type_t esp32_ds_type;
+#endif
+
 #if MICROPY_PY_ESP32_PCNT
 extern const mp_obj_type_t esp32_pcnt_type;
 

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -218,6 +218,10 @@
 #define MICROPY_PY_ESP32_PCNT               (SOC_PCNT_SUPPORTED)
 #endif
 
+#ifndef MICROPY_PY_ESP32_DS
+#define MICROPY_PY_ESP32_DS                 (0)
+#endif
+
 // fatfs configuration
 #define MICROPY_FATFS_ENABLE_LFN            (1)
 #define MICROPY_FATFS_RPATH                 (2)

--- a/ports/esp32/tools/gen_ds_blob.py
+++ b/ports/esp32/tools/gen_ds_blob.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+#
+# Generate an ESP32 digital-signature provisioning blob.
+#
+# This is a tool for provisioning an ESP32 board that uses
+# the digital-signature peripheral. It reads:
+# - a private RSA key in PEM format
+# - the 32-byte HMAC key file that was burned into the target
+#
+# and writes the `ds_blob.bin` used with `esp32.DS.sign()`.
+#
+# See `tests/ports/esp32/esp32_ds.py` for a concrete example of the hardware
+# flow.
+#
+# To create the HMAC key file:
+#
+#     head -c 32 /dev/random > ds_hmac_key.bin
+#
+# To generate a private RSA key for provisioning:
+#
+#     openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out rsa_private.pem
+#
+# To burn the HMAC key onto the board, use:
+#
+#     espefuse.py --chip esp32s3 --port /dev/ttyACM0 burn_key \
+#         BLOCK_KEY1 ds_hmac_key.bin HMAC_DOWN_DIGITAL_SIGNATURE
+#
+# The blob format depends on the RSA size supported by the selected target, so
+# the script validates both the target and the key length before writing.
+import argparse
+import hashlib
+import hmac
+import os
+import struct
+import sys
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+SUPPORTED_TARGETS = {
+    "esp32s2": [4096, 3072, 2048, 1024],
+    "esp32c3": [3072, 2048, 1024],
+    "esp32s3": [4096, 3072, 2048, 1024],
+    "esp32c6": [3072, 2048, 1024],
+    "esp32h2": [3072, 2048, 1024],
+    "esp32p4": [4096, 3072, 2048, 1024],
+    "esp32c5": [3072, 2048, 1024],
+}
+
+ESP_DS_IV_LEN = 16
+
+
+def modinv(a: int, m: int) -> int:
+    t, new_t = 0, 1
+    r, new_r = m, a % m
+    while new_r != 0:
+        q = r // new_r
+        t, new_t = new_t, t - q * new_t
+        r, new_r = new_r, r - q * new_r
+    if r != 1:
+        raise ValueError("inverse does not exist")
+    if t < 0:
+        t += m
+    return t
+
+
+def int_to_le_padded(n: int, pad_bytes: int) -> bytes:
+    if n < 0:
+        raise ValueError("negative integer not supported")
+    if n == 0:
+        raw = b"\x00"
+    else:
+        raw = n.to_bytes((n.bit_length() + 7) // 8, "little")
+    if len(raw) > pad_bytes:
+        raise ValueError(f"integer does not fit in {pad_bytes} bytes")
+    return raw + (b"\x00" * (pad_bytes - len(raw)))
+
+
+def load_rsa_private_key(path: str):
+    with open(path, "rb") as f:
+        pem = f.read()
+    key = serialization.load_pem_private_key(pem, password=None, backend=default_backend())
+    numbers = key.private_numbers()
+    n = numbers.public_numbers.n
+    d = numbers.d
+    e = numbers.public_numbers.e
+    return n, d, e
+
+
+def read_exact(path: str, expected_len: int) -> bytes:
+    with open(path, "rb") as f:
+        data = f.read()
+    if len(data) != expected_len:
+        raise ValueError(f"{path}: expected {expected_len} bytes, got {len(data)}")
+    return data
+
+
+def rsa_bits_to_len_enum(bits: int) -> int:
+    if bits not in (1024, 2048, 3072, 4096):
+        raise ValueError(f"unsupported RSA size: {bits}")
+    return bits // 32 - 1
+
+
+def build_ds_blob(
+    target: str, rsa_pem_path: str, hmac_key_path: str, out_path: str, iv_path: str | None
+):
+    if target not in SUPPORTED_TARGETS:
+        raise ValueError(f"unsupported target: {target}")
+
+    max_key_bits = max(SUPPORTED_TARGETS[target])
+    max_key_bytes = max_key_bits // 8
+    esp_ds_c_len = max_key_bytes * 3 + 32 + 8 + 8
+
+    hmac_key = read_exact(hmac_key_path, 32)
+    iv = read_exact(iv_path, ESP_DS_IV_LEN) if iv_path else os.urandom(ESP_DS_IV_LEN)
+
+    n, d, e = load_rsa_private_key(rsa_pem_path)
+    key_bits = n.bit_length()
+
+    if key_bits not in SUPPORTED_TARGETS[target]:
+        raise ValueError(f"RSA size {key_bits} is not supported on {target}")
+
+    rsa_length = rsa_bits_to_len_enum(key_bits)
+
+    y = int_to_le_padded(d, max_key_bytes)
+    m = int_to_le_padded(n, max_key_bytes)
+
+    rr = 1 << (key_bits * 2)
+    rb_int = rr % n
+    rb = int_to_le_padded(rb_int, max_key_bytes)
+
+    mprime = (-modinv(n, 1 << 32)) & 0xFFFFFFFF
+    length = rsa_length
+
+    aes_key = hmac.new(hmac_key, b"\xff" * 32, hashlib.sha256).digest()
+
+    md_in = y + m + rb + struct.pack("<II", mprime, length) + iv
+    md = hashlib.sha256(md_in).digest()
+
+    p = y + m + rb + md + struct.pack("<II", mprime, length) + (b"\x08" * 8)
+
+    if len(p) != esp_ds_c_len:
+        raise ValueError(f"internal error: plaintext length {len(p)} != {esp_ds_c_len}")
+
+    cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv), backend=default_backend())
+    encryptor = cipher.encryptor()
+    c = encryptor.update(p) + encryptor.finalize()
+
+    if len(c) != esp_ds_c_len:
+        raise ValueError(f"internal error: ciphertext length {len(c)} != {esp_ds_c_len}")
+
+    blob = struct.pack("<I", rsa_length) + iv + c
+
+    with open(out_path, "wb") as f:
+        f.write(blob)
+
+    print(f"wrote {out_path}")
+    print(f"  target        : {target}")
+    print(f"  max_key_bits  : {max_key_bits}")
+    print(f"  rsa_bits      : {key_bits}")
+    print(f"  public_exp    : {e}")
+    print(f"  rsa_length    : {rsa_length}")
+    print(f"  iv            : {iv.hex()}")
+    print(f"  c_len         : {len(c)}")
+    print(f"  blob_len      : {len(blob)}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target", default="esp32s3", choices=sorted(SUPPORTED_TARGETS.keys()))
+    ap.add_argument("--key", required=True, help="RSA private key PEM")
+    ap.add_argument("--hmac", required=True, help="32-byte HMAC key file")
+    ap.add_argument("--out", required=True, help="output ds_blob.bin")
+    ap.add_argument("--iv", help="optional 16-byte IV file")
+    args = ap.parse_args()
+
+    try:
+        build_ds_blob(args.target, args.key, args.hmac, args.out, args.iv)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/README.md
+++ b/tests/README.md
@@ -249,3 +249,46 @@ $ openssl ecparam -name prime256v1 -genkey -noout -out ec_key.pem
 $ openssl pkey -in ec_key.pem -out ec_key.der -outform DER
 $ openssl req -new -x509 -key ec_key.pem -out ec_cert.der -outform DER -days 3650 -nodes -subj '/CN=micropython.local/O=MicroPython/C=AU'
 ```
+
+### ESP32 digital signature test
+
+The `tests/ports/esp32/esp32_ds.py` test exercises `esp32.DS.sign()` against a
+fixed 2048-bit RSA test vector. It embeds the private key, derives the DS blob
+at runtime, and skips cleanly when `esp32.DS` is not enabled in the target
+firmware.
+
+To run it on hardware, provision the matching HMAC key in `KEY1` without read
+or write protection.
+
+> **Warning: burning the key onto the board is not reversible. The key block is
+one-way programmed and cannot be erased. Use a board you can dedicate to this
+test setup.**
+
+The test vector uses the fixed 32-byte HMAC key
+`00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff`.
+If you want to generate a fresh random key file for your own board setup, you can use:
+
+```
+$ head -c 32 /dev/random > ds_hmac_key.bin
+```
+
+For this regression test, the file you burn must contain the fixed key above.
+
+Provision the key to `KEY1` on the board with no read or write protection:
+
+```
+$ espefuse.py --chip esp32s3 --port /dev/ttyUSB0 burn_key --no-write-protect --no-read-protect BLOCK_KEY1 ds_hmac_key.bin HMAC_DOWN_DIGITAL_SIGNATURE
+```
+
+The board is now ready to run the test.
+
+For host-side setup or for generating a matching `ds_blob.bin` from a private
+key and the same 32-byte HMAC key file, use `ports/esp32/tools/gen_ds_blob.py`:
+
+```
+$ python3 ports/esp32/tools/gen_ds_blob.py --key rsa_private.pem --hmac ds_hmac_key.bin --out ds_blob.bin
+```
+
+This tool is also useful for board users who want to generate their own DS
+blobs for a provisioning setup. See `tests/ports/esp32/esp32_ds.py` for a
+concrete example of how DS is exercised on actual hardware.

--- a/tests/ports/esp32/esp32_ds.py
+++ b/tests/ports/esp32/esp32_ds.py
@@ -1,0 +1,267 @@
+# Test the ESP32-S3 digital signature peripheral.
+#
+# The target must be built with MICROPY_PY_ESP32_DS=1. If the feature is not
+# enabled on the board under test, the script prints SKIP and exits.
+#
+# The fixed HMAC key used here must be provisioned into KEY1 without read or
+# write protection so the test remains repeatable.
+
+try:
+    import uhashlib as hashlib
+except ImportError:
+    import hashlib
+
+try:
+    import ubinascii as binascii
+except ImportError:
+    import binascii
+
+try:
+    from cryptolib import aes
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import struct
+
+try:
+    import esp32
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+RSA_BYTES = 256
+MAX_KEY_BYTES = 512
+MESSAGE = b"esp32.DS test payload"
+HMAC_KEY = bytes.fromhex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
+IV = bytes.fromhex("0102030405060708090a0b0c0d0e0f10")
+
+PRIVATE_KEY_PEM = """-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCJnKLi77098HWx
+K6rOQDeaInY2srstEMj30CrhcPUeeUJFKgowdPtlm55EqzEomowX5U0UD4M0I2OT
+UR1FUfkWCT3IiVQVYecXgyMbCTiHAkdn2ztTanLUiCDzTJks97MM1lcQAxKfyFtp
+inAvB43kKNE8/2lvM3In6xmZEjRJgjBduayYYphAMIaxctc+54tEUGH8yWxhNLYg
+kNiDVXC8F2A1XKzBp6wXzARUoHRYo2MdnwGYPJfk41h9u8lpoXMA+O6Gm83IijdZ
+BFhJw78tXZaN937b/mQlnNgxW+QhO4/7NsoQl8R4Xb34nHnmo68/napeNR04GEkO
+JznRQ1HTAgMBAAECggEALjJgWFDlNdLwn66qI51ZTSw+hTRRM9rLrK28h3w1Paq1
+faSUURokf0LTyfeyhBAF8cuvqYlfoXQz7HOxoODY/vXRQO4hRSBdxP3oHh5lVKWG
+NS5a5zD4JbMhZKwVTAxHloqqJZzydqN7VJ399TvS/YJaY+DWk1cw/oelS0baOMa2
+0pkHB64YhhW/4DMXYlbvdcDTa1+kr4+JyFClMCI6/T/mdwTro7OZiRVD5w3YDtMM
+xRhaHpaY7dWi0e2tu9XohPMsYFjs+6QRGIacFaeZdIkZgsDjpqA6o/lRQMcrvum7
+i+l0w0/7yRe0EX9H+YUSQ8pwSzKFG95DKl25p67KwQKBgQC8RLHi5kF6J+t5sflq
+Wu4slQbwplgNudoqCY39qdb5n+5Co/f3t1DfuJz0DHb3pyISHIM+ddjlaIUYL+uL
+WQ1ZrdwDL2cN6fa9fcdyUHIOmgxD+N20H4auYMOSTjjgx/ez+nmpvq/m7io6V0YO
+3HHv/LiHXr+oV3Czm51pbc3QswKBgQC7HokxvzHn26rIiIWFE4+aOply3wv8a/BC
+8uB9CEzTS439aE2CYeJhCPD8kSsReRfmhesfOJUP4bK1Rb53gUChhhTdDrMcXiOf
+sHHYjgFmtakCe6kARz/mxtbExmEzVXpVQJ6WAemNK5WmIM3XxHLXKbT5mhD6QS5i
+cLN+Sv7KYQKBgADWvYQpSnlk3CO6q0XSCeWg9Fr2IsZM4a/2Qu+yZgbOs50QZfZw
+lqeohup/c7g+wmQaRGtu0vySrqUg8Ye5adnQcH6DI45oUHUfrlfQC/IMtalH3pUC
+3vK/858fQhmeSng+0XP0KYx52y5PXTyLtuY+1gOkZG43lYT3WIgzuQsJAoGAF37F
+EUcFmCxf7GAgC86h+GalP+Q72A0hlPZ0M57oLpvND2WaXeW2jCKYR85ejwoacyqb
+lEcBiIX5b4N7X/wNxnpUglFHMier53A7S0rBaEklGJe4Z72Ki4qqCvkx2UVBYBUG
+FKXW0pAHcV2rGw2isdudyr2KpjGrBldKYnA+P+ECgYAesmbRIpPMmI6XEtUOuAXH
+LKSogialcAaV4EUwJVASQFNi+t3bwRwFPauNEJp7VSrTY8MefOieaowgE4qRV/sX
+vP+RHvEaq7oR0KP8qZxLtwT8wkynAjfSj3ntvuC7R3eGS5tX4SpcBNK9hHfKj9CC
+MPYp3Xz+OVuqc4/frJ/G8w==
+-----END PRIVATE KEY-----"""
+
+SHA256_DIGESTINFO_PREFIX = bytes(
+    (
+        0x30,
+        0x31,
+        0x30,
+        0x0D,
+        0x06,
+        0x09,
+        0x60,
+        0x86,
+        0x48,
+        0x01,
+        0x65,
+        0x03,
+        0x04,
+        0x02,
+        0x01,
+        0x05,
+        0x00,
+        0x04,
+        0x20,
+    )
+)
+
+
+def sha256(data):
+    h = hashlib.sha256()
+    h.update(data)
+    return h.digest()
+
+
+def hmac_sha256(key, msg):
+    block_size = 64
+    if len(key) > block_size:
+        key = sha256(key)
+    key = key + (b"\x00" * (block_size - len(key)))
+    o_key = bytes((b ^ 0x5C) for b in key)
+    i_key = bytes((b ^ 0x36) for b in key)
+    return sha256(o_key + sha256(i_key + msg))
+
+
+def int_to_le_padded(n, pad_bytes):
+    if n < 0:
+        raise ValueError("negative integer not supported")
+    if n == 0:
+        raw = b"\x00"
+    else:
+        raw = n.to_bytes((int_bit_length(n) + 7) // 8, "little")
+    if len(raw) > pad_bytes:
+        raise ValueError("integer does not fit")
+    return raw + (b"\x00" * (pad_bytes - len(raw)))
+
+
+def modinv(a, m):
+    t, new_t = 0, 1
+    r, new_r = m, a % m
+    while new_r != 0:
+        q = r // new_r
+        t, new_t = new_t, t - q * new_t
+        r, new_r = new_r, r - q * new_r
+    if r != 1:
+        raise ValueError("inverse does not exist")
+    if t < 0:
+        t += m
+    return t
+
+
+def reverse_bytes(b):
+    n = len(b)
+    out = bytearray(n)
+    i = 0
+    while i < n:
+        out[i] = b[n - 1 - i]
+        i += 1
+    return bytes(out)
+
+
+def int_bit_length(x):
+    n = 0
+    while x:
+        x >>= 1
+        n += 1
+    return n
+
+
+def der_read_len(buf, i):
+    first = buf[i]
+    i += 1
+    if first < 0x80:
+        return first, i
+    n = first & 0x7F
+    if n == 0 or n > 4:
+        raise ValueError("bad DER length")
+    val = 0
+    for _ in range(n):
+        val = (val << 8) | buf[i]
+        i += 1
+    return val, i
+
+
+def der_read_tlv(buf, i, expected_tag=None):
+    tag = buf[i]
+    i += 1
+    length, i = der_read_len(buf, i)
+    start = i
+    end = i + length
+    if end > len(buf):
+        raise ValueError("truncated DER")
+    if expected_tag is not None and tag != expected_tag:
+        raise ValueError("unexpected DER tag")
+    return tag, start, end
+
+
+def der_read_integer(buf, i):
+    _, start, end = der_read_tlv(buf, i, 0x02)
+    val = buf[start:end]
+    while len(val) > 1 and val[0] == 0x00:
+        val = val[1:]
+    return int.from_bytes(val, "big"), end
+
+
+def parse_rsa_private_key_from_pem(pem_text):
+    body = []
+    for line in pem_text.splitlines():
+        if line and not line.startswith("-----"):
+            body.append(line.strip())
+    der = binascii.a2b_base64("".join(body))
+
+    _, pos, top_e = der_read_tlv(der, 0, 0x30)
+    _, _, pos = der_read_tlv(der, pos, 0x02)  # version
+    _, _, pos = der_read_tlv(der, pos, 0x30)  # algorithm identifier
+    _, key_s, key_e = der_read_tlv(der, pos, 0x04)
+    if key_e != top_e:
+        raise ValueError("unexpected trailing data in private key")
+
+    rsa_der = der[key_s:key_e]
+    _, rsa_s, rsa_e = der_read_tlv(rsa_der, 0, 0x30)
+    pos = rsa_s
+    _, pos = der_read_integer(rsa_der, pos)  # version
+    n, pos = der_read_integer(rsa_der, pos)
+    e, pos = der_read_integer(rsa_der, pos)
+    d, pos = der_read_integer(rsa_der, pos)
+    while pos != rsa_e:
+        _, pos = der_read_integer(rsa_der, pos)
+    return n, d, e
+
+
+def build_ds_blob(n, d, key_bits, rsa_length, iv, hmac_key):
+    y = int_to_le_padded(d, MAX_KEY_BYTES)
+    m = int_to_le_padded(n, MAX_KEY_BYTES)
+    rb = int_to_le_padded((1 << (key_bits * 2)) % n, MAX_KEY_BYTES)
+    mprime = (-modinv(n, 1 << 32)) & 0xFFFFFFFF
+    aes_key = hmac_sha256(hmac_key, b"\xff" * 32)
+    md_in = y + m + rb + struct.pack("<II", mprime, rsa_length) + iv
+    md = sha256(md_in)
+    p = y + m + rb + md + struct.pack("<II", mprime, rsa_length) + (b"\x08" * 8)
+    cipher = aes(aes_key, 2, iv)
+    c = cipher.encrypt(p)
+    return struct.pack("<I", rsa_length) + iv + c
+
+
+def emsa_pkcs1_v1_5_sha256(message, k):
+    digest = sha256(message)
+    t = SHA256_DIGESTINFO_PREFIX + digest
+    if k < len(t) + 11:
+        raise ValueError("RSA modulus too short for PKCS#1 v1.5 SHA-256")
+    ps = b"\xff" * (k - len(t) - 3)
+    return b"\x00\x01" + ps + b"\x00" + t
+
+
+if not hasattr(esp32, "DS"):
+    print("SKIP")
+    raise SystemExit
+
+n, d, e = parse_rsa_private_key_from_pem(PRIVATE_KEY_PEM)
+rsa_bytes = (int_bit_length(n) + 7) // 8
+if rsa_bytes != RSA_BYTES:
+    raise ValueError("unexpected RSA size: %d" % rsa_bytes)
+
+blob = build_ds_blob(n, d, int_bit_length(n), rsa_bytes // 4 - 1, IV, HMAC_KEY)
+if len(blob) != 1604:
+    raise ValueError("unexpected DS blob length: %d" % len(blob))
+
+ds = esp32.DS()
+message = reverse_bytes(emsa_pkcs1_v1_5_sha256(MESSAGE, RSA_BYTES))
+sig_le = ds.sign(message, blob, esp32.DS.KEY1)
+
+if len(sig_le) != RSA_BYTES:
+    raise ValueError("unexpected signature length: %d != %d" % (len(sig_le), RSA_BYTES))
+
+recovered = pow(int.from_bytes(sig_le, "little"), e, n).to_bytes(RSA_BYTES, "big")
+expected = emsa_pkcs1_v1_5_sha256(MESSAGE, RSA_BYTES)
+if recovered != expected:
+    print("DS TEST FAILED")
+    print("expected block prefix:", expected[:32].hex())
+    print("got block prefix     :", recovered[:32].hex())
+    raise ValueError("signature verification failed")
+
+print("DS TEST PASSED")

--- a/tests/ports/esp32/esp32_ds.py.exp
+++ b/tests/ports/esp32/esp32_ds.py.exp
@@ -1,0 +1,1 @@
+DS TEST PASSED


### PR DESCRIPTION
### Summary

Micropython builds don't have access to the underlying ESP-IDF DS (Digital Signature Peripheral), which allows to use keys saved in eFuses to retrieve an encrypted private key to then generate a signature for a given payload.
This PR adds an entrypoint to support DS operations from ESP-IDF via esp32.DS, which is added to builds via new board variants for ESPS3:
```bash
make BOARD=ESP32_GENERIC_S3 BOARD_VARIANT=SPIRAM_OCT_DS
```
and
```bash
make BOARD=ESP32_GENERIC_S3 BOARD_VARIANT=DS
```
Other variants and builds don't include DS, as it is a somewhat niche use case.
Having this functionality available allows for device verification/authentication.

### Testing

* I built both Octal SPIRAM and regular ESP32 S3 builds with and without DS. It was included conditionally as expected.
* Non S3 builds don't compile DS support.
* e2e testing was performed:
  * Created and burnt HMAC key into ESP32-S3
  * Generated a new RSA key
  * Generate a new DS blob and save it onto the board
  * Sign a test payload using this feature
  * Verify the signature on PC
  * Signature is valid.

### Trade-offs and Alternatives

Main tradeoff is a slight increase in build size, which is balanced with increased functionality.
DS support remains fully opt-in.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

### Additional notes

Using this functionality requires building a DS blob that encrypts a private key using the HMAC key burnt into the eFuses in a format that ESP-IDF accepts. I have the python script that generates them but was unsure where to put it, if at all. It was made using the same logic as the ESP-IDF test files for DS.
I also have the testing code I used on the board to perform payload signing using the feature and DS blob.
I think they would be very useful but I'd like some guidance on this.