### PR TITLE
docs: Add ROMFS documentation pages.

### DIFF
--- a/docs/library/vfs.rst
+++ b/docs/library/vfs.rst
@@ -50,6 +50,9 @@ represented by VFS classes.
 
     Will raise ``OSError(EINVAL)`` if *mount_point* is not found.
 
+Filesystem Types
+----------------
+
 .. class:: VfsFat(block_dev)
 
     Create a filesystem object that uses the FAT filesystem format.  Storage of
@@ -106,6 +109,46 @@ represented by VFS classes.
     If *root* is specified then it should be a path in the host filesystem to use
     as the root of the ``VfsPosix`` object.  Otherwise the current directory of
     the host filesystem is used.
+
+
+.. class:: VfsRom(buffer)
+
+    This class is only available when the firmware is built with
+    ``MICROPY_VFS_ROM`` enabled.
+
+    Create a filesystem object that uses the :ref:`ROMFS read-only filesystem
+    format <romfs>`.  *buffer* must be an object supporting the buffer protocol
+    (e.g. ``bytes``, ``bytearray``, or ``memoryview``) that contains a valid
+    ROMFS image.
+    The constructor validates that *buffer* begins with the ROMFS magic bytes
+    (``b"\xd2\xcd\x31"``).  If the buffer is too small or not a valid ROMFS
+    then ``OSError(ENODEV)`` is raised.
+
+
+
+
+    See :ref:`romfs` for more information on the ROMFS filesystem and how to
+    deploy images using :ref:`mpremote <mpremote>`.
+
+   .. method:: VfsRom.open(path, mode)
+
+       Open a file from the ROMFS.  Only read modes (``''``, ``'r'``,
+       ``'rt'``, ``'rb'``) are supported. 
+       For binary files opened in read mode,
+       the returned object also supports the buffer protocol so that a
+       ``memoryview`` of the file data can be obtained, which refers
+       directly into the ROMFS memory (zero-copy).
+
+   .. method:: VfsRom.statvfs(path)
+
+       The block size is reported as 1 and
+       the block count represents the total size of the ROMFS image in bytes.
+
+   .. method:: VfsRom.chdir(path)
+
+       Change directory within the ROMFS.  Only the root (``'/'``) is
+       supported; changing to any subdirectory raises ``OSError(EOPNOTSUPP)``.
+
 
 .. _littlefs v1 filesystem format: https://github.com/ARMmbed/littlefs/tree/v1
 .. _littlefs v2 filesystem format: https://github.com/ARMmbed/littlefs
@@ -214,3 +257,32 @@ that the block device supports the extended interface.
        ``op`` is intercepted, the return value for operations 4 and 5 are as
        detailed above. Other operations should return 0 on success and non-zero
        for failure, with the value returned being an ``OSError`` errno code.
+
+
+Miscellaneous Functions
+-----------------------
+
+.. function:: rom_ioctl(op, ...)
+
+   Low-level interface for accessing the read-only memory (ROM) partition(s)
+   of the device. This function is only available on ports that support ROMFS
+   (i.e. where ``MICROPY_VFS_ROM_IOCTL`` is enabled).
+
+   The supported operations are:
+
+   - ``vfs.rom_ioctl(1)`` -- Return the number of available ROM partitions.
+   - ``vfs.rom_ioctl(2, id)`` -- Return the ROM partition with index *id* as
+     a ``memoryview`` object. The memory can be read but not written directly.
+   - ``vfs.rom_ioctl(3, id, length)`` -- Prepare a ROM partition for writing.
+     Erases the first *length* bytes of the partition with index *id*.
+     Returns the minimum write size in bytes (the alignment required for
+     subsequent writes).
+   - ``vfs.rom_ioctl(4, id, offset, buf)`` -- Write *buf* (a bytes-like object)
+     to the ROM partition with index *id* at byte *offset*.
+   - ``vfs.rom_ioctl(5, id)`` -- Complete a write sequence to partition *id*
+     (performs any finalisation needed after writing, such as cache flushing).
+
+   These operations are used internally by ``mpremote`` to deploy ROMFS images.
+   Most users do not need to call ``vfs.rom_ioctl()`` directly.
+
+See :ref:`romfs` for more information.

--- a/docs/library/vfs.rst
+++ b/docs/library/vfs.rst
@@ -50,6 +50,9 @@ represented by VFS classes.
 
     Will raise ``OSError(EINVAL)`` if *mount_point* is not found.
 
+Filesystem Types
+----------------
+
 .. class:: VfsFat(block_dev)
 
     Create a filesystem object that uses the FAT filesystem format.  Storage of
@@ -107,10 +110,86 @@ represented by VFS classes.
     as the root of the ``VfsPosix`` object.  Otherwise the current directory of
     the host filesystem is used.
 
