### PR TITLE
nrf/boards: Increase stack to 6k for nRF51x22 boards with 32k RAM.

### DIFF
--- a/ports/nrf/boards/nrf51x22_256k_32k.ld
+++ b/ports/nrf/boards/nrf51x22_256k_32k.ld
@@ -9,5 +9,5 @@ _ram_size = 32K;
 _micropy_hw_romfs_part0_size = 12K;
 
 /* Default stack size when there is no SoftDevice */
-_stack_size        = 4K;
+_stack_size        = 6K;
 _minimum_heap_size = 24K;


### PR DESCRIPTION
### Summary

Increase the stack from 4k to 6k for PCA10028 and PCA10031 boards.

4k stack is not much and that causes some tests crash with a stack-overflow exception (eg `extmod/vfs_userfs.py` when run with `--via-mpy`).  With the increased stack size there are no longer any tests that fail due to stack overflow on PCA10028.

### Testing

PCA10028 and PCA10031 still build without error.

PCA10028 now passes more tests.

### Generative AI

I did not use generative AI tools when creating this PR.
