### PR TITLE
esp32/network_lan: fix Ethernet event handler base filtering

### DIFF
--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -70,29 +70,36 @@ static uint8_t eth_status = 0;
 
 static void eth_event_handler(void *arg, esp_event_base_t event_base,
     int32_t event_id, void *event_data) {
-    switch (event_id) {
-        case ETHERNET_EVENT_CONNECTED:
-            eth_status = ETH_CONNECTED;
-            ESP_LOGI("ethernet", "Ethernet Link Up");
-            break;
-        case ETHERNET_EVENT_DISCONNECTED:
-            eth_status = ETH_DISCONNECTED;
-            ESP_LOGI("ethernet", "Ethernet Link Down");
-            break;
-        case ETHERNET_EVENT_START:
-            eth_status = ETH_STARTED;
-            ESP_LOGI("ethernet", "Ethernet Started");
-            break;
-        case ETHERNET_EVENT_STOP:
-            eth_status = ETH_STOPPED;
-            ESP_LOGI("ethernet", "Ethernet Stopped");
-            break;
-        case IP_EVENT_ETH_GOT_IP:
-            eth_status = ETH_GOT_IP;
-            ESP_LOGI("ethernet", "Ethernet Got IP");
-            break;
-        default:
-            break;
+    if (event_base == ETH_EVENT) {
+        switch (event_id) {
+            case ETHERNET_EVENT_CONNECTED:
+                eth_status = ETH_CONNECTED;
+                ESP_LOGI("ethernet", "Ethernet Link Up");
+                break;
+            case ETHERNET_EVENT_DISCONNECTED:
+                eth_status = ETH_DISCONNECTED;
+                ESP_LOGI("ethernet", "Ethernet Link Down");
+                break;
+            case ETHERNET_EVENT_START:
+                eth_status = ETH_STARTED;
+                ESP_LOGI("ethernet", "Ethernet Started");
+                break;
+            case ETHERNET_EVENT_STOP:
+                eth_status = ETH_STOPPED;
+                ESP_LOGI("ethernet", "Ethernet Stopped");
+                break;
+            default:
+                break;
+        }
+    } else if (event_base == IP_EVENT) {
+        switch (event_id) {
+            case IP_EVENT_ETH_GOT_IP:
+                eth_status = ETH_GOT_IP;
+                ESP_LOGI("ethernet", "Ethernet Got IP");
+                break;
+            default:
+                break;
+        }
     }
 }
 

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -80,29 +80,36 @@ static uint8_t eth_status = 0;
 
 static void eth_event_handler(void *arg, esp_event_base_t event_base,
     int32_t event_id, void *event_data) {
-    switch (event_id) {
-        case ETHERNET_EVENT_CONNECTED:
-            eth_status = ETH_CONNECTED;
-            ESP_LOGI("ethernet", "Ethernet Link Up");
-            break;
-        case ETHERNET_EVENT_DISCONNECTED:
-            eth_status = ETH_DISCONNECTED;
-            ESP_LOGI("ethernet", "Ethernet Link Down");
-            break;
-        case ETHERNET_EVENT_START:
-            eth_status = ETH_STARTED;
-            ESP_LOGI("ethernet", "Ethernet Started");
-            break;
-        case ETHERNET_EVENT_STOP:
-            eth_status = ETH_STOPPED;
-            ESP_LOGI("ethernet", "Ethernet Stopped");
-            break;
-        case IP_EVENT_ETH_GOT_IP:
-            eth_status = ETH_GOT_IP;
-            ESP_LOGI("ethernet", "Ethernet Got IP");
-            break;
-        default:
-            break;
+    if (event_base == ETH_EVENT) {
+        switch (event_id) {
+            case ETHERNET_EVENT_CONNECTED:
+                eth_status = ETH_CONNECTED;
+                ESP_LOGI("ethernet", "Ethernet Link Up");
+                break;
+            case ETHERNET_EVENT_DISCONNECTED:
+                eth_status = ETH_DISCONNECTED;
+                ESP_LOGI("ethernet", "Ethernet Link Down");
+                break;
+            case ETHERNET_EVENT_START:
+                eth_status = ETH_STARTED;
+                ESP_LOGI("ethernet", "Ethernet Started");
+                break;
+            case ETHERNET_EVENT_STOP:
+                eth_status = ETH_STOPPED;
+                ESP_LOGI("ethernet", "Ethernet Stopped");
+                break;
+            default:
+                break;
+        }
+    } else if (event_base == IP_EVENT) {
+        switch (event_id) {
+            case IP_EVENT_ETH_GOT_IP:
+                eth_status = ETH_GOT_IP;
+                ESP_LOGI("ethernet", "Ethernet Got IP");
+                break;
+            default:
+                break;
+        }
     }
 }
 


### PR DESCRIPTION
Prevent WiFi IP events from corrupting Ethernet status.

### Summary

Fix for [#19123](https://github.com/micropython/micropython/issues/19123)

The LAN handler was subscribed to all `ETH_EVENT` and `IP_EVENT` events but dispatches only on event_id. Because `event_base` was ignored, WiFi events such as `IP_EVENT_STA_LOST_IP` could collide numerically with Ethernet events and overwrite `eth_status`.

This causes LAN.status() / LAN.isconnected() to become incorrect, while Ethernet remained functional.

Fix:
- check `event_base` before handling `event_id`

### Testing

Tested the code that reproduced this issue on ESP32-Ethernet-Kit v1.2 board.
After the fix was applied, the issue was no longer observed. 

### Generative AI

I did not use generative AI tools when creating this PR.
