### PR TITLE
extmod/modtls_mbedtls: Allow ports to override CTR-DRBG pers string.

### DIFF
--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -48,6 +48,16 @@
 #include "mbedtls/pk.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
+
+// Personalization string for the CTR-DRBG instance created per TLS context.
+// It is mixed into the DRBG seed alongside the entropy source.  Ports that
+// have access to a device-unique identifier (chip ID, MAC address, etc.)
+// should override this in their mpconfigport.h to improve DRBG diversity
+// across devices, e.g.:
+//   #define MICROPY_SSL_CTR_DRBG_PERS_STRING "mpy-" DEVICE_SERIAL_STR
+#ifndef MICROPY_SSL_CTR_DRBG_PERS_STRING
+#define MICROPY_SSL_CTR_DRBG_PERS_STRING "mpy"
+#endif
 #ifdef MBEDTLS_SSL_PROTO_DTLS
 #include "mbedtls/timing.h"
 #endif
@@ -304,7 +314,7 @@ static mp_obj_t ssl_context_make_new(const mp_obj_type_t *type_in, size_t n_args
     psa_crypto_init();
     #endif
 
-    const byte seed[] = "mpy";
+    const byte seed[] = MICROPY_SSL_CTR_DRBG_PERS_STRING;
     int ret = mbedtls_ctr_drbg_seed(&self->ctr_drbg, mbedtls_entropy_func, &self->entropy, seed, sizeof(seed));
     if (ret != 0) {
         mbedtls_raise_error(ret);


### PR DESCRIPTION
## Summary

Every MicroPython TLS context was seeded with the four-byte literal
`"mpy"` as the personalisation argument to `mbedtls_ctr_drbg_seed()`.

NIST SP 800-90A section 8.7.1 defines the personalisation string as a
value that differentiates DRBG instances that share the same entropy
source.  Using an identical string on every device defeats this purpose.

The impact is most serious on platforms where the hardware RNG has
limited entropy at boot time:

- **ESP8266** -- no dedicated TRNG; sole entropy source is ADC noise.
- **RP2040** -- ROSC-based RNG; entropy quality before the first read is
  not guaranteed by the datasheet.
- **STM32 without HSE** -- internal RC oscillator is the only entropy
  source before the external crystal is enabled.

On these boards, two devices that happen to boot with a similar entropy
pool state will produce identical CTR-DRBG output, yielding identical
TLS session keys and nonces.

## Fix

Replace the hardcoded `"mpy"` with a `MICROPY_SSL_CTR_DRBG_PERS_STRING`
macro.

The default value remains `"mpy"` so no existing port breaks.  Ports
that have access to a device-unique identifier (chip serial number, MAC
address, eFuse) can override the macro in their `mpconfigport.h` to
maximise DRBG diversity at zero runtime memory cost:

```c
// Example in mpconfigport.h for a port with a chip serial number:
#define MICROPY_SSL_CTR_DRBG_PERS_STRING  "mpy-" CHIP_SERIAL_STR
```

The change is a one-line substitution in `modtls_mbedtls.c` with no
runtime overhead and no change to the ABI or wire format.

## Testing

No automated test exists for CTR-DRBG personalisation.  The macro
mechanism was verified by inspection of the preprocessed output.
