### PR TITLE
ports/esp32: Add ESP32 LAN to WIFI NAPT support.

### DIFF
--- a/docs/esp32/quickref.rst
+++ b/docs/esp32/quickref.rst
@@ -195,6 +195,15 @@ These are working configurations for LAN interfaces of some popular ESP32 boards
     lan = network.LAN(id=0, mdc=Pin(23), mdio=Pin(18), power=Pin(5),
                       phy_type=network.PHY_IP101, phy_addr=1)
 
+Custom builds can also enable LAN uplink forwarding to the WiFi access-point
+interface. On such builds, once the LAN interface obtains an IPv4 address,
+MicroPython configures the AP DHCP server to advertise the LAN DNS server and
+enables IPv4 NAPT on the AP interface.
+
+For example, to enable this on ``ESP32_GENERIC`` builds::
+
+    make BOARD=ESP32_GENERIC CMAKE_ARGS='-DMICROPY_PY_ESP32_LWIP_NAT=1'
+
 
 .. _esp32_spi_ethernet:
 

--- a/ports/esp32/boards/ESP32_GENERIC/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC/mpconfigboard.cmake
@@ -2,3 +2,9 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.base
     boards/sdkconfig.ble
 )
+
+if(MICROPY_PY_ESP32_LWIP_NAT)
+    list(APPEND SDKCONFIG_DEFAULTS
+        boards/sdkconfig.nat
+    )
+endif()

--- a/ports/esp32/boards/ESP32_GENERIC_S3/mpconfigboard.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_S3/mpconfigboard.cmake
@@ -6,3 +6,9 @@ set(SDKCONFIG_DEFAULTS
     boards/sdkconfig.spiram_sx
     boards/ESP32_GENERIC_S3/sdkconfig.board
 )
+
+if(MICROPY_PY_ESP32_LWIP_NAT)
+    list(APPEND SDKCONFIG_DEFAULTS
+        boards/sdkconfig.nat
+    )
+endif()

