### PR TITLE
py/mpconfig: Enable unicode support at the basic feature level.

### DIFF
--- a/docs/reference/unicode_support.rst
+++ b/docs/reference/unicode_support.rst
@@ -3,8 +3,9 @@
 Unicode Support
 ===============
 
-MicroPython provides Unicode support for strings, with the level of support
-depending on the build configuration.
+MicroPython provides Unicode support for strings.  All Tier 1, 2 and 3 ports
+have Unicode support enabled by default, but it is possible to change that with
+a different build configuration.
 
 Terminology
 -----------
@@ -151,7 +152,9 @@ Unicode features are controlled by several build-time flags in ``mpconfigport.h`
     Unicode character and string operations work on character boundaries rather
     than byte boundaries.
 
-    Default: Enabled at ``MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES`` and above.
+    Default: Enabled at ``MICROPY_CONFIG_ROM_LEVEL_BASIC_FEATURES`` and above.
+
+    Enabled on all Tier 1, 2 and 3 ports.
 
 ``MICROPY_PY_BUILTINS_STR_UNICODE_CHECK``
     Enable UTF-8 validation during string operations. When disabled, string
@@ -159,12 +162,17 @@ Unicode features are controlled by several build-time flags in ``mpconfigport.h`
 
     Default: Follows ``MICROPY_PY_BUILTINS_STR_UNICODE`` setting.
 
+    Enabled on all Tier 1, 2 and 3 ports.
+
 ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``
     Enable the ``'ignore'`` and ``'replace'`` error handlers for
     :meth:`bytes.decode`. When enabled, invalid UTF-8 bytes can be either
     skipped (``'ignore'``) or replaced with U+FFFD (``'replace'``).
 
     Default: Enabled at ``MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES`` and above.
+
+    Enabled on alif, esp32, esp8266, mimxrt, renesas-ra, rp2, samd (SAMD51 only),
+    stm32, unix and webassembly ports.
 
 Example Configuration
 ~~~~~~~~~~~~~~~~~~~~~

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1367,7 +1367,7 @@ typedef time_t mp_timestamp_t;
 
 // Whether str object is proper unicode
 #ifndef MICROPY_PY_BUILTINS_STR_UNICODE
-#define MICROPY_PY_BUILTINS_STR_UNICODE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
+#define MICROPY_PY_BUILTINS_STR_UNICODE (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_BASIC_FEATURES)
 #endif
 
 // Whether to check for valid UTF-8 when converting bytes to str


### PR DESCRIPTION
### Summary

MicroPython allows unicode to be disabled to reduce firmware size, in which case str objects are essentially the same as bytes objects when it comes to code points between 128 and 255.  But that behaviour has subtle differences to when unicode is enabled, eg string lengths can be different.

Since unicode strings are arguably an important feature of Python, and users would likely be tripped up with it disabled, this commit changes the default level at which unicode is enabled from "extra" down to "basic".

Costs about +1600 bytes on ARM Cortex-M targets.

### Testing

Tested on ADAFRUIT_ITSYBITSY_M0_EXPRESS running the full test suite.  There were no regressions, and more tests now run (the unicode ones).

Built all samd boards, they all still fit in flash.

### Trade-offs and Alternatives

This obviously increases code size for some boards, but as argued above it's a worthy feature if the board has room for it.

### Generative AI

I did not use generative AI tools when creating this PR.