+.. class:: VfsRom(buffer)
+
+    This class is only available when the firmware is built with
+    ``MICROPY_VFS_ROM`` enabled.
+
+    Create a filesystem object that uses the :ref:`ROMFS read-only filesystem
+    format <romfs>`.  *buffer* must be an object supporting the buffer protocol
+    (e.g. ``bytes``, ``bytearray``, or ``memoryview``) that contains a valid
+    ROMFS image.
+    The constructor validates that *buffer* begins with the ROMFS magic bytes
+    (``b"\xd2\xcd\x31"``).  If the buffer is too small or not a valid ROMFS
+    then ``OSError(ENODEV)`` is raised.
+
+    See :ref:`romfs` for more information on the ROMFS filesystem and how to
+    deploy images using :ref:`mpremote <mpremote>`.
+
+   .. method:: VfsRom.open(path, mode)
+
+       Open a file from the ROMFS.  Only read modes (``''``, ``'r'``,
+       ``'rt'``, ``'rb'``) are supported.
+       For binary files opened in read mode,
+       the returned object also supports the buffer protocol so that a
+       ``memoryview`` of the file data can be obtained, which refers
+       directly into the ROMFS memory (zero-copy).
+
+   .. method:: VfsRom.statvfs(path)
+
+       The block size is reported as 1 and
+       the block count represents the total size of the ROMFS image in bytes.
+
+   .. method:: VfsRom.chdir(path)
+
+       Change directory within the ROMFS.  Only the root (``'/'``) is
+       supported; changing to any subdirectory raises ``OSError(EOPNOTSUPP)``.
+
 .. _littlefs v1 filesystem format: https://github.com/ARMmbed/littlefs/tree/v1
 .. _littlefs v2 filesystem format: https://github.com/ARMmbed/littlefs
 .. _littlefs issue 295: https://github.com/ARMmbed/littlefs/issues/295
 .. _littlefs issue 347: https://github.com/ARMmbed/littlefs/issues/347
+
+Miscellaneous Functions
+-----------------------
+
+.. function:: rom_ioctl(op, ...)
+
+   Low-level interface for accessing the read-only memory (ROM) partition(s)
+   of the device. This function is only available on ports that support ROMFS
+   (i.e. where ``MICROPY_VFS_ROM_IOCTL`` is enabled).
+
+   The supported operations are:
+
+   - ``vfs.rom_ioctl(1)`` -- Return the number of available ROM partitions.
+   - ``vfs.rom_ioctl(2, id)`` -- Return ROM partition *id* as an object that
+     supports the buffer protocol.  Depending on the port, this is either a
+     block device or a ``memoryview``.  A block device supports the standard
+     block protocol, including erase and write operations.  If a ``memoryview``
+     is returned, the port must provide erase and write operations through
+     ``vfs.rom_ioctl()`` operations 3, 4, and 5 below.
+   - ``vfs.rom_ioctl(3, id, length)`` -- Prepare the first *length* bytes of
+     ROM partition *id* for writing (for example, by erasing flash).  Returns
+     the minimum write size in bytes (the alignment required for subsequent
+     writes).
+   - ``vfs.rom_ioctl(3, id, offset, length)`` -- Prepare *length* bytes of ROM
+     partition *id*, starting at byte *offset*, for writing.  This form allows
+     a partition to be prepared incrementally. Returns
+     the minimum write size in bytes.
+   - ``vfs.rom_ioctl(4, id, offset, buf)`` -- Write *buf* (a bytes-like object)
+     to the ROM partition with index *id* at byte *offset*.
+   - ``vfs.rom_ioctl(5, id)`` -- Complete a write sequence to partition *id*
+     (performs any finalisation needed after writing, such as cache flushing).
+   - ``vfs.rom_ioctl(6, id)`` -- Return the minimum number of bytes of ROM
+     partition *id* that can be prepared at once.  A positive return value
+     indicates that the four-argument form of operation 3 is supported;
+     *offset* and *length* must be aligned to this value.  Otherwise, only the
+     three-argument form of operation 3 is supported.
+
+   These operations are used internally by ``mpremote`` to deploy ROMFS images.
+   Most users do not need to call ``vfs.rom_ioctl()`` directly.
+
+   See :ref:`romfs` for more information.
 
 Block devices
 -------------

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -31,5 +31,6 @@ implementation and the best practices to use them.
    packages.rst
    asm_thumb2_index.rst
    filesystem.rst
+   romfs.rst
    pyboard.py.rst
    micropython2_migration.rst

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -31,6 +31,7 @@ implementation and the best practices to use them.
    packages.rst
    asm_thumb2_index.rst
    filesystem.rst