--- a/ports/esp32/boards/sdkconfig.nat
+++ b/ports/esp32/boards/sdkconfig.nat
@@ -1,0 +1,4 @@
+# MicroPython on ESP32, ESP IDF configuration for LAN forwarding/NAT
+
+CONFIG_LWIP_IP_FORWARD=y
+CONFIG_LWIP_IPV4_NAPT=y

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -98,4 +98,19 @@ static inline void esp_exceptions(esp_err_t e) {
 void socket_events_deinit(void);
 void esp_initialise_wifi(void);
 
+#if MICROPY_PY_NETWORK_WLAN
+void esp_network_enable_ap_napt(esp_netif_t *uplink_netif);
+#else
+static inline void esp_network_enable_ap_napt(esp_netif_t *uplink_netif) {
+    (void)uplink_netif;
+}
+#endif
+
+#if MICROPY_PY_NETWORK_LAN
+void esp_network_reapply_lan_ap_napt(void);
+#else
+static inline void esp_network_reapply_lan_ap_napt(void) {
+}
+#endif
+
 #endif

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -78,6 +78,19 @@ const mp_obj_type_t lan_if_type;
 static lan_if_obj_t lan_obj = {{{&lan_if_type}, ESP_IF_ETH, NULL}, false, false};
 static uint8_t eth_status = 0;
 
+static bool lan_has_ipv4(void) {
+    esp_netif_ip_info_t ip;
+    return lan_obj.base.netif != NULL
+           && esp_netif_get_ip_info(lan_obj.base.netif, &ip) == ESP_OK
+           && ip.ip.addr != 0;
+}
+
+void esp_network_reapply_lan_ap_napt(void) {
+    if (lan_obj.base.active && lan_has_ipv4()) {
+        esp_network_enable_ap_napt(lan_obj.base.netif);
+    }
+}
+
 static void eth_event_handler(void *arg, esp_event_base_t event_base,
     int32_t event_id, void *event_data) {
     if (event_base == ETH_EVENT) {
@@ -106,6 +119,7 @@ static void eth_event_handler(void *arg, esp_event_base_t event_base,
             case IP_EVENT_ETH_GOT_IP:
                 eth_status = ETH_GOT_IP;
                 ESP_LOGI("ethernet", "Ethernet Got IP");
+                esp_network_reapply_lan_ap_napt();
                 break;
             default:
                 break;

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -41,6 +41,7 @@
 #include "modnetwork.h"
 
 #include "esp_wifi.h"
+#include "esp_err.h"
 #include "esp_log.h"
 #include "esp_psram.h"
 #if !CONFIG_ESP_HOSTED_ENABLED
@@ -174,6 +175,7 @@ static void network_wlan_wifi_event_handler(void *event_handler_arg, esp_event_b
 
         case WIFI_EVENT_AP_START:
             wlan_ap_obj.active = true;
+            esp_network_reapply_lan_ap_napt();
             break;
 
         case WIFI_EVENT_AP_STOP:
@@ -215,12 +217,51 @@ static void require_if(mp_obj_t wlan_if, int if_no) {
     }
 }
 
+#if MICROPY_PY_NETWORK_WLAN && CONFIG_LWIP_IPV4_NAPT
+static bool esp_network_stop_ap_dhcps(void) {
+    esp_err_t err = esp_netif_dhcps_stop(wlan_ap_obj.netif);
+    return err == ESP_OK || err == ESP_ERR_ESP_NETIF_DHCP_ALREADY_STOPPED;
+}
+
+static void esp_network_start_ap_dhcps(void) {
+    (void)esp_netif_dhcps_start(wlan_ap_obj.netif);
+}
+
+void esp_network_enable_ap_napt(esp_netif_t *uplink_netif) {
+    if (uplink_netif == NULL || wlan_ap_obj.netif == NULL || !wlan_ap_obj.active) {
+        return;
+    }
+
+    if (!esp_netif_is_netif_up(wlan_ap_obj.netif)) {
+        return;
+    }
+
+    (void)esp_netif_set_default_netif(uplink_netif);
+
+    esp_netif_dns_info_t dns;
+    if (esp_netif_get_dns_info(uplink_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK) {
+        uint8_t dhcps_offer_dns = 0x02;
+        if (esp_network_stop_ap_dhcps()) {
+            (void)esp_netif_dhcps_option(
+                wlan_ap_obj.netif, ESP_NETIF_OP_SET, ESP_NETIF_DOMAIN_NAME_SERVER,
+                &dhcps_offer_dns, sizeof(dhcps_offer_dns));
+            (void)esp_netif_set_dns_info(wlan_ap_obj.netif, ESP_NETIF_DNS_MAIN, &dns);
+            esp_network_start_ap_dhcps();
+        }
+    }
+
+    (void)esp_netif_napt_disable(wlan_ap_obj.netif);
+    (void)esp_netif_napt_enable(wlan_ap_obj.netif);
+}
+#else
+void esp_network_enable_ap_napt(esp_netif_t *uplink_netif) {
+    (void)uplink_netif;
+}
+#endif
+
 void esp_initialise_wifi(void) {
     static int wifi_initialized = 0;
     if (!wifi_initialized) {
-        esp_exceptions(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, network_wlan_wifi_event_handler, NULL, NULL));
-        esp_exceptions(esp_event_handler_instance_register(IP_EVENT, ESP_EVENT_ANY_ID, network_wlan_ip_event_handler, NULL, NULL));
-
         wlan_sta_obj.base.type = &esp_network_wlan_type;
         wlan_sta_obj.if_id = ESP_IF_WIFI_STA;
         wlan_sta_obj.netif = esp_netif_create_default_wifi_sta();
@@ -230,6 +271,9 @@ void esp_initialise_wifi(void) {
         wlan_ap_obj.if_id = ESP_IF_WIFI_AP;
         wlan_ap_obj.netif = esp_netif_create_default_wifi_ap();
         wlan_ap_obj.active = false;
+
+        esp_exceptions(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, network_wlan_wifi_event_handler, NULL, NULL));
+        esp_exceptions(esp_event_handler_instance_register(IP_EVENT, ESP_EVENT_ANY_ID, network_wlan_ip_event_handler, NULL, NULL));
 
         wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
         #if CONFIG_SPIRAM_IGNORE_NOTFOUND
@@ -304,6 +348,9 @@ static mp_obj_t network_wlan_active(size_t n_args, const mp_obj_t *args) {
         // Wait for the interface to be in the correct state.
         while (self->active != active) {
             MICROPY_EVENT_POLL_HOOK;
+        }
+        if (active && self->if_id == ESP_IF_WIFI_AP) {
+            esp_network_reapply_lan_ap_napt();
         }
     }
 

--- a/tests/ports/esp32/esp32_lan_napt.py
+++ b/tests/ports/esp32/esp32_lan_napt.py
@@ -1,0 +1,230 @@
+# Board-contained smoke tests for an ESP32 LAN uplink and AP setup used with
+# lwIP NAPT.
+#
+# This is a hardware-gated integration test. It validates prerequisites and
+# control-plane state around an AP+LAN NAPT setup. It does not prove end-to-end
+# NAT translation because no traffic originates from a separate AP client.
+#
+# It requires a board/firmware build with CONFIG_LWIP_IPV4_NAPT enabled plus a
+# working LAN uplink that acquires DNS via DHCP. Set LAN_ARGS below to match the
+# Ethernet hardware under test.
+
+import time
+import unittest
+
+try:
+    import network
+    import socket
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+# Example:
+# LAN_ARGS = {
+#     "mdc": 23,
+#     "mdio": 18,
+#     "power": 5,
+#     "phy_type": network.PHY_LAN8720,
+#     "phy_addr": 0,
+# }
+#
+# SPI Ethernet example:
+# from machine import Pin, SPI
+# spi = SPI(1, sck=Pin(13), mosi=Pin(11), miso=Pin(12))
+# LAN_ARGS = {
+#     "spi": spi,
+#     "cs": Pin(14),
+#     "int": Pin(10),
+#     "reset": Pin(9),
+#     "phy_type": network.PHY_W5500,
+#     "phy_addr": 0,
+# }
+LAN_ARGS = None
+TIMEOUT_MS = 15000
+PROBE_BY_IP_HOST = "1.1.1.1"
+PROBE_PORT = 80
+INVALID_TEST_DNS = "254.254.254.254"
+# Use distinct hostname sets across the pass/fail/pass sequence to avoid resolver
+# cache hits and to reduce false failures from any single domain being unavailable.
+PROBE_BY_NAME_HOST_SETS = (
+    ("example.com", "iana.org", "python.org"),
+    ("micropython.org", "www.example.org", "docs.python.org"),
+    ("one.one.one.one", "dns.google", "pypi.org"),
+)
+
+
+class Test(unittest.TestCase):
+    def _wait_for_ap_dns(self, ap, expected_dns, failure_message):
+        start = time.ticks_ms()
+        while time.ticks_diff(time.ticks_ms(), start) < TIMEOUT_MS:
+            ap_dns = ap.ifconfig()[3]
+            if ap_dns == expected_dns:
+                return ap_dns
+            time.sleep_ms(250)
+
+        self.fail(
+            "{} (expected {}, got {})".format(failure_message, expected_dns, ap.ifconfig()[3])
+        )
+
+    def _assert_public_tcp_uplink(self):
+        sock = socket.socket()
+        try:
+            sock.settimeout(5)
+            sock.connect((PROBE_BY_IP_HOST, PROBE_PORT))
+            print("Connected to {}:{}".format(PROBE_BY_IP_HOST, PROBE_PORT))
+        except OSError as exc:
+            self.fail(
+                "LAN uplink could not open TCP socket to {}:{}: {}".format(
+                    PROBE_BY_IP_HOST, PROBE_PORT, exc
+                )
+            )
+        finally:
+            sock.close()
+
+    def _assert_public_dns_uplink(self, hosts):
+        errors = []
+        for host in hosts:
+            try:
+                addr = socket.getaddrinfo(host, PROBE_PORT)[0][-1]
+            except OSError as exc:
+                errors.append("{} lookup: {}".format(host, exc))
+                continue
+
+            sock = socket.socket()
+            try:
+                sock.settimeout(5)
+                sock.connect(addr)
+                print("Resolved and connected to {} via {}".format(host, addr[0]))
+                return
+            except OSError as exc:
+                errors.append("{} connect {}: {}".format(host, addr, exc))
+            finally:
+                sock.close()
+
+        self.fail("No DNS-dependent uplink probe succeeded: {}".format("; ".join(errors)))
+
+    def _assert_public_dns_lookup_fails(self, hosts):
+        successes = []
+        failures = []
+
+        for host in hosts:
+            try:
+                addr = socket.getaddrinfo(host, PROBE_PORT)[0][-1]
+                successes.append("{} -> {}".format(host, addr[0]))
+            except OSError as exc:
+                print("DNS lookup failed for {} as expected: {}".format(host, exc))
+                failures.append(host)
+
+        if successes:
+            self.fail("DNS lookup unexpectedly succeeded for: {}".format(", ".join(successes)))
+
+        if not failures:
+            self.fail("No DNS-dependent failure probes were attempted")
+
+    def _restart_ap(self, ap):
+        ap.active(False)
+        time.sleep_ms(100)
+        ap.active(True)
+
+    def _set_lan_dns(self, lan, dns_server):
+        ip, subnet, gateway, _ = lan.ifconfig()
+        lan.ifconfig((ip, subnet, gateway, dns_server))
+        current_dns = lan.ifconfig()[3]
+        self.assertEqual(current_dns, dns_server)
+        return current_dns
+
+    def _bring_up_lan_and_ap(self):
+        if LAN_ARGS is None:
+            self.skipTest("configure LAN_ARGS for the test board")
+
+        if not hasattr(network, "LAN") or not hasattr(network, "WLAN"):
+            self.skipTest("LAN or WLAN support not available")
+
+        ap = network.WLAN(network.WLAN.IF_AP)
+        ap.active(False)
+        time.sleep_ms(100)
+        ap.config(ssid="mp-napt-test")
+        ap.active(True)
+
+        try:
+            lan = network.LAN(**LAN_ARGS)
+        except Exception as exc:
+            ap.active(False)
+            self.skipTest("LAN unavailable: {}".format(exc))
+
+        lan.active(True)
+
+        start = time.ticks_ms()
+        while time.ticks_diff(time.ticks_ms(), start) < TIMEOUT_MS:
+            if lan.isconnected():
+                break
+            time.sleep_ms(250)
+        else:
+            ap.active(False)
+            self.skipTest("LAN link or DHCP did not become ready")
+
+        print("LAN ifconfig:", lan.ifconfig())
+        print("AP ifconfig:", ap.ifconfig())
+
+        lan_dns = lan.ifconfig()[3]
+        if not lan_dns or lan_dns == "0.0.0.0":
+            ap.active(False)
+            self.skipTest("LAN DNS not available")
+
+        try:
+            ap_dns = self._wait_for_ap_dns(ap, lan_dns, "AP DNS was not updated from LAN uplink")
+        except AssertionError:
+            ap.active(False)
+            raise
+
+        print("LAN DNS:", lan_dns)
+        print("AP DNS:", ap_dns)
+        return ap, lan, lan_dns, ap_dns
+
+    def test_ap_dns_matches_lan_dns(self):
+        ap, _, lan_dns, ap_dns = self._bring_up_lan_and_ap()
+        try:
+            self.assertEqual(ap_dns, lan_dns)
+        finally:
+            ap.active(False)
+
+    def test_ap_propagates_dns_changes_and_dns_dependent_uplink_follows(self):
+        ap, lan, lan_dns, _ = self._bring_up_lan_and_ap()
+        try:
+            # Verify pass/fail/pass across baseline DNS, invalid DNS, and restored DNS.
+            self._assert_public_dns_uplink(PROBE_BY_NAME_HOST_SETS[0])
+
+            if INVALID_TEST_DNS == lan_dns:
+                self.skipTest("choose an INVALID_TEST_DNS different from the uplink DNS")
+
+            updated_lan_dns = self._set_lan_dns(lan, INVALID_TEST_DNS)
+            self._restart_ap(ap)
+            self._wait_for_ap_dns(
+                ap,
+                updated_lan_dns,
+                "AP DNS was not updated from the LAN DNS after applying the invalid DNS",
+            )
+            self._assert_public_dns_lookup_fails(PROBE_BY_NAME_HOST_SETS[1])
+
+            restored_lan_dns = self._set_lan_dns(lan, lan_dns)
+            self._restart_ap(ap)
+            self._wait_for_ap_dns(
+                ap,
+                restored_lan_dns,
+                "AP DNS was not updated from the LAN DNS after AP restart",
+            )
+            self._assert_public_dns_uplink(PROBE_BY_NAME_HOST_SETS[2])
+        finally:
+            ap.active(False)
+
+    def test_lan_uplink_can_open_public_tcp_socket(self):
+        ap, _, _, _ = self._bring_up_lan_and_ap()
+        try:
+            self._assert_public_tcp_uplink()
+        finally:
+            ap.active(False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This PR adds optional ESP32 LAN-to-WiFi AP uplink forwarding support for builds
    that enable lwIP IPv4 NAPT.

It introduces a dedicated NAT sdkconfig fragment and wires it into
`ESP32_GENERIC` and `ESP32_GENERIC_S3` builds when
`MICROPY_PY_ESP32_LWIP_NAT` is enabled:

```bash
make BOARD=ESP32_GENERIC CMAKE_ARGS='-DMICROPY_PY_ESP32_LWIP_NAT=1'
```
```bash
make BOARD=ESP32_GENERIC_S3 CMAKE_ARGS='-DMICROPY_PY_ESP32_LWIP_NAT=1'
```

At runtime, when the LAN interface has IPv4 connectivity, MicroPython
configures the WiFi AP side to use that LAN uplink by setting the uplink netif
as default, propagating the uplink DNS server through the AP DHCP server, and
enabling IPv4 NAPT on the AP netif.

The AP-side configuration is applied both when the LAN interface gets IPv4 and
when the AP starts or restarts while LAN IPv4 is already present. The reapply
path checks the LAN netif's current IPv4 state instead of relying only on cached
Ethernet event status. This fixes AP restart cases such as channel changes,
where clients can reconnect to the AP but lose internet access unless DNS/NAPT
state is re-applied.

The change also documents the build option and adds an ESP32 hardware-gated
smoke test for the AP+LAN setup.

### Testing

- Added a hardware-gated ESP32 integration test in tests/ports/esp32/esp32_lan_napt.py.
- The test brings up LAN and AP together, waits for DHCP on the LAN uplink, and verifies that the AP DNS server is updated to match the LAN DNS server.
- The test verifies that the LAN uplink can open a public TCP socket by IP.
- The test verifies DNS-dependent uplink behavior with the LAN DNS server.
- The test changes the LAN DNS server to an invalid address, restarts the AP, verifies that the AP DNS server follows the changed LAN DNS value, and verifies that DNS lookups fail.
- The test restores the original LAN DNS server, restarts the AP again, verifies that the AP DNS server is restored, and verifies that DNS-dependent uplink access works again.
- Built an image with the feature enabled and tested LAN uplink plus WiFi AP internet access on ESP32-S3-ETH (https://spotpear.com/wiki/ESP32-S3R8-PoE-ETH-RJ45-Camera-Micro-SD-Pico-W5500-OV2640-OV5640.html).

### Trade-offs and Alternatives

The main trade-off is extra build and runtime surface for a fairly specific
ESP32 deployment pattern, which is why the feature remains opt-in behind
MICROPY_PY_ESP32_LWIP_NAT.

An alternative would be to enable the required lwIP options for all affected
    ESP32 builds, but that would impose the cost on users who do not need LAN
uplink forwarding.

Another alternative would be to keep the runtime hook only on the LAN "got IP"
event, but that leaves AP restarts in a broken state because the AP-side
forwarding state is not guaranteed to survive an AP cycle.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.
