### PR TITLE
alif: Add support for building C++ user modules.

### DIFF
--- a/ports/alif/mcu/ensemble.ld.S
+++ b/ports/alif/mcu/ensemble.ld.S
@@ -75,6 +75,14 @@ SECTIONS
     . = ALIGN(16);
   } > ROM
 
+  /* For C++ exception handling */
+  .ARM :
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } > ROM
+
   .copy.table : ALIGN(4)
   {
     __copy_table_start__ = .;

--- a/ports/alif/nosys_stubs.c
+++ b/ports/alif/nosys_stubs.c
@@ -24,6 +24,7 @@
  * THE SOFTWARE.
  */
 #include <errno.h>
+#include <unistd.h>
 
 int _write(int handle, char *buffer, int size) {
     errno = ENOSYS;
@@ -42,5 +43,14 @@ int _close(int f) {
 
 int _lseek(int f, int ptr, int dir) {
     errno = ENOSYS;
+    return -1;
+}
+
+pid_t _getpid(void) {
+    return 0;
+}
+
+int _kill(pid_t pid, int sig) {
+    errno = EINVAL;
     return -1;
 }

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1066,7 +1066,7 @@ function ci_alif_ae3_build {
     make ${MAKEOPTS} -C ports/alif BOARD=OPENMV_AE3 MCU_CORE=M55_HP submodules
     make ${MAKEOPTS} -C ports/alif BOARD=OPENMV_AE3 MCU_CORE=M55_HE submodules
     make ${MAKEOPTS} -C ports/alif BOARD=OPENMV_AE3 MCU_CORE=M55_DUAL
-    make ${MAKEOPTS} -C ports/alif BOARD=ALIF_ENSEMBLE MCU_CORE=M55_DUAL
+    make ${MAKEOPTS} -C ports/alif BOARD=ALIF_ENSEMBLE MCU_CORE=M55_DUAL USER_C_MODULES=../../examples/usercmodule
 }
 
 function _ci_help {


### PR DESCRIPTION
### Summary

This allows alif boards to build and run `examples/usercmodule`.

Also adds it to CI.

### Testing

Built and run on OPENMV_AE3.  The three user-C-module tests in `tests/misc/` now run and pass.

### Generative AI

I did not use generative AI tools when creating this PR.

