### PR TITLE
docs/rp2/quickref: Fix I2C default pins for Pico in hardware example.

### DIFF
--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -336,7 +336,7 @@ has the same methods as software I2C above::
 
     from machine import Pin, I2C
 
-    i2c = I2C(0)   # default assignment: scl=Pin(9), sda=Pin(8)
+    i2c = I2C(0)   # default assignment for Pico: scl=Pin(5), sda=Pin(4)
     i2c = I2C(1, scl=Pin(3), sda=Pin(2), freq=400_000)
 
 I2S bus


### PR DESCRIPTION
### Summary

The hardware I2C example in the RP2 quickref showed the fallback defaults `scl=Pin(9), sda=Pin(8)`, which only apply on boards without `PICO_DEFAULT_I2C` defined. For the Raspberry Pi Pico itself, the actual defaults come from the Pico SDK and are `scl=Pin(5), sda=Pin(4)` — matching the SoftI2C example two snippets above. This corrects the comment so a reader running the example on a Pico sees pin numbers that match reality.

Source of truth: [`ports/rp2/machine_i2c.h:43-50`](https://github.com/micropython/micropython/blob/master/ports/rp2/machine_i2c.h#L43-L50).

Fixes #17562.

### Testing

- Cross-checked the default selection logic in `ports/rp2/machine_i2c.h`.
- Confirmed consistency with the SoftI2C example earlier in the same file (uses `scl=Pin(5), sda=Pin(4)`).
- Built the docs locally with `make -C docs html` (Sphinx 8.1.3, `-W --keep-going`) — completed with zero warnings.
- Visually verified the rendered "Hardware I2C bus" section in `docs/build/html/rp2/quickref.html#hardware-i2c-bus`; the updated comment displays correctly with proper syntax highlighting.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
