### PR TITLE
alif: implement wake up sources for `machine.lightsleep()`

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -113,6 +113,7 @@ SRC_C = \
 	alif_flash.c \
 	cyw43_port_spi.c \
 	fatfs_port.c \
+	lptimer_ext.c \
 	machine_pin.c \
 	machine_i2c.c \
 	machine_spi.c \

--- a/ports/alif/boards/OPENMV_AE3/board.c
+++ b/ports/alif/boards/OPENMV_AE3/board.c
@@ -88,6 +88,16 @@ const ospi_flash_settings_t ospi_flash_settings[] = {
 };
 const size_t ospi_flash_settings_len = 3;
 
+static void board_config_user_button_irq(void) {
+    #if CORE_M55_HP
+    // Configure the user button to wake on rising edge (button release).
+    mp_hal_pin_config_irq_rising(pin_SW, true);
+    NVIC_ClearPendingIRQ(LPGPIO_IRQ7_IRQn);
+    NVIC_SetPriority(LPGPIO_IRQ7_IRQn, IRQ_PRI_GPIO);
+    NVIC_EnableIRQ(LPGPIO_IRQ7_IRQn);
+    #endif
+}
+
 void board_startup(void) {
     // Switch the USB multiplexer to use the Alif USB port.
     mp_hal_pin_output(pin_USB_D_SEL);
@@ -182,6 +192,9 @@ void board_early_init(void) {
 }
 
 MP_WEAK void board_enter_stop(void) {
+    // Allow the user button to wake the device.
+    board_config_user_button_irq();
+
     // Let USB_D_SEL float, so it doesn't source 30uA through the 110k resistors to GND.
     mp_hal_pin_input(pin_USB_D_SEL);
 
@@ -209,7 +222,8 @@ MP_WEAK void board_enter_stop(void) {
 }
 
 MP_WEAK void board_enter_standby(void) {
-
+    // Allow the user button to wake the device.
+    board_config_user_button_irq();
 }
 
 MP_WEAK void board_exit_standby(void) {

--- a/ports/alif/lptimer_ext.c
+++ b/ports/alif/lptimer_ext.c
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 OpenMV LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "irq.h"
+#include "lptimer.h"
+#include "lptimer_ext.h"
+#include "sys_ctrl_lptimer.h"
+
+#define LPTIMER ((LPTIMER_Type *)LPTIMER_BASE)
+#define LPTIMER_CH_A (0)
+
+void lptimer_set_wakeup(uint64_t timeout_us) {
+    lptimer_disable_counter(LPTIMER, LPTIMER_CH_A);
+
+    ANA_REG->MISC_CTRL |= 1U << 0; // SEL_32K, select LXFO
+
+    select_lptimer_clk(LPTIMER_CLK_SOURCE_32K, LPTIMER_CH_A);
+
+    // Maximum 131 second timeout, to not overflow 32-bit ticks when
+    // LPTIMER is clocked at 32768Hz.
+    if (timeout_us > 131000000ULL) {
+        timeout_us = 131000000ULL;
+    }
+    uint32_t timeout_ticks = timeout_us * 32768ULL / 1000000ULL;
+
+    // Set up the LPTIMER interrupt to fire after the given timeout.
+    lptimer_set_mode_userdefined(LPTIMER, LPTIMER_CH_A);
+    lptimer_load_count(LPTIMER, LPTIMER_CH_A, &timeout_ticks);
+    lptimer_clear_interrupt(LPTIMER, LPTIMER_CH_A);
+    lptimer_unmask_interrupt(LPTIMER, LPTIMER_CH_A);
+
+    lptimer_enable_counter(LPTIMER, LPTIMER_CH_A);
+}

--- a/ports/alif/lptimer_ext.c
+++ b/ports/alif/lptimer_ext.c
@@ -32,6 +32,10 @@
 #define LPTIMER ((LPTIMER_Type *)LPTIMER_BASE)
 #define LPTIMER_CH_A (0)
 
+void LPTIMER0_IRQHandler(void) {
+    lptimer_clear_interrupt(LPTIMER, LPTIMER_CH_A);
+}
+
 void lptimer_init(void) {
     // LPTIMER is not reset on CPU reset and may still be active, so reset it now.
     lptimer_cancel_wakeup();
@@ -56,6 +60,10 @@ void lptimer_set_wakeup(uint64_t timeout_us) {
     lptimer_load_count(LPTIMER, LPTIMER_CH_A, &timeout_ticks);
     lptimer_clear_interrupt(LPTIMER, LPTIMER_CH_A);
     lptimer_unmask_interrupt(LPTIMER, LPTIMER_CH_A);
+
+    NVIC_SetPriority(LPTIMER0_IRQ_IRQn, IRQ_PRI_RTC);
+    NVIC_ClearPendingIRQ(LPTIMER0_IRQ_IRQn);
+    NVIC_EnableIRQ(LPTIMER0_IRQ_IRQn);
 
     lptimer_enable_counter(LPTIMER, LPTIMER_CH_A);
 }

--- a/ports/alif/lptimer_ext.c
+++ b/ports/alif/lptimer_ext.c
@@ -32,6 +32,11 @@
 #define LPTIMER ((LPTIMER_Type *)LPTIMER_BASE)
 #define LPTIMER_CH_A (0)
 
+void lptimer_init(void) {
+    // LPTIMER is not reset on CPU reset and may still be active, so reset it now.
+    lptimer_cancel_wakeup();
+}
+
 void lptimer_set_wakeup(uint64_t timeout_us) {
     lptimer_disable_counter(LPTIMER, LPTIMER_CH_A);
 
@@ -53,4 +58,10 @@ void lptimer_set_wakeup(uint64_t timeout_us) {
     lptimer_unmask_interrupt(LPTIMER, LPTIMER_CH_A);
 
     lptimer_enable_counter(LPTIMER, LPTIMER_CH_A);
+}
+
+void lptimer_cancel_wakeup(void) {
+    lptimer_disable_counter(LPTIMER, LPTIMER_CH_A);
+    lptimer_mask_interrupt(LPTIMER, LPTIMER_CH_A);
+    lptimer_clear_interrupt(LPTIMER, LPTIMER_CH_A);
 }

--- a/ports/alif/lptimer_ext.h
+++ b/ports/alif/lptimer_ext.h
@@ -28,7 +28,12 @@
 
 #include <stdint.h>
 
+void lptimer_init(void);
+
 // Configure the LPTIMER to wake the CPU via an IRQ after the given timeout.
 void lptimer_set_wakeup(uint64_t timeout_us);
+
+// Cancel any pending wakeup started by lptimer_set_wakeup().
+void lptimer_cancel_wakeup(void);
 
 #endif // MICROPY_INCLUDED_ALIF_LPTIMER_EXT_H

--- a/ports/alif/lptimer_ext.h
+++ b/ports/alif/lptimer_ext.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 OpenMV LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ALIF_LPTIMER_EXT_H
+#define MICROPY_INCLUDED_ALIF_LPTIMER_EXT_H
+
+#include <stdint.h>
+
+// Configure the LPTIMER to wake the CPU via an IRQ after the given timeout.
+void lptimer_set_wakeup(uint64_t timeout_us);
+
+#endif // MICROPY_INCLUDED_ALIF_LPTIMER_EXT_H

--- a/ports/alif/machine_pin.c
+++ b/ports/alif/machine_pin.c
@@ -52,11 +52,12 @@ typedef struct _machine_pin_irq_obj_t {
 // Defines a single GPIO IRQ handler
 #define DEFINE_GPIO_IRQ_HANDLER(pname, port, pin) \
     void pname##_IRQ##pin##Handler(void) { \
+        gpio_interrupt_eoi((GPIO_Type *)pname##_BASE, pin); \
         machine_pin_irq_obj_t *irq = MACHINE_PIN_IRQ_OBJECT(port, pin); \
-        machine_pin_obj_t *self = MP_OBJ_TO_PTR(irq->base.parent); \
-        gpio_interrupt_eoi(self->gpio, pin); \
-        irq->flags = irq->trigger; \
-        mp_irq_handler(&irq->base); \
+        if (irq != NULL) { \
+            irq->flags = irq->trigger; \
+            mp_irq_handler(&irq->base); \
+        } \
     }
 
 // Defines all 8 pin IRQ handlers for a port

--- a/ports/alif/machine_rtc.c
+++ b/ports/alif/machine_rtc.c
@@ -120,6 +120,10 @@ void machine_rtc_set_wakeup(uint32_t seconds) {
     MICROPY_END_ATOMIC_SECTION(atomic_state);
 }
 
+void machine_rtc_cancel_wakeup(void) {
+    lprtc_interrupt_disable(machine_rtc.rtc);
+}
+
 static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         // Get datetime.

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -38,6 +38,7 @@
 #include "shared/runtime/softtimer.h"
 #include "shared/tinyusb/mp_usbd.h"
 #include "tusb.h"
+#include "lptimer_ext.h"
 #include "modmachine.h"
 #include "mpbthciport.h"
 #include "mpuart.h"
@@ -79,6 +80,7 @@ int main(void) {
 
     MICROPY_BOARD_EARLY_INIT();
 
+    lptimer_init();
     machine_rtc_init();
 
     #if MICROPY_HW_ENABLE_UART_REPL

--- a/ports/alif/modmachine.c
+++ b/ports/alif/modmachine.c
@@ -27,6 +27,7 @@
 // This file is never compiled standalone, it's included directly from
 // extmod/modmachine.c via MICROPY_PY_MACHINE_INCLUDEFILE.
 
+#include "lptimer_ext.h"
 #include "modmachine.h"
 #include "se_services.h"
 #include "tusb.h"
@@ -115,31 +116,6 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     #if MICROPY_HW_ENABLE_USBDEV
     mp_machine_enable_usb(true);
     #endif
-}
-
-#include "lptimer.h"
-#include "sys_ctrl_lptimer.h"
-
-#define LPTIMER ((LPTIMER_Type *)LPTIMER_BASE)
-#define LPTIMER_CH_A (0)
-
-static void lptimer_set_wakeup(uint64_t timeout_us) {
-    lptimer_disable_counter(LPTIMER, LPTIMER_CH_A);
-
-    ANA_REG->MISC_CTRL |= 1 << 0; // SEL_32K, select LXFO
-
-    select_lptimer_clk(LPTIMER_CLK_SOURCE_32K, LPTIMER_CH_A);
-
-    // Maximum 131 second timeout, to not overflow 32-bit ticks when
-    // LPTIMER is clocked at 32768Hz.
-    uint32_t timeout_ticks = (uint64_t)MIN(timeout_us, 131000000) * 32768 / 1000000;
-
-    // Set up the LPTIMER interrupt to fire after the given timeout.
-    lptimer_set_mode_userdefined(LPTIMER, LPTIMER_CH_A);
-    lptimer_load_count(LPTIMER, LPTIMER_CH_A, &timeout_ticks);
-    lptimer_clear_interrupt(LPTIMER, LPTIMER_CH_A);
-    lptimer_unmask_interrupt(LPTIMER, LPTIMER_CH_A);
-    lptimer_enable_counter(LPTIMER, LPTIMER_CH_A);
 }
 
 MP_NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args) {

--- a/ports/alif/modmachine.c
+++ b/ports/alif/modmachine.c
@@ -92,7 +92,31 @@ static void mp_machine_enable_usb(bool enable) {
 }
 #endif
 
+static void mp_machine_config_wakeup(mp_int_t sleep_ms, bool enable) {
+    if (sleep_ms >= 0) {
+        // RTC has a resolution of 1 second so use LPTIMER for small sleep duration.
+        if (sleep_ms < 10000) {
+            if (enable) {
+                lptimer_set_wakeup(sleep_ms * 1000);
+            } else {
+                lptimer_cancel_wakeup();
+            }
+        } else {
+            if (enable) {
+                machine_rtc_set_wakeup(sleep_ms / 1000);
+            } else {
+                machine_rtc_cancel_wakeup();
+            }
+        }
+    }
+}
+
 static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
+    mp_int_t sleep_ms = -1;
+    if (n_args != 0) {
+        sleep_ms = mp_obj_get_int(args[0]);
+    }
+
     #if MICROPY_HW_ENABLE_USBDEV
     mp_machine_enable_usb(false);
     #endif
@@ -103,9 +127,13 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
 
     __disable_irq();
 
+    mp_machine_config_wakeup(sleep_ms, true);
+
     // This enters the deepest possible CPU sleep state, without
     // losing CPU state. CPU and subsystem power will remain on.
     pm_core_enter_deep_sleep();
+
+    mp_machine_config_wakeup(sleep_ms, false);
 
     __enable_irq();
 
@@ -134,13 +162,7 @@ MP_NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args
 
     __disable_irq();
 
-    if (sleep_ms >= 0) {
-        if (sleep_ms < 10000) {
-            lptimer_set_wakeup(sleep_ms * 1000);
-        } else {
-            machine_rtc_set_wakeup(sleep_ms / 1000);
-        }
-    }
+    mp_machine_config_wakeup(sleep_ms, true);
 
     // If power is removed from the subsystem, the function does
     // not return, and the CPU will reboot when/if the subsystem

--- a/ports/alif/modmachine.h
+++ b/ports/alif/modmachine.h
@@ -28,5 +28,6 @@
 
 void machine_rtc_init(void);
 void machine_rtc_set_wakeup(uint32_t seconds);
+void machine_rtc_cancel_wakeup(void);
 
 #endif // MICROPY_INCLUDED_ALIF_MODMACHINE_H

--- a/ports/alif/mphalport.h
+++ b/ports/alif/mphalport.h
@@ -312,6 +312,16 @@ static inline void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin) {
     gpio_set_direction_output(pin->gpio, pin->pin);
 }
 
+static inline void mp_hal_pin_config_irq_rising(mp_hal_pin_obj_t pin, bool enable) {
+    if (enable) {
+        gpio_enable_interrupt(pin->gpio, pin->pin);
+        gpio_interrupt_set_edge_trigger(pin->gpio, pin->pin);
+        gpio_interrupt_set_polarity_high(pin->gpio, pin->pin);
+    } else {
+        gpio_disable_interrupt(pin->gpio, pin->pin);
+    }
+}
+
 static inline void mp_hal_pin_config_irq_falling(mp_hal_pin_obj_t pin, bool enable) {
     if (enable) {
         gpio_enable_interrupt(pin->gpio, pin->pin);

--- a/ports/alif/mphalport.h
+++ b/ports/alif/mphalport.h
@@ -315,8 +315,10 @@ static inline void mp_hal_pin_open_drain(mp_hal_pin_obj_t pin) {
 static inline void mp_hal_pin_config_irq_rising(mp_hal_pin_obj_t pin, bool enable) {
     if (enable) {
         gpio_enable_interrupt(pin->gpio, pin->pin);
+        gpio_unmask_interrupt(pin->gpio, pin->pin);
         gpio_interrupt_set_edge_trigger(pin->gpio, pin->pin);
         gpio_interrupt_set_polarity_high(pin->gpio, pin->pin);
+        gpio_interrupt_eoi(pin->gpio, pin->pin);
     } else {
         gpio_disable_interrupt(pin->gpio, pin->pin);
     }
@@ -325,8 +327,10 @@ static inline void mp_hal_pin_config_irq_rising(mp_hal_pin_obj_t pin, bool enabl
 static inline void mp_hal_pin_config_irq_falling(mp_hal_pin_obj_t pin, bool enable) {
     if (enable) {
         gpio_enable_interrupt(pin->gpio, pin->pin);
+        gpio_unmask_interrupt(pin->gpio, pin->pin);
         gpio_interrupt_set_edge_trigger(pin->gpio, pin->pin);
         gpio_interrupt_set_polarity_low(pin->gpio, pin->pin);
+        gpio_interrupt_eoi(pin->gpio, pin->pin);
     } else {
         gpio_disable_interrupt(pin->gpio, pin->pin);
     }


### PR DESCRIPTION
### Summary

This PR implements on alif the following wake-up sources for `machine.lightsleep()`:
- LPTIMER, for when a timeout argument is passed to `machine.lightsleep(timeout_ms)`
- LPGPIO, enabled on OPENMV_AE3

It also includes a fix for `machine.deepsleep()` to cancel any existing LPTIMER state upon reset.

Addresses #19190.

### Testing

Tested on OPENMV_AE3:
- calling `machine.lightsleep(2_000)` and `machine.lightsleep(15_000)`, the device wakes after the specified time
- calling `machine.lightsleep()`, then pressing the user button wakes the device

### Generative AI

I did not use generative AI tools when creating this PR.
