### PR TITLE
docs/library/rp2.DMA: Correct and add pack_ctrl defaults.

### DIFF
--- a/docs/library/rp2.DMA.rst
+++ b/docs/library/rp2.DMA.rst
@@ -132,10 +132,10 @@ Methods
       address register will change when an address is incremented, causing the
       address to wrap at the next ``1 << ring_size`` byte boundary. Which
       address is wrapped is controlled by the ``ring_sel`` flag. A zero value
-      disables address wrapping.
+      disables address wrapping (default: 0).
 
     - *ring_sel*: ``bool`` Set to ``False`` to have the ``ring_size`` apply to the read address
-      or ``True`` to apply to the write address.
+      or ``True`` to apply to the write address (default: ``False``).
 
     - *chain_to*: ``int`` The channel number for a channel to trigger after this transfer
       completes. Setting this value to this DMA object's own channel number
@@ -143,7 +143,8 @@ Methods
 
     - *treq_sel*: ``int`` Select a Transfer Request signal. See section 2.5.3 in the RP2040
       datasheet for details. You may also pass a :class:`DMATimer` instance to use that timer
-      for pacing the transfer.
+      for pacing the transfer.  The default is ``0x3f`` (``PERMANENT``), which means the
+      DMA channel runs at full bus speed without waiting for any external request.
 
     - *irq_quiet*: ``bool`` Do not generate interrupt at the end of each transfer. Interrupts
       will instead be generated when a zero value is written to the trigger
@@ -151,16 +152,16 @@ Methods
       ``True``).
 
     - *bswap*: ``bool`` If set to true, bytes in words or half-words will be reversed before
-      writing (default: ``True``).
+      writing (default: ``False``).
 
     - *sniff_en*: ``bool`` Set to ``True`` to allow data to be accessed by the chip's sniff
       hardware (default: ``False``).
 
     - *write_err*: ``bool`` Setting this to ``True`` will clear a previously reported write
-      error.
+      error (default: ``False``).
 
     - *read_err*: ``bool`` Setting this to ``True`` will clear a previously reported read
-      error.
+      error (default: ``False``).
 
     See the description of the ``CH0_CTRL_TRIG`` register in section 2.5.7 of the RP2040
     datasheet for details of all of these fields.


### PR DESCRIPTION
### Summary

The `DMA.pack_ctrl()` keyword reference had one incorrect default and five missing ones. All values verified against `DEFAULT_DMA_CONFIG` (`ports/rp2/rp2_dma.c:518-523`) and the field table at `rp2_dma.c:271-294`.

| Field | Old docs | Actual default | Source |
|-------|----------|----------------|--------|
| `bswap` | `True` (wrong) | `False` | bit not set in `DEFAULT_DMA_CONFIG` |
| `ring_size` | (missing) | `0` | bit not set |
| `ring_sel` | (missing) | `False` | bit not set |
| `treq_sel` | (missing) | `0x3f` (`PERMANENT`) | explicit `DMA_CH0_CTRL_TRIG_TREQ_SEL_VALUE_PERMANENT` |
| `write_err` | (missing) | `False` | bit not set |
| `read_err` | (missing) | `False` | bit not set |

Also added a short note on the `treq_sel` line that `0x3f` (`PERMANENT`) means "no external pacing — run at full bus speed", since this value is not listed in the DREQ table in the RP2040 datasheet and was confusing enough that the issue reporter asked for the note explicitly.

Fixes #18551.

### Testing

- Cross-checked every default against `ports/rp2/rp2_dma.c` (`DEFAULT_DMA_CONFIG` macro and `rp2_dma_ctrl_fields_table`).
- Diff is `docs/library/rp2.DMA.rst` only; no behaviour change.
- Built the docs locally with `make -C docs html` (Sphinx 8.1.3, `-W --keep-going`) — completed with zero warnings.
- Visually verified the rendered `DMA.pack_ctrl` section in `docs/build/html/library/rp2.DMA.html#rp2.DMA.pack_ctrl`; all six fixed/added defaults render correctly with proper formatting (inline code for values, full paragraph for the `treq_sel` explainer).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
