### PR TITLE
tests/cpydiff: Document dir() not post-processing __dir__ result.

### DIFF
--- a/tests/cpydiff/core_class_dir.py
+++ b/tests/cpydiff/core_class_dir.py
@@ -1,0 +1,14 @@
+"""
+categories: Core,Classes
+description: dir() does not convert __dir__ return value to a sorted list
+cause: MicroPython's dir() returns the value from __dir__ as-is, without iterating it into a list or sorting it.
+workaround: Have __dir__ return a sorted list directly.
+"""
+
+
+class C:
+    def __dir__(self):
+        return "cba"
+
+
+print(dir(C()))


### PR DESCRIPTION
### Summary

Fixes #19145.

Adds a `tests/cpydiff/` entry documenting that MicroPython's `dir()` does not iterate the `__dir__` return value into a list or sort it, whereas CPython does both.

The conclusion in the issue was that overriding `__dir__` is rare enough in real code that adding the iterate-and-sort step in `mp_builtin_dir` is not worth the binary footprint, so documenting the divergence under `tests/cpydiff/` is the agreed follow-up.

The reproduction uses a class whose `__dir__` returns a `str` (`"cba"`):

```
CPython:     ['a', 'b', 'c']
MicroPython: cba
```

Both interpreters produce visible output (no traceback), so the difference is captured by a single `print()` call — `tools/gen-cpydiff.py` renders it as a side-by-side table in the generated docs.

### Testing

- Ran `tools/gen-cpydiff.py` on the unix port `build-standard` MicroPython and confirmed the new entry appears in `docs/genrst/core_language.rst` with the expected CPython vs MicroPython output table.
- Pre-commit hooks (`tools/codeformat.py`, `ruff`, `ruff format`, `codespell`) all pass.

### Trade-offs and Alternatives

#19169 separately makes `dir()` itself disable-able at compile time, which is orthogonal. The divergence remains for builds that include `dir()`.

### Generative AI

I used generative AI tools to translate the documentation and to draft this PR description. A human has reviewed all of the resulting content and is responsible for the code and the description above.
