### PR TITLE
Two format-string fixes.

### DIFF
--- a/extmod/machine_can.c
+++ b/extmod/machine_can.c
@@ -664,8 +664,8 @@ static void machine_can_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
             break;
     }
 
-    mp_printf(print, "CAN(%d, bitrate=%u, mode=CAN.%q, sjw=%u, tseg1=%u, tseg2=%u, f_clock=%u)",
-        self->can_idx + 1,
+    mp_printf(print, "CAN(" UINT_FMT ", bitrate=%u, mode=CAN.%q, sjw=%u, tseg1=%u, tseg2=%u, f_clock=%u)",
+        self->can_idx + 1U,
         actual_bitrate,
         mode,
         self->sjw,

--- a/ports/unix/coverage.c
+++ b/ports/unix/coverage.c
@@ -647,10 +647,10 @@ static mp_obj_t extra_coverage(void) {
         mp_printf(&mp_plat_print, "mp_obj_list_optional_arg same list? %d\n", MP_OBJ_TO_PTR(list) == as_ptr);
 
         as_ptr = mp_obj_list_optional_arg(mp_const_none, list_len);
-        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list len %d\n", as_ptr->len);
+        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list len " SIZE_FMT "\n", as_ptr->len);
 
         as_ptr = mp_obj_list_optional_arg(MP_OBJ_NULL, list_len);
-        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list from NULL len %d\n", as_ptr->len);
+        mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list from NULL len " SIZE_FMT "\n", as_ptr->len);
     }
 
     // runtime utils


### PR DESCRIPTION
### Summary

In a build for #17556, a new diagnostic occurred:
```
coverage.c: In function ‘extra_coverage’:
coverage.c:650:9: error: argument 3: Format ‘%d’ requires a ‘int’ or ‘unsigned int’ (32 bits), not ‘long unsigned int’ [size 64] [-Werror=format=]
  650 |         mp_printf(&mp_plat_print, "mp_obj_list_optional_arg new list len %d\n", as_ptr->len);
```

The preprocessor macro SIZE_FMT exists specifically for formatting objects of type `size_t`, use it.

Another diagnostic in machine_can.c was fixed through use of INT_FMT.

### Testing

I built locally. The same change is at the top of #17556 and it will be CI tested there using the format string checker.



### Generative AI

I did not use generative AI tools when creating this PR.