+   romfs.rst
    unicode_support.rst
    pyboard.py.rst
    micropython2_migration.rst

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -382,28 +382,13 @@ The full list of supported commands are:
   This happens automatically when ``mpremote`` terminates, but it can be used
   in a sequence to unmount an earlier mount before subsequent command are run.
 
-.. _mpremote_command_romfs:
-
 - **romfs** -- manage ROMFS partitions on the device:
 
   .. code-block:: bash
 
       $ mpremote romfs <sub-command>
 
-  ``<sub-command>`` may be:
-
-  - ``romfs query`` to list all the available ROMFS partitions and their size
-  - ``romfs [-o <output>] build <source>`` to create a ROMFS image from the given
-    source directory; the default output file is the source appended by ``.romfs``
-  - ``romfs [-p <partition>] deploy <source>`` to deploy a ROMFS image to the device;
-    will also create a temporary ROMFS image if the source is a directory
-
-  The ``build`` and ``deploy`` sub-commands both support the ``-m``/``--mpy`` option
-  to automatically compile ``.py`` files to ``.mpy`` when creating the ROMFS image.
-  This option is enabled by default, but only works if the ``mpy_cross`` Python
-  package has been installed (eg via ``pip install mpy_cross``).  If the package is
-  not installed then a warning is printed and ``.py`` files remain as is.  Compiling
-  of ``.py`` files can be disabled with the ``--no-mpy`` option.
+  See :ref:`mpremote ROMFS commands <mpremote_command_romfs>` for details.
 
 .. _mpremote_command_rtc:
 
@@ -453,6 +438,107 @@ The full list of supported commands are:
 
   This will make the device enter its bootloader. The bootloader is port- and
   board-specific (e.g. DFU on stm32, UF2 on rp2040/Pico).
+
+.. _mpremote_command_romfs:
+
+ROMFS commands
+--------------
+
+The ``romfs`` command provides three sub-commands for managing ROMFS images on
+a connected device.
+
+.. _mpremote_command_romfs_query:
+
+mpremote romfs query
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs query
+
+Lists all available ROMFS partitions on the device and their sizes.  Also
+shows the first 12 bytes of each partition in hex and reports whether a
+valid ROMFS image is present.
+
+Example output::
+
+    ROMFS0 partition has size 131072 bytes (32 blocks of 4096 bytes each)
+      Raw contents: d2:cd:31:XX:XX:XX:XX:XX:XX:XX:XX:XX ...
+      ROMFS image size: 1234
+
+.. _mpremote_command_romfs_build:
+
+mpremote romfs build
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs [-o <output>] build <source>
+
+Build a ROMFS image from the directory *source* on the host PC.  The image
+is written to *output* (default: ``<source>.romfs``).
+
+Options:
+
+- ``-o <output>``, ``--output <output>``: Specify the output file path.
+- ``-m``, ``--mpy`` (default): Automatically compile ``.py`` files to
+  ``.mpy`` using ``mpy_cross`` before adding them to the image.  This requires
+  the ``mpy_cross`` Python package (``pip install mpy_cross``); without it,
+  ``mpremote`` prints a warning and leaves the ``.py`` files unchanged.
+- ``--no-mpy``: Disable automatic compilation of ``.py`` files.
+
+Example::
+
+    $ mpremote romfs build myapp/
+    Building romfs filesystem, source directory: myapp/
+    /
+    |-- main.py -> .mpy
+    \-- lib/
+        \-- helper.py -> .mpy
+    Writing 2048 bytes to output file myapp.romfs
+
+.. _mpremote_command_romfs_deploy:
+
+mpremote romfs deploy
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs [-p <partition>] deploy <source>
+
+Deploy a ROMFS image to the device.  *source* can be either:
+
+- A directory on the host: the ROMFS image is built in memory and deployed
+  directly.
+- A ``.romfs`` or ``.img`` file: the image is read from disk and deployed.
+
+Options:
+
+- ``-p <partition>``, ``--partition <partition>``: Specify the target
+  partition index (default: ``0``).
+- ``-m``, ``--mpy`` (default): Compile ``.py`` to ``.mpy`` when *source*
+  is a directory.  If ``mpy_cross`` is not installed, ``mpremote`` prints a
+  warning and leaves the ``.py`` files unchanged.
+- ``--no-mpy``: Disable automatic compilation of ``.py`` files.
+
+After deployment, the device must be soft-reset for the new ROMFS to be
+mounted at ``/rom``.
+
+Example::
+
+    $ mpremote romfs deploy myapp/
+    Building romfs filesystem, source directory: myapp/
+    /
+    |-- main.py -> .mpy
+    \-- lib/
+        \-- helper.py -> .mpy
+    Image size is 2048 bytes
+    ROMFS0 partition has size 131072 bytes (32 blocks of 4096 bytes each)
+    Preparing ROMFS0 partition for writing
+    Deploying ROMFS to ROMFS0 partition
+    ROMFS image deployed
+
+    $ mpremote soft-reset
 
 .. _mpremote_reset:
 

