### PR TITLE
shared/tinyusb: Implement tusb_time_delay_ms_api using mp_hal_delay_ms.

### DIFF
--- a/shared/tinyusb/mp_usbd.c
+++ b/shared/tinyusb/mp_usbd.c
@@ -64,4 +64,9 @@ void mp_usbd_hex_str(char *out_str, const uint8_t *bytes, size_t bytes_len) {
     out_str[hex_len] = 0;
 }
 
+// Required by TinyUSB drivers that need a blocking delay (e.g. dwc2 USB_HS_PHYC PLL init).
+void tusb_time_delay_ms_api(uint32_t ms) {
+    mp_hal_delay_ms(ms);
+}
+
 #endif // MICROPY_HW_ENABLE_USBDEV


### PR DESCRIPTION
### Summary

Found while testing #19201: PYBD_SF3 fails to link with TinyUSB enabled, with an undefined reference to `tusb_time_millis_api`. The root cause (identified by @dpgeorge) is that `tusb_time_delay_ms_api()` - a weak function in TinyUSB whose default implementation busy-loops on `tusb_time_millis_api()` - gets pulled into the binary on boards with an internal USB HS PHY (`USB_HS_PHYC`). The dwc2 driver calls it to wait 2ms for the PHYC PLL to stabilise during init, and PYBD_SF3 (STM32F722) is currently the only MicroPython board where this code path is reached.

Rather than implementing `tusb_time_millis_api()` and keeping the busy-wait, this overrides `tusb_time_delay_ms_api()` directly using `mp_hal_delay_ms()`, which handles both IRQ-enabled and IRQ-disabled contexts correctly.

### Testing

Built PYBD_SF3 with `CFLAGS_EXTRA=-DMICROPY_HW_TINYUSB_STACK=1` (previously failed to link, now builds cleanly). Also built all 79 defined stm32 boards with TinyUSB forced on to confirm no regressions.

### Trade-offs and Alternatives

Could implement `tusb_time_millis_api()` instead, but that leaves the busy-wait in place. `tusb_time_delay_ms_api()` is the right override since it's the actual call site.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.