### PR TITLE
esp32/machine_timer: Use GPTimer instead of low level + add support for virtual timers using ESP Timer

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -284,8 +284,7 @@ with a timer ID of 0, 0 and 1, or from 0 to 3 (inclusive)::
     tim1 = Timer(1)
     tim1.init(period=2000, mode=Timer.PERIODIC, callback=lambda t:print(1))
 
-The period is in milliseconds. When using UART.IRQ_RXIDLE, timer 0 is needed for
-the IRQ_RXIDLE mechanism and must not be used otherwise.
+The period is in milliseconds.
 
 Timer callbacks are scheduled as soft interrupts on this port; hard
 callbacks are not implemented. Specifying ``hard=True`` will raise

--- a/docs/library/machine.Timer.rst
+++ b/docs/library/machine.Timer.rst
@@ -20,8 +20,7 @@ There are two types of Timer in MicroPython, but not all ports support both:
 
 - Virtual timers. These are managed in software, and are generally more
   flexible. Multiple virtual timers can be constructed and active at once. The
-  ``id`` of a virtual timer is ``-1``. Not all ports support virtual timers, but
-  it's recommended to use them when available.
+  ``id`` of a virtual timer is ``-1``.
 - Hardware timers. Hardware timers have integer ``id`` values starting at ``0``.
   The number of available ``id`` values is determined by the hardware. Hardware
   timers may be more accurate for very fine sub-millisecond timing (especially

--- a/docs/library/machine.UART.rst
+++ b/docs/library/machine.UART.rst
@@ -224,8 +224,7 @@ Methods
 
 
    .. note::
-     - The ESP32 port does not support the option hard=True. It uses Timer(0)
-       for UART.IRQ_RXIDLE, so this timer cannot be used for other means.
+     - The ESP32 port does not support the option hard=True.
 
      - The rp2 port's UART.IRQ_TXIDLE is only triggered when the message
        is longer than 5 characters and the trigger happens when still 5 characters

--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -170,6 +170,7 @@ list(APPEND IDF_COMPONENTS
     esp_app_format
     esp_mm
     esp_common
+    esp_driver_gptimer
     esp_eth
     esp_event
     esp_hw_support

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -35,200 +35,222 @@
 #include "py/runtime.h"
 #include "modmachine.h"
 
-#include "hal/timer_hal.h"
-#include "hal/timer_ll.h"
-#include "soc/timer_periph.h"
-#include "esp_private/esp_clk_tree_common.h"
-#include "esp_private/periph_ctrl.h"
 #include "machine_timer.h"
+#include "esp_clk_tree.h"
+
+#if !MICROPY_ENABLE_FINALISER
+#error "machine.Timer requires MICROPY_ENABLE_FINALISER."
+#endif
 
 #define TIMER_CLK_SRC GPTIMER_CLK_SRC_DEFAULT
 #define TIMER_DIVIDER  8
 
-#define TIMER_FLAGS    0
-
-#if CONFIG_IDF_TARGET_ESP32P4
-static uint8_t __DECLARE_RCC_ATOMIC_ENV __attribute__ ((unused));
-#endif
 const mp_obj_type_t machine_timer_type;
 
-static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
-static mp_obj_t machine_timer_deinit(mp_obj_t self_in);
+uint32_t machine_timer_freq_hz(machine_timer_obj_t *self) {
+    if (self->id >= 0) {
+        // The timer source clock is APB or a fixed PLL (depending on chip), both constant frequency.
+        uint32_t freq;
+        check_esp_err(esp_clk_tree_src_get_freq_hz(TIMER_CLK_SRC, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &freq));
+        assert(freq % TIMER_DIVIDER == 0); // Source clock should divide evenly into TIMER_DIVIDER
+        return freq / TIMER_DIVIDER;
+    }
 
-uint32_t machine_timer_freq_hz(void) {
-    // The timer source clock is APB or a fixed PLL (depending on chip), both constant frequency.
-    uint32_t freq;
-    check_esp_err(esp_clk_tree_src_get_freq_hz(TIMER_CLK_SRC, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &freq));
-    assert(freq % TIMER_DIVIDER == 0); // Source clock should divide evenly into TIMER_DIVIDER
-    return freq / TIMER_DIVIDER;
+    // Virtual timers always use microsecond resolution
+    return 1000000;
 }
 
-void machine_timer_deinit_all(void) {
-    // Disable, deallocate and remove all timers from list
-    machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head);
-    while (*t != NULL) {
-        machine_timer_deinit(*t);
-        machine_timer_obj_t *next = (*t)->next;
-        m_del_obj(machine_timer_obj_t, *t);
-        *t = next;
+static bool machine_timer_isr_hardware(gptimer_handle_t timer, const gptimer_alarm_event_data_t *event_data, void *self_in) {
+    machine_timer_obj_t *self = self_in;
+    return self->handler(self);
+}
+
+static void machine_timer_isr_virtual(void *self_in) {
+    machine_timer_obj_t *self = self_in;
+    if (self->repeat) {
+        self->virtual_started = esp_timer_get_time();
+    } else {
+        self->virtual_stopped = esp_timer_get_time();
+    }
+    if (self->handler(self)) {
+        #if CONFIG_ESP_TIMER_SUPPORTS_ISR_DISPATCH_METHOD
+        esp_timer_isr_dispatch_need_yield();
+        #endif
     }
 }
 
-static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
-    machine_timer_obj_t *self = self_in;
-    qstr mode = self->repeat ? MP_QSTR_PERIODIC : MP_QSTR_ONE_SHOT;
-    uint64_t period = self->period / (machine_timer_freq_hz() / 1000); // convert to ms
-    #if SOC_TIMER_GROUP_TIMERS_PER_GROUP == 1
-    mp_printf(print, "Timer(%u, mode=%q, period=%lu)", self->group, mode, period);
-    #else
-    mp_printf(print, "Timer(%u, mode=%q, period=%lu)", (self->group << 1) | self->index, mode, period);
-    #endif
+static bool machine_timer_handler(machine_timer_obj_t *self) {
+    mp_sched_schedule(self->handler_ctx, self);
+    mp_hal_wake_main_task_from_isr();
+    // Above function already yields, thus we return false
+    // so the timer ISR doesn't needlessly yield again
+    return false;
 }
 
-machine_timer_obj_t *machine_timer_create(mp_uint_t timer) {
+machine_timer_obj_t *machine_timer_create(mp_int_t id) {
+    // Check hardware timer ID is valid
+    if (id >= SOC_TIMER_GROUP_TOTAL_TIMERS) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Timer(%d) doesn't exist, there are only %d hardware timers"), id, SOC_TIMER_GROUP_TOTAL_TIMERS);
+    }
 
-    machine_timer_obj_t *self = NULL;
-    #if SOC_TIMER_GROUP_TIMERS_PER_GROUP == 1
-    mp_uint_t group = timer & 1;
-    mp_uint_t index = 0;
-    #else
-    mp_uint_t group = (timer >> 1) & 1;
-    mp_uint_t index = timer & 1;
-    #endif
-
-    // Check whether the timer is already initialized, if so use it
-    for (machine_timer_obj_t *t = MP_STATE_PORT(machine_timer_obj_head); t; t = t->next) {
-        if (t->group == group && t->index == index) {
-            self = t;
-            break;
+    // Check whether this hardware timer is already initialized, if so reuse it
+    if (id >= 0) {
+        for (machine_timer_obj_t *t = MP_STATE_PORT(machine_timer_obj_head); t; t = t->next) {
+            if (t->id == id) {
+                return t;
+            }
         }
     }
-    // The timer does not exist, create it.
-    if (self == NULL) {
-        self = mp_obj_malloc(machine_timer_obj_t, &machine_timer_type);
-        self->group = group;
-        self->index = index;
-        self->handle = NULL;
 
-        // Add the timer to the linked-list of timers
+    // We want hardware timer IDs to be deterministic, meaning a specific ID always
+    // maps the the same hardware peripheral. gptimer_new_timer() returns the first
+    // available timer, starting from ID 0. Thus we ensure we initialize all timers
+    // in order (or to be more precise, we always initialize timers with a lower ID
+    // first) so that the first available timer ID is always the timer ID requested
+    // regardless of the order in which timer IDs are created and deleted in Python.
+    if (id > 0) {
+        machine_timer_create(id - 1);
+    }
+
+    machine_timer_obj_t *self = mp_obj_malloc_with_finaliser(machine_timer_obj_t, &machine_timer_type);
+    self->id = id;
+    self->period = 0;
+    self->repeat = false;
+    self->virtual_started = 0;
+    self->virtual_stopped = 0;
+    self->handler = NULL;
+    self->handler_ctx = NULL;
+
+    if (id >= 0) {
+        const gptimer_config_t hardware_config = {
+            .clk_src = TIMER_CLK_SRC,
+            .direction = GPTIMER_COUNT_UP,
+            .resolution_hz = machine_timer_freq_hz(self),
+        };
+        check_esp_err(gptimer_new_timer(&hardware_config, &self->handle.hardware));
+        gptimer_event_callbacks_t hardware_event_callbacks = {
+            .on_alarm = machine_timer_isr_hardware
+        };
+        esp_err_t result = gptimer_register_event_callbacks(self->handle.hardware, &hardware_event_callbacks, (void *)self);
+        if (result != ESP_OK) {
+            gptimer_del_timer(self->handle.hardware);
+            check_esp_err(result);
+        }
+
+        // Hardware timers are immediately added to the
+        // linked-list of timers so they can be reused
+        self->next = MP_STATE_PORT(machine_timer_obj_head);
+        MP_STATE_PORT(machine_timer_obj_head) = self;
+    } else {
+        const esp_timer_create_args_t virtual_args = {
+            .callback = machine_timer_isr_virtual,
+            .arg = (void *)self,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "mpy_machine_timer",
+            .skip_unhandled_events = true,
+        };
+        check_esp_err(esp_timer_create(&virtual_args, &self->handle.virtual));
+    }
+
+    return self;
+}
+
+void machine_timer_configure(machine_timer_obj_t *self) {
+    // Period must be non-zero
+    if (self->period == 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("Timer period is too short for this timer"));
+    }
+
+    if (self->id >= 0) {
+        gptimer_alarm_config_t alarm_config = {
+            .reload_count = 0,
+            .alarm_count = self->period,
+            .flags.auto_reload_on_alarm = self->repeat,
+        };
+        check_esp_err(gptimer_set_alarm_action(self->handle.hardware, &alarm_config));
+        esp_err_t result = gptimer_enable(self->handle.hardware);
+        if (result != ESP_ERR_INVALID_STATE) {
+            check_esp_err(result);
+        }
+    } else {
+        // Virtual timers need no configuration but should be
+        // be added to the linked-list of timers so they are
+        // not automatically garbage collected while running
+        for (machine_timer_obj_t *t = MP_STATE_PORT(machine_timer_obj_head); t; t = t->next) {
+            if (t == self) {
+                return;
+            }
+        }
         self->next = MP_STATE_PORT(machine_timer_obj_head);
         MP_STATE_PORT(machine_timer_obj_head) = self;
     }
-    return self;
 }
 
-static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
-    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
-
-    // Create the new timer.
-    uint32_t timer_number = mp_obj_get_int(args[0]);
-    if (timer_number >= SOC_TIMER_GROUP_TOTAL_TIMERS) {
-        mp_raise_ValueError(MP_ERROR_TEXT("invalid Timer number"));
-    }
-    machine_timer_obj_t *self = machine_timer_create(timer_number);
-
-    if (n_args > 1 || n_kw > 0) {
-        mp_map_t kw_args;
-        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
-        machine_timer_init_helper(self, n_args - 1, args + 1, &kw_args);
-    }
-
-    return self;
-}
-
-void machine_timer_disable(machine_timer_obj_t *self) {
-    if (self->hal_context.dev != NULL) {
-        // Disable the counter and alarm.
-        timer_ll_enable_counter(self->hal_context.dev, self->index, false);
-        timer_ll_enable_alarm(self->hal_context.dev, self->index, false);
-    }
-
-    if (self->handle) {
-        // Disable the interrupt
-        ESP_ERROR_CHECK(esp_intr_disable(self->handle));
-    }
-
-    // We let the disabled timer stay in the list, as it might be
-    // referenced elsewhere
-}
-
-static void machine_timer_isr(void *self_in) {
-    machine_timer_obj_t *self = self_in;
-
-    uint32_t intr_status = timer_ll_get_intr_status(self->hal_context.dev);
-
-    if (intr_status & TIMER_LL_EVENT_ALARM(self->index)) {
-        timer_ll_clear_intr_status(self->hal_context.dev, TIMER_LL_EVENT_ALARM(self->index));
-        if (self->repeat) {
-            timer_ll_enable_alarm(self->hal_context.dev, self->index, true);
-        }
-        self->handler(self);
-    }
-}
-
-static void machine_timer_isr_handler(machine_timer_obj_t *self) {
-    mp_sched_schedule(self->callback, self);
-    mp_hal_wake_main_task_from_isr();
-}
-
-void machine_timer_enable(machine_timer_obj_t *self) {
-    // Initialise the timer.
-    timer_hal_init(&self->hal_context, self->group, self->index);
-
-    PERIPH_RCC_ACQUIRE_ATOMIC(timer_group_periph_signals.groups[self->index].module, ref_count) {
-        if (ref_count == 0) {
-            timer_ll_enable_bus_clock(self->index, true);
-            timer_ll_reset_register(self->index);
-        }
-    }
-
-    timer_ll_enable_counter(self->hal_context.dev, self->index, false);
-
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-    esp_clk_tree_enable_src(TIMER_CLK_SRC, true);
-    #elif TIMER_CLK_SRC != SOC_MOD_CLK_APB
-    // esp_clk_tree_enable_src() is only required on some newer chips where timer
-    // source clock may not be enabled by default
-    #error "This chip requires ESP-IDF v5.4 or newer for working Timer."
-    #endif
-
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
-    timer_ll_set_clock_source(self->hal_context.dev, self->index, TIMER_CLK_SRC);
-    timer_ll_enable_clock(self->hal_context.dev, self->index, true);
-    #else
-    timer_ll_set_clock_source(self->group, self->index, TIMER_CLK_SRC);
-    timer_ll_enable_clock(self->group, self->index, true);
-    #endif
-    timer_ll_set_clock_prescale(self->hal_context.dev, self->index, TIMER_DIVIDER);
-    timer_hal_set_counter_value(&self->hal_context, 0);
-    timer_ll_set_count_direction(self->hal_context.dev, self->index, GPTIMER_COUNT_UP);
-
-    // Allocate and enable the alarm interrupt.
-    timer_ll_enable_intr(self->hal_context.dev, TIMER_LL_EVENT_ALARM(self->index), false);
-    timer_ll_clear_intr_status(self->hal_context.dev, TIMER_LL_EVENT_ALARM(self->index));
-    if (self->handle) {
-        ESP_ERROR_CHECK(esp_intr_enable(self->handle));
+void machine_timer_start(machine_timer_obj_t *self) {
+    if (self->id >= 0) {
+        check_esp_err(gptimer_set_raw_count(self->handle.hardware, 0));
+        check_esp_err(gptimer_start(self->handle.hardware));
     } else {
-        ESP_ERROR_CHECK(esp_intr_alloc(
-            timer_group_periph_signals.groups[self->group].timer_irq_id[self->index],
-            TIMER_FLAGS,
-            machine_timer_isr,
-            self,
-            &self->handle
-            ));
+        self->virtual_started = esp_timer_get_time();
+        if (self->repeat) {
+            check_esp_err(esp_timer_start_periodic(self->handle.virtual, self->period));
+        } else {
+            check_esp_err(esp_timer_start_once(self->handle.virtual, self->period));
+        }
     }
-    timer_ll_enable_intr(self->hal_context.dev, TIMER_LL_EVENT_ALARM(self->index), true);
+}
 
-    // Enable the alarm to trigger at the given period.
-    timer_ll_set_alarm_value(self->hal_context.dev, self->index, self->period);
-    timer_ll_enable_alarm(self->hal_context.dev, self->index, true);
+void machine_timer_stop(machine_timer_obj_t *self) {
+    esp_err_t result;
+    if (self->id >= 0) {
+        result = gptimer_stop(self->handle.hardware);
+    } else {
+        result = esp_timer_stop(self->handle.virtual);
+        if (result == ESP_OK) {
+            self->virtual_stopped = esp_timer_get_time();
+        }
+    }
+    if (result != ESP_ERR_INVALID_STATE) {
+        check_esp_err(result);
+    }
+}
 
-    // Set the counter to reload at 0 if it's in repeat mode.
-    timer_ll_set_reload_value(self->hal_context.dev, self->index, 0);
-    timer_ll_enable_auto_reload(self->hal_context.dev, self->index, self->repeat);
+mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
+    machine_timer_obj_t *self = self_in;
+    machine_timer_stop(self);
+    if (self->id >= 0) {
+        esp_err_t result = gptimer_disable(self->handle.hardware);
+        if (result != ESP_ERR_INVALID_STATE) {
+            check_esp_err(result);
+        }
+    } else {
+        // Virtual timers may be immediately garbage collected
+        // (hardware timers must stay in the list to be reused)
+        for (machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head); *t != NULL; t = &(*t)->next) {
+            if (*t == self) {
+                *t = self->next;
+                break;
+            }
+        }
+    }
+    self->period = 0;
+    self->repeat = false;
+    self->virtual_started = 0;
+    self->virtual_stopped = 0;
+    self->handler = NULL;
+    self->handler_ctx = NULL;
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
-    // Enable the counter.
-    timer_ll_enable_counter(self->hal_context.dev, self->index, true);
+// Called by board port soft reset routine to deactivate all timers before reboot.
+void machine_timer_deinit_all(void) {
+    machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head);
+    while (*t != NULL) {
+        machine_timer_obj_t *next = (*t)->next;
+        machine_timer_deinit(*t);
+        *t = next;
+    }
 }
 
 static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -253,7 +275,11 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
         { MP_QSTR_hard,         MP_ARG_KW_ONLY | MP_ARG_BOOL, {.u_bool = false} },
     };
 
-    machine_timer_disable(self);
+    // If previously initialized, indicated by a handler being set, first deinitialize
+    // (Deiniting is always safe, but needlessly prints an error if already deinited)
+    if (self->handler != NULL) {
+        machine_timer_deinit(self);
+    }
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
@@ -264,56 +290,101 @@ static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n
 
     #if MICROPY_PY_BUILTINS_FLOAT
     if (args[ARG_freq].u_obj != mp_const_none) {
-        self->period = (uint64_t)(machine_timer_freq_hz() / mp_obj_get_float(args[ARG_freq].u_obj));
+        self->period = (uint64_t)(machine_timer_freq_hz(self) / mp_obj_get_float(args[ARG_freq].u_obj));
     }
     #else
     if (args[ARG_freq].u_int != 0xffffffff) {
-        self->period = TIMER_SCALE / ((uint64_t)args[ARG_freq].u_int);
+        self->period = machine_timer_freq_hz(self) / ((uint64_t)args[ARG_freq].u_int);
     }
     #endif
     else {
-        self->period = (((uint64_t)args[ARG_period].u_int) * machine_timer_freq_hz()) / args[ARG_tick_hz].u_int;
+        self->period = (((uint64_t)args[ARG_period].u_int) * machine_timer_freq_hz(self)) / args[ARG_tick_hz].u_int;
     }
 
     self->repeat = args[ARG_mode].u_int;
-    self->handler = machine_timer_isr_handler;
-    self->callback = args[ARG_callback].u_obj;
 
-    machine_timer_enable(self);
+    self->handler = machine_timer_handler;
+    self->handler_ctx = args[ARG_callback].u_obj;
+
+    machine_timer_configure(self);
+    machine_timer_start(self);
 
     return mp_const_none;
 }
 
-static mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
-    machine_timer_obj_t *self = self_in;
-
-    machine_timer_disable(self);
-    if (self->handle) {
-        ESP_ERROR_CHECK(esp_intr_free(self->handle));
-        self->handle = NULL;
+static mp_obj_t machine_timer_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    // Get timer ID, or default to -1 (virtual)
+    mp_int_t id = -1;
+    if (n_args > 0) {
+        id = mp_obj_get_int(args[0]);
+        --n_args;
+        ++args;
     }
 
-    return mp_const_none;
+    machine_timer_obj_t *self = machine_timer_create(id);
+
+    if (n_args > 0 || n_kw > 0) {
+        // Start the timer
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        machine_timer_init_helper(self, n_args, args, &kw_args);
+    }
+
+    return self;
 }
-static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
 static mp_obj_t machine_timer_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
     return machine_timer_init_helper(args[0], n_args - 1, args + 1, kw_args);
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_timer_init_obj, 1, machine_timer_init);
 
+static mp_obj_t machine_timer_del(mp_obj_t self_in) {
+    machine_timer_obj_t *self = self_in;
+
+    machine_timer_deinit(self);
+    if (self->id >= 0) {
+        // Hardware timers must first be removed from the linked-list of timers,
+        // virtual timers will already have been removed during deinitialization
+        for (machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head); *t != NULL; t = &(*t)->next) {
+            if (*t == self) {
+                *t = self->next;
+                break;
+            }
+        }
+        check_esp_err(gptimer_del_timer(self->handle.hardware));
+    } else {
+        check_esp_err(esp_timer_delete(self->handle.virtual));
+    }
+
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_del_obj, machine_timer_del);
+
 static mp_obj_t machine_timer_value(mp_obj_t self_in) {
     machine_timer_obj_t *self = self_in;
-    if (self->handle == NULL) {
-        mp_raise_ValueError(MP_ERROR_TEXT("timer not set"));
+    uint64_t result;
+    if (self->id >= 0) {
+        check_esp_err(gptimer_get_raw_count(self->handle.hardware, &result));
+    } else {
+        if (esp_timer_is_active(self->handle.virtual)) {
+            result = esp_timer_get_time() - self->virtual_started;
+        } else {
+            result = self->virtual_stopped - self->virtual_started;
+        }
     }
-    uint64_t result = timer_ll_get_counter_value(self->hal_context.dev, self->index);
-    return MP_OBJ_NEW_SMALL_INT((mp_uint_t)(result / (machine_timer_freq_hz() / 1000))); // value in ms
+    return MP_OBJ_NEW_SMALL_INT((mp_uint_t)(result / (machine_timer_freq_hz(self) / 1000))); // value in ms
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_value_obj, machine_timer_value);
 
+static void machine_timer_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    machine_timer_obj_t *self = self_in;
+    qstr mode = self->repeat ? MP_QSTR_ONE_SHOT : MP_QSTR_PERIODIC;
+    uint64_t period = self->period / (machine_timer_freq_hz(self) / 1000); // convert to ms
+    mp_printf(print, "Timer(%d, mode=%q, period=%lu)", self->id, mode, period);
+}
+
 static const mp_rom_map_elem_t machine_timer_locals_dict_table[] = {
-    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&machine_timer_deinit_obj) },
+    { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&machine_timer_del_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_timer_deinit_obj) },
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_timer_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_value), MP_ROM_PTR(&machine_timer_value_obj) },