--- a/docs/reference/romfs.rst
+++ b/docs/reference/romfs.rst
@@ -1,0 +1,302 @@
+.. _romfs:
+
+Working with ROMFS
+==================
+
+.. contents::
+
+Overview
+--------
+
+ROMFS (Read-Only Memory Filesystem) is a lightweight, read-only filesystem
+optimised for microcontrollers and embedded systems
+where code and data need to be stored in flash memory and
+accessed efficiently without being copied into RAM.
+
+The key benefits of ROMFS are:
+
+- **Zero-copy imports**: ``.mpy`` bytecode files stored in a ROMFS can be
+  executed directly from flash memory (memory-mapped) rather than being copied
+  into RAM first.  This is similar to how :ref:`frozen modules <manifest>` work,
+  but does not require reflashing the entire firmware.
+- **Low RAM overhead**: Constant objects (strings, bytes, etc.) in ``.mpy``
+  files loaded from ROMFS are referenced directly from flash, not duplicated
+  in RAM.
+- **Flexible deployment**: A ROMFS image can be built on a host PC and deployed
+  to the device using ``mpremote``, without rebuilding the firmware.
+- **Standard filesystem interface**: A ROMFS is mounted in the :ref:`VFS
+  <filesystem>` and accessed via normal Python file operations (``open``,
+  ``os.listdir``, ``import``, etc.).
+
+ROMFS is complementary to both the read-write LittleFS/FAT filesystems (which
+live in other flash partitions) and to :ref:`frozen modules <manifest>` (which
+are compiled into the firmware itself).
+
+.. note::
+
+   ROMFS requires firmware that has been built with ROMFS support enabled
+   (``MICROPY_VFS_ROM``).  Not all ports or boards include this by default;
+   check your board's documentation or build configuration.
+
+Port support
+------------
+
+The following ports support ROMFS.  On these ports, if a ROMFS partition is
+configured for the board, it will be automatically detected at boot time and
+mounted at ``/rom`` in the VFS.  Both ``/rom`` and ``/rom/lib`` are
+automatically added to ``sys.path`` so that modules stored there can be
+imported directly.
+
+==============  ====================================================
+Port            Notes
+==============  ====================================================
+alif            Supported on boards with ROMFS partition configured.
+esp32           Supported with custom partition table.
+esp8266         Supported on 2MiB+ boards (ESP8266_GENERIC FLASH_2M_ROMFS variant).
+mimxrt          Supported on boards with ROMFS partition configured.
+nrf             Supported on boards with ROMFS partition configured.
+qemu            Supported (used for CI testing).
+renesas-ra      Supported on boards with ROMFS partition configured.
+rp2             Supported on boards with ROMFS partition configured.
+samd            Supported on boards with ROMFS partition configured.
+stm32           Supported on boards with ROMFS partition configured.
+unix            Supported (primarily for testing).
+==============  ====================================================
+
+Workflow
+--------
+
+The typical workflow for using ROMFS is:
+
+1. Create a directory on your PC with the Python files (or ``.mpy`` files)
+   you want to deploy.
+2. Use ``mpremote romfs deploy <directory>`` to build and deploy the ROMFS
+   image to the device.
+3. The ROMFS will be mounted at ``/rom`` on next boot (or can be mounted
+   immediately if the device is soft-reset).
+4. Python code on the device can then ``import`` modules from the ROMFS just
+   like from any other filesystem.
+
+For example::
+
+    # On the host PC, with a directory "myapp/" containing app.py:
+    $ mpremote romfs deploy myapp/
+
+After a soft-reset, the device will have ``/rom/app.py`` (or ``/rom/app.mpy``
+if ``mpy_cross`` is installed) available for import.
+
+See the :ref:`mpremote romfs commands <mpremote_command_romfs>` section for
+full details of the ``mpremote`` commands.
+
+.rst
+Automatic mounting at boot
+--------------------------
+
+When ROMFS support is enabled in the firmware, MicroPython will automatically
+attempt to mount the first ROM partition at ``/rom`` during initialisation
+(after ``mp_init()``).  If the partition contains a valid ROMFS image, it is
+mounted and both ``/rom`` and ``/rom/lib`` are added to ``sys.path``
+automatically.
+
+This means that after deploying a ROMFS image with ``mpremote``, a soft-reset
+is sufficient to make the new modules importable.
+
+If no valid ROMFS image is found in the partition (e.g. on a freshly-programmed
+board), the mount is silently skipped.
+
+Using mpremote to manage ROMFS
+------------------------------
+
+The :ref:`mpremote <mpremote>` tool provides three sub-commands for managing
+ROMFS images on a connected device.
+
+.. _mpremote_command_romfs_query:
+
+mpremote romfs query
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs query
+
+Lists all available ROMFS partitions on the device and their sizes.  Also
+shows the first 12 bytes of each partition in hex and reports whether a
+valid ROMFS image is present.
+
+Example output::
+
+    ROMFS0 partition has size 131072 bytes (32 blocks of 4096 bytes each)
+      Raw contents: d2:cd:31:XX:XX:XX:XX:XX:XX:XX:XX:XX ...
+      ROMFS image size: 1234
+
+.. _mpremote_command_romfs_build:
+
+mpremote romfs build
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs [-o <output>] build <source>
+
+Build a ROMFS image from the directory *source* on the host PC.  The image
+is written to *output* (default: ``<source>.romfs``).
+
+Options:
+
+- ``-o <output>``, ``--output <output>``: Specify the output file path.
+- ``-m``, ``--mpy`` (default): Automatically compile ``.py`` files to
+  ``.mpy`` using ``mpy_cross`` before adding them to the image.  Requires the
+  ``mpy_cross`` Python package (``pip install mpy_cross``).
+- ``--no-mpy``: Disable automatic compilation of ``.py`` files.
+
+Example::
+
+    $ mpremote romfs build myapp/
+    Building romfs filesystem, source directory: myapp/
+    /
+    |-- main.py -> .mpy
+    \-- lib/
+        \-- helper.py -> .mpy
+    Writing 2048 bytes to output file myapp.romfs
+
+.. _mpremote_command_romfs_deploy:
+
+mpremote romfs deploy
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    $ mpremote romfs [-p <partition>] deploy <source>
+
+Deploy a ROMFS image to the device.  *source* can be either:
+
+- A directory on the host: the ROMFS image is built in memory and deployed
+  directly.
+- A ``.romfs`` or ``.img`` file: the image is read from disk and deployed.
+
+Options:
+
+- ``-p <partition>``, ``--partition <partition>``: Specify the target
+  partition index (default: ``0``).
+- ``-m``, ``--mpy`` (default): Compile ``.py`` to ``.mpy`` when *source*
+  is a directory.
+- ``--no-mpy``: Disable automatic compilation of ``.py`` files.
+
+After deployment, the device must be soft-reset for the new ROMFS to be
+mounted at ``/rom``.
+
+Example::
+
+    $ mpremote romfs deploy myapp/
+    Building romfs filesystem, source directory: myapp/
+    /
+    |-- main.py -> .mpy
+    \-- lib/
+        \-- helper.py -> .mpy
+    Image size is 2048 bytes
+    ROMFS0 partition has size 131072 bytes (32 blocks of 4096 bytes each)
+    Preparing ROMFS0 partition for writing
+    Deploying ROMFS to ROMFS0 partition
+    ROMFS image deployed
+
+    $ mpremote soft-reset
+
+ROMFS usage examples
+--------------------
+
+Deploying a simple application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suppose you have a project directory ``myapp/`` with the following structure::
+
+    myapp/
+        main.py
+        utils.py
+        lib/
+            helper.py
+
+To deploy it to the device's ROMFS::
+
+    $ mpremote romfs deploy myapp/
+
+After a soft-reset, the modules are importable from the ROMFS::
+
+    import main
+    import utils
+    from lib import helper
+
+Listing ROMFS contents from Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After mounting, the ROMFS contents can be explored like any other
+filesystem::
+
+    import os
+
+    for entry in os.ilistdir('/rom'):
+        print(entry)
+
+    # Or simply:
+    print(os.listdir('/rom'))
+
+
+Mount a ROMFS image from flash
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    import vfs
+    dev = vfs.rom_ioctl(2, 0)   # get partition 0 as a memoryview
+    fs = vfs.VfsRom(dev)
+    vfs.mount(fs, '/rom')
+
+Mount a ROMFS image stored in a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A ROMFS image stored as a file on the device can be mounted as a filesystem.  For example, if
+``/flash/app.romfs`` exists::
+
+
+    import vfs
+    with open('/flash/app.romfs', 'rb') as f:
+        romfs_data = f.read()
+    fs = vfs.VfsRom(romfs_data)
+    vfs.mount(fs, '/rom2')
+
+This also allows a ROMFS image stored as a file within an outer ROMFS to be mounted as a
+nested filesystem.  For example, if ``/rom/inner.romfs`` exists, you can mount it as::
+
+    import vfs
+    with open('/rom/inner.romfs', 'rb') as f:
+        inner_romfs_data = f.read()
+    fs = vfs.VfsRom(inner_romfs_data)
+    vfs.mount(fs, '/rom/inner')
+
+
+ROMFS image format
+------------------
+
+The ROMFS image format is a compact binary format designed for memory-mapped
+access on constrained systems. 
+
+A brief overview:
+
+- The image starts with the magic bytes ``0xd2 0xcd 0x31`` (encoded as
+  ``"RM1"`` with the high bits of the first two bytes set).
+- The remainder of the image is composed of *records*, each with a type tag
+  (varuint), a length (varuint), and a payload.
+- Record types include: padding, verbatim data, indirect data pointer,
+  directory, file.
+- Directory and file names are stored as length-prefixed byte strings.
+- File data can be stored verbatim (inline) or via an indirect pointer to
+  elsewhere in the image, which enables alignment for memory-mapped access.
+- Unknown record types are silently skipped, providing forwards compatibility.
+
+This format is defined in ``extmod/vfs_rom.c`` in the MicroPython source.
+The Python implementation used by ``mpremote`` to build images is in
+``tools/mpremote/mpremote/romfs.py``.
+
+.. seealso::
+
+   - :ref:`filesystem` -- Overview of the MicroPython VFS and available
+     filesystem types.
+   - :ref:`manifest` -- How to freeze Python modules into firmware.
+   - :ref:`mpy_files` -- MicroPython ``.mpy`` binary file format.
+   - :ref:`mpremote` -- The full ``mpremote`` command reference.

