### PR TITLE
samd: fix UART IRQ events

### DIFF
--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -167,7 +167,7 @@ void common_uart_irq_handler(int uart_id) {
                     uart->USART.DATA.bit.DATA =
                         ringbuf_get(&self->write_buffer) | (ringbuf_get(&self->write_buffer) << 8);
                 }
-            } else {
+            } else if (uart->USART.INTENCLR.bit.DRE != 0) {
                 #if MICROPY_PY_MACHINE_UART_IRQ
                 // Set the TXIDLE flag
                 mp_irq_flags |= SERCOM_USART_INTFLAG_TXC;

--- a/ports/samd/machine_uart.c
+++ b/ports/samd/machine_uart.c
@@ -184,7 +184,7 @@ void common_uart_irq_handler(int uart_id) {
         // Check the flags to see if the uart user handler should be called
         // The handler for RXIDLE is called in the timer callback
         if (self->mp_irq_trigger & mp_irq_flags) {
-            self->mp_irq_flags = mp_irq_flags;
+            self->mp_irq_flags = self->mp_irq_trigger & mp_irq_flags;
             mp_irq_handler(self->mp_irq_obj);
         }
         #endif


### PR DESCRIPTION
### Summary

This PR fixes two related issues with UART Python IRQ events:
- The UART DRE flag is always set if the DATA register is empty.  That would lead to a TXIDLE event each time the IRQ handler was run.  To fix that, only fire the TXIDLE event if the DRE interrupt flag is enabled.
- The C IRQ handler can be called with multiple IRQ flags active, eg both RXC and DRE set.  But the Python IRQ handler should only see the events that it registered.  So mask the flags as appropriate.

### Testing

`tests/extmod/machine_uart_irq_txidle.py` now passes on `ADAFRUIT_ITSYBITSY_M0_EXPRESS`

There are no regressions to other tests.

### Generative AI

I did not use generative AI tools when creating this PR.
