### PR TITLE
ports/zephyr: Give a little bit of time to putchar.

### DIFF
--- a/ports/zephyr/uart_core.c
+++ b/ports/zephyr/uart_core.c
@@ -140,7 +140,7 @@ int mp_console_init(void) {
     tty_set_rx_buf(&mp_console_serial, mp_console_rxbuf, sizeof(mp_console_rxbuf));
 
     tty_set_rx_timeout(&mp_console_serial, 0);
-    tty_set_tx_timeout(&mp_console_serial, 1);
+    tty_set_tx_timeout(&mp_console_serial, 2);
 
     return 0;
 }


### PR DESCRIPTION
### Summary
Allow putchar to wait a little as sometimes the CPU is very significantly faster than the UART.

So as to avoid missing most of the text.


### Testing

Yes

### Trade-offs and Alternatives

A really big putchar buffer (issues show up often still with 1KB size buffer!) 

### Generative AI

No.
