### PR TITLE
py/modbuiltins: Let "dir" be disabled if requested.

### DIFF
--- a/ports/nrf/mpconfigport.h
+++ b/ports/nrf/mpconfigport.h
@@ -277,6 +277,7 @@
 #define MICROPY_PY_ATTRTUPLE                  (1)
 #define MICROPY_PY_BUILTINS_BYTEARRAY         (1)
 #define MICROPY_PY_BUILTINS_DICT_FROMKEYS     (1)
+#define MICROPY_PY_BUILTINS_DIR               (1)
 #define MICROPY_PY_BUILTINS_ENUMERATE         (1)
 #define MICROPY_PY_BUILTINS_EVAL_EXEC         (1)
 #define MICROPY_PY_BUILTINS_FILTER            (1)

--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -155,6 +155,7 @@ static mp_obj_t mp_builtin_chr(mp_obj_t o_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_chr_obj, mp_builtin_chr);
 
+#if MICROPY_PY_BUILTINS_DIR
 static mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
     mp_obj_t dir = mp_obj_new_list(0, NULL);
     if (n_args == 0) {
@@ -187,6 +188,7 @@ static mp_obj_t mp_builtin_dir(size_t n_args, const mp_obj_t *args) {
     return dir;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_builtin_dir_obj, 0, 1, mp_builtin_dir);
+#endif
 
 static mp_obj_t mp_builtin_divmod(mp_obj_t o1_in, mp_obj_t o2_in) {
     return mp_binary_op(MP_BINARY_OP_DIVMOD, o1_in, o2_in);
@@ -687,7 +689,9 @@ static const mp_rom_map_elem_t mp_module_builtins_globals_table[] = {
     #if MICROPY_CPYTHON_COMPAT
     { MP_ROM_QSTR(MP_QSTR_delattr), MP_ROM_PTR(&mp_builtin_delattr_obj) },
     #endif
+    #if MICROPY_PY_BUILTINS_DIR
     { MP_ROM_QSTR(MP_QSTR_dir), MP_ROM_PTR(&mp_builtin_dir_obj) },
+    #endif
     { MP_ROM_QSTR(MP_QSTR_divmod), MP_ROM_PTR(&mp_builtin_divmod_obj) },
     #if MICROPY_PY_BUILTINS_EVAL_EXEC
     { MP_ROM_QSTR(MP_QSTR_eval), MP_ROM_PTR(&mp_builtin_eval_obj) },

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1479,6 +1479,11 @@ typedef time_t mp_timestamp_t;
 #define MICROPY_PY_BUILTINS_ROUND_INT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EXTRA_FEATURES)
 #endif
 
+// Whether to implement dir() to enumerate object fields.
+#ifndef MICROPY_PY_BUILTINS_DIR
+#define MICROPY_PY_BUILTINS_DIR (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_CORE_FEATURES)
+#endif
+
 // Whether to support complete set of special methods for user
 // classes, or only the most used ones. "Inplace" methods are
 // controlled by MICROPY_PY_ALL_INPLACE_SPECIAL_METHODS below.

--- a/tests/basics/builtin_dir.py
+++ b/tests/basics/builtin_dir.py
@@ -1,5 +1,12 @@
 # test builtin dir
 
+try:
+    dir
+except NameError:
+    print("SKIP")
+    raise SystemExit
+
+
 # dir of locals
 print('__name__' in dir())
 


### PR DESCRIPTION
### Summary

This PR makes it possible to disable the `dir` built-in function from being included in the interpreter image.

The function in question is rarely used outside of interactive contexts, and in production code the main use of this function is to implement interactive debug/management consoles over a serial port.  However, outside of that scope, the space taken by such function could probably be better used elsewhere.

This is always enabled by default and requires an explicit user intervention for its removal from the base configuration.

The lack of a `dir` method can also make things a bit easier on the compliance front when it comes to security checklists.

This is a follow-up to the discussion in #19145 regarding MicroPython's behaviour of `dir` compared to CPython.

### Testing

The regular test suite was executed successfully with these changes on Linux/x64.  Manual testing was performed to make sure `dir` was not available to the interpreter when `MICROPY_PY_BUILTINS_DIR` was explicitly turned off in a port's `mpconfigport.h` configuration file.

### Generative AI

I did not use generative AI tools when creating this PR.