### PR TITLE
webassembly: Fix GC tracing of object returned from top-level functions.

### DIFF
--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -53,18 +53,18 @@ static size_t external_call_depth = 0;
 #define CSTACK_SIZE (32 * 1024)
 
 #if MICROPY_GC_SPLIT_HEAP_AUTO
-static void gc_collect_top_level(void);
+static void gc_collect_top_level(mp_obj_t root_obj);
 #endif
 
 void external_call_depth_inc(void) {
     ++external_call_depth;
 }
 
-void external_call_depth_dec(void) {
+void external_call_depth_dec(mp_obj_t root_obj) {
     --external_call_depth;
     #if MICROPY_GC_SPLIT_HEAP_AUTO
     if (external_call_depth == 0) {
-        gc_collect_top_level();
+        gc_collect_top_level(root_obj);
     }
     #endif
 }
@@ -134,11 +134,12 @@ void mp_js_do_import(const char *name, uint32_t *out) {
         }
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(ret, out);
+        external_call_depth_dec(ret);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }
 
 void mp_js_do_exec(const char *src, size_t len, uint32_t *out) {
@@ -153,11 +154,12 @@ void mp_js_do_exec(const char *src, size_t len, uint32_t *out) {
         mp_obj_t ret = mp_call_function_0(module_fun);
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(ret, out);
+        external_call_depth_dec(ret);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }
 
 void mp_js_do_exec_async(const char *src, size_t len, uint32_t *out) {
@@ -173,7 +175,7 @@ void mp_js_repl_init(void) {
 int mp_js_repl_process_char(int c) {
     external_call_depth_inc();
     int ret = pyexec_event_repl_process_char(c);
-    external_call_depth_dec();
+    external_call_depth_dec(MP_OBJ_NULL);
     return ret;
 }
 
@@ -192,10 +194,11 @@ void gc_collect(void) {
 }
 
 // Collect at the top-level, where there are no root pointers from stack/registers.
-static void gc_collect_top_level(void) {
+static void gc_collect_top_level(mp_obj_t root_obj) {
     if (gc_collect_pending) {
         gc_collect_pending = false;
         gc_collect_start();
+        gc_collect_root(&root_obj, 1);
         gc_collect_end();
     }
 }

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -264,11 +264,12 @@ void proxy_c_to_js_call(uint32_t c_ref, uint32_t n_args, uint32_t *args_value, u
         mp_obj_t member = mp_call_function_n_kw(obj, n_args, 0, args);
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(member, out);
+        external_call_depth_dec(member);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }
 
 void proxy_c_to_js_dir(uint32_t c_ref, uint32_t *out) {
@@ -291,11 +292,12 @@ void proxy_c_to_js_dir(uint32_t c_ref, uint32_t *out) {
         }
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(dir, out);
+        external_call_depth_dec(dir);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }
 
 bool proxy_c_to_js_has_attr(uint32_t c_ref, const char *attr_in) {
@@ -338,11 +340,12 @@ void proxy_c_to_js_lookup_attr(uint32_t c_ref, const char *attr_in, uint32_t *ou
         }
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(member, out);
+        external_call_depth_dec(member);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }
 
 static bool proxy_c_to_js_store_helper(uint32_t c_ref, const char *attr_in, uint32_t *value_in) {
@@ -367,11 +370,11 @@ static bool proxy_c_to_js_store_helper(uint32_t c_ref, const char *attr_in, uint
             mp_store_attr(obj, attr, value);
         }
         nlr_pop();
-        external_call_depth_dec();
+        external_call_depth_dec(MP_OBJ_NULL);
         return true;
     } else {
         // uncaught exception
-        external_call_depth_dec();
+        external_call_depth_dec(MP_OBJ_NULL);
         return false;
     }
 }
@@ -448,22 +451,22 @@ bool proxy_c_to_js_iternext(uint32_t c_ref, uint32_t *out) {
         mp_obj_t obj = proxy_c_get_obj(c_ref);
         mp_obj_t iter = mp_iternext_allow_raise(obj);
         if (iter == MP_OBJ_STOP_ITERATION) {
-            external_call_depth_dec();
+            external_call_depth_dec(MP_OBJ_NULL);
             nlr_pop();
             return false;
         }
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(iter, out);
-        external_call_depth_dec();
+        external_call_depth_dec(iter);
         return true;
     } else {
         if (mp_obj_is_subclass_fast(MP_OBJ_FROM_PTR(((mp_obj_base_t *)nlr.ret_val)->type), MP_OBJ_FROM_PTR(&mp_type_StopIteration))) {
-            external_call_depth_dec();
+            external_call_depth_dec(MP_OBJ_NULL);
             return false;
         } else {
             // uncaught exception
             proxy_convert_mp_to_js_exc_cside(nlr.ret_val, out);
-            external_call_depth_dec();
+            external_call_depth_dec(nlr.ret_val);
             return true;
         }
     }
@@ -610,9 +613,10 @@ void proxy_c_to_js_resume(uint32_t c_ref, uint32_t *args) {
         mp_obj_t ret = proxy_resume_execute(obj, mp_const_none, mp_const_none, resolve, reject);
         nlr_pop();
         proxy_convert_mp_to_js_obj_cside(ret, args);
+        external_call_depth_dec(ret);
     } else {
         // uncaught exception
         proxy_convert_mp_to_js_exc_cside(nlr.ret_val, args);
+        external_call_depth_dec(nlr.ret_val);
     }
-    external_call_depth_dec();
 }

--- a/ports/webassembly/proxy_c.h
+++ b/ports/webassembly/proxy_c.h
@@ -45,7 +45,7 @@ extern const mp_obj_type_t mp_type_jsproxy;
 extern const mp_obj_type_t mp_type_JsException;
 
 void external_call_depth_inc(void);
-void external_call_depth_dec(void);
+void external_call_depth_dec(mp_obj_t root_obj);
 
 void proxy_c_init(void);
 mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value);

--- a/tests/ports/webassembly/gc_behaviour.mjs
+++ b/tests/ports/webassembly/gc_behaviour.mjs
@@ -1,0 +1,31 @@
+// Test GC behaviour, that objects are not prematurely collected.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+// This test converts a Python list/dict to the corresponding JavaScript object and
+// returns it to JavaScript.  Internally it will be wrapped in a `JsProxy`, and the
+// call to `gc.collect()` will force a GC collection upon exit of the `make_xxx()`
+// function call but before the `JsProxy` is passed to JavaScript.  The test ensures
+// that the `JsProxy` doesn't get prematurely collected before JavaScript has a chance
+// to receive the underlying JavaScript object.
+
+mp.runPython(`
+import gc, js, jsffi
+
+def make_list():
+    obj = jsffi.to_js([1, 2, 3])
+    print(obj)
+    js.console.log(obj)
+    gc.collect()
+    return obj
+
+def make_dict():
+    obj = jsffi.to_js({"key": "value"})
+    print(obj)
+    js.console.log(obj)
+    gc.collect()
+    return obj
+`);
+
+console.log(mp.globals.get("make_list")());
+console.log(mp.globals.get("make_dict")());

--- a/tests/ports/webassembly/gc_behaviour.mjs.exp
+++ b/tests/ports/webassembly/gc_behaviour.mjs.exp
@@ -1,0 +1,6 @@
+<JsProxy 2>
+[ 1, 2, 3 ]
+[ 1, 2, 3 ]
+<JsProxy 3>
+{ key: 'value' }
+{ key: 'value' }


### PR DESCRIPTION
### Summary

This commit makes sure that the GC explicitly traces the Python object returned from all top-level functions.  Without this, it's possible that a JsProxy that is created as the return object is freed on the Python side (and hence the underlying JavaScript object entry set to `undefined`) just prior to the top-level C function returning.  So when it does return and control resumes on the JavaScript side, the JavaScript object corresponding to the JsProxy is gone.

For example, the case covered by the test added here has the return value (Python object) from `proxy_c_to_js_call()` reclaimed by the Python GC via `proxy_js_free_obj()` before it can be accessed from the JavaScript side, and so the JavaScript reference in `proxy_js_ref` is `undefined`,

### Testing

I found this in a web app I'm building, there was some strange behaviour which was traced to the issue fixed here.  That web app now behaves correctly with this fix.

Also added a test which triggers the same problem.  It'll run in CI.

### Trade-offs and Alternatives

There may be other ways to structure the fix, but PR #18021 already fixed a related case, and this PR is extending/improving upon that fix.

### Generative AI

I did not use generative AI tools when creating this PR.
