### PR TITLE
py/objint_mpz: Accept bool in 3-arg pow().

### DIFF
--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -343,9 +343,12 @@ mp_obj_t mp_obj_int_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
 }
 
 #if MICROPY_PY_BUILTINS_POW3
-static mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
+static mpz_t *mp_mpz_for_integer(mp_obj_t arg, mpz_t *temp) {
     if (mp_obj_is_small_int(arg)) {
         mpz_init_from_int(temp, MP_OBJ_SMALL_INT_VALUE(arg));
+        return temp;
+    } else if (mp_obj_is_bool(arg)) {
+        mpz_init_from_int(temp, arg == mp_const_true);
         return temp;
     } else {
         mp_obj_int_t *arp_p = MP_OBJ_TO_PTR(arg);
@@ -354,17 +357,17 @@ static mpz_t *mp_mpz_for_int(mp_obj_t arg, mpz_t *temp) {
 }
 
 mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
-    if (!mp_obj_is_int(base) || !mp_obj_is_int(exponent) || !mp_obj_is_int(modulus)) {
+    if (!mp_obj_is_integer(base) || !mp_obj_is_integer(exponent) || !mp_obj_is_integer(modulus)) {
         mp_raise_TypeError(MP_ERROR_TEXT("pow() with 3 arguments requires integers"));
-    } else if (modulus == MP_OBJ_NEW_SMALL_INT(0)) {
+    } else if (modulus == MP_OBJ_NEW_SMALL_INT(0) || modulus == mp_const_false) {
         mp_raise_ValueError(MP_ERROR_TEXT("divide by zero"));
     } else {
         mp_obj_int_t *res_p = mp_obj_int_new_mpz();
 
         mpz_t l_temp, r_temp, m_temp;
-        mpz_t *lhs = mp_mpz_for_int(base,     &l_temp);
-        mpz_t *rhs = mp_mpz_for_int(exponent, &r_temp);
-        mpz_t *mod = mp_mpz_for_int(modulus,  &m_temp);
+        mpz_t *lhs = mp_mpz_for_integer(base,     &l_temp);
+        mpz_t *rhs = mp_mpz_for_integer(exponent, &r_temp);
+        mpz_t *mod = mp_mpz_for_integer(modulus,  &m_temp);
 
         mpz_pow3_inpl(&(res_p->mpz), lhs, rhs, mod);
 

--- a/tests/basics/builtin_pow3.py
+++ b/tests/basics/builtin_pow3.py
@@ -28,3 +28,11 @@ try:
     print(pow(4, 5, "z"))
 except TypeError:
     print("TypeError expected")
+
+# bool acts as int in all three positions (CPython compat)
+print(pow(True, 1, 1))
+print(pow(1, True, 1))
+print(pow(1, 1, True))
+print(pow(False, 5, 7))
+print(pow(2, False, 7))
+print(pow(2, 5, True))

--- a/tests/basics/builtin_pow3_intbig.py
+++ b/tests/basics/builtin_pow3_intbig.py
@@ -25,3 +25,9 @@ try:
     print(pow(1, 2, 0))
 except ValueError:
     print("ValueError")
+
+# bool False as modulus should raise ValueError, like int 0
+try:
+    print(pow(1, 2, False))
+except ValueError:
+    print("ValueError")


### PR DESCRIPTION
### Summary

Fixes #19144.

CPython's 3-arg `pow()` accepts `bool` in any operand position because `bool` is an `int` subtype. In the MPZ long-int configuration MicroPython rejected `bool` with `TypeError` because `mp_obj_int_pow3` used the strict `mp_obj_is_int` gate and `mp_mpz_for_int` had no bool branch:

```
>>> pow(1, 1, True)
TypeError: pow() with 3 arguments requires integers   # MicroPython
0                                                     # CPython
```

This PR switches the type check to `mp_obj_is_integer`, materialises bool operands as `0`/`1`-valued `mpz_t` in the helper (renamed `mp_mpz_for_integer` to match the new input domain), and extends the modulus-zero check to recognise `mp_const_false` so `pow(1, 1, False)` raises `ValueError` instead of asserting inside `mpz_divmod_inpl`.

The non-MPZ 3-arg path (`py/modbuiltins.c:374`) already handles bool via `mp_binary_op`, so no change is needed there.

### Testing

- Built `ports/unix` with the default MPZ configuration.
- Extended `tests/basics/builtin_pow3.py` with bool in each of base/exponent/modulus positions; added the `pow(1, 2, False)` ValueError check to `tests/basics/builtin_pow3_intbig.py` next to the existing `pow(1, 2, 0)` case. Both files pass.
- Ran the full `tests/basics/` suite (543 tests pass, 30 skipped — same skip set as `master`).
- Manually verified `pow(1, 1, False)` raises `ValueError` rather than segfaulting (the latter is what a naive type-check relaxation produces).

Could not test other ports / hardware targets locally.

### Trade-offs and Alternatives

Firmware size cost on `ports/unix` `build-standard` (x86-64):

| Build | text (bytes) | Δ |
|---|---:|---:|
| `master` | 750,967 | — |
| This PR | 751,079 | **+112** |

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.