### PR TITLE
nrf/Makefile: Update nrfutil deploy rules for latest nrfutil.

### DIFF
--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -449,12 +449,12 @@ sd: nrfutil_dfu_sd nrfutil_dfu_deploy
 
 nrfutil_dfu_sd: $(BUILD)/$(OUTPUT_FILENAME).hex
 	$(Q)hexmerge.py -o $(BUILD)/stripped_sd.hex --range=0x1000: $(SOFTDEV_HEX)
-	$(Q)nrfutil pkg generate --hw-version 52 --sd-req 0x00 --sd-id 0x00 --softdevice $(BUILD)/stripped_sd.hex $(BUILD)/stripped_sd.zip
-	$(Q)nrfutil dfu usb-serial -pkg $(BUILD)/stripped_sd.zip -p $(NRFUTIL_PORT) -t 0
+	$(Q)nrfutil nrf5sdk-tools pkg generate --hw-version 52 --sd-req 0x00 --sd-id 0x00 --softdevice $(BUILD)/stripped_sd.hex $(BUILD)/stripped_sd.zip
+	$(Q)nrfutil nrf5sdk-tools dfu usb-serial -pkg $(BUILD)/stripped_sd.zip -p $(NRFUTIL_PORT) -t 0
 
 nrfutil_dfu_deploy: $(BUILD)/$(OUTPUT_FILENAME).hex
-	$(Q)nrfutil pkg generate --hw-version 52 --sd-req $(NRFUTIL_SD_REQ) --application-version 1 --application $(BUILD)/$(OUTPUT_FILENAME).hex $(BUILD)/$(OUTPUT_FILENAME)_dfu.zip
-	$(Q)nrfutil dfu usb-serial -pkg $(BUILD)/$(OUTPUT_FILENAME)_dfu.zip -p $(NRFUTIL_PORT) -t 0
+	$(Q)nrfutil nrf5sdk-tools pkg generate --hw-version 52 --sd-req $(NRFUTIL_SD_REQ) --application-version 1 --application $(BUILD)/$(OUTPUT_FILENAME).hex $(BUILD)/$(OUTPUT_FILENAME)_dfu.zip
+	$(Q)nrfutil nrf5sdk-tools dfu usb-serial -pkg $(BUILD)/$(OUTPUT_FILENAME)_dfu.zip -p $(NRFUTIL_PORT) -t 0
 
 deploy: nrfutil_dfu_deploy
 

--- a/ports/nrf/README.md
+++ b/ports/nrf/README.md
@@ -207,9 +207,15 @@ for more tips about using the BMP with GDB.
 
 ## nRFUtil Targets
 
-Install the necessary Python packages that will be used for flashing using the bootloader:
+First install the base `nrfutil` CLI tool from
+[Nordic Semiconductor](https://www.nordicsemi.com/Products/Development-tools/nRF-Util).
+Then install the SDK sub-package of that tool in order to get access to the `pkg`
+and `dfu` commands:
 
-    sudo pip install nrfutil
+    nrfutil install nrf5sdk-tools
+
+Then install the necessary Python packages:
+
     sudo pip install intelhex
 
 The `intelhex` provides the `hexmerge.py` utility which is used by the Makefile


### PR DESCRIPTION
### Summary

The old `nrfutil` runs only under CPython 2.x and has been replaced by a new stand-alone `nrfutil` executable, available directly from Nordic.

Update the Makefile to work with this new version, and also update the README to describe how to install it.

### Testing

Tested on PCA10059 with the new `nrfutil` tool on Arch Linux.  It's now possible to deploy firmware again.

### Generative AI

I did not use generative AI tools when creating this PR.
