### PR TITLE
ci: Avoid unneeded CI runs triggered by changes to MPRemote

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,7 +1,11 @@
 name: JavaScript code lint and formatting with Biome
 
-on: [push, pull_request]
-
+on:
+  push:
+  pull_request:
+      - '.github/workflows/biome.yml'
+      - 'tests/**'
+      - 'ports/webassembly/**'
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -2,20 +2,21 @@ name: JavaScript code lint and formatting with Biome
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/biome.yml"
+      - "tests/**"
+      - "ports/webassembly/**"
   pull_request:
-    paths:
-      - '.github/workflows/biome.yml'
-      - 'tests/**'
-      - 'ports/webassembly/**'
+    paths: *paths
 jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-    - name: Setup Biome
-      uses: biomejs/setup-biome@v2
-      with:
-        version: 1.5.3
-    - name: Run Biome
-      run: biome ci --indent-style=space --indent-width=4 tests/ ports/webassembly
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: 1.5.3
+      - name: Run Biome
+        run: biome ci --indent-style=space --indent-width=4 tests/ ports/webassembly

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -1,7 +1,12 @@
 name: JavaScript code lint and formatting with Biome
 
-on: [push, pull_request]
-
+on:
+  push:
+  pull_request:
+    paths:
+      - '.github/workflows/biome.yml'
+      - 'tests/**'
+      - 'ports/webassembly/**'
 jobs:
   eslint:
     runs-on: ubuntu-latest

--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/*.yml'
       - 'tools/**'
+      - '!tools/mpremote/**'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - docs/**
       - py/**
       - tests/cpydiff/**
+      - tools/gen-cpydiff.py
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,12 +2,13 @@ name: Build docs
 
 on:
   push:
-  pull_request:
-    paths:
+    paths: &paths
       - docs/**
       - py/**
       - tests/cpydiff/**
       - tools/gen-cpydiff.py
+  pull_request:
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-    - name: Install Python packages
-      run: pip install -r docs/requirements.txt
-    - name: Build unix port
-      run: tools/ci.sh unix_build_helper
-    - name: Build docs
-      run: make -C docs/ html
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+      - name: Install Python packages
+        run: pip install -r docs/requirements.txt
+      - name: Build unix port
+        run: tools/ci.sh unix_build_helper
+      - name: Build docs
+        run: make -C docs/ html

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,13 +2,14 @@ name: Check examples
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "examples/**"
+      - "ports/unix/**"
+      - "py/**"
+      - "shared/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'examples/**'
-      - 'ports/unix/**'
-      - 'py/**'
-      - 'shared/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +19,6 @@ jobs:
   embedding:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh embedding_build
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh embedding_build

--- a/.github/workflows/mpremote.yml
+++ b/.github/workflows/mpremote.yml
@@ -2,10 +2,11 @@ name: Package mpremote
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/**'
+    paths: *paths
 
 jobs:
   build:

--- a/.github/workflows/mpy_format.yml
+++ b/.github/workflows/mpy_format.yml
@@ -2,14 +2,15 @@ name: .mpy file format and tools
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "examples/**"
+      - "mpy-cross/**"
+      - "py/**"
+      - "tests/**"
+      - "tools/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'examples/**'
-      - 'mpy-cross/**'
-      - 'py/**'
-      - 'tests/**'
-      - 'tools/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,10 +20,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh mpy_format_setup
-    - name: Test mpy-tool.py
-      run: tools/ci.sh mpy_format_test
-    - name: Test mpy-cross debug emitter
-      run: tools/ci.sh mpy_cross_debug_emitter
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh mpy_format_setup
+      - name: Test mpy-tool.py
+        run: tools/ci.sh mpy_format_test
+      - name: Test mpy-cross debug emitter
+        run: tools/ci.sh mpy_cross_debug_emitter

--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
-      - ports/**
+      - 'tools/*.*'
+      - 'ports/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ports.yml
+++ b/.github/workflows/ports.yml
@@ -2,11 +2,12 @@ name: Build ports metadata
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "ports/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'ports/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
-    - name: Build ports download metadata
-      run: mkdir boards && ./tools/autobuild/build-downloads.py . ./boards
+      - uses: actions/checkout@v7
+      - name: Build ports download metadata
+        run: mkdir boards && ./tools/autobuild/build-downloads.py . ./boards

--- a/.github/workflows/ports_alif.yml
+++ b/.github/workflows/ports_alif.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_alif.yml
+++ b/.github/workflows/ports_alif.yml
@@ -2,16 +2,17 @@ name: alif port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/alif/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/alif/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_func:  # names are functions in ci.sh
+        ci_func: # names are functions in ci.sh
           - alif_ae3_build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh alif_setup
-    - name: Build ci_${{matrix.ci_func }}
-      run: tools/ci.sh ${{ matrix.ci_func }}
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh alif_setup
+      - name: Build ci_${{matrix.ci_func }}
+        run: tools/ci.sh ${{ matrix.ci_func }}

--- a/.github/workflows/ports_cc3200.yml
+++ b/.github/workflows/ports_cc3200.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_cc3200.yml
+++ b/.github/workflows/ports_cc3200.yml
@@ -2,8 +2,7 @@ name: cc3200 port
 
 on:
   push:
-  pull_request:
-    paths:
+    paths: &paths
       - '.github/workflows/*.yml'
       - 'tools/*.*'
       - 'py/**'
@@ -12,6 +11,9 @@ on:
       - 'lib/**'
       - 'drivers/**'
       - 'ports/cc3200/**'
+  pull_request:
+    paths: *paths
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -2,8 +2,7 @@ name: esp32 port
 
 on:
   push:
-  pull_request:
-    paths:
+    paths: &paths
       - '.github/workflows/*.yml'
       - 'tools/*.*'
       - 'py/**'
@@ -12,6 +11,8 @@ on:
       - 'lib/**'
       - 'drivers/**'
       - 'ports/esp32/**'
+  pull_request:
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ports_esp8266.yml
+++ b/.github/workflows/ports_esp8266.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_esp8266.yml
+++ b/.github/workflows/ports_esp8266.yml
@@ -2,8 +2,7 @@ name: esp8266 port
 
 on:
   push:
-  pull_request:
-    paths:
+    paths: &paths
       - '.github/workflows/*.yml'
       - 'tools/*.*'
       - 'py/**'
@@ -12,6 +11,8 @@ on:
       - 'lib/**'
       - 'drivers/**'
       - 'ports/esp8266/**'
+  pull_request:
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ports_mimxrt.yml
+++ b/.github/workflows/ports_mimxrt.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_mimxrt.yml
+++ b/.github/workflows/ports_mimxrt.yml
@@ -2,16 +2,17 @@ name: mimxrt port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/mimxrt/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/mimxrt/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: 'micropython repo'  # test build with space in path
+        working-directory: "micropython repo" # test build with space in path
     steps:
-    - uses: actions/checkout@v7
-      with:
-        path: 'micropython repo'
-    - name: Install packages
-      run: tools/ci.sh mimxrt_setup
-    - name: Build
-      run: tools/ci.sh mimxrt_build
+      - uses: actions/checkout@v7
+        with:
+          path: "micropython repo"
+      - name: Install packages
+        run: tools/ci.sh mimxrt_setup
+      - name: Build
+        run: tools/ci.sh mimxrt_build

--- a/.github/workflows/ports_nrf.yml
+++ b/.github/workflows/ports_nrf.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_nrf.yml
+++ b/.github/workflows/ports_nrf.yml
@@ -2,16 +2,17 @@ name: nrf port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/nrf/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/nrf/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh nrf_setup
-    - name: Build
-      run: tools/ci.sh nrf_build
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh nrf_setup
+      - name: Build
+        run: tools/ci.sh nrf_build

--- a/.github/workflows/ports_powerpc.yml
+++ b/.github/workflows/ports_powerpc.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_psoc-edge.yml
+++ b/.github/workflows/ports_psoc-edge.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_psoc-edge.yml
+++ b/.github/workflows/ports_psoc-edge.yml
@@ -2,16 +2,17 @@ name: psoc-edge port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/psoc-edge/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/psoc-edge/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +22,8 @@ jobs:
   build_psoc_edge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh psoc_edge_setup
-    - name: Build
-      run: tools/ci.sh psoc_edge_build
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh psoc_edge_setup
+      - name: Build
+        run: tools/ci.sh psoc_edge_build

--- a/.github/workflows/ports_qemu.yml
+++ b/.github/workflows/ports_qemu.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_qemu.yml
+++ b/.github/workflows/ports_qemu.yml
@@ -2,17 +2,18 @@ name: qemu port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/qemu/**"
+      - "tests/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/qemu/**'
-      - 'tests/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,54 +24,54 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_func:  # names are functions in ci.sh
+        ci_func: # names are functions in ci.sh
           - bigendian
           - sabrelite
           - thumb_softfp
           - thumb_hardfp
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh qemu_setup_arm
-    - name: Build and run test suite ci_qemu_build_arm_${{ matrix.ci_func }}
-      run: tools/ci.sh qemu_build_arm_${{ matrix.ci_func }}
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh qemu_setup_arm
+      - name: Build and run test suite ci_qemu_build_arm_${{ matrix.ci_func }}
+        run: tools/ci.sh qemu_build_arm_${{ matrix.ci_func }}
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   build_and_test_rv32:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh qemu_setup_rv32
-    - name: Build and run test suite
-      run: tools/ci.sh qemu_build_rv32
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh qemu_setup_rv32
+      - name: Build and run test suite
+        run: tools/ci.sh qemu_build_rv32
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   build_and_test_rv64:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh qemu_setup_rv64
-    - name: Build and run test suite
-      run: tools/ci.sh qemu_build_rv64
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh qemu_setup_rv64
+      - name: Build and run test suite
+        run: tools/ci.sh qemu_build_rv64
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   build_and_test_ppc64:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh qemu_setup_ppc64
-    - name: Build and run test suite
-      run: tools/ci.sh qemu_build_ppc64
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh qemu_setup_ppc64
+      - name: Build and run test suite
+        run: tools/ci.sh qemu_build_ppc64
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures

--- a/.github/workflows/ports_renesas-ra.yml
+++ b/.github/workflows/ports_renesas-ra.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_renesas-ra.yml
+++ b/.github/workflows/ports_renesas-ra.yml
@@ -2,16 +2,17 @@ name: renesas-ra port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/renesas-ra/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/renesas-ra/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,9 +22,8 @@ jobs:
   build_renesas_ra_board:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh renesas_ra_setup
-    - name: Build
-      run: tools/ci.sh renesas_ra_board_build
-
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh renesas_ra_setup
+      - name: Build
+        run: tools/ci.sh renesas_ra_board_build

--- a/.github/workflows/ports_rp2.yml
+++ b/.github/workflows/ports_rp2.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_rp2.yml
+++ b/.github/workflows/ports_rp2.yml
@@ -2,16 +2,17 @@ name: rp2 port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/rp2/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/rp2/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: 'micropython repo'  # test build with space in path
+        working-directory: "micropython repo" # test build with space in path
     steps:
-    - uses: actions/checkout@v7
-      with:
-        path: 'micropython repo'
-    - name: Install packages
-      run: tools/ci.sh rp2_setup
-    - name: Build
-      run: tools/ci.sh rp2_build
+      - uses: actions/checkout@v7
+        with:
+          path: "micropython repo"
+      - name: Install packages
+        run: tools/ci.sh rp2_setup
+      - name: Build
+        run: tools/ci.sh rp2_build

--- a/.github/workflows/ports_samd.yml
+++ b/.github/workflows/ports_samd.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_samd.yml
+++ b/.github/workflows/ports_samd.yml
@@ -2,16 +2,17 @@ name: samd port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/samd/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/samd/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,8 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh samd_setup
-    - name: Build
-      run: tools/ci.sh samd_build
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh samd_setup
+      - name: Build
+        run: tools/ci.sh samd_build

--- a/.github/workflows/ports_stm32.yml
+++ b/.github/workflows/ports_stm32.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_stm32.yml
+++ b/.github/workflows/ports_stm32.yml
@@ -2,16 +2,17 @@ name: stm32 port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "drivers/**"
+      - "ports/stm32/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'drivers/**'
-      - 'ports/stm32/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,16 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_func:  # names are functions in ci.sh
+        ci_func: # names are functions in ci.sh
           - stm32_pyb_build
           - stm32_build_cmod
           - stm32_nucleo_build
           - stm32_misc_build
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh stm32_setup && tools/ci.sh stm32_path >> $GITHUB_PATH
-    - name: Build ci_${{matrix.ci_func }}
-      run: tools/ci.sh ${{ matrix.ci_func }}
-
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh stm32_setup && tools/ci.sh stm32_path >> $GITHUB_PATH
+      - name: Build ci_${{matrix.ci_func }}
+        run: tools/ci.sh ${{ matrix.ci_func }}

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -2,18 +2,19 @@ name: unix port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "examples/**"
+      - "mpy-cross/**"
+      - "ports/unix/**"
+      - "tests/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'examples/**'
-      - 'mpy-cross/**'
-      - 'ports/unix/**'
-      - 'tests/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,438 +24,438 @@ jobs:
   minimal:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_minimal_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_minimal_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_minimal_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_minimal_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   reproducible:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build with reproducible date
-      run: tools/ci.sh unix_minimal_build
-      env:
-        SOURCE_DATE_EPOCH: 1234567890
-    - name: Check reproducible build date
-      run: echo | ports/unix/build-minimal/micropython -i | grep 'on 2009-02-13;'
+      - uses: actions/checkout@v7
+      - name: Build with reproducible date
+        run: tools/ci.sh unix_minimal_build
+        env:
+          SOURCE_DATE_EPOCH: 1234567890
+      - name: Check reproducible build date
+        run: echo | ports/unix/build-minimal/micropython -i | grep 'on 2009-02-13;'
 
   standard:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_standard_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_standard_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_standard_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_standard_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   standard_v2:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_standard_v2_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_standard_v2_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_standard_v2_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_standard_v2_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   standard_error_terse:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_standard_error_terse_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_standard_error_terse_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_standard_error_terse_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_standard_error_terse_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   standard_error_none:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_standard_error_none_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_standard_error_none_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_standard_error_none_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_standard_error_none_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_coverage_setup
-    - name: Build
-      run: tools/ci.sh unix_coverage_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_coverage_run_tests
-    - name: Test merging .mpy files
-      run: tools/ci.sh unix_coverage_run_mpy_merge_tests
-    - name: Build native mpy modules
-      run: tools/ci.sh native_mpy_modules_build
-    - name: Test importing .mpy generated by mpy_ld.py
-      run: tools/ci.sh unix_coverage_run_native_mpy_tests
-    - name: Run gcov coverage analysis
-      run: |
-        (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
-        (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
-      with:
-        # Only fail the job on error if a token is set, or we're running against upstream repo.
-        # This avoids the annoying situation of the job failing on every push to a fork (if no token is set).
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' || github.repository_owner == 'micropython' }}
-        verbose: true
-        flags: unix-coverage-64bit
-        name: unix-coverage-64bit
-        # note: when a fork opens a PR into MicroPython repo, the pull_request trigger can't access
-        # secrets so this token value will be empty (codecov will do a 'tokenless' upload).
-        token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_coverage_setup
+      - name: Build
+        run: tools/ci.sh unix_coverage_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_coverage_run_tests
+      - name: Test merging .mpy files
+        run: tools/ci.sh unix_coverage_run_mpy_merge_tests
+      - name: Build native mpy modules
+        run: tools/ci.sh native_mpy_modules_build
+      - name: Test importing .mpy generated by mpy_ld.py
+        run: tools/ci.sh unix_coverage_run_native_mpy_tests
+      - name: Run gcov coverage analysis
+        run: |
+          (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
+          (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          # Only fail the job on error if a token is set, or we're running against upstream repo.
+          # This avoids the annoying situation of the job failing on every push to a fork (if no token is set).
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' || github.repository_owner == 'micropython' }}
+          verbose: true
+          flags: unix-coverage-64bit
+          name: unix-coverage-64bit
+          # note: when a fork opens a PR into MicroPython repo, the pull_request trigger can't access
+          # secrets so this token value will be empty (codecov will do a 'tokenless' upload).
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   coverage_32bit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_32bit_setup
-    - name: Build
-      run: tools/ci.sh unix_coverage_32bit_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_coverage_32bit_run_tests
-    - name: Build native mpy modules
-      run: tools/ci.sh native_mpy_modules_32bit_build
-    - name: Test importing .mpy generated by mpy_ld.py
-      run: tools/ci.sh unix_coverage_32bit_run_native_mpy_tests
-    - name: Run gcov coverage analysis
-      run: |
-        (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
-        (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v7
-      with:
-        # See corresponding comment above.
-        fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' || github.repository_owner == 'micropython' }}
-        verbose: true
-        flags: unix-coverage-32bit
-        name: unix-coverage-32bit
-        # See corresponding comment above.
-        token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_32bit_setup
+      - name: Build
+        run: tools/ci.sh unix_coverage_32bit_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_coverage_32bit_run_tests
+      - name: Build native mpy modules
+        run: tools/ci.sh native_mpy_modules_32bit_build
+      - name: Test importing .mpy generated by mpy_ld.py
+        run: tools/ci.sh unix_coverage_32bit_run_native_mpy_tests
+      - name: Run gcov coverage analysis
+        run: |
+          (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
+          (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          # See corresponding comment above.
+          fail_ci_if_error: ${{ secrets.CODECOV_TOKEN != '' || github.repository_owner == 'micropython' }}
+          verbose: true
+          flags: unix-coverage-32bit
+          name: unix-coverage-32bit
+          # See corresponding comment above.
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   nanbox:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_32bit_setup
-    - name: Build
-      run: tools/ci.sh unix_nanbox_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_nanbox_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_32bit_setup
+      - name: Build
+        run: tools/ci.sh unix_nanbox_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_nanbox_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   longlong:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_32bit_setup
-    - name: Build
-      run: tools/ci.sh unix_longlong_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_longlong_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_32bit_setup
+      - name: Build
+        run: tools/ci.sh unix_longlong_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_longlong_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   float:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_float_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_float_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_float_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_float_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   gil_enabled:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Build
-      run: tools/ci.sh unix_gil_enabled_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_gil_enabled_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Build
+        run: tools/ci.sh unix_gil_enabled_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_gil_enabled_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   stackless_clang:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh unix_clang_setup
-    - name: Build
-      run: tools/ci.sh unix_stackless_clang_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_stackless_clang_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh unix_clang_setup
+      - name: Build
+        run: tools/ci.sh unix_stackless_clang_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_stackless_clang_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   float_clang:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh unix_clang_setup
-    - name: Build
-      run: tools/ci.sh unix_float_clang_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_float_clang_run_tests
-    - name: Build native mpy modules
-      run: tools/ci.sh native_mpy_modules_clang_build
-    - name: Test importing .mpy generated by mpy_ld.py
-      run: tools/ci.sh unix_standard_run_native_mpy_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh unix_clang_setup
+      - name: Build
+        run: tools/ci.sh unix_float_clang_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_float_clang_run_tests
+      - name: Build native mpy modules
+        run: tools/ci.sh native_mpy_modules_clang_build
+      - name: Test importing .mpy generated by mpy_ld.py
+        run: tools/ci.sh unix_standard_run_native_mpy_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   settrace_stackless:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Build
-      run: tools/ci.sh unix_settrace_stackless_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_settrace_stackless_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Build
+        run: tools/ci.sh unix_settrace_stackless_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_settrace_stackless_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   repr_b:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_32bit_setup
-    - name: Build
-      run: tools/ci.sh unix_repr_b_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_repr_b_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_32bit_setup
+      - name: Build
+        run: tools/ci.sh unix_repr_b_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_repr_b_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   macos:
     runs-on: macos-26
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      with:
-        python-version: '3.8'
-    - name: Build
-      run: tools/ci.sh unix_macos_build
-    - name: Run tests
-      run: tools/ci.sh unix_macos_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.8"
+      - name: Build
+        run: tools/ci.sh unix_macos_build
+      - name: Run tests
+        run: tools/ci.sh unix_macos_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   qemu_mips:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_qemu_mips_setup
-    - name: Build
-      run: tools/ci.sh unix_qemu_mips_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_qemu_mips_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_qemu_mips_setup
+      - name: Build
+        run: tools/ci.sh unix_qemu_mips_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_qemu_mips_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   qemu_arm:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_qemu_arm_setup
-    - name: Build
-      run: tools/ci.sh unix_qemu_arm_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_qemu_arm_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_qemu_arm_setup
+      - name: Build
+        run: tools/ci.sh unix_qemu_arm_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_qemu_arm_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   qemu_riscv64:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_qemu_riscv64_setup
-    - name: Build
-      run: tools/ci.sh unix_qemu_riscv64_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_qemu_riscv64_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_qemu_riscv64_setup
+      - name: Build
+        run: tools/ci.sh unix_qemu_riscv64_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_qemu_riscv64_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   qemu_loong64:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_qemu_loong64_setup
-    - name: Build
-      run: tools/ci.sh unix_qemu_loong64_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_qemu_loong64_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_qemu_loong64_setup
+      - name: Build
+        run: tools/ci.sh unix_qemu_loong64_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_qemu_loong64_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   qemu_x64:
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_qemu_x64_setup
-    - name: Build
-      run: tools/ci.sh unix_qemu_x64_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_qemu_x64_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_qemu_x64_setup
+      - name: Build
+        run: tools/ci.sh unix_qemu_x64_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_qemu_x64_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   sanitize_address:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_coverage_setup
-    - name: Build
-      run: tools/ci.sh unix_sanitize_address_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_sanitize_address_run_tests
-    - name: Test merging .mpy files
-      run: tools/ci.sh unix_coverage_run_mpy_merge_tests
-    - name: Build native mpy modules
-      run: tools/ci.sh native_mpy_modules_build
-    - name: Test importing .mpy generated by mpy_ld.py
-      run: tools/ci.sh unix_coverage_run_native_mpy_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_coverage_setup
+      - name: Build
+        run: tools/ci.sh unix_sanitize_address_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_sanitize_address_run_tests
+      - name: Test merging .mpy files
+        run: tools/ci.sh unix_coverage_run_mpy_merge_tests
+      - name: Build native mpy modules
+        run: tools/ci.sh native_mpy_modules_build
+      - name: Test importing .mpy generated by mpy_ld.py
+        run: tools/ci.sh unix_coverage_run_native_mpy_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures
 
   sanitize_undefined:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
-      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
-      with:
-        python-version: '3.11'
-    - name: Install packages
-      run: tools/ci.sh unix_coverage_setup
-    - name: Build
-      run: tools/ci.sh unix_sanitize_undefined_build
-    - name: Run main test suite
-      run: tools/ci.sh unix_sanitize_undefined_run_tests
-    - name: Test merging .mpy files
-      run: tools/ci.sh unix_coverage_run_mpy_merge_tests
-    - name: Build native mpy modules
-      run: tools/ci.sh native_mpy_modules_build
-    - name: Test importing .mpy generated by mpy_ld.py
-      run: tools/ci.sh unix_coverage_run_native_mpy_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+        # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+        with:
+          python-version: "3.11"
+      - name: Install packages
+        run: tools/ci.sh unix_coverage_setup
+      - name: Build
+        run: tools/ci.sh unix_sanitize_undefined_build
+      - name: Run main test suite
+        run: tools/ci.sh unix_sanitize_undefined_run_tests
+      - name: Test merging .mpy files
+        run: tools/ci.sh unix_coverage_run_mpy_merge_tests
+      - name: Build native mpy modules
+        run: tools/ci.sh native_mpy_modules_build
+      - name: Test importing .mpy generated by mpy_ld.py
+        run: tools/ci.sh unix_coverage_run_native_mpy_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures

--- a/.github/workflows/ports_webassembly.yml
+++ b/.github/workflows/ports_webassembly.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_webassembly.yml
+++ b/.github/workflows/ports_webassembly.yml
@@ -2,16 +2,17 @@ name: webassembly port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "ports/webassembly/**"
+      - "tests/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'ports/webassembly/**'
-      - 'tests/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,13 +22,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh webassembly_setup
-    - name: Build
-      run: tools/ci.sh webassembly_build
-    - name: Run tests
-      run: tools/ci.sh webassembly_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh webassembly_setup
+      - name: Build
+        run: tools/ci.sh webassembly_build
+      - name: Run tests
+        run: tools/ci.sh webassembly_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_windows.yml
+++ b/.github/workflows/ports_windows.yml
@@ -2,16 +2,17 @@ name: windows port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/*.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "ports/unix/**"
+      - "ports/windows/**"
   pull_request:
-    paths:
-      - '.github/workflows/*.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'ports/unix/**'
-      - 'ports/windows/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,68 +26,68 @@ jobs:
         platform: [x86, x64]
         configuration: [Debug, Release]
         variant: [dev, standard]
-        visualstudio: ['2019', '2022']
+        visualstudio: ["2019", "2022"]
         include:
-        - visualstudio: '2019'
-          # The v142 toolset (VS 2019 compiler) is pre-installed on
-          # windows-2022 as a component of VS 2022.  Use VS 2022's
-          # MSBuild and select the v142 toolset via PlatformToolset.
-          vs_version: '[17, 18)'
-          platform_toolset: v142
-        - visualstudio: '2022'
-          vs_version: '[17, 18)'
-          platform_toolset: v143
+          - visualstudio: "2019"
+            # The v142 toolset (VS 2019 compiler) is pre-installed on
+            # windows-2022 as a component of VS 2022.  Use VS 2022's
+            # MSBuild and select the v142 toolset via PlatformToolset.
+            vs_version: "[17, 18)"
+            platform_toolset: v142
+          - visualstudio: "2022"
+            vs_version: "[17, 18)"
+            platform_toolset: v143
         # trim down the number of jobs in the matrix
         exclude:
-        - variant: standard
-          configuration: Debug
-        - visualstudio: '2019'
-          configuration: Debug
+          - variant: standard
+            configuration: Debug
+          - visualstudio: "2019"
+            configuration: Debug
     runs-on: windows-2022
     env:
       CI_BUILD_CONFIGURATION: ${{ matrix.configuration }}
     steps:
-    - name: Install Python 3.11
-      # As of 20260112 the default Python version in Windows image is 3.12, which breaks settrace tests
-      # Use 3.11 for now
-      uses: actions/setup-python@v7
-      with:
-        python-version: '3.11'
-    - uses: microsoft/setup-msbuild@v3
-      with:
-        vs-version: ${{ matrix.vs_version }}
-    - uses: actions/checkout@v7
-    - name: Build mpy-cross.exe
-      run: msbuild mpy-cross\mpy-cross.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PlatformToolset=${{ matrix.platform_toolset }}
-    - name: Update submodules
-      run: git submodule update --init lib/micropython-lib
-    - name: Build micropython.exe
-      run: msbuild ports\windows\micropython.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }}
-    - name: Get micropython.exe path
-      id: get_path
-      run: |
-        $exePath="$(msbuild ports\windows\micropython.vcxproj -nologo -v:m -t:ShowTargetPath -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }})"
-        echo ("micropython=" + $exePath.Trim()) >> $env:GITHUB_OUTPUT
-    - name: Run tests
-      id: test
-      env:
-        MICROPY_MICROPYTHON: ${{ steps.get_path.outputs.micropython }}
-      working-directory: tests
-      run: python run-tests.py
-    - name: Print failures
-      if: failure() && steps.test.conclusion == 'failure'
-      working-directory: tests
-      run: python run-tests.py --print-failures
-    - name: Run mpy tests
-      id: test_mpy
-      env:
-        MICROPY_MICROPYTHON: ${{ steps.get_path.outputs.micropython }}
-      working-directory: tests
-      run: python run-tests.py --via-mpy -d basics float micropython
-    - name: Print mpy failures
-      if: failure() && steps.test_mpy.conclusion == 'failure'
-      working-directory: tests
-      run: python run-tests.py --print-failures
+      - name: Install Python 3.11
+        # As of 20260112 the default Python version in Windows image is 3.12, which breaks settrace tests
+        # Use 3.11 for now
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: microsoft/setup-msbuild@v3
+        with:
+          vs-version: ${{ matrix.vs_version }}
+      - uses: actions/checkout@v7
+      - name: Build mpy-cross.exe
+        run: msbuild mpy-cross\mpy-cross.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PlatformToolset=${{ matrix.platform_toolset }}
+      - name: Update submodules
+        run: git submodule update --init lib/micropython-lib
+      - name: Build micropython.exe
+        run: msbuild ports\windows\micropython.vcxproj -maxcpucount -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }}
+      - name: Get micropython.exe path
+        id: get_path
+        run: |
+          $exePath="$(msbuild ports\windows\micropython.vcxproj -nologo -v:m -t:ShowTargetPath -property:Configuration=${{ matrix.configuration }} -property:Platform=${{ matrix.platform }} -property:PyVariant=${{ matrix.variant }} -property:PlatformToolset=${{ matrix.platform_toolset }})"
+          echo ("micropython=" + $exePath.Trim()) >> $env:GITHUB_OUTPUT
+      - name: Run tests
+        id: test
+        env:
+          MICROPY_MICROPYTHON: ${{ steps.get_path.outputs.micropython }}
+        working-directory: tests
+        run: python run-tests.py
+      - name: Print failures
+        if: failure() && steps.test.conclusion == 'failure'
+        working-directory: tests
+        run: python run-tests.py --print-failures
+      - name: Run mpy tests
+        id: test_mpy
+        env:
+          MICROPY_MICROPYTHON: ${{ steps.get_path.outputs.micropython }}
+        working-directory: tests
+        run: python run-tests.py --via-mpy -d basics float micropython
+      - name: Print mpy failures
+        if: failure() && steps.test_mpy.conclusion == 'failure'
+        working-directory: tests
+        run: python run-tests.py --print-failures
 
   build-mingw:
     strategy:
@@ -106,42 +107,42 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/setup-python@v7
-      # note: can go back to installing mingw-w64-${{ matrix.env }}-python after
-      # MSYS2 updates to Python >3.12 (due to settrace compatibility issue)
-      with:
-        python-version: '3.11'
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: ${{ matrix.sys }}
-        update: true
-        install: >-
-          make
-          mingw-w64-${{ matrix.env }}-gcc
-          pkg-config
-          git
-          diffutils
-        path-type: inherit  # Remove when setup-python is removed
-    - uses: actions/checkout@v7
-    - name: Build mpy-cross.exe
-      run: make -C mpy-cross -j2
-    - name: Update submodules
-      run: make -C ports/windows VARIANT=${{ matrix.variant }} submodules
-    - name: Build micropython.exe
-      run: make -C ports/windows -j2 VARIANT=${{ matrix.variant }}
-    - name: Run tests
-      id: test
-      run: make -C ports/windows test_full VARIANT=${{ matrix.variant }}
-    - name: Print failures
-      if: failure() && steps.test.conclusion == 'failure'
-      working-directory: tests
-      run: python run-tests.py --print-failures
+      - uses: actions/setup-python@v7
+        # note: can go back to installing mingw-w64-${{ matrix.env }}-python after
+        # MSYS2 updates to Python >3.12 (due to settrace compatibility issue)
+        with:
+          python-version: "3.11"
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.sys }}
+          update: true
+          install: >-
+            make
+            mingw-w64-${{ matrix.env }}-gcc
+            pkg-config
+            git
+            diffutils
+          path-type: inherit # Remove when setup-python is removed
+      - uses: actions/checkout@v7
+      - name: Build mpy-cross.exe
+        run: make -C mpy-cross -j2
+      - name: Update submodules
+        run: make -C ports/windows VARIANT=${{ matrix.variant }} submodules
+      - name: Build micropython.exe
+        run: make -C ports/windows -j2 VARIANT=${{ matrix.variant }}
+      - name: Run tests
+        id: test
+        run: make -C ports/windows test_full VARIANT=${{ matrix.variant }}
+      - name: Print failures
+        if: failure() && steps.test.conclusion == 'failure'
+        working-directory: tests
+        run: python run-tests.py --print-failures
 
   cross-build-on-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: Install packages
-      run: tools/ci.sh windows_setup
-    - name: Build
-      run: tools/ci.sh windows_build
+      - uses: actions/checkout@v7
+      - name: Install packages
+        run: tools/ci.sh windows_setup
+      - name: Build
+        run: tools/ci.sh windows_build

--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/ports_zephyr.yml'
-      - 'tools/**'
+      - 'tools/*.*'
       - 'py/**'
       - 'extmod/**'
       - 'shared/**'

--- a/.github/workflows/ports_zephyr.yml
+++ b/.github/workflows/ports_zephyr.yml
@@ -2,16 +2,17 @@ name: zephyr port
 
 on:
   push:
+    paths: &paths
+      - ".github/workflows/ports_zephyr.yml"
+      - "tools/*.*"
+      - "py/**"
+      - "extmod/**"
+      - "shared/**"
+      - "lib/**"
+      - "ports/zephyr/**"
+      - "tests/**"
   pull_request:
-    paths:
-      - '.github/workflows/ports_zephyr.yml'
-      - 'tools/*.*'
-      - 'py/**'
-      - 'extmod/**'
-      - 'shared/**'
-      - 'lib/**'
-      - 'ports/zephyr/**'
-      - 'tests/**'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,44 +22,44 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: jlumbroso/free-disk-space@main
-      with:
-        # Only free up a few things so this step runs quickly.
-        # (android would save 9.6GiB, but takes about 13m)
-        # (large-packages would save 4.6GiB, but takes about 3m)
-        android: false
-        dotnet: true
-        haskell: true
-        large-packages: false
-        docker-images: false
-        tool-cache: true
-        swap-storage: false
-    - uses: actions/checkout@v7
-    - id: versions
-      name: Read Zephyr version
-      run: source tools/ci.sh && echo "ZEPHYR=$ZEPHYR_VERSION" | tee "$GITHUB_OUTPUT"
-    - name: Cached Zephyr Workspace
-      id: cache_workspace
-      uses: actions/cache@v6
-      with:
-        # note that the Zephyr CI docker image is 15GB. At time of writing
-        # GitHub caches are limited to 10GB total for a project. So we only
-        # cache the "workspace"
-        path: ./zephyrproject
-        key: zephyr-workspace-${{ steps.versions.outputs.ZEPHYR }}
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: zephyr
-    - name: Install packages
-      run: tools/ci.sh zephyr_setup
-    - name: Install Zephyr
-      if: steps.cache_workspace.outputs.cache-hit != 'true'
-      run: tools/ci.sh zephyr_install
-    - name: Build
-      run: tools/ci.sh zephyr_build
-    - name: Run main test suite
-      run: tools/ci.sh zephyr_run_tests
-    - name: Print failures
-      if: failure()
-      run: tests/run-tests.py --print-failures
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          # Only free up a few things so this step runs quickly.
+          # (android would save 9.6GiB, but takes about 13m)
+          # (large-packages would save 4.6GiB, but takes about 3m)
+          android: false
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          tool-cache: true
+          swap-storage: false
+      - uses: actions/checkout@v7
+      - id: versions
+        name: Read Zephyr version
+        run: source tools/ci.sh && echo "ZEPHYR=$ZEPHYR_VERSION" | tee "$GITHUB_OUTPUT"
+      - name: Cached Zephyr Workspace
+        id: cache_workspace
+        uses: actions/cache@v6
+        with:
+          # note that the Zephyr CI docker image is 15GB. At time of writing
+          # GitHub caches are limited to 10GB total for a project. So we only
+          # cache the "workspace"
+          path: ./zephyrproject
+          key: zephyr-workspace-${{ steps.versions.outputs.ZEPHYR }}
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: zephyr
+      - name: Install packages
+        run: tools/ci.sh zephyr_setup
+      - name: Install Zephyr
+        if: steps.cache_workspace.outputs.cache-hit != 'true'
+        run: tools/ci.sh zephyr_install
+      - name: Build
+        run: tools/ci.sh zephyr_build
+      - name: Run main test suite
+        run: tools/ci.sh zephyr_run_tests
+      - name: Print failures
+        if: failure()
+        run: tests/run-tests.py --print-failures


### PR DESCRIPTION

### Summary

Changes to a mpremote PR triggers nearly all CI runs to run a full build of all the boards and ports,

While I do not think the CI runs incur any charges, for this project - it does take actual time to run and holds up other runs that are more useful.

This can be clearly seen in last month's [CI performance reporting](https://github.com/micropython/micropython/actions/metrics/performance?dateRangeType=DATE_RANGE_TYPE_PREVIOUS_MONTH) :

- Avg job run time: 3m 59s
- Avg job queue time : 22m 1s

where the trend seems to be that that delay is climbing significantly.

Also see [Discussion](https://github.com/orgs/micropython/discussions/19114)

### Testing

CI will test.

### Generative AI

I did not use generative AI tools when creating this PR.
