### PR TITLE
Refactor PSRAM clock frequency handling

### DIFF
--- a/ports/rp2/rp2_psram.c
+++ b/ports/rp2/rp2_psram.c
@@ -119,6 +119,11 @@ size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
         return 0;
     }
 
+    // Read clock speed before entering direct mode (flash access is
+    // unavailable while QMI direct mode is enabled)
+    const int max_psram_freq = 133000000;
+    const int clock_hz = clock_get_hz(clk_sys);
+
     // Enable direct mode, PSRAM CS, clkdiv of 10.
     qmi_hw->direct_csr = 10 << QMI_DIRECT_CSR_CLKDIV_LSB | \
         QMI_DIRECT_CSR_EN_BITS | \
@@ -138,8 +143,6 @@ size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
     // Using an rxdelay equal to the divisor isn't enough when running the APS6404 close to 133MHz.
     // So: don't allow running at divisor 1 above 100MHz (because delay of 2 would be too late),
     // and add an extra 1 to the rxdelay if the divided clock is > 100MHz (i.e. sys clock > 200MHz).
-    const int max_psram_freq = 133000000;
-    const int clock_hz = clock_get_hz(clk_sys);
     int divisor = (clock_hz + max_psram_freq - 1) / max_psram_freq;
     if (divisor == 1 && clock_hz > 100000000) {
         divisor = 2;


### PR DESCRIPTION
Read clock speed before entering direct mode (flash access is unavailable while QMI direct mode is enabled)

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Fix PSRAM init crash when system clock differs from default
Move clock_get_hz() call before QMI direct mode is enabled.
Flash access is unavailable during direct mode, causing a bus fault
on the instruction fetch when clock_configure_undivided is not
in the XIP cache. Confirmed via debugprobe on WeAct RP2350A.

NOTE - Failed Checks are happening in areas of the code far away from what I changed.

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

Testing: This fix was developed and tested on the arduino-pico port which shares this code. Tested on WeAct RP2350A with APS6404L 8MB PSRAM stacked on flash (CS on GPIO 8).
Before fix: intermittent boot failure (bus fault / double fault / lockup) at any non-default clock speed (tested 133MHz and 200MHz). After fix: reliable cold boot at 250MHz, PSRAM stress tests passing.
Root cause confirmed via debugprobe: clock_get_hz() is called while QMI direct mode is enabled, causing a bus fault on flash instruction fetch when clock_configure_undivided is not in the XIP cache.
I have not tested this directly on a MicroPython build, but the code and the bug are identical.

     If you leave this section empty then your Pull Request may be closed. -->

Tested on multiple RP2350 boards. (Weact.)

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above. (earlphilhower)

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
