### PR TITLE
rp2: Optimise `mcountinhibit` CSR manipulation when built in RV32 mode.

### DIFF
--- a/ports/rp2/machine_bitstream.c
+++ b/ports/rp2/machine_bitstream.c
@@ -40,14 +40,6 @@
 
 #if PICO_RISCV
 
-__attribute__((naked)) void mcycle_init(void) {
-    __asm volatile (
-        "li a0, 4\n"
-        "csrw mcountinhibit, a0\n"
-        "ret\n"
-        );
-}
-
 __attribute__((naked)) uint32_t mcycle_get(void) {
     __asm volatile (
         "csrr a0, mcycle\n"
@@ -99,7 +91,8 @@ void __time_critical_func(machine_bitstream_high_low)(mp_hal_pin_obj_t pin, uint
 
     #elif PICO_RISCV
 
-    mcycle_init();
+    // Uninhibit the cycle counter.
+    __asm volatile ("csrci mcountinhibit, 1\n");
 
     for (size_t i = 0; i < len; ++i) {
         uint8_t b = buf[i];

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -130,8 +130,7 @@ mp_uint_t mp_hal_stdout_tx_strn(const char *str, mp_uint_t len) {
 #if PICO_RISCV
 __attribute__((naked)) mp_uint_t mp_hal_ticks_cpu(void) {
     __asm volatile (
-        "li a0, 4\n" // mask value to uninhibit mcycle counter
-        "csrw mcountinhibit, a0\n" // uninhibit mcycle counter
+        "csrci mcountinhibit, 1\n" // uninhibit mcycle counter
         "csrr a0, mcycle\n" // get mcycle counter
         "ret\n"
         );


### PR DESCRIPTION
### Summary

This PR performs a couple of minor changes to how the `MCOUNTINHIBIT.CY` bit is manipulated for the `rp2` port when built for RISC-V.

The inline assembler sequences used have been improved, with some minor size benefits and some efficiency gains for code that has tighter timing constraints.

Now `time.ticks_cpu` should take one less cycle, and setting up bitstream pulse groups is going to spend three or four cycles less during its initialisation phase.

### Testing

The code was built and executed on a RP2350 in RISC-V mode, making sure that `time.ticks_cpu` still worked even after manually altering the contents of the `mcountinhibit` CSR.

The same was done for a simple `bitstream` invocation, comparing the output to a previous run.

### Generative AI

I did not use generative AI tools when creating this PR.
