### PR TITLE
tests/run-tests.py: Skip string_escape.py as an mpy if no unicode.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -893,6 +893,8 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         skip_tests.add("float/float_parse_doubleprec.py")
 
     if not args.unicode:
+        if args.via_mpy:
+            skip_tests.add("basics/string_escape.py")  # stores a utf-8 character in the mpy file
         skip_tests.add("extmod/json_loads.py")  # tests loading a utf-8 character
 
     if skip_slice:


### PR DESCRIPTION
### Summary

`mpy-cross` has unicode strings enabled, so when a .py is compiled to .mpy it will store strings encoded as utf-8.  If a target does not have unicode enabled then tests with utf-8 characters will fail.

Skip such tests (currently only one) in such situations.

### Testing

Tested on ADAFRUIT_ITSYBITSY_M0_EXPRESS, the `string_escape.py` test now passes when used with `--via-mpy` (prior to this change it would fail).

### Alternative

An alternative here would be for targets with unicode disabled but mpy loading enabled (which is where the issue lies) to have a special utf-8 parser used when loading mpy files.  It would convert utf-8 into bytes.  Eg the byte sequence `c2:80` in a string in an mpy file would be converted to `80`, and `c3:bf` would be converted to `ff`, etc.  Higher unicode code points would be an error.  But I don't think that's worth the effort.

### Generative AI

I did not use generative AI tools when creating this PR.
