### PR TITLE
esp32/machine_hw_spi: Fix for SOFTSPI disabled.

### DIFF
--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -103,6 +103,7 @@
     } while (0)
 #endif
 
+#if MICROPY_PY_MACHINE_SOFTSPI
 // Temporary support for legacy construction of SoftSPI via SPI type.
 #define MP_MACHINE_SPI_CHECK_FOR_LEGACY_SOFTSPI_CONSTRUCTION(n_args, n_kw, all_args) \
     do { \
@@ -115,6 +116,7 @@
             return MP_OBJ_TYPE_GET_SLOT(&mp_machine_soft_spi_type, make_new)(&mp_machine_soft_spi_type, n_args, n_kw, all_args); \
         } \
     } while (0)
+#endif
 
 #if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_SOFTI2C
 

--- a/ports/esp32/machine_hw_spi.c
+++ b/ports/esp32/machine_hw_spi.c
@@ -436,7 +436,9 @@ static void machine_hw_spi_init(mp_obj_base_t *self_in, size_t n_args, const mp_
 }
 
 mp_obj_t machine_hw_spi_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
+    #if MICROPY_PY_MACHINE_SOFTSPI
     MP_MACHINE_SPI_CHECK_FOR_LEGACY_SOFTSPI_CONSTRUCTION(n_args, n_kw, all_args);
+    #endif
 
     mp_arg_val_t args[MP_ARRAY_SIZE(spi_allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(spi_allowed_args), spi_allowed_args, args);


### PR DESCRIPTION
I am trying to reduce my local firmware size by disabling some features.

To disable soft SPI set zero in line
#define MICROPY_PY_MACHINE_SOFTSPI          (0)
in file
ports/esp32/mpconfigport.h

I did not use generative AI tools when creating this PR.
