### PR TITLE
stm32/tinyusb_port: Add missing USB_HS_PHYC_PLL1_PLLSEL constants.

### DIFF
--- a/ports/stm32/tinyusb_port/tusb_config.h
+++ b/ports/stm32/tinyusb_port/tusb_config.h
@@ -46,6 +46,22 @@
 #endif
 #endif
 
+#if defined(USB_HS_PHYC) && !defined(USB_HS_PHYC_PLL1_PLLSEL_Pos)
+// Providing missing definitions of USB_HS_PHYC_PLL1_PLLSEL constants, required by TinyUSB.
+// (These are added in a newer version of the STM32F7xx CMSIS files.)
+#define USB_HS_PHYC_PLL1_PLLSEL_Pos               (1U)
+#define USB_HS_PHYC_PLL1_PLLSEL_Msk               (0x7UL << USB_HS_PHYC_PLL1_PLLSEL_Pos)
+#define USB_HS_PHYC_PLL1_PLLSEL                   (USB_HS_PHYC_PLL1_PLLSEL_Msk)
+#define USB_HS_PHYC_PLL1_PLLSEL_1                 (0x1UL << USB_HS_PHYC_PLL1_PLLSEL_Pos)
+#define USB_HS_PHYC_PLL1_PLLSEL_2                 (0x2UL << USB_HS_PHYC_PLL1_PLLSEL_Pos)
+#define USB_HS_PHYC_PLL1_PLLSEL_3                 (0x4UL << USB_HS_PHYC_PLL1_PLLSEL_Pos)
+#define USB_HS_PHYC_PLL1_PLLSEL_12MHZ             (0x00000000U)
+#define USB_HS_PHYC_PLL1_PLLSEL_12_5MHZ           (USB_HS_PHYC_PLL1_PLLSEL_1)
+#define USB_HS_PHYC_PLL1_PLLSEL_16MHZ             (USB_HS_PHYC_PLL1_PLLSEL_1 | USB_HS_PHYC_PLL1_PLLSEL_2)
+#define USB_HS_PHYC_PLL1_PLLSEL_24MHZ             (USB_HS_PHYC_PLL1_PLLSEL_3)
+#define USB_HS_PHYC_PLL1_PLLSEL_25MHZ             (USB_HS_PHYC_PLL1_PLLSEL_2 | USB_HS_PHYC_PLL1_PLLSEL_3)
+#endif
+
 #include "shared/tinyusb/tusb_config.h"
 
 #endif // MICROPY_INCLUDED_STM32_TINYUSB_PORT_TUSB_CONFIG_H


### PR DESCRIPTION
### Summary

Add missing constants needed by TinyUSB's synopsys/dwc2 driver.  They are not available in the current version of stm32lib used in this repository.

Follow up to #18933, which accidentally broke the build of PYBD_SF3.

### Testing

Built PYBD_SF3 board.  Prior to this PR it would not build.  Now it builds.

Note that TinyUSB isn't used by this board, but the TinyUSB files are nevertheless compiled for it.

### Trade-offs and Alternatives

Could update stm32lib to have a newer STM32F7xx CMSIS, but that's a lot more work.

### Generative AI

I did not use generative AI tools when creating this PR.