--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -243,16 +243,6 @@ mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_1(machine_timer_deinit_obj, machine_timer_deinit);
 
-// Called by board port soft reset routine to deactivate all timers before reboot.
-void machine_timer_deinit_all(void) {
-    machine_timer_obj_t **t = &MP_STATE_PORT(machine_timer_obj_head);
-    while (*t != NULL) {
-        machine_timer_obj_t *next = (*t)->next;
-        machine_timer_deinit(*t);
-        *t = next;
-    }
-}
-
 static mp_obj_t machine_timer_init_helper(machine_timer_obj_t *self, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum {
         ARG_mode,

--- a/ports/esp32/machine_timer.h
+++ b/ports/esp32/machine_timer.h
@@ -30,33 +30,45 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_TIMER_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_TIMER_H
 
-#include "hal/timer_hal.h"
-#include "hal/timer_ll.h"
-#include "soc/timer_periph.h"
+#include "driver/gptimer.h"
+#include "esp_timer.h"
 
 typedef struct _machine_timer_obj_t {
     mp_obj_base_t base;
 
-    timer_hal_context_t hal_context;
-    mp_uint_t group;
-    mp_uint_t index;
+    // Positive means hardware, -1 means virtual
+    mp_int_t id;
+    union {
+        gptimer_handle_t hardware;
+        esp_timer_handle_t virtual;
+    } handle;
 
-    mp_uint_t repeat;
-    // ESP32 timers are 64-bit
+    // Period is in units of the timers' frequency,
+    // as returned by machine_timer_freq_hz()
     uint64_t period;
+    bool repeat;
 
-    mp_obj_t callback;
+    // Virtual timers don't have counters, thus we
+    // emulate it by calculating based on the time
+    int64_t virtual_started;
+    int64_t virtual_stopped;
 
-    intr_handle_t handle;
-    void (*handler)(struct _machine_timer_obj_t *timer);
+    // Default handler simply schedules execution of the context
+    // (which usually is a callable Python object). Other C code
+    // may set different handlers; see for example UART's RXIDLE.
+    bool (*handler)(struct _machine_timer_obj_t *timer);
+    mp_obj_t handler_ctx;
 
+    // Pointer to next timer in linked list of active timers
     struct _machine_timer_obj_t *next;
 } machine_timer_obj_t;
 
-machine_timer_obj_t *machine_timer_create(mp_uint_t timer);
-void machine_timer_enable(machine_timer_obj_t *self);
-void machine_timer_disable(machine_timer_obj_t *self);
-
-uint32_t machine_timer_freq_hz(void);
+// Externalize machine timer for use elsewhere in board support
+machine_timer_obj_t *machine_timer_create(mp_int_t id);
+uint32_t machine_timer_freq_hz(machine_timer_obj_t *self);
+void machine_timer_configure(machine_timer_obj_t *self);
+void machine_timer_start(machine_timer_obj_t *self);
+void machine_timer_stop(machine_timer_obj_t *self);
+mp_obj_t machine_timer_deinit(mp_obj_t self_in);
 
 #endif // MICROPY_INCLUDED_ESP32_MACHINE_TIMER_H

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -59,7 +59,7 @@
 #define UART_IRQ_RXIDLE (0x1000)
 #define UART_IRQ_BREAK (1 << UART_BREAK)
 #define MP_UART_ALLOWED_FLAGS (UART_IRQ_RX | UART_IRQ_RXIDLE | UART_IRQ_BREAK)
-#define RXIDLE_TIMER_MIN (machine_timer_freq_hz() * 5 / 10000) // 500us minimum rxidle time
+#define RXIDLE_TIMER_MIN (500) // 500us minimum rxidle time
 #define UART_QUEUE_SIZE (3)
 
 typedef struct _machine_uart_default_pins_t {
@@ -119,7 +119,6 @@ typedef struct _machine_uart_obj_t {
     mp_irq_obj_t *mp_irq_obj;  // user IRQ object
     machine_timer_obj_t *rxidle_timer;
     uint8_t rxidle_state;
-    uint16_t rxidle_period;
 } machine_uart_obj_t;
 
 static const char *_parity_name[] = {"None", "1", "0"};
@@ -146,20 +145,22 @@ static bool uart_is_repl(uart_port_t uart_num) {
     { MP_ROM_QSTR(MP_QSTR_IRQ_RXIDLE), MP_ROM_INT(UART_IRQ_RXIDLE) }, \
     { MP_ROM_QSTR(MP_QSTR_IRQ_BREAK), MP_ROM_INT(UART_IRQ_BREAK) }, \
 
-static void uart_timer_callback(machine_timer_obj_t *timer) {
-    // The UART object is referred here by the callback field.
-    machine_uart_obj_t *self = (machine_uart_obj_t *)timer->callback;
+static bool uart_timer_callback(machine_timer_obj_t *timer) {
+    machine_uart_obj_t *self = (machine_uart_obj_t *)timer->handler_ctx;
     if (self->rxidle_state == RXIDLE_ALERT) {
         // At the first call, just switch the state
         self->rxidle_state = RXIDLE_ARMED;
     } else if (self->rxidle_state == RXIDLE_ARMED) {
-        // At the second call, run the irq callback and stop the timer
+        // At the second call, stop the timer and run the irq callback
+        machine_timer_stop(self->rxidle_timer);
         self->rxidle_state = RXIDLE_STANDBY;
         self->mp_irq_flags = UART_IRQ_RXIDLE;
         mp_irq_handler(self->mp_irq_obj);
         mp_hal_wake_main_task_from_isr();
-        machine_timer_disable(self->rxidle_timer);
     }
+    // Above function already yields, thus we return false
+    // so the timer ISR doesn't needlessly yield again
+    return false;
 }
 
 static void uart_event_task(void *self_in) {
@@ -173,10 +174,8 @@ static void uart_event_task(void *self_in) {
                 // Event of UART receiving data
                 case UART_DATA:
                     if (self->mp_irq_trigger & UART_IRQ_RXIDLE) {
-                        if (self->rxidle_state != RXIDLE_INACTIVE) {
-                            if (self->rxidle_state == RXIDLE_STANDBY) {
-                                machine_timer_enable(self->rxidle_timer);
-                            }
+                        if (self->rxidle_state == RXIDLE_STANDBY) {
+                            machine_timer_start(self->rxidle_timer);
                         }
                         self->rxidle_state = RXIDLE_ALERT;
                     }
@@ -509,7 +508,7 @@ static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
         self->uart_event_task = NULL;
     }
     if (self->rxidle_timer != NULL) {
-        machine_timer_disable(self->rxidle_timer);
+        machine_timer_stop(self->rxidle_timer);
         if (self->rxidle_state > RXIDLE_STANDBY) {
             // Currently deinit(),init() sequence resumes any previously
             // configured irqs, and we currently also rely on this when changing
@@ -573,17 +572,17 @@ static void uart_irq_configure_timer(machine_uart_obj_t *self, mp_uint_t trigger
         self->mp_irq_obj->ishard = false;
         uint32_t baudrate;
         uart_get_baudrate(self->uart_num, &baudrate);
-        mp_int_t period = machine_timer_freq_hz() * 20 / baudrate + 1;
-        if (period < RXIDLE_TIMER_MIN) {
-            period = RXIDLE_TIMER_MIN;
+        // Wait for 2 characters worth of time before triggering the RXIDLE event
+        uint8_t bits_per_character = 1 + self->bits + self->parity + self->stop;
+        uint64_t period_us = ((2 * bits_per_character) * 1000000) / baudrate;
+        if (period_us < RXIDLE_TIMER_MIN) {
+            period_us = RXIDLE_TIMER_MIN;
         }
-        self->rxidle_period = period;
-        self->rxidle_timer->period = period;
-        self->rxidle_timer->handler = uart_timer_callback;
-        // The Python callback is not used. So use this
-        // data field to hold a reference to the UART object.
-        self->rxidle_timer->callback = self;
+        self->rxidle_timer->period = (period_us * machine_timer_freq_hz(self->rxidle_timer)) / 1000000 + 1;
         self->rxidle_timer->repeat = true;
+        self->rxidle_timer->handler = uart_timer_callback;
+        self->rxidle_timer->handler_ctx = self;
+        machine_timer_configure(self->rxidle_timer);
         self->rxidle_state = RXIDLE_STANDBY;
     }
 }
@@ -641,8 +640,17 @@ static mp_irq_obj_t *mp_machine_uart_irq(machine_uart_obj_t *self, bool any_args
         }
         self->mp_irq_obj->ishard = false;
         self->mp_irq_trigger = trigger;
-        self->rxidle_timer = machine_timer_create(RXIDLE_TIMER_IDX);
-        uart_irq_configure_timer(self, trigger);
+
+        // Set up the RXIDLE timer
+        if (handler != mp_const_none) {
+            if (self->rxidle_timer == NULL) {
+                self->rxidle_timer = machine_timer_create(RXIDLE_TIMER_IDX);
+            }
+            uart_irq_configure_timer(self, trigger);
+        } else if (self->rxidle_timer != NULL) {
+            machine_timer_deinit(self->rxidle_timer);
+            self->rxidle_timer = NULL;
+        }
 
         // Start a task for handling events
         if (handler != mp_const_none && self->uart_event_task == NULL && self->uart_queue != NULL) {

--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -93,8 +93,9 @@ enum {
     RXIDLE_ALERT,
 };
 
-// RXIDLE irq feature uses this machine.Timer id
-#define RXIDLE_TIMER_IDX 0
+// machine.Timer id used for RXIDLE IRQ. If a hardware timer it should not be
+// used elsewhere (and thus also no more than one RXIDLE IRQ should be used).
+#define RXIDLE_TIMER_IDX (-1)
 
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -197,12 +197,9 @@ soft_reset_exit:
     wifi_csi_deinit();
     #endif
 
-    // Deinit uart before timers, as esp32 uart
-    // depends on a timer instance
     #if MICROPY_PY_MACHINE_UART
     machine_uart_deinit_all();
     #endif
-    machine_timer_deinit_all();
 
     #if MICROPY_PY_ESP32_PCNT
     esp32_pcnt_deinit_all();

--- a/ports/esp32/modmachine.h
+++ b/ports/esp32/modmachine.h
@@ -18,7 +18,6 @@ void machine_pins_init(void);
 void machine_pins_deinit(void);
 void machine_pwm_deinit_all(void);
 // TODO: void machine_rmt_deinit_all(void);
-void machine_timer_deinit_all(void);
 void machine_uart_deinit_all(void);
 void machine_i2s_init0();
 

--- a/tests/extmod/machine_timer.py
+++ b/tests/extmod/machine_timer.py
@@ -19,15 +19,11 @@ import unittest
 # Hardware timers are only supported on the esp32 port
 SUPPORTS_HARDWARE_TIMERS = sys.platform == "esp32"
 
-# Virtual timers are not supported on the esp32 port
-SUPPORTS_VIRTUAL_TIMERS = sys.platform != "esp32"
-
 # Hard IRQs are not supported on the esp32 port
 SUPPORTS_HARD_IRQ = sys.platform != "esp32"
 
 
 class Test(unittest.TestCase):
-    @unittest.skipUnless(SUPPORTS_VIRTUAL_TIMERS, "no virtual timers")
     def test_virtual_create(self):
         self._test_create(-1)
         self._test_create_multiple(-1, -1)
@@ -37,12 +33,10 @@ class Test(unittest.TestCase):
         self._test_create(0)
         self._test_create_multiple(0, 1)
 
-    @unittest.skipUnless(SUPPORTS_VIRTUAL_TIMERS, "no virtual timers")
     def test_virtual_softirq(self):
         self._test_all_freq_period(-1, Timer.ONE_SHOT, False)
         self._test_all_freq_period(-1, Timer.PERIODIC, False)
 
-    @unittest.skipUnless(SUPPORTS_VIRTUAL_TIMERS, "no virtual timers")
     @unittest.skipUnless(SUPPORTS_HARD_IRQ, "no hard-irq support")
     def test_virtual_hardirq(self):
         self._test_all_freq_period(-1, Timer.ONE_SHOT, True)


### PR DESCRIPTION
### Summary

This is an alternative for https://github.com/micropython/micropython/pull/18263. This fixes https://github.com/micropython/micropython/issues/19162.

This PR reworks the Timer implementation to use the higher-level GPTimer library instead of the lower level interface from the ESP-IDF. The lower level interface has additional complexity and is explicitly marked as not being stable / subject to undocumented changes.

The higher level GPTimer interface abstracts away these details yet should still provide us with the exact same functionality.

After seeing the work by @LucienMP in https://github.com/micropython/micropython/pull/18263 and having a use case for virtual timers myself I also immediately integrated full support for virtual timers based on his initial work in that PR.

The reworked Timer uses finalisers to automatically stop and destroy timers that are no longer being used upon garbage collection. Thus we no longer need to explicitly deinit the timers during a soft reboot.

An additional commit also switches the UART RXIDLE functionality to use a virtual timer, freeing up one of the hardware timers for other purposes. Additionally that means we can now also have multiple UARTs with RXIDLE functionality at the same time. I've made it configurable so that specific boards that can spare the timer can still choose to use a hardware timer for this.

### Testing

Tested on the original ESP32 and ESP32-S3, using both official dev boards from Espressif as well as a number of custom boards. Tested the timer functionality manually, and with RXIDLE using PPP.

I've updated the machine_timer tests. That work has been split off into https://github.com/micropython/micropython/pull/19197. This PR includes a commit that also enables the virtual timer tests on the ESP32 port. These updated tests run successfully on the ESP32, ESP32-S3 and ESP32-C6.

### Trade-offs and Alternatives

There is a non-insignificant code size cost. I haven't yet run the component-size to identify where that comes from, but I expect it to be the cost of now depending on both the GPTimer (which itselfs builds upon the lower level interface we used previously) and ESP Timer code, so presumably not a low we can do about that. If desirable we could gate hardware and/or virtual timers behind a flag so it may be disabled for boards that don't need/use one or the other. I've prototyped it locally, and although it does appear to result in small size reduction, it also makes the code harder to read due to the large number of `#if`'s, which I dislike.

### Generative AI

I did not use generative AI tools when creating this PR.