### PR TITLE
tests/cpydiff: Document 3-arg `pow()` rejecting `bool` on MPZ builds.

### DIFF
--- a/tests/cpydiff/types_int_pow3_bool.py
+++ b/tests/cpydiff/types_int_pow3_bool.py
@@ -1,0 +1,26 @@
+"""
+categories: Types,int
+description: 3-argument ``pow()`` rejects ``bool`` operands.
+cause: On builds configured with ``MICROPY_LONGINT_IMPL_MPZ`` (the default
+for unix and most ports), the 3-argument ``pow()`` requires its operands to
+pass a strict integer type check, which excludes ``bool``.
+workaround: Convert ``bool`` operands to ``int`` explicitly, e.g. ``pow(int(b), y, m)``.
+"""
+
+# bool in base position
+try:
+    print(pow(True, 1, 1))
+except TypeError as e:
+    print("TypeError")
+
+# bool in exponent position
+try:
+    print(pow(1, True, 1))
+except TypeError as e:
+    print("TypeError")
+
+# bool in modulus position
+try:
+    print(pow(1, 1, True))
+except TypeError as e:
+    print("TypeError")


### PR DESCRIPTION
### Summary

Documents the CPython divergence reported in #19144 as a `cpydiff/` entry, instead of the code fix proposed in #19148.

On builds configured with `MICROPY_LONGINT_IMPL_MPZ` (the default for `unix` and most ports), the 3-argument `pow()` requires its operands to pass a strict integer type check, which excludes `bool`:

```shell
>>> pow(True, 1, 1)   # base
>>> pow(1, True, 1)   # exponent
>>> pow(1, 1, True)   # modulus
TypeError: pow() with 3 arguments requires integers   # MicroPython (MPZ)
0                                                     # CPython (all three)
```

### Trade-offs and Alternatives

- **Alternative: code fix.** #19148 took the implementation route. Per reviewer consensus, the size cost was not justified for the rarity of `pow(x, y, bool)` usage. Closing that PR in favour of this documentation.
- **Scope.** Only the MPZ path is documented. The non-MPZ 3-arg path (`py/modbuiltins.c`) already accepts `bool` via `mp_binary_op`, so it is not a divergence and is intentionally not mentioned in the entry to keep the user-facing description tight. The `cause` field names `MICROPY_LONGINT_IMPL_MPZ` so readers on non-MPZ builds know the entry does not apply to them.
- **Categorisation.** Filed under `Types,int` to match the existing `types_int_*` entries (`to_bytes`, `bit_length`, `subclassconv`); `Core,Functions` was considered but its existing entries cover function-call mechanics, not per-builtin input-domain quirks. Suggestions for a better category are welcome.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.

Fix #19144.
