### PR TITLE
shared/tinyusb: Add USB device qualifier descriptor.

### DIFF
--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -98,6 +98,9 @@ void mp_usbd_hex_str(char *out_str, const uint8_t *bytes, size_t bytes_len);
 // Built-in USB device and configuration descriptor values
 extern const tusb_desc_device_t mp_usbd_builtin_desc_dev;
 extern const uint8_t mp_usbd_builtin_desc_cfg[MP_USBD_BUILTIN_DESC_CFG_LEN];
+#if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
+extern const tusb_desc_device_qualifier_t mp_usbd_builtin_desc_qual;
+#endif
 
 void mp_usbd_task_callback(mp_sched_node_t *node);
 

--- a/shared/tinyusb/mp_usbd_descriptor.c
+++ b/shared/tinyusb/mp_usbd_descriptor.c
@@ -53,6 +53,21 @@ const tusb_desc_device_t mp_usbd_builtin_desc_dev = {
     .bNumConfigurations = 1,
 };
 
+#if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
+// Device qualifier descriptor for high-speed devices.
+const tusb_desc_device_qualifier_t mp_usbd_builtin_desc_qual = {
+    .bLength = sizeof(tusb_desc_device_qualifier_t),
+    .bDescriptorType = TUSB_DESC_DEVICE_QUALIFIER,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .bNumConfigurations = 0x01,
+    .bReserved = 0x00,
+};
+#endif
+
 const uint8_t mp_usbd_builtin_desc_cfg[MP_USBD_BUILTIN_DESC_CFG_LEN] = {
     TUD_CONFIG_DESCRIPTOR(1, USBD_ITF_BUILTIN_MAX, USBD_STR_0, MP_USBD_BUILTIN_DESC_CFG_LEN,
         0, USBD_MAX_POWER_MA),
@@ -148,6 +163,12 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     (void)index;
     return mp_usbd_builtin_desc_cfg;
 }
+
+#if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
+uint8_t const *tud_descriptor_device_qualifier_cb(void) {
+    return (uint8_t const *)&mp_usbd_builtin_desc_qual;
+}
+#endif
 
 #else
 

--- a/shared/tinyusb/mp_usbd_runtime.c
+++ b/shared/tinyusb/mp_usbd_runtime.c
@@ -126,6 +126,12 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     return result ? result : &mp_usbd_builtin_desc_cfg;
 }
 
+#if (CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED)
+uint8_t const *tud_descriptor_device_qualifier_cb(void) {
+    return (const uint8_t *)&mp_usbd_builtin_desc_qual;
+}
+#endif
+
 const char *mp_usbd_runtime_string_cb(uint8_t index) {
     mp_obj_usb_device_t *usbd = MP_OBJ_TO_PTR(MP_STATE_VM(usbd));
     nlr_buf_t nlr;


### PR DESCRIPTION
### Summary

USB 2.0 requires high-speed capable devices to provide a Device Qualifier descriptor. This patch adds the descriptor for static/runtime to conform with the specs.

### Testing

Tested N6 and AE3, both seem fine. Checked the descriptor on macos and linux, seems to be sent correctly:
```
Device Qualifier (for other device speed):
  bLength                10
  bDescriptorType         6
  bcdUSB               2.00
  bDeviceClass          239 Miscellaneous Device
  bDeviceSubClass         2 [unknown]
  bDeviceProtocol         1 Interface Association
  bMaxPacketSize0        64
  bNumConfigurations      1
Device Status:     0x0000
  (Bus Powered)
```

### Generative AI

I did not use generative AI tools when creating this PR.