### PR TITLE
py/objarray: Guard array allocation size against overflow.

### DIFF
--- a/py/objarray.c
+++ b/py/objarray.c
@@ -96,6 +96,9 @@ static void array_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t 
 #if MICROPY_PY_BUILTINS_BYTEARRAY || MICROPY_PY_ARRAY
 static mp_obj_array_t *array_new(char typecode, size_t n) {
     int typecode_size = mp_binary_get_size('@', typecode, NULL);
+    if (n > SIZE_MAX / (size_t)typecode_size) {
+        m_malloc_fail(SIZE_MAX);
+    }
     mp_obj_array_t *o = m_new_obj(mp_obj_array_t);
     #if MICROPY_PY_BUILTINS_BYTEARRAY && MICROPY_PY_ARRAY
     o->base.type = (typecode == BYTEARRAY_TYPECODE) ? &mp_type_bytearray : &mp_type_array;

--- a/tests/basics/array_construct_len_overflow_intbig.py
+++ b/tests/basics/array_construct_len_overflow_intbig.py
@@ -1,0 +1,22 @@
+# test construction of array.array from an object with an overflowing len
+
+try:
+    from array import array
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class TooLong:
+    def __len__(self):
+        return 1 << 61
+
+    def __iter__(self):
+        for _ in range(4):
+            yield 1.23
+
+
+try:
+    array("d", TooLong())
+except MemoryError:
+    print("MemoryError")

--- a/tests/basics/array_construct_len_overflow_intbig.py.exp
+++ b/tests/basics/array_construct_len_overflow_intbig.py.exp
@@ -1,0 +1,1 @@
+MemoryError


### PR DESCRIPTION
Fixes #18620.

## Summary

`array_new()` allocates the backing buffer for `array.array()` as `typecode_size * n` bytes, where `n` comes from the initializer's `__len__`. With a large enough `n` the multiplication overflows `size_t`, so the allocation is sized for a small (or zero-byte) buffer while `o->len` still records the original huge value. The subsequent fill loop in `array_construct()` then writes through a NULL or undersized `items` pointer.

This PR adds an overflow check before allocation and raises `MemoryError` via the existing `m_malloc_fail()` path when the requested array would exceed `SIZE_MAX` bytes.

## Reproducer

```python
from array import array


class Boom:
    def __len__(self):
        return 1 << 61

    def __iter__(self):
        for _ in range(4):
            yield 1.23


array("d", Boom())
```

Before the patch, on a 64-bit Unix port build:

- standard build: segmentation fault (exit 139), writing to address 0 in `mp_binary_set_val_array()`.
- ASan/UBSan build: null pointer store reported in `py/binary.c`.

After the patch the same script raises `MemoryError` cleanly.

## Tests

A regression test is added at `tests/basics/array_construct_len_overflow_intbig.py`. The `_intbig` suffix gates it on builds with long-int support, since the literal `1 << 61` is not representable as a small int on 32-bit small-int-only configurations.

```text
make -C mpy-cross -j$(nproc)
make -C ports/unix submodules
make -C ports/unix -j$(nproc)
env MICROPY_MICROPYTHON=../ports/unix/build-standard/micropython \
    python3 tests/run-tests.py -d basics
```

Result: 545 tests pass, 30 skipped (no new failures or regressions). Targeted check:

```text
basics/array_construct.py                       pass
basics/array_construct_len_overflow_intbig.py   pass
float/array_construct.py                        pass
```

An ASan/UBSan Unix build was also used to verify the original reproducer no longer crashes.

## Code formatting

- C: `tools/codeformat.py -c -f py/objarray.c` with uncrustify v0.72.
- Python: `ruff check` and `ruff format --check` on the new test file (both clean).

## Notes

- The check is placed in `array_new()` rather than `array_construct()` so it also covers `bytearray(<huge int>)` and any other call site that funnels through `array_new()`.
- Long-int representation of the test's `__len__` value on 32-bit configs would already break the existing `MP_OBJ_SMALL_INT_VALUE(len_in)` assumption in `array_construct()`, which is a separate latent issue; the regression test deliberately scopes itself to bignum-capable builds via the `_intbig` suffix.
