### PR TITLE
tests: use stdin/stdout when compiling using mpy-cross, instead of temporary files

### DIFF
--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -14,6 +14,7 @@ from glob import glob
 from test_utils import (
     base_path,
     pyboard,
+    set_injected_prologue,
     get_test_instance,
     prepare_script_for_target,
     create_test_report,
@@ -292,6 +293,12 @@ def main():
     cmd_parser.add_argument("--via-mpy", action="store_true", help="compile code to .mpy first")
     cmd_parser.add_argument("--mpy-cross-flags", default="", help="flags to pass to mpy-cross")
     cmd_parser.add_argument(
+        "--begin",
+        metavar="PROLOGUE",
+        default=None,
+        help="prologue python file to execute before module import",
+    )
+    cmd_parser.add_argument(
         "-r",
         "--result-dir",
         default=base_path("results"),
@@ -307,6 +314,12 @@ def main():
     if args.diff_time or args.diff_score:
         compute_diff(args.N[0], args.M[0], args.diff_score)
         sys.exit(0)
+
+    prologue = ""
+    if args.begin:
+        with open(args.begin, "rt") as source:
+            prologue = source.read()
+    set_injected_prologue(prologue)
 
     # N, M = 50, 25 # esp8266
     # N, M = 100, 100 # pyboard, esp32

--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -141,7 +141,7 @@ def run_benchmarks(args, target, param_n, param_m, n_average, test_list):
 
         # Process script through mpy-cross if needed
         if hasattr(target, "enter_raw_repl") or args.via_mpy:
-            crash, test_script_target = prepare_script_for_target(args, script_text=test_script)
+            crash, test_script_target = prepare_script_for_target(args, test_script, test_file)
             if crash:
                 test_results.append((test_file, "fail", "preparation"))
                 print("CRASH:", test_script_target)

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -29,7 +29,6 @@ from test_utils import (
     get_results_filename,
     convert_device_shortcut_to_real_device,
     get_test_instance,
-    prepare_script_for_target,
     create_test_report,
     FLAKY_REASON_PREFIX,
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 
 # See stackoverflow.com/questions/2632199: __file__ nor sys.argv[0]
 # are guaranteed to always work, this one should though.
@@ -224,34 +223,27 @@ def get_test_instance(test_instance, baudrate, user, password):
     return pyb
 
 
-def prepare_script_for_target(args, *, script_text=None, force_plain=False):
+def prepare_script_for_target(args, script_text, script_name, force_plain=False):
     if force_plain or (not args.via_mpy and args.emit == "bytecode"):
         # A plain test to run as-is, no processing needed.
         pass
     elif args.via_mpy:
-        tempname = tempfile.mktemp(dir="")
-        mpy_filename = tempname + ".mpy"
-
-        script_filename = tempname + ".py"
-        with open(script_filename, "wb") as f:
-            f.write(script_text)
-
         try:
-            subprocess.check_output(
+            # Compile the script with mpy-cross (using stdin/stdout).
+            p = subprocess.run(
                 [MPYCROSS]
                 + args.mpy_cross_flags.split()
-                + ["-o", mpy_filename, "-X", "emit=" + args.emit, script_filename],
-                stderr=subprocess.STDOUT,
+                + ["-s", script_name, "-X", "emit=" + args.emit, "--", "-"],
+                input=script_text,
+                capture_output=True,
+                check=True,
             )
+            assert p.stderr == b""
+            mpy_data = p.stdout
         except subprocess.CalledProcessError as er:
-            return True, b"mpy-cross crash\n" + er.output
+            return True, b"mpy-cross crash\n" + er.output + er.stderr
 
-        with open(mpy_filename, "rb") as f:
-            script_text = b"__buf=" + bytes(repr(f.read()), "ascii") + b"\n"
-
-        rm_f(mpy_filename)
-        rm_f(script_filename)
-
+        script_text = b"__buf=" + bytes(repr(mpy_data), "ascii") + b"\n"
         script_text += bytes(_injected_import_hook_code, "ascii")
     else:
         print("error: using emit={} must go via .mpy".format(args.emit))
@@ -274,7 +266,7 @@ def run_script_on_remote_target(pyb, args, test_file, is_special, requires_targe
         else:
             script = b"print('START TEST')\n" + script
 
-    had_crash, script = prepare_script_for_target(args, script_text=script, force_plain=is_special)
+    had_crash, script = prepare_script_for_target(args, script, test_file, force_plain=is_special)
 
     if had_crash:
         return True, script


### PR DESCRIPTION
### Summary

This change pipes data into and out of mpy-cross using stdin/stdout, instead of creating two temporary files.  That should be more efficient, reducing load on the filesystem.

As part of this change, pass through the correct .py filename to mpy-cross' "-s" argument, to make error messages a little easier to understand.

Also fix a related bug with missing prologue in `run-perfbench.py` that was found when testing this change.

### Testing

Ran on a bare-metal target, using `--via-mpy` and `--via-mpy --emit native`.  The tests still run.

Also tested the cases of mpy-cross crashing due to invalid arguments passed into it, and due to a syntax error in a .py file.

### Generative AI

I did not use generative AI tools when creating this PR.
