### PR TITLE
extmod: Place lwIP memory in a dedicated section.

### DIFF
--- a/extmod/lwip-include/lwipopts_common.h
+++ b/extmod/lwip-include/lwipopts_common.h
@@ -109,6 +109,13 @@
 // Needed for PPP.
 #define sys_jiffies sys_now
 
+#if MICROPY_PY_LWIP_SECTION
+// Place lwIP memory in a dedicated section to allow relocating it.
+// Note: alignment is enforced without adding trailing padding bytes.
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) \
+    __attribute__((section(".lwip"), aligned(MEM_ALIGNMENT))) u8_t variable_name[size]
+#endif
+
 typedef uint32_t sys_prot_t;
 
 #endif // MICROPY_INCLUDED_LWIPOPTS_COMMON_H


### PR DESCRIPTION
### Summary

Place lwIP memory in its own section to allow to relocating it via the linker script. This macro also aligns the memory without adding trailing padding bytes. See comments in `src/include/lwip/arch.h` this is how this macro is intended to be used:

> You can declare your own version here e.g. to enforce alignment without adding trailing padding bytes (see LWIP_MEM_ALIGN_BUFFER) or your own section placement requirements.

### Testing

Tested relocating lwIP memory to DRAM, with MBs of buffers, works well.

### Generative AI

I did not use generative AI tools when creating this PR.