### PR TITLE
alif: improve `mp_hal_ticks_ms()` and `mp_hal_ticks_cpu()` when SysTick is the system timer.

### DIFF
--- a/ports/alif/mphalport.c
+++ b/ports/alif/mphalport.c
@@ -133,7 +133,7 @@ mp_uint_t mp_hal_ticks_us(void) {
 mp_uint_t mp_hal_ticks_ms(void) {
     // Convert system tick to millisecond counter.
     #if MICROPY_HW_SYSTEM_TICK_USE_SYSTICK
-    return system_tick_get_u64() / 1000ULL;
+    return system_tick_get_ms_fast();
     #elif MICROPY_HW_SYSTEM_TICK_USE_LPTIMER
     return system_tick_get_u64() * 1000ULL / system_tick_source_hz;
     #else

--- a/ports/alif/mphalport.c
+++ b/ports/alif/mphalport.c
@@ -116,7 +116,19 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, size_t len) {
 }
 
 mp_uint_t mp_hal_ticks_cpu(void) {
+    #if MICROPY_HW_SYSTEM_TICK_USE_SYSTICK || MICROPY_HW_SYSTEM_TICK_USE_LPTIMER
+    // SysTick and LPTIMER run relatively slowly, so use cycle counter for CPU ticks.
+    if (!(DWT->CTRL & DWT_CTRL_CYCCNTENA_Msk)) {
+        // Enable CYCCNT.
+        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+        DWT->CYCCNT = 0;
+        DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+    }
+    return DWT->CYCCNT;
+    #else
+    // UTIMER runs at CPU frequency so use it directly as CPU ticks.
     return system_tick_get_u32();
+    #endif
 }
 
 mp_uint_t mp_hal_ticks_us(void) {

--- a/ports/alif/system_tick.c
+++ b/ports/alif/system_tick.c
@@ -31,6 +31,11 @@
 
 #if MICROPY_HW_SYSTEM_TICK_USE_SYSTICK
 
+// SysTick is used as the system timer source, with the following properties:
+// - SysTick IRQ fires every 1ms to update a millisecond counter
+// - access to the millisecond counter is very fast
+// - ms ticks will be lost if IRQs are disabled for longer than 1ms
+
 #include "shared/runtime/softtimer.h"
 #include "pendsv.h"
 
@@ -92,6 +97,12 @@ void system_tick_wfe_with_timeout_us(uint32_t timeout_us) {
 }
 
 #elif MICROPY_HW_SYSTEM_TICK_USE_LPTIMER
+
+// LPTIMER is used as the system timer source, with the following properties:
+// - 64-bit hardware counter running at 32768Hz
+// - reading the counter is very slow due to the LPTIMER being clocked at a very
+//   slow rate, and synchronisation to the CPU bus takes a long time
+// - delays are tickless, CPU only wakes up at end of timeout
 
 #include "lptimer.h"
 #include "sys_ctrl_lptimer.h"
@@ -221,6 +232,11 @@ void system_tick_schedule_after_us(uint32_t ticks_us) {
 }
 
 #elif MICROPY_HW_SYSTEM_TICK_USE_UTIMER
+
+// UTIMER is used as the system timer source, with the following properties:
+// - 32-bit counter with 32-bit overflow variable running at 400MHz
+// - costs about 10uW
+// - delays are tickless, CPU only wakes up at end of timeout
 
 #include "utimer.h"
 

--- a/ports/alif/system_tick.h
+++ b/ports/alif/system_tick.h
@@ -41,4 +41,11 @@ void system_tick_wfe_with_timeout_us(uint32_t timeout_us);
 void system_tick_schedule_after_us(uint32_t ticks_us);
 void system_tick_schedule_callback(void);
 
+#if MICROPY_HW_SYSTEM_TICK_USE_SYSTICK
+static inline uint32_t system_tick_get_ms_fast(void) {
+    extern volatile uint32_t system_tick_ms_counter;
+    return system_tick_ms_counter;
+}
+#endif
+
 #endif // MICROPY_INCLUDED_ALIF_SYSTEM_TICK_H


### PR DESCRIPTION
### Summary

This PR has the following commits related to the system ticker:
- Document differences between SysTick/LPTIMER/UTIMER.
- Add `system_tick_get_ms_fast()` to use when SysTick is enabled, that just reads the value of the SysTick counter.
- Use DWT->CYCCNT for CPU tick if SysTick/LPTIMER is used, because otherwise `time.ticks_cpu()` uses only a microsecond-accurate counter.
- ~~Add `mp_hal_ticks_ms_fast()` helper function, which just reads the value of the SysTick counter.~~
- ~~Switch system ticks to use SysTick on HP core.~~

This is based on discussion in #19076.

Note: the last two commits were removed due to discussion above.

### Testing

Tested on OPENMV_AE3, inspecting `time.ticks_cpu/ms/us()` and running the full test suite.  It passes.

### Trade-offs and Alternatives

~~This changes the ticks implementation from UTIMER to SysTick.  So now the alif port is tick-based, ie wakes up every 1ms, which is a bit of a shame because the UTIMER implementation is tickless.  But testing showed that UTIMER consumes more power than SysTick.~~

~~Could instead just switch to SysTick on OPENMV_AE3, instead of doing it for all boards.~~

### Generative AI

I did not use generative AI tools when creating this PR.
