### PR TITLE
tests/run-perfbench.py: Skip large tests based on bm_params.

### DIFF
--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import argparse
+import re
 from glob import glob
 
 from test_utils import (
@@ -118,6 +119,19 @@ def run_benchmarks(args, target, param_n, param_m, n_average, test_list):
         with open(BENCH_SCRIPT_DIR + "benchrun.py", "rb") as f:
             test_script += f.read()
         test_script += b"bm_run(%u, %u)\n" % (param_n, param_m)
+
+        # Search for the bm_params dict, to extract the minimum memory required.
+        m = re.search(rb"bm_params = {\s+\((\d+), (\d+)\):", test_script)
+        if not m:
+            print(f"Test file '{test_file}' doesn't contain valid 'bm_params'")
+            sys.exit(2)
+        min_m = int(m.group(2))
+
+        # Skip the test if the target doesn't have enough memory.
+        if param_m < min_m:
+            test_results.append((test_file, "skip", "too large"))
+            print("SKIP: too large")
+            continue
 
         # Write full test script if needed
         if 0:
@@ -313,14 +327,10 @@ def main():
             args.mpy_cross_flags = "-march=armv7m"
 
     if len(args.files) == 0:
-        tests_skip = ("benchrun.py",)
-        if M <= 25:
-            # These scripts are too big to be compiled by the target
-            tests_skip += ("bm_chaos.py", "bm_hexiom.py", "misc_raytrace.py")
         tests = sorted(
             BENCH_SCRIPT_DIR + test_file
             for test_file in os.listdir(BENCH_SCRIPT_DIR)
-            if test_file.endswith(".py") and test_file not in tests_skip
+            if test_file.endswith(".py") and test_file != "benchrun.py"
         )
     else:
         tests = sorted(args.files)


### PR DESCRIPTION
### Summary

A large benchmark test cannot run on small targets if the target doesn't have enough RAM to load the test, or to run it.  Prior to the change in this commit, `run-perfbench.py` had an explicit list of tests which were too large for small targets to load, and `bm_params` took care of deciding if the target had enough RAM to run the test.

Having an explicit list for large test scripts is not very general.  This commit improves the situation by using `bm_params` to also decide if the target will be able to load the test.  It does this by using a regex to search for `bm_params` and extracting the first pair of N/M values.  The M is the minimum memory the target needs in order to run the test, and the test will be skipped entirely (not even loaded) if the target has less than that minimum.

This means that tests that are too big to load on the target will be properly skipped, instead of attempting to download to the target and fail with a `MemoryError`.

Note: it's not really possible to exec the test script on the host to extract `bm_params` because some tests cannot run under CPython.

### Testing

Tested on PYBV10, PYBD_SF6 and ESP32_GENERIC_C3.  All tests still run (none are skipped).

Tested on ADAFRUIT_ITSYBITSY_M0_EXPRESS using N=48 and M=20.  8 tests are now skipped because they are too large and the test run completes without failure.

### Trade-offs and Alternatives

Instead of regex I thought to `exec()` the code on the host to extract `bm_params`, but as mentioned above that can't work because CPython cannot execute some of the tests (eg due to `@micropython.viper`).

### Generative AI

I did not use generative AI tools when creating this PR.

