### PR TITLE
docs/reference/mpremote: Clarify how the run command treats main.py.

### DIFF
--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -211,6 +211,12 @@ The full list of supported commands are:
   a single piece of code without having to worry about deploying it to the
   filesystem.
 
+  **Note:** Only the contents of the local file are sent to the device; the
+  local filename has no special meaning, so passing a file called ``main.py``
+  is no different from any other name.  The script is executed in raw REPL
+  after a soft reset, so the device's own ``main.py`` is not run beforehand.
+  Any ``main.py`` already stored on the device filesystem is left untouched.
+
   By default, ``mpremote run`` will display any output from the script until it
   terminates. The ``--no-follow`` flag can be specified to return immediately and leave
   the device running the script in the background.

--- a/docs/reference/mpremote.rst
+++ b/docs/reference/mpremote.rst
@@ -215,6 +215,12 @@ The full list of supported commands are:
   terminates. The ``--no-follow`` flag can be specified to return immediately and leave
   the device running the script in the background.
 
+  **Note:** Only the contents of the local file are sent to the device; the
+  local filename has no special meaning, so passing a file called ``main.py``
+  is no different from any other name.  The script is executed in raw REPL
+  after a soft reset, so the device's own ``main.py`` is not run beforehand.
+  Any ``main.py`` already stored on the device filesystem is left untouched.
+
 .. _mpremote_command_fs:
 
 - **fs** -- execute filesystem commands on the device:


### PR DESCRIPTION
### Summary

Issue #15955 reports the impression that `mpremote run /path/to/main.py` runs the device's own `main.py` instead of the local file. Reading the implementation (`tools/mpremote/mpremote/commands.py:508` `do_run` → `_do_execbuffer` → `ensure_raw_repl` → `enter_raw_repl(soft_reset=True)` in `transport_serial.py:162`):

1. The local file is read as raw bytes — the filename is never sent to the device.
2. Soft reset happens inside raw REPL (Ctrl-A then Ctrl-D), which re-runs `boot.py` but does **not** run `main.py` (this is the standard raw-REPL behaviour MicroPython relies on).
3. The local script bytes are then executed.

So neither the local filename nor the on-device `main.py` should affect what runs. The existing docs do not mention this flow, which is what makes the reporter's confusion possible. This PR adds a short `**Note:**` (matching the existing in-file style on lines 108, 113, 171, 294, 351, 438) spelling that out.

Fixes #15955.

### Testing

- Cross-checked the run / raw-REPL flow in `tools/mpremote/mpremote/commands.py` and `tools/mpremote/mpremote/transport_serial.py`.
- Matched the in-file Note style (`**Note:**` inline).
- Built the docs locally with `make -C docs html` (Sphinx 8.1.3, `-W --keep-going`) — completed with zero warnings.
- Visually verified the rendered `run` section in `docs/build/html/reference/mpremote.html#mpremote-command-run`; the Note paragraph displays correctly with `main.py` formatted as inline code three times.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
