### PR TITLE
esp8266: Remove obsolete --verify option from ESP8266.

### DIFF
--- a/ports/esp8266/Makefile
+++ b/ports/esp8266/Makefile
@@ -196,7 +196,7 @@ FROZEN_EXTRA_DEPS = $(CONFVARS_FILE)
 
 deploy: $(FWBIN)
 	$(ECHO) "Writing $< to the board"
-	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write_flash --verify --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
+	$(Q)$(ESPTOOL) --port $(PORT) --baud $(BAUD) write_flash --flash_size=$(FLASH_SIZE) --flash_mode=$(FLASH_MODE) 0 $<
 
 erase:
 	$(ECHO) "Erase flash"

--- a/ports/esp8266/README.md
+++ b/ports/esp8266/README.md
@@ -240,8 +240,7 @@ While the port is in beta, it's known to be generally stable. If you
 experience strange bootloops, crashes, lockups, here's a list to check against:
 
 - You didn't erase flash before programming MicroPython firmware.
-- Firmware can be occasionally flashed incorrectly. Just retry. Recent
-  esptool.py versions have --verify option.
+- Firmware can be occasionally flashed incorrectly. Just retry.
 - Power supply you use doesn't provide enough power for ESP8266 or isn't
   stable enough.
 - A module/flash may be defective (not unheard of for cheap modules).


### PR DESCRIPTION
### Summary

`--verify` has been the default forever (or, at least, for over decade since the "flasher stub" was added). The option was removed entirely in esptool v5.0.

Unlike the fixes in #17826, this change is needed for flashing to work at all with esptool v5.x (and should have no impact on earlier versions, as it was already the default).

*This work was funded through GitHub Sponsors.*

### Generative AI

I did not use generative AI tools when creating this PR.
