### PR TITLE
py/modbuiltins: Pass input() prompt through to mp_hal_readline.

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -220,12 +220,20 @@ MP_DEFINE_CONST_FUN_OBJ_1(mp_builtin_hex_obj, mp_builtin_hex);
 #endif
 
 static mp_obj_t mp_builtin_input(size_t n_args, const mp_obj_t *args) {
+    const char *prompt_str = "";
+    vstr_t prompt;
     if (n_args == 1) {
-        mp_obj_print(args[0], PRINT_STR);
+        vstr_init(&prompt, 0);
+        mp_print_t print = { &prompt, (mp_print_strn_t)vstr_add_strn };
+        mp_obj_print_helper(&print, args[0], PRINT_STR);
+        prompt_str = vstr_null_terminated_str(&prompt);
     }
     vstr_t line;
     vstr_init(&line, 16);
-    int ret = mp_hal_readline(&line, "");
+    int ret = mp_hal_readline(&line, prompt_str);
+    if (n_args == 1) {
+        vstr_clear(&prompt);
+    }
     if (ret == CHAR_CTRL_C) {
         mp_raise_type(&mp_type_KeyboardInterrupt);
     }


### PR DESCRIPTION
###Summary
builtins.input() prints its prompt argument via mp_obj_print() and then calls mp_hal_readline(&line, "") with an empty string.  The prompt parameter of mp_hal_readline is therefore unused for any caller reached through input().

This rules out a useful pattern for out-of-tree ports say a custom mp_hal_readline that wants to handle prompt and read atomically for example a remote line editor that issues a single request containing both the prompt to display and the buffer to fill has no way to recover the prompt from input() because by the time the readline call arrives the prompt has already been written to stdout as a separate stream.

This change captures the rendered prompt into a vstr (so non-string arguments still go through PRINT_STR), passes the C string to mp_hal_readline, and drops the now-redundant explicit print.

  ### Testing

  - `ports/unix` standard variant builds clean
  - `tests/run-tests.py -d basics` — 543 tests pass, 0 fail.
  - Smoke-tested over piped stdin: `input('Name: ')`, `input()`,
    `input(42)`, `input('µ -> ')` prompt printed exactly once,
    return values correct.

  ### Trade-offs and Alternatives

  Out-of-tree ports that define a custom `mp_hal_readline` whose body
  ignores the `prompt` argument would now silently lose prompt display.
  Every in-tree implementation already prints the prompt, so this is a
  contract-tightening rather than a contract-breaking change for
  in-tree code, but it is worth flagging for downstream maintainers.

  An alternative would be to leave the `mp_obj_print` in place and have
  `shared/readline` skip its own print when called from `input()`
  that would preserve the old contract but requires a new flag or a
  second entry point, which is more invasive than the present change.

  ### Generative AI

  I used generative AI tools when creating parts of the PR text, but the code change and testing and submission was done by a human. 