### PR TITLE
esp32: Cleanup and improvements to multi_espnow tests.

### DIFF
--- a/tests/multi_espnow/20_send_echo.py
+++ b/tests/multi_espnow/20_send_echo.py
@@ -27,7 +27,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":

--- a/tests/multi_espnow/30_lmk_echo.py
+++ b/tests/multi_espnow/30_lmk_echo.py
@@ -45,7 +45,7 @@ def echo_server(e):
 
         #  Echo the message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if peer not in peers:

--- a/tests/multi_espnow/40_recv_test.py
+++ b/tests/multi_espnow/40_recv_test.py
@@ -28,7 +28,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":

--- a/tests/multi_espnow/50_esp32_rssi_test.py
+++ b/tests/multi_espnow/50_esp32_rssi_test.py
@@ -29,7 +29,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":

--- a/tests/multi_espnow/60_irq_test.py
+++ b/tests/multi_espnow/60_irq_test.py
@@ -29,7 +29,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":

--- a/tests/multi_espnow/70_channel.py
+++ b/tests/multi_espnow/70_channel.py
@@ -21,6 +21,11 @@ if sys.platform == "esp8266":
     print("SKIP")
     raise SystemExit
 
+# Workaround for a bug in ESP32-C6 where it doesn't select channels cleanly
+# (probably an ESP-IDF v5.5.x bug, needs further investigation.)
+if "ESP32-C6" in sys.implementation._machine:
+    print("SKIP")
+    raise SystemExit
 
 timeout_ms = 1000
 default_pmk = b"MicroPyth0nRules"

--- a/tests/multi_espnow/75_rate.py
+++ b/tests/multi_espnow/75_rate.py
@@ -49,17 +49,21 @@ def init_sta():
 # Receiver
 def instance0():
     sta, e = init_sta()
-    multitest.globals(PEER=sta.config("mac"))
-    multitest.next()
-    while True:
-        peer, msg = e.recv(timeout_ms)
-        if peer is None:
-            print("Timeout")
-            break
-        # Note that we don't have any way in Python to tell what data rate this message
-        # was received with, so we're assuming the rate was correct.
-        print(msg)
-    e.active(False)
+    try:
+        multitest.globals(PEER=sta.config("mac"))
+        multitest.next()
+        while True:
+            peer, msg = e.recv(timeout_ms)
+            if peer is None:
+                print("Timeout")
+                break
+            # Note that we don't have any way in Python to tell what data rate this message
+            # was received with, so we're assuming the rate was correct.
+            print(msg)
+    finally:
+        # Important to stop both even if the test is skipped due to the other instance
+        sta.active(False)
+        e.active(False)
 
 
 # Sender
@@ -67,26 +71,27 @@ def instance1():
     sta, e = init_sta()
     multitest.next()
     peer = PEER
-
-    e.add_peer(peer)
-    # Test normal, non-LR rates
-    for msg, rate in (
-        (b"default rate", None),
-        (b"5Mbit", espnow.RATE_5M),
-        (b"11Mbit", espnow.RATE_11M),
-        (b"24Mbit", espnow.RATE_24M),
-        (b"54Mbit", espnow.RATE_54M),
-        (b"250K LR", espnow.RATE_LORA_250K),
-        (b"500K LR", espnow.RATE_LORA_500K),
-        # switch back to non-LR rates to check it's all OK
-        (b"1Mbit again", espnow.RATE_1M),
-        (b"11Mbit again", espnow.RATE_11M),
-    ):
-        if rate is not None:
-            e.config(rate=rate)
-        for _ in range(3):
-            e.send(peer, msg)
-        time.sleep_ms(50)  # give messages some time to be received before continuing
-    e.del_peer(peer)
-
-    e.active(False)
+    try:
+        e.add_peer(peer)
+        # Test normal, non-LR rates
+        for msg, rate in (
+            (b"default rate", None),
+            (b"5Mbit", espnow.RATE_5M),
+            (b"11Mbit", espnow.RATE_11M),
+            (b"24Mbit", espnow.RATE_24M),
+            (b"54Mbit", espnow.RATE_54M),
+            (b"250K LR", espnow.RATE_LORA_250K),
+            (b"500K LR", espnow.RATE_LORA_500K),
+            # switch back to non-LR rates to check it's all OK
+            (b"1Mbit again", espnow.RATE_1M),
+            (b"11Mbit again", espnow.RATE_11M),
+        ):
+            if rate is not None:
+                e.config(rate=rate)
+            for _ in range(3):
+                e.send(peer, msg)
+            time.sleep_ms(50)  # give messages some time to be received before continuing
+        e.del_peer(peer)
+    finally:
+        sta.active(False)
+        e.active(False)

--- a/tests/multi_espnow/80_asyncio_client.py
+++ b/tests/multi_espnow/80_asyncio_client.py
@@ -66,6 +66,8 @@ async def client(e):
     e.add_peer(peer)
     multitest.next()
 
+    multitest.wait("server ready")
+
     print("airecv() test...")
     msgs = []
     for i in range(5):
@@ -93,6 +95,7 @@ def instance0():
     init(e, True, False)
     multitest.globals(PEERS=[network.WLAN(i).config("mac") for i in (0, 1)])
     multitest.next()
+    multitest.broadcast("server ready")
     print("Server Start")
     echo_server(e)
     print("Server Done")

--- a/tests/multi_espnow/80_asyncio_client.py
+++ b/tests/multi_espnow/80_asyncio_client.py
@@ -29,7 +29,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":

--- a/tests/multi_espnow/90_memory_test.py
+++ b/tests/multi_espnow/90_memory_test.py
@@ -31,7 +31,7 @@ def echo_server(e):
 
         #  Echo the MAC and message back to the sender
         if not e.send(peer, msg, sync):
-            print("ERROR: send() failed to", peer)
+            print("ERROR: send() failed to", peer.hex())
             return
 
         if msg == b"!done":


### PR DESCRIPTION
### Summary

While working on #16737 I noticed some issues with the multi_espnow tests, and some opportunity for small improvements. Submitted separately in this PR.

* Improved logging of peer addresses.
* Fixed a bug where the STA instance was left running at the end of the 75_rate.py test, meaning the data rate stayed locked to the value used in the test. If the other instance skipped this test then subsequent tests would fail.
* Fixed a possible race condition setting up the asyncio test.
* Explicitly skipped the channel test on ESP32C6 as it fails (see https://github.com/micropython/micropython/pull/16737#issuecomment-3555185710). I think this is an ESP-IDF bug (unconfirmed).   

### Testing

The `multi_espnow` tests don't currently pass in master if using ESP-IDF V5.4 or newer (because ESP-NOW V2 support is enabled by default). ~~I've only tested these commits on top of the branch from #16737, and will mark as Draft until that PR is merged and can rebase this one.~~ EDIT: Now rebased.

* Tested between an original ESP32 and an ESP32C6, and between original ESP32 and an ESP8266 board.
* There are still some random failures running these tests (maybe 25% of runs get one random failure) which I think is due to ESP-NOW not doing reliable delivery. I also saw at least one time when ESP-NOW would stop working entirely until the board was hard reset. I suspect this may be a bug in the test where it leaves the STA Wi-Fi peripheral enabled through the entire run and therefore can get stuck in a weird state, rather than a bug in ESP-IDF or the ESP-NOW library. However I don't know.

### Generative AI

I did not use generative AI tools when creating this PR.