### PR TITLE
esp32/machine_i2c: Fix for SOFTI2C disabled.

### DIFF
--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -88,6 +88,7 @@
 #define MICROPY_PY_MACHINE_UART_IRQ (0)
 #endif
 
+#if MICROPY_PY_MACHINE_SOFTI2C
 // Temporary support for legacy construction of SoftI2C via I2C type.
 #define MP_MACHINE_I2C_CHECK_FOR_LEGACY_SOFTI2C_CONSTRUCTION(n_args, n_kw, all_args) \
     do { \
@@ -100,6 +101,7 @@
             return MP_OBJ_TYPE_GET_SLOT(&mp_machine_soft_i2c_type, make_new)(&mp_machine_soft_i2c_type, n_args, n_kw, all_args); \
         } \
     } while (0)
+#endif
 
 // Temporary support for legacy construction of SoftSPI via SPI type.
 #define MP_MACHINE_SPI_CHECK_FOR_LEGACY_SOFTSPI_CONSTRUCTION(n_args, n_kw, all_args) \

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -332,10 +332,12 @@ static void machine_hw_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_p
 }
 
 mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    #if MICROPY_PY_MACHINE_SOFTI2C
     // Create a SoftI2C instance if no id is specified (or is -1) but other arguments are given
     if (n_args != 0) {
         MP_MACHINE_I2C_CHECK_FOR_LEGACY_SOFTI2C_CONSTRUCTION(n_args, n_kw, all_args);
     }
+    #endif
 
     // Parse args
     enum { ARG_id, ARG_scl, ARG_sda, ARG_freq, ARG_timeout };


### PR DESCRIPTION
I am trying to reduce my local firmware size by disabling some features.

To disable soft I2C set zero in line
#define MICROPY_PY_MACHINE_SOFTI2C          (0)
in file
micropython\ports\esp32\mpconfigport.h

I did not use generative AI tools when creating this PR.

Hope for a fast acceptance. Thanks.