### PR TITLE
py/objint_mpz: Fix `pow(x, y, 0)` error message to match CPython.

### DIFF
--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -357,7 +357,7 @@ mp_obj_t mp_obj_int_pow3(mp_obj_t base, mp_obj_t exponent,  mp_obj_t modulus) {
     if (!mp_obj_is_int(base) || !mp_obj_is_int(exponent) || !mp_obj_is_int(modulus)) {
         mp_raise_TypeError(MP_ERROR_TEXT("pow() with 3 arguments requires integers"));
     } else if (modulus == MP_OBJ_NEW_SMALL_INT(0)) {
-        mp_raise_ValueError(MP_ERROR_TEXT("divide by zero"));
+        mp_raise_ValueError(MP_ERROR_TEXT("pow() 3rd argument cannot be 0"));
     } else {
         mp_obj_int_t *res_p = mp_obj_int_new_mpz();
 


### PR DESCRIPTION
### Summary

#17716 intended to raise a `ValueError` "with a string that matches CPython (3.11.2)" for `pow(x, y, 0)`, but the committed literal reused the QSTR `"divide by zero"` shared with `ZeroDivisionError` instead of CPython's dedicated `"pow() 3rd argument cannot be 0"`. This PR realises the original intent by replacing the shared literal with CPython's message.

#### AS-IS (MicroPython v1.28.0)
```
ValueError: divide by zero
```

#### TO-BE (matching CPython v3.11.15)
```
ValueError: pow() 3rd argument cannot be 0
```

> For reference, CPython raises this message from `long_pow` in [`Objects/longobject.c`](https://github.com/python/cpython/blob/v3.11.15/Objects/longobject.c#L4423-L4430):
> 
> ```c
> if (c) {
>     /* if modulus == 0:
>            raise ValueError() */
>     if (Py_SIZE(c) == 0) {
>         PyErr_SetString(PyExc_ValueError,
>                         "pow() 3rd argument cannot be 0");
>         goto Error;
>     }
> ```

### Testing

Built and ran the existing pow test on the unix port:

```
$ make -C ports/unix -j
$ cd tests && ./run-tests.py basics/builtin_pow3_intbig.py
```

### Trade-offs and Alternatives

The new literal adds one QSTR entry (`"pow() 3rd argument cannot be 0"`) instead of reusing the existing `"divide by zero"`. The size impact is a single additional string in the QSTR pool; this is accepted as the cost of producing a diagnostic that correctly distinguishes `pow()`'s contract from a true division-by-zero.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.