### PR TITLE
tests/cpydiff/types_range_limits: Cover positive long-int range args.

### DIFF
--- a/tests/cpydiff/types_range_limits.py
+++ b/tests/cpydiff/types_range_limits.py
@@ -1,7 +1,7 @@
 """
 categories: Types,range
-description: Range objects with large start or stop arguments misbehave.
-cause: Intermediate calculations overflow the C mp_int_t type
+description: Range arguments must fit in a machine word; large start or stop values misbehave.
+cause: Range stores its arguments as the C mp_int_t type, and intermediate calculations also use it.
 workaround: Avoid using such ranges
 """
 
@@ -10,6 +10,12 @@ from sys import maxsize
 # A range including `maxsize-1` cannot be created
 try:
     print(range(-maxsize - 1, 0))
+except OverflowError:
+    print("OverflowError")
+
+# A range with start or stop outside [-maxsize, maxsize] cannot be created, even if the range itself would be small.
+try:
+    print(range(maxsize + 1, maxsize + 2))
 except OverflowError:
     print("OverflowError")
 


### PR DESCRIPTION
### Summary

Issue #17026 reports that `range(sys.maxsize + 1, sys.maxsize + 2)` raises `OverflowError` in MicroPython but works fine in CPython, and asks for it to appear in the CPython differences docs.

The existing `tests/cpydiff/types_range_limits.py` already covers the symmetric negative case (`range(-maxsize - 1, 0)`), so rather than create a new entry I extended this one with the positive case and tightened the description so it's clear the limitation is on the magnitude of each argument (must fit in `mp_int_t`), not on the size of the resulting range.

`tools/gen-cpydiff.py` will regenerate the rendered comparison table from this file on the next docs build.

Fixes #17026.

### Testing

- Ran `python3 tests/cpydiff/types_range_limits.py` under CPython 3 and confirmed the new line produces `range(9223372036854775808, 9223372036854775809)`; existing examples are unchanged in output.
- Ran `make -C docs html` locally (Sphinx 8.1.3, `-W --keep-going`) — completed with zero warnings; regenerated `docs/genrst/builtin_types.rst` shows the new contrast row in the side-by-side table, and the rendered HTML section verified visually.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
