### PR TITLE
esp32: support IDF v5.5.4 and make it the recommended version

### DIFF
--- a/.github/workflows/code_size.yml
+++ b/.github/workflows/code_size.yml
@@ -38,6 +38,12 @@ jobs:
           echo "IDF_VER="$(yq .env.IDF_NEWEST_VER < .github/workflows/ports_esp32.yml) \
           | tee "${GITHUB_OUTPUT}"
 
+    # The reference and current commit may be configured for different ESP-IDF versions
+    # but we use the same ESP-IDF version to build both, so disable the
+    # MICROPY_MAINTAINER_BUILD check (it'll be verified on the normal esp32 CI).
+    - name: Disable extra checks for older ESP-IDF
+      run: echo "MICROPY_MAINTAINER_BUILD=0" >> ${GITHUB_ENV}
+
     - name: Setup ESP-IDF
       uses: ./.github/actions/setup_esp32
       with:

--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.1"
+   IDF_NEWEST_VER: &newest "v5.5.2"
 
 jobs:
   build_idf:

--- a/extmod/nimble/modbluetooth_nimble.c
+++ b/extmod/nimble/modbluetooth_nimble.c
@@ -584,9 +584,6 @@ void nimble_reset_gatts_bss(void) {
     // These variables are defined in ble_hs.c and are only ever incremented
     // (during service registration) and never reset.
     // See https://github.com/apache/mynewt-nimble/issues/896
-    extern uint16_t ble_hs_max_attrs;
-    extern uint16_t ble_hs_max_services;
-    extern uint16_t ble_hs_max_client_configs;
     ble_hs_max_attrs = 0;
     ble_hs_max_services = 0;
     ble_hs_max_client_configs = 0;

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.1. MicroPython
-also supports v5.3, v5.4, v5.4.1 and v5.4.2.
+current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/boards/sdkconfig.ble
+++ b/ports/esp32/boards/sdkconfig.ble
@@ -18,3 +18,7 @@ CONFIG_BT_NIMBLE_PINNED_TO_CORE=1
 # Increase NimBLE task stack size from the default, because Python code
 # (BLE IRQ handlers) will most likely run on this task.
 CONFIG_BT_NIMBLE_TASK_STACK_SIZE=6144
+
+# The MicroPython NimBLE bindings do not currently support dynamic NimBLE
+# state, so disable it.
+CONFIG_BT_NIMBLE_STATIC_TO_DYNAMIC=n

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -315,6 +315,10 @@ foreach(comp ${__COMPONENT_NAMES_RESOLVED})
     micropy_gather_target_properties(${comp})
 endforeach()
 
+# Explicitly add extra definitions for MicroPython's preprocessing stage
+# (these are not picked up by the above micropy_gather_target_properties).
+list(APPEND MICROPY_CPP_DEF_EXTRA "ESP_PLATFORM")
+
 # Include the main MicroPython cmake rules.
 include(${MICROPY_DIR}/py/mkrules.cmake)
 

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.1
+    version: 5.5.2
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/tools/metrics_esp32.py
+++ b/ports/esp32/tools/metrics_esp32.py
@@ -35,14 +35,18 @@ import sys
 import subprocess
 from dataclasses import dataclass
 
-IDF_VERS = ("v5.5.1", "v5.4.2")
+IDF_VERS = ("v5.5.4", "v5.5.1")
 
 BUILDS = (
     ("ESP32_GENERIC", ""),
     ("ESP32_GENERIC", "D2WD"),
     ("ESP32_GENERIC", "SPIRAM"),
     ("ESP32_GENERIC_C2", ""),
+    ("ESP32_GENERIC_C3", ""),
+    ("ESP32_GENERIC_C5", ""),
     ("ESP32_GENERIC_C6", ""),
+    ("ESP32_GENERIC_P4", ""),
+    ("ESP32_GENERIC_P4", "C6_WIFI"),
     ("ESP32_GENERIC_S3", ""),
     ("ESP32_GENERIC_S3", "SPIRAM_OCT"),
 )
@@ -226,7 +230,8 @@ def idf_install():
 def switch_ver(idf_ver):
     print(f"Switching version to {idf_ver}...", file=sys.stderr)
     idf_git("switch", "--detach", idf_ver)
-    idf_git("submodule", "update", "--init", "--recursive")
+    idf_git("submodule", "update", "--init", "--recursive", "--force")
+    idf_git("submodule", "foreach", "--recursive", "git clean -ffdx")
     idf_install()
 
 


### PR DESCRIPTION
### Summary

EDIT: now targeting IDF v5.5.2 due to possible issues with v5.5.3 and v5.5.4.  See discussion below.

This PR updates the esp32 port to support IDF ~~v5.5.4~~ v5.5.2, tests that version in CI, and makes it the recommended version.

Also includes a minor related fix to `extmod/nimble/modbluetooth_nimble.c`.

Building all generic boards against v5.5.1 and v5.5.4 using `ports/esp32/tools/metrics_esp32.py` gives:

| BOARD | BOARD_VARIANT | IDF Version | Binary Size | Static IRAM Size | Static DRAM Size |
|-------|---------------|-------------|-------------|------------------|------------------|
| ESP32_GENERIC |  | v5.5.1 | 1699227 | 120215 | 54512 |
|  |  | v5.5.4 | 1716987 (+17760/1.0) | 115807 (-4408/-3.7) | 54836 (+324/0.6) |
| ESP32_GENERIC | D2WD | v5.5.1 | 1396911 | 112279 | 53684 |
|  |  | v5.5.4 | 1408791 (+11880/0.9) | 108639 (-3640/-3.2) | 54016 (+332/0.6) |
| ESP32_GENERIC | SPIRAM | v5.5.1 | 1545911 | 117639 | 54168 |
|  |  | v5.5.4 | 1541203 (-4708/-0.3) | 113715 (-3924/-3.3) | 54516 (+348/0.6) |
| ESP32_GENERIC_C2 |  | v5.5.1 | 1508902 | 42180 | 38344 |
|  |  | v5.5.4 | 1505818 (-3084/-0.2) | 40620 (-1560/-3.7) | 38740 (+396/1.0) |
| ESP32_GENERIC_C3 |  | v5.5.1 | 1660062 | 93452 | 41888 |
|  |  | v5.5.4 | 1673134 (+13072/0.8) | 89524 (-3928/-4.2) | 41552 (-336/-0.8) |
| ESP32_GENERIC_C5 |  | v5.5.1 | 1839392 | 64866 | 49060 |
|  |  | v5.5.4 | 1867752 (+28360/1.5) | 62358 (-2508/-3.9) | 49556 (+496/1.0) |
| ESP32_GENERIC_C6 |  | v5.5.1 | 1867280 | 91542 | 46252 |
|  |  | v5.5.4 | 1890976 (+23696/1.3) | 88316 (-3226/-3.5) | 46152 (-100/-0.2) |
| ESP32_GENERIC_P4 |  | v5.5.1 | 1559176 | 97222 | 27360 |
|  |  | v5.5.4 | 1573448 (+14272/0.9) | 101672 (+4450/4.6) | 28680 (+1320/4.8) |
| ESP32_GENERIC_P4 | C6_WIFI | v5.5.1 | 1733912 | 97620 | 36144 |
|  |  | v5.5.4 | 1765140 (+31228/1.8) | 101972 (+4352/4.5) | 31680 (-4464/-12.4) |
| ESP32_GENERIC_S3 |  | v5.5.1 | 1689663 | 112575 | 49492 |
|  |  | v5.5.4 | 1707031 (+17368/1.0) | 105999 (-6576/-5.8) | 49152 (-340/-0.7) |
| ESP32_GENERIC_S3 | SPIRAM_OCT | v5.5.1 | 1693119 | 115215 | 50312 |
|  |  | v5.5.4 | 1710423 (+17304/1.0) | 108643 (-6572/-5.7) | 49928 (-384/-0.8) |

Firmware size increases on almost all SoCs by quite a bit, around 20k.  But it's very nice to see IRAM usage decrease by about 4k on everything except ESP32-P4.

This `metrics_esp32.py` script is also updated with changes I needed to make to get it to generate the above table.

### Testing

Tested with ESP32_GENERIC firmware, running as many tests as possible from the test suite.  The only regressions are:
- `tests/multi_espnow/70_channel.py` seems to always fail (between two ESP32's at least) with data sent to a wrong channel being received
- `tests/multi_bluetooth/ble_gap_device_name.py` fails with a timeout near the end of the test when run against PYDF_SF6 (but ESP32 <-> ESP32 passes this test)

TODO: test some other SoCs.

### Trade-offs and Alternatives

This increases code size, but there's not much we can do about that, we need to keep supporting the latest IDF.

I needed to set `CONFIG_BT_NIMBLE_STATIC_TO_DYNAMIC=n` because otherwise BLE crashes upon start up.  Maybe in the future we can fix this and enable this option to save some RAM.

I needed to add a small hack to cmake to manually include a missing compile definition to the qstr extraction phase: `list(APPEND MICROPY_CPP_DEF_EXTRA "ESP_PLATFORM")`.  I'm not sure why this (and a few other definitions) are missing from qstr extraction, but without this one the NimBLE code fails to compile because it picks up the wrong configuration header (the default one instead of the ESP specific config header).

### Generative AI

I did not use generative AI tools when creating this PR.