--- a/docs/reference/romfs.rst
+++ b/docs/reference/romfs.rst
@@ -63,6 +63,45 @@ stm32           Supported on boards with ROMFS partition configured.
 unix            Supported (primarily for testing).
 ==============  ====================================================
 
+Enabling ROMFS for a port or board
+----------------------------------
+
+ROMFS support is not enabled in exactly the same way on every port.  In
+general a board or variant configuration for ROMFS needs three things:
+
+1. Enable the ROMFS feature in the firmware build.  Some ports define
+   ``MICROPY_VFS_ROM`` directly, and others derive it from board settings.
+2. Provide one or more ROMFS partitions or memory regions that the firmware can
+   expose via ``vfs.rom_ioctl()``.
+
+3. On most bare-metal ports, enabling ROMFS also requires the board's linker
+   layout or flash map to reserve space for the ROMFS partition.
+
+To see how a given port enables ROMFS, search that port's ``mpconfigport.h``,
+board ``mpconfigboard.h``/``mpconfigboard.mk`` files, linker scripts, and any
+``vfs_rom_ioctl.c`` implementation.
+
+The most common patterns are:
+
+- **ESP32**: provide a partition table with a ``romfs`` entry.  See the
+  example partition table in ``ports/esp32/partitions-4MiB-romfs.csv``.
+- **ESP8266**: has a defined board variant ``ESP8266_GENERIC/FLASH_2M_ROMFS``.
+- **rp2**, **samd**, **mimxrt**: set ``MICROPY_HW_ROMFS_BYTES`` to a non-zero
+  size in the board or MCU makefile.
+- **stm32**: set one or more of these board-level macros:
+  ``MICROPY_HW_ROMFS_ENABLE_INTERNAL_FLASH``,
+  ``MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI``, or
+  ``MICROPY_HW_ROMFS_ENABLE_EXTERNAL_XSPI``.
+- **alif**: set ``MICROPY_HW_ROMFS_ENABLE_PART0`` or
+  ``MICROPY_HW_ROMFS_ENABLE_PART1`` in the board configuration.
+- **nrf**: define ``_micropy_hw_romfs_part0_size`` in the board linker script.
+- **qemu**: set ``MICROPY_HW_ROMFS_PART0_START`` and
+  ``MICROPY_HW_ROMFS_PART0_SIZE`` in the board makefile.
+- **renesas-ra**: define ``_micropy_hw_romfs_part0_start`` and
+  ``_micropy_hw_romfs_part0_size`` in the board linker script.
+
+
+
 Workflow
 --------
 

--- a/docs/reference/romfs.rst
+++ b/docs/reference/romfs.rst
@@ -1,0 +1,253 @@
+.. _romfs:
+
+Working with ROMFS
+==================
+
+.. contents::
+
+Overview
+--------
+
+ROMFS (Read-Only Memory Filesystem) is a lightweight, read-only filesystem
+optimised for microcontrollers and embedded systems
+where code and data need to be stored in flash memory and
+accessed efficiently without being copied into RAM.
+
+The key benefits of ROMFS are:
+
+- **Zero-copy imports**: ``.mpy`` bytecode files stored in a ROMFS can be
+  executed directly from flash memory (memory-mapped) rather than being copied
+  into RAM first.  This is similar to how :ref:`frozen modules <manifest>` work,
+  but does not require reflashing the entire firmware.
+- **Low RAM overhead**: String and byte constant objects in ``.mpy``
+  files loaded from ROMFS are referenced directly from flash, not duplicated
+  in RAM.
+- **Flexible deployment**: A ROMFS image can be built on a host PC and deployed
+  to the device using ``mpremote``, without rebuilding the firmware.
+- **Standard filesystem interface**: A ROMFS is mounted in the :ref:`VFS
+  <filesystem>` and accessed via normal Python file operations (``open``,
+  ``os.listdir``, ``import``, etc.).
+
+ROMFS is complementary to both the read-write LittleFS/FAT filesystems (which
+live in other flash partitions) and to :ref:`frozen modules <manifest>` (which
+are compiled into the firmware itself).
+
+.. note::
+
+   ROMFS requires firmware that has been built with ROMFS support enabled
+   (``MICROPY_VFS_ROM``).  Not all ports or boards include this by default;
+   check your board's documentation or build configuration.
+
+Port support
+------------
+
+The following ports support ROMFS.  On these ports, if a ROMFS partition is
+configured for the board, it will be automatically detected at boot time and
+mounted at ``/rom`` in the VFS.  Both ``/rom`` and ``/rom/lib`` are
+automatically added to ``sys.path`` so that modules stored there can be
+imported directly.
+
+==============  ====================================================
+Port            Notes
+==============  ====================================================
+alif            Supported on boards with ROMFS partition configured.
+esp32           Supported with custom partition table.
+esp8266         Supported on 2MiB+ boards (ESP8266_GENERIC FLASH_2M_ROMFS variant).
+mimxrt          Supported on boards with ROMFS partition configured.
+nrf             Supported on boards with ROMFS partition configured.
+qemu            Supported (used for CI testing).
+renesas-ra      Supported on boards with ROMFS partition configured.
+rp2             Supported on boards with ROMFS partition configured.
+samd            Supported on boards with ROMFS partition configured.
+stm32           Supported on boards with ROMFS partition configured.
+unix            Supported (primarily for testing).
+==============  ====================================================
+
+Enabling ROMFS for a port or board
+----------------------------------
+
+The ROMFS implementation is port specific at this time and requires too much detail to explain here.
+
+Workflow
+--------
+
+The typical workflow for using ROMFS is:
+
+1. Create a directory on your PC with the Python files (or ``.mpy`` files)
+   you want to deploy.
+2. Use ``mpremote romfs deploy <directory>`` to build and deploy the ROMFS
+   image to the device.
+3. The ROMFS will be mounted at ``/rom`` on next boot (or can be mounted
+   immediately if the device is soft-reset).
+4. Python code on the device can then ``import`` modules from the ROMFS just
+   like from any other filesystem.
+
+For example, on the host PC, with a directory "myapp/" containing app.py::
+
+    $ mpremote romfs deploy myapp/
+
+After a soft-reset, the device will have ``/rom/app.mpy`` available for import
+(or ``/rom/app.py`` if ``mpy_cross`` is not installed).
+
+Alternatively, you can build the ROMFS image on the host PC first, then deploy
+it to the device::
+
+    $ mpremote romfs build myapp
+    $ mpremote romfs deploy myapp.romfs
+
+See the :ref:`mpremote romfs commands <mpremote_command_romfs>` section for
+full details of the ``mpremote`` commands.
+
+Automatic mounting at boot
+--------------------------
+
+When ROMFS support is enabled in the firmware, MicroPython will automatically
+attempt to mount the first ROM partition at ``/rom`` during initialisation
+(after ``mp_init()``).  If the partition contains a valid ROMFS image, it is
+mounted and both ``/rom`` and ``/rom/lib`` are added to ``sys.path``
+automatically.
+
+This means that after deploying a ROMFS image with ``mpremote``, a soft-reset
+is sufficient to make the new modules importable.
+
+If no valid ROMFS image is found in the partition (e.g. on a freshly-programmed
+board), the mount is silently skipped.
+
+Using mpremote to manage ROMFS
+------------------------------
+
+The :ref:`mpremote <mpremote>` ``romfs`` command can query ROMFS partitions,
+build ROMFS images, and deploy images to a connected device.  See
+:ref:`mpremote ROMFS commands <mpremote_command_romfs>` for command syntax,
+options, and examples.
+
+ROMFS usage examples
+--------------------
+
+Deploying a simple application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suppose you have a project directory ``myapp/`` with the following structure::
+
+ ── myapp
+    ├── myapp.py
+    ├── utils.py
+    └── lib
+        └── helper.py
+
+To deploy it to the device's ROMFS::
+
+    $ mpremote romfs deploy myapp/
+    $ mpremote tree
+      tree :
+      :/
+      └── rom
+          ├── lib
+          │   └── helper.mpy
+          ├── myapp.mpy
+          └── utils.mpy
+
+After a soft-reset, the modules are importable from the ROMFS as its mount point
+and lib folder have been added to ``sys.path``::
+
+    import myapp
+    import utils
+    import helper
+
+Listing ROMFS contents from Python
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After mounting, the ROMFS contents can be explored like any other
+filesystem::
+
+    import os
+
+    for entry in os.ilistdir('/rom'):
+        print(entry)
+
+    # Or simply:
+    print(os.listdir('/rom'))
+
+Manually mount a second ROMFS image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If there are multiple ROMFS partitions, it is possible to mount
+a second ROMFS image from another partition on the device.
+For example, if the second ROMFS partition is at index 2, you can
+mount it using::
+
+    import vfs
+    dev = vfs.rom_ioctl(2, 1)  # get second partition
+    vfs.mount(vfs.VfsRom(dev), "/rom2")
+
+Mount a ROMFS image stored in a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A ROMFS image stored as a file within a ROMFS can be mounted as a
+nested filesystem without copying it into RAM.  For example, if
+``/rom/data.romfs`` exists, you can mount it using::
+
+    # boot.py
+    import vfs
+    with open('/rom/data.romfs', 'rb') as f:
+        fs = vfs.VfsRom(f)
+    vfs.mount(fs, '/data')
+
+Then after a soft-reset, the nested ROMFS is available at ``/data``::
+
+    $ mpremote tree
+      tree :
+      :/
+      ├── boot.py
+      ├── data
+      │   └── facts.db
+      ├── main.py
+      └── rom
+          ├── data.romfs
+          ├── lib
+          │   └── helper.mpy
+          ├── myapp.mpy
+          └── utils.mpy
+
+ROMFS filesystem format
+=======================
+ROMFS is a flexible and extensible filesystem format designed to represent a
+directory hierarchy with files, where those files are read-only and their data
+can be memory mapped.
+
+Concepts:
+
+- ``varuint`` : An unsigned integer that is encoded in a variable number of bytes.
+  It is stored big-endian with the high bit of the byte set if there are following bytes.
+- ``record`` : A variable sized element with a type. It is stored as two ``varuint``'s and then
+  a payload. The first ``varuint`` is the record kind and the second ``varuint`` is the
+  payload length (which may be zero bytes long).
+
+A ROMFS filesystem is a record with record kind 0x14a6b1, chosen so the encoded value
+is ``0xd2-0xcd-0x31`` which is ``"RM1"`` with the first two bytes having their high bit set.
+If the ROMFS record's payload is non-empty then it contains records.
+
+Record types:
+
+- ``0`` -- **unused**: Can be used to detect corruption of the filesystem.
+- ``1`` -- **padding/comments**: Can contain any data in the payload.
+- ``2`` -- **verbatim data**: Used to store file data.
+- ``3`` -- **indirect data**: Points to an offset within the ROMFS payload.
+- ``4`` -- **directory**: The payload contains a ``varuint`` giving the length of
+  the directory name in bytes, followed by the name and optional nested records
+  for the directory contents (including optional metadata).
+- ``5`` -- **file**: The payload contains a ``varuint`` giving the length of the
+  filename in bytes, followed by the name and optional nested records.
+
+Unknown record types are silently skipped, providing forwards compatibility.
+
+This format is defined in ``extmod/vfs_rom.c`` in the MicroPython source.
+The Python implementation used by ``mpremote`` to build images is in
+``tools/mpremote/mpremote/romfs.py``.
+
+.. seealso::
+
+   - :ref:`filesystem` -- Overview of the MicroPython VFS and available
+     filesystem types.
+   - :ref:`manifest` -- How to freeze Python modules into firmware.
+   - :ref:`mpy_files` -- MicroPython ``.mpy`` binary file format.
+   - :ref:`mpremote` -- The full ``mpremote`` command reference.


### PR DESCRIPTION
### Summary

This PR adds documentation for the ROMFS feature with explanations on how to use `mpremote` to build  and deploy a romfs image.

Closes: #19124 

### Testing

I have built the docs locally , and validated the examples in the code using mpremote v1.28.0  against 
- a custom build of an esp32-C6 with ROMFS.
- a SAMD51 SEEED_WIO_TERMINAL

### Trade-offs and Alternatives

I currently did not include: 
- an example of how to add a board variant with ROMFS support
- documentation for the C-API.

I decided against adding a list of ports / boards that support ROMFS today, although it would be useful to be able to filter on the boards/variants that support this in the downloads section or elsewhere. A re search for `MICROPY_VFS_ROM.*1` works, but leaves to be desired.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
documentation and code samples and is responsible for the code and the description above.
