### PR TITLE
nrf/boards: Use 64 byte raw-paste buffer on PCA10031.

### DIFF
--- a/ports/nrf/boards/PCA10031/mpconfigboard.h
+++ b/ports/nrf/boards/PCA10031/mpconfigboard.h
@@ -58,3 +58,8 @@
 #define MICROPY_HW_SPI0_MISO        (17)
 
 #define HELP_TEXT_BOARD_LED         "1,2,3"
+
+// The JLink CDC on the PCA10031 cannot accept more than 64 incoming bytes at a time.
+// That makes the UART REPL unreliable in general.  But it can be improved to some
+// extent by setting the raw-paste buffer size to that limit of 64.
+#define MICROPY_REPL_STDIN_BUFFER_MAX (64)


### PR DESCRIPTION
### Summary

Tiny fix: Apply the same workaround as added in cc7eb1a5351c0d7d60f084dc79ccd0fa047b259e for other boards to the NRF51-Dongle, since it also suffers from the same limitation. This change makes it possible to run unit tests against it.

### Generative AI

I did not use generative AI tools when creating this PR.