### PR TITLE
float_format_ints: Another valid alternative result.

### DIFF
--- a/tests/float/float_format_ints.py
+++ b/tests/float/float_format_ints.py
@@ -46,6 +46,14 @@ if is_float32 and val_str == "2147483500.000000":
 if is_REPR_C and val_str == "2147483200.000000":
     val_str = "2147483520.000000"
 
+# When using REPR_C, x86 and clang, 2147483520.0 is the same
+# as 2147483100.0, the second being "simple" but rounded differently
+# due to x87 extra precision on intermediates.
+# Both representations are valid.
+if is_REPR_C and val_str == "2147483100.000000":
+    val_str = "2147483520.000000"
+
+
 print(val_str)
 
 # Very large positive integers can be a test for precision and resolution.


### PR DESCRIPTION
### Summary

As described in #19120 `clang -m32` rounds some floating point reprs differently, likely due to x87 temporary excess precision. Accept this value in addition to the other values that are accepted.

Ping @yoctopuce 

Closes: #19120

### Testing

Locally, I applied #19119 and followed the test procedure in #19120.

This combination is not CI-tested.

### Generative AI

I did not use generative AI tools when creating this PR.