### PR TITLE
alif: Fix jump to bootloader.

### DIFF
--- a/ports/alif/boards/OPENMV_AE3/board.c
+++ b/ports/alif/boards/OPENMV_AE3/board.c
@@ -96,6 +96,11 @@ void board_startup(void) {
 
 void board_enter_bootloader(void) {
     *((uint32_t *)OMV_BOOT_MAGIC_ADDR) = OMV_BOOT_MAGIC_VALUE;
+
+    // Clear TRCENA (if it was enabled for DWT CYCCNT) before
+    // calling NVIC_SystemReset(), otherwise it spins forever.
+    CoreDebug->DEMCR &= ~(CoreDebug_DEMCR_TRCENA_Msk);
+
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
### Summary

Clear TRCENA (if it was enabled for DWT CYCCNT) before calling NVIC_SystemReset(), otherwise it spins forever. Just started noticing this issue after enabling CYCCNT unconditionally for ticks.

### Testing

Tested with AE3, gets stuck in NVIC reset for(;;) without this patch.

### Generative AI

I did not use generative AI tools when creating this PR.