### PR TITLE
webassembly: support converting buffer protocol objects to `Uint8Array` in `jsffi.to_js()`

### DIFF
--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -59,10 +59,8 @@ EXPORTED_FUNCTIONS_EXTRA += ,\
 	_proxy_c_to_js_call,\
 	_proxy_c_to_js_delete_attr,\
 	_proxy_c_to_js_dir,\
-	_proxy_c_to_js_get_array,\
-	_proxy_c_to_js_get_dict,\
 	_proxy_c_to_js_get_iter,\
-	_proxy_c_to_js_get_type,\
+	_proxy_c_to_js_get_type_and_data,\
 	_proxy_c_to_js_has_attr,\
 	_proxy_c_to_js_iternext,\
 	_proxy_c_to_js_lookup_attr,\

--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -69,6 +69,7 @@ EXPORTED_FUNCTIONS_EXTRA += ,\
 	_proxy_convert_mp_to_js_obj_cside
 
 EXPORTED_RUNTIME_METHODS_EXTRA += ,\
+	HEAPU8,\
 	PATH,\
 	PATH_FS,\
 	UTF8ToString,\

--- a/ports/webassembly/objpyproxy.js
+++ b/ports/webassembly/objpyproxy.js
@@ -99,6 +99,11 @@ class PyProxy {
             }
             Module._free(item);
             js_obj_out = js_dict;
+        } else if (type === 4) {
+            // Buffer protocol; create a copy of the data to a new Uint8Array.
+            const len = Module.getValue(obj_data, "i32");
+            const buf = Module.getValue(obj_data + 4, "i32");
+            js_obj_out = Module.HEAPU8.slice(buf, buf + len);
         } else {
             // Cannot convert to JS, leave as a PyProxy.
             js_obj_out = js_obj;

--- a/ports/webassembly/objpyproxy.js
+++ b/ports/webassembly/objpyproxy.js
@@ -35,25 +35,20 @@ class PyProxy {
             return js_obj;
         }
 
+        const obj_data = Module._malloc(2 * 4);
         const type = Module.ccall(
-            "proxy_c_to_js_get_type",
+            "proxy_c_to_js_get_type_and_data",
             "number",
-            ["number"],
-            [js_obj._ref],
+            ["number", "pointer"],
+            [js_obj._ref, obj_data],
         );
 
+        let js_obj_out;
         if (type === 1 || type === 2) {
             // List or tuple.
-            const array_ref = Module._malloc(2 * 4);
             const item = Module._malloc(3 * 4);
-            Module.ccall(
-                "proxy_c_to_js_get_array",
-                "null",
-                ["number", "pointer"],
-                [js_obj._ref, array_ref],
-            );
-            const len = Module.getValue(array_ref, "i32");
-            const items_ptr = Module.getValue(array_ref + 4, "i32");
+            const len = Module.getValue(obj_data, "i32");
+            const items_ptr = Module.getValue(obj_data + 4, "i32");
             const js_array = [];
             for (let i = 0; i < len; ++i) {
                 Module.ccall(
@@ -65,23 +60,13 @@ class PyProxy {
                 const js_item = proxy_convert_mp_to_js_obj_jsside(item);
                 js_array.push(PyProxy.toJs(js_item));
             }
-            Module._free(array_ref);
             Module._free(item);
-            return js_array;
-        }
-
-        if (type === 3) {
+            js_obj_out = js_array;
+        } else if (type === 3) {
             // Dict.
-            const map_ref = Module._malloc(2 * 4);
             const item = Module._malloc(3 * 4);
-            Module.ccall(
-                "proxy_c_to_js_get_dict",
-                "null",
-                ["number", "pointer"],
-                [js_obj._ref, map_ref],
-            );
-            const alloc = Module.getValue(map_ref, "i32");
-            const table_ptr = Module.getValue(map_ref + 4, "i32");
+            const alloc = Module.getValue(obj_data, "i32");
+            const table_ptr = Module.getValue(obj_data + 4, "i32");
             const js_dict = {};
             for (let i = 0; i < alloc; ++i) {
                 const mp_key = Module.getValue(table_ptr + i * 8, "i32");
@@ -112,13 +97,15 @@ class PyProxy {
                     js_dict[js_key] = PyProxy.toJs(js_value);
                 }
             }
-            Module._free(map_ref);
             Module._free(item);
-            return js_dict;
+            js_obj_out = js_dict;
+        } else {
+            // Cannot convert to JS, leave as a PyProxy.
+            js_obj_out = js_obj;
         }
 
-        // Cannot convert to JS, leave as a PyProxy.
-        return js_obj;
+        Module._free(obj_data);
+        return js_obj_out;
     }
 }
 

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -390,6 +390,7 @@ bool proxy_c_to_js_delete_attr(uint32_t c_ref, const char *attr_in) {
 uint32_t proxy_c_to_js_get_type_and_data(uint32_t c_ref, uint32_t *out) {
     mp_obj_t obj = proxy_c_get_obj(c_ref);
     const mp_obj_type_t *type = mp_obj_get_type(obj);
+    mp_buffer_info_t bufinfo;
     if (type == &mp_type_tuple || type == &mp_type_list) {
         size_t len;
         mp_obj_t *items;
@@ -406,6 +407,10 @@ uint32_t proxy_c_to_js_get_type_and_data(uint32_t c_ref, uint32_t *out) {
         out[0] = map->alloc;
         out[1] = (uintptr_t)map->table;
         return 3;
+    } else if (mp_get_buffer(obj, &bufinfo, MP_BUFFER_READ)) {
+        out[0] = bufinfo.len;
+        out[1] = (uintptr_t)bufinfo.buf;
+        return 4;
     } else {
         return 0;
     }

--- a/ports/webassembly/proxy_c.c
+++ b/ports/webassembly/proxy_c.c
@@ -387,34 +387,28 @@ bool proxy_c_to_js_delete_attr(uint32_t c_ref, const char *attr_in) {
     return proxy_c_to_js_store_helper(c_ref, attr_in, NULL);
 }
 
-uint32_t proxy_c_to_js_get_type(uint32_t c_ref) {
+uint32_t proxy_c_to_js_get_type_and_data(uint32_t c_ref, uint32_t *out) {
     mp_obj_t obj = proxy_c_get_obj(c_ref);
     const mp_obj_type_t *type = mp_obj_get_type(obj);
-    if (type == &mp_type_tuple) {
-        return 1;
-    } else if (type == &mp_type_list) {
-        return 2;
+    if (type == &mp_type_tuple || type == &mp_type_list) {
+        size_t len;
+        mp_obj_t *items;
+        mp_obj_get_array(obj, &len, &items);
+        out[0] = len;
+        out[1] = (uintptr_t)items;
+        if (type == &mp_type_tuple) {
+            return 1;
+        } else {
+            return 2;
+        }
     } else if (type == &mp_type_dict) {
+        mp_map_t *map = mp_obj_dict_get_map(obj);
+        out[0] = map->alloc;
+        out[1] = (uintptr_t)map->table;
         return 3;
     } else {
-        return 4;
+        return 0;
     }
-}
-
-void proxy_c_to_js_get_array(uint32_t c_ref, uint32_t *out) {
-    mp_obj_t obj = proxy_c_get_obj(c_ref);
-    size_t len;
-    mp_obj_t *items;
-    mp_obj_get_array(obj, &len, &items);
-    out[0] = len;
-    out[1] = (uintptr_t)items;
-}
-
-void proxy_c_to_js_get_dict(uint32_t c_ref, uint32_t *out) {
-    mp_obj_t obj = proxy_c_get_obj(c_ref);
-    mp_map_t *map = mp_obj_dict_get_map(obj);
-    out[0] = map->alloc;
-    out[1] = (uintptr_t)map->table;
 }
 
 EM_JS(void, js_get_error_info, (int jsref, uint32_t * out_name, uint32_t * out_message), {

--- a/tests/ports/webassembly/jsffi_to_js.mjs
+++ b/tests/ports/webassembly/jsffi_to_js.mjs
@@ -26,3 +26,22 @@ console.log(Reflect.ownKeys(y));
 console.log(Array.isArray(z));
 console.log(z);
 console.log(Reflect.ownKeys(z));
+
+/**********************************************************/
+// Test using to_js on objects with the buffer protocol.
+
+console.log("= TEST BUFFER =====");
+
+mp.runPython(`
+import jsffi
+buf1 = jsffi.to_js(b"1234")
+print(buf1)
+buf2 = jsffi.to_js(bytearray(b"5678"))
+print(buf2)
+buf3 = jsffi.to_js(memoryview(b"abcd"))
+print(buf3)
+`);
+
+console.log(mp.globals.get("buf1"));
+console.log(mp.globals.get("buf2"));
+console.log(mp.globals.get("buf3"));

--- a/tests/ports/webassembly/jsffi_to_js.mjs.exp
+++ b/tests/ports/webassembly/jsffi_to_js.mjs.exp
@@ -9,3 +9,10 @@ true
 false
 { three: 3 }
 [ 'three' ]
+= TEST BUFFER =====
+<JsProxy 4>
+<JsProxy 5>
+<JsProxy 6>
+Uint8Array(4) [ 49, 50, 51, 52 ]
+Uint8Array(4) [ 53, 54, 55, 56 ]
+Uint8Array(4) [ 97, 98, 99, 100 ]


### PR DESCRIPTION
### Summary

This adds support for explicit conversion from bytes/bytearray/memoryview/etc to JavaScript `Uint8Array`.  Eg:
```py
import js, jsffi

js.console.log(jsffi.to_js(b'1234'))
```
That now works and prints `Uint8Array[4] [ 49, 50, 51, 52]` in the JS console.  The array contains a copy of the data (ie not a reference).

This matches Pyodide behaviour, eg `pyodide.ffi.to_js(b'1234')` returns the same `Uint8Array`.

Also includes a clean up of the conversion function to make it more efficient.

### Testing

Added a test that runs under CI.

### Generative AI

I did not use generative AI tools when creating this PR.
