### PR TITLE
stm32/boards/WEACT_F411_BLACKPILL: Document SPI flash pin usage and PB4.

### DIFF
--- a/ports/stm32/boards/WEACT_F411_BLACKPILL/README.md
+++ b/ports/stm32/boards/WEACT_F411_BLACKPILL/README.md
@@ -25,6 +25,23 @@ If these peripherals / features are enabled then these external pins must be avo
 there are no conflicts. [pins.csv](pins.csv) should be consulted to check all pins assigned
 to alternate functions on the board.
 
+Pin notes
+---------
+
+The on-board SPI flash chip footprint shares pins with the gpio headers,
+so when the flash is loaded and enabled in the build the following pins
+should not be used for other purposes:
+
+* PA4, PA5 and PA7 are used by SPI1 (FLASH_CS, FLASH_SCK, FLASH_MOSI) on all
+  variants.
+* PA6 is used as FLASH_MISO on v1.3 and v3.1; on v2.0 the MISO line is
+  routed to PB4 instead.  Because of this, SPI3 is not usable on v2.0 when
+  the flash is in use (PB4 conflicts with SPI3_MISO).
+* On v3.1, users have reported that PB4 can behave unreliably as a
+  general-purpose input when a flash chip is loaded, even though MISO is
+  routed to PA6 on this revision.  As a workaround, configure PB4 as an
+  output and drive it low before any other use.
+
 Customising the build
 ---------------------
 


### PR DESCRIPTION
### Summary

The board README only mentions in passing that "pins used by features like spiflash and USB are also broken out to the gpio headers". This PR adds an explicit "Pin notes" subsection that:

- Lists the SPI1 / FLASH_* pin assignments per variant (PA4 / PA5 / PA7 on all variants; PA6 on v1.3 + v3.1, PB4 on v2.0). All pulled from `mpconfigboard.h` and `pins.csv`.
- Calls out the SPI3 ↔ PB4 conflict on v2.0 (the existing comment on `mpconfigboard.h:76` only).
- Documents the empirical PB4 quirk on v3.1 reported by the issue author, with the suggested workaround (drive PB4 as a low output before any other use).

Fixes #18432.

### Testing

- Cross-checked pin assignments against `ports/stm32/boards/WEACT_F411_BLACKPILL/mpconfigboard.h` (SPI1 at L65-69, SPI3 conflict comment at L76, V20 MISO at L102) and `pins.csv`.
- Markdown rendering looks correct on the GitHub preview.
- I do not have a v3.1 board to independently verify the PB4 behaviour described in #18432, so the wording attributes the observation to the original reporter and presents the fix as a workaround rather than a definitive characterisation. Happy to soften / strengthen as a maintainer prefers.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
