### PR TITLE
tools/validateboard.py: Introduce a board.json validator script.

### DIFF
--- a/tools/validateboard.py
+++ b/tools/validateboard.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+#
+# This file is part of the MicroPython project, https://micropython.org/
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2026 Alessandro Gatti
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import enum
+import functools
+import json
+import pathlib
+import sys
+from urllib import parse as urllib_parse
+
+
+class ViolationKind(enum.Enum):
+    SUGGESTION = enum.auto()
+    WARNING = enum.auto()
+    ERROR = enum.auto()
+    NONE = enum.auto()
+
+
+MANDATORY_KEYS = ("deploy", "docs", "url", "features", "images", "mcu", "product", "vendor")
+OPTIONAL_KEYS = ("deploy_options", "features_non_filterable", "thumbnail", "variants")
+
+
+KNOWN_IMAGE_EXTENSIONS = (".jpg", ".png", ".webp", ".gif")
+
+# TODO: Should all of these be kept or leave just a subset?
+# TODO: Should `microSD` and `SDCard` be merged into one entry?
+KNOWN_FEATURES = (
+    "10BASE-T1S",
+    "12x12 RGB LED Matrix",
+    "3 Axis IMU",
+    "5x5 RGB LED Matrix",
+    "Audio Codec",
+    "BLE",
+    "Battery Charging",
+    "CAN",
+    "Camera",
+    "Capacitive Touch",
+    "DAC",
+    "Display",
+    "Dual-core",
+    "Environment Sensor",
+    "Ethernet",
+    "External Flash",
+    "External RAM",
+    "Feather",
+    "I2C BAT Fuel Gauge",
+    "I2S Audio Amplifier + Speaker",
+    "IMU",
+    "JST-PH",
+    "JST-SH",
+    "LoRa",
+    "Microphone",
+    "PoE",
+    "RGB LED",
+    "SDCard",
+    "Second LDO",
+    "Secure Element",
+    "T1S",
+    "TinyPICO Compatible",
+    "TinyPICO Nano Compatible",
+    "USB",
+    "USB-C",
+    "Watch",
+    "WiFi",
+    "microSD",
+    "mikroBUS",
+)
+
+
+def tag_lists(tag, *lists):
+    tagged = []
+    for old_list in lists:
+        tagged.append([(tag, entry) for entry in old_list])
+    return tagged
+
+
+def check_deploy(board_json, board_file):
+    errors = []
+    warnings = []
+
+    deploy = board_json.get("deploy", None)
+    if deploy is None:
+        errors.append("missing key")
+    else:
+        # TODO: Can be a plain string too?
+        if type(deploy) is list:
+            for entry in deploy:
+                if type(entry) is str:
+                    entry_path = board_file.parent / entry
+                    if not entry_path.exists():
+                        errors.append('missing file: "{}"'.format(entry))
+                else:
+                    errors.append("non-string element: {}".repr(entry))
+        else:
+            errors.append("must be a list")
+    return tag_lists("deploy", [], errors, warnings)
+
+
+def generic_check_url(key, board_json, *_, empty=None):
+    errors = []
+    warnings = []
+
+    value = board_json.get(key, None)
+    if value is None:
+        errors.append("missing key")
+    else:
+        if type(value) is str:
+            if value.strip() != value:
+                warnings.append("leading/trailing whitespace")
+            if value:
+                if parsed_url := urllib_parse.urlsplit(value.strip()):
+                    scheme, *_ = parsed_url
+                    if scheme not in ("http", "https", "ftp"):
+                        errors.append("unknown URL scheme {}".format(scheme))
+                else:
+                    errors.append("potential malformed URL {}".format(value))
+            else:
+                if empty is ViolationKind.WARNING:
+                    warnings.append("value is empty")
+                elif empty is ViolationKind.ERROR:
+                    errors.append("value is empty")
+                elif empty is ViolationKind.NONE:
+                    pass
+                else:
+                    raise Exception("unexpected violation kind value: {}".format(repr(empty)))
+        else:
+            errors.append("must be a string")
+    return tag_lists(key, [], errors, warnings)
+
+
+def generic_check_features(key, board_json, *_, missing=None):
+    suggestions = []
+    errors = []
+    warnings = []
+
+    features = board_json.get(key, None)
+    if features is None:
+        if missing is ViolationKind.ERROR:
+            errors.append("missing key")
+        elif missing is ViolationKind.WARNING:
+            errors.append("missing key")
+        elif missing is ViolationKind.NONE:
+            pass
+        else:
+            raise Exception("unexpected violation kind value: {}".format(repr(missing)))
+    else:
+        if type(features) is list:
+            if not features:
+                suggestions.append("list is empty")
+            else:
+                for feature in features:
+                    if type(feature) is str:
+                        if feature != feature.strip():
+                            warnings.append("`{}` has trailing/leading whitespace".format(feature))
+                        feature = feature.strip()
+                        if feature not in KNOWN_FEATURES:
+                            warnings.append(
+                                "`{}` is not known (possible misspelling?)".format(feature)
+                            )
+                    else:
+                        errors.append("non-string element: {}".repr(feature))
+        else:
+            errors.append("must be a list")
+
+    return tag_lists(key, suggestions, errors, warnings)
+
+
+def _check_image_path(image, empty):
+    error = None
+    warnings = []
+    if type(image) is str:
+        if image != image.strip():
+            warnings.append("`{}` has trailing/leading whitespace".format(image))
+        if not image:
+            if empty is ViolationKind.ERROR:
+                error = "value is empty"
+            elif empty is ViolationKind.WARNING:
+                warnings.append("value is empty")
+            elif empty is ViolationKind.NONE:
+                pass
+            else:
+                raise Exception("unexpected violation kind value: {}".format(repr(empty)))
+        else:
+            image_path = pathlib.PosixPath(image)
+            if image_path.suffix not in KNOWN_IMAGE_EXTENSIONS:
+                if image_path.suffix.lower() in KNOWN_IMAGE_EXTENSIONS:
+                    warnings.append('non-lowercase extension: "{}"'.format(image_path))
+                else:
+                    error = 'unknown extension: "{}"'.format(image_path)
+    else:
+        error = "non-string element: {}".repr(image)
+
+    return error, warnings
+
+
+def check_images(board_json, *_):
+    errors = []
+    warnings = []
+
+    images = board_json.get("images", None)
+    if images is None:
+        errors.append("missing key")
+    else:
+        if type(images) is list:
+            if not images:
+                warnings.append("list is empty")
+            else:
+                for image in images:
+                    new_error, new_warnings = _check_image_path(image, ViolationKind.ERROR)
+                    if new_error:
+                        errors.append(new_error)
+                    elif new_warnings:
+                        warnings.extend(new_warnings)
+        else:
+            errors.append("must be a list")
+
+    return tag_lists("images", [], errors, warnings)
+
+
+def check_thumbnail(board_json, *_):
+    suggestions = []
+    errors = []
+    warnings = []
+
+    thumbnail = board_json.get("thumbnail", None)
+    if thumbnail is None:
+        suggestions.append("missing key")
+    else:
+        new_error, new_warnings = _check_image_path(thumbnail, ViolationKind.WARNING)
+        if new_error:
+            errors.append(new_error)
+        elif new_warnings:
+            warnings.extend(new_warnings)
+
+    return tag_lists("thumbnail", suggestions, errors, warnings)
+
+
+def generic_check_dict(key, board_json, *_, missing=None):
+    errors = []
+    warnings = []
+
+    dictionary = board_json.get(key, None)
+    if dictionary is None:
+        if missing is ViolationKind.ERROR:
+            errors.append("missing key")
+        elif missing is ViolationKind.WARNING:
+            errors.append("missing key")
+        elif missing is ViolationKind.NONE:
+            pass
+        else:
+            raise Exception("unexpected violation kind value: {}".format(repr(missing)))
+    else:
+        if type(dictionary) is dict:
+            if not dictionary:
+                warnings.append("dict is empty")
+            else:
+                for key, value in dictionary.items():
+                    if type(key) is not str:
+                        errors.append("non-string key: {}".format(repr(key)))
+                    if type(value) is not str:
+                        errors.append(
+                            "non-string value: {} for key {}".format(repr(value), repr(key))
+                        )
+                    if not key:
+                        errors.append("empty key found")
+                    if key != key.strip():
+                        errors.append("key {} has leading/trailing whitespace".format(key))
+                    if not value:
+                        errors.append("empty value found for key {}".format(key))
+                    if value != value.strip():
+                        warnings.append(
+                            "value {} for key {} has leading/trailing whitespace".format(
+                                value, key
+                            )
+                        )
+        else:
+            errors.append("must be a dict")
+
+    return tag_lists(key, [], errors, warnings)
+
+
+def generic_check_string(key, board_json, *_):
+    errors = []
+    warnings = []
+    value = board_json.get(key, None)
+    if value is None:
+        errors.append("missing key")
+    else:
+        if type(value) is str:
+            if value.strip() != value:
+                warnings.append("leading/trailing whitespace")
+            if not value:
+                errors.append("value is empty")
+        else:
+            errors.append("must be a string")
+    return tag_lists(key, [], errors, warnings)
+
+
+if len(sys.argv) < 2:
+    print("Usage: {} <board JSON metadata file>")
+    sys.exit()
+
+
+board_file = pathlib.PosixPath(sys.argv[1])
+if not board_file.exists():
+    raise FileNotFoundError('board path "{}" was not found'.format(sys.argv[1]))
+elif not board_file.is_file():
+    raise IOError('board path "{}" does not point to a file'.format(sys.argv[1]))
+
+print("Checking {}...".format(sys.argv[1]))
+
+suggestions = []
+errors = []
+warnings = []
+
+with board_file.open("rt") as board_json_file:
+    board_json = json.load(board_json_file)
+    if type(board_json) is dict:
+        for checker in (
+            check_deploy,
+            functools.partial(generic_check_url, "docs", empty=ViolationKind.WARNING),
+            functools.partial(generic_check_url, "url", empty=ViolationKind.ERROR),
+            functools.partial(generic_check_features, "features", missing=ViolationKind.ERROR),
+            functools.partial(
+                generic_check_features, "features_non_filterable", missing=ViolationKind.NONE
+            ),
+            check_images,
+            functools.partial(generic_check_string, "mcu"),
+            functools.partial(generic_check_string, "product"),
+            functools.partial(generic_check_string, "vendor"),
+            check_thumbnail,
+            functools.partial(generic_check_dict, "deploy_options", missing=ViolationKind.NONE),
+            functools.partial(generic_check_dict, "variants", missing=ViolationKind.NONE),
+        ):
+            new_suggestions, new_errors, new_warnings = checker(board_json, board_file)
+            suggestions.extend(new_suggestions)
+            errors.extend(new_errors)
+            warnings.extend(new_warnings)
+
+        for key in board_json:
+            if key not in MANDATORY_KEYS and key not in OPTIONAL_KEYS:
+                errors.append(("<root>", "unknown key {}".format(repr(key))))
+    else:
+        errors.append(("<root>", "JSON must only contain a single object"))
+
+print(
+    "\n{} error(s), {} warning(s), and {} suggestion(s) found:".format(
+        len(errors), len(warnings), len(suggestions)
+    )
+)
+
+if errors:
+    print("\nERRORS:")
+    for key, error in errors:
+        print("× {} - {}".format(key, error))
+
+if warnings:
+    print("\nWARNINGS:")
+    for key, warning in warnings:
+        print("⚠ {} - {}".format(key, warning))
+
+if suggestions:
+    print("\nSUGGESTIONS:")
+    for key, suggestion in suggestions:
+        print("! {} - {}".format(key, suggestion))
+
+print()


### PR DESCRIPTION
### Summary

This PR inroduces a simple Python script that checks a board's `board.json` file for correctness, reporting errors and indicating warnings and possible suggestions.

Regarding the violation severities, I had to work with what's available in the board JSON files available in the repo.  This means I might have got things wrong and whatnot, especially on which fields are required, and which ones aren't.

Right now the following checks are performed, with their respective violation kind:

* unknown keys must not be present (error)
* `deploy`, `docs`, `url`, `features`, `images`, `mcu`, `product`, `vendor` must be present (error)
* `deploy`, `features`, `images` must be lists (error)
* `docs`, `url` must be present (error)
* `docs` should not be empty (warning)
* `url` must not be empty (error)
* `docs`, `url` point to either an http, https, or ftp URL (error)
* `features`, `features_non_filterable` should not be empty (warning)
* `features`, `features_non_filterable` must only contain strings (error)
* `features`, `features_non_filterable` must contain known entries (warning)
* `features`, `features_non_filterable` elements must not have leading/trailing whitespace (warning)
* `images` must not have empty elements (error)
* `images` entries must not have leading/trailing whitespace (warning)
* `images` entries must end with either .jpg, .png, .webp, or .gif (error)
* `images` should end with a known lowercase extension (warning)
* `mcu`, `product`, `vendor` must not be empty (error)
* `mcu`, `product`, `vendor` must not have leading/trailing whitespace (warning)
* `thumbnail` should be present (suggestion)
* `thumbnail` must not have leading/trailing whitespace (warning)
* `thumbnail` must end with either .jpg, .png, .webp, or .gif (error)
* `thumbnail` end with a known lowercase extension (warning)
* `deploy_options`, `variants` must be a dictionary (error)
* `deploy_options`, `variants` must only contain string keys and string values (error)
* `deploy_options`, `variants` must not contain empty keys or empty values (error)
* `deploy_options`, `variants` keys and values must not have leading/trailing whitespace (warning)

Parts like input argument parsing are pretty minimal, as I'd rather get the rules right first.  Once the rules are sorted out then a JSONSchema file could be produced, and most of this code would end up being replaced with a single validator invocation instead.

Maybe this could be turned into a CI check, along with updated developer documentation to mention this script, but that may come later once rules are sorted out.

### Testing

I used this to successfully check the CH32V board definitions I'm working on.  I've also processed all available board definitions through this tool, with some interesting results [1].

`vermin` also checked the minimum Python version to run this script to be 3.8, in line with the rest of the Python scripts.

### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

[1]

* Errors
	- Unknown key `old_variants`: ESP32_GENERIC_S3, ESP8266_GENERIC
	- `images` missing: LILYGO_T3_S3
	- `url` is empty: B_L072Z_LRWAN1, CERB40, LEGO_HUB_NO6, LEGO_HUB_NO7, NETDUINO_PLUS_2, NUCLEO_F091RC, NUCLEO_F401RE, NUCLEO_F411RE, NUCLEO_F412ZG, NUCLEO_F413ZH, NUCLEO_F429ZI, NUCLEO_F439ZI, NUCLEO_F446RE, NUCLEO_F722ZE, NUCLEO_F746ZG, NUCLEO_F767ZI, NUCLEO_H563ZI, NUCLEO_H743ZI, NUCLEO_H743ZI2, NUCLEO_L073RZ, NUCLEO_L432KC, NUCLEO_L452RE, NUCLEO_L476RG, NUCLEO_U5A5ZJ_Q, NUCLEO_WB55, PYBV10, STM32F411DISC, STM32F429DISC, STM32F439, STM32F4DISC, STM32F769DISC, STM32F7DISC, STM32H7B3I_DK, STM32L476DISC, USBDONGLE_WB55
	- `docs` is missing: WEACTSTUDIO_MINI_STM32H743
* Warnings
	- `docs` is empty: ACTINIUS_ICARUS, ADAFRUIT_F405_EXPRESS, ADAFRUIT_FEATHER_M0_EXPRESS, ADAFRUIT_FEATHER_M4_EXPRESS, ADAFRUIT_FEATHER_RP2040, ADAFRUIT_ITSYBITSY_M0_EXPRESS, ADAFRUIT_ITSYBITSY_M4_EXPRESS, ADAFRUIT_ITSYBITSY_RP2040, ADAFRUIT_METRO_M4_EXPRESS, ADAFRUIT_METRO_M7, ADAFRUIT_NEOKEY_TRINKEY, ADAFRUIT_QTPY_RP2040, ADAFRUIT_QTPY_SAMD21, ADAFRUIT_TRINKET_M0, ALIF_ENSEMBLE, ARDUINO_GIGA, ARDUINO_NANO_33_BLE_SENSE, ARDUINO_NANO_ESP32, ARDUINO_NANO_RP2040_CONNECT, ARDUINO_NICLA_VISION, ARDUINO_OPTA, ARDUINO_PORTENTA_C33, ARDUINO_PORTENTA_H7, ARDUINO_PRIMO, BLUEIO_TAG_EVIM, B_L072Z_LRWAN1, B_L475E_IOT01A, CERB40, CYTRON_MOTION_2350_PRO, CYTRON_NANOXRP_CONTROLLER, DVK_BL652, EK_RA4M1, EK_RA4W1, EK_RA6M1, EK_RA6M2, ESP32_GENERIC, ESP32_GENERIC_C2, ESP32_GENERIC_C3, ESP32_GENERIC_C5, ESP32_GENERIC_C6, ESP32_GENERIC_P4, ESP32_GENERIC_S2, ESP32_GENERIC_S3, ESP8266_GENERIC, ESPRUINO_PICO, EVK_NINA_B3, FEATHER52, GARATRONIC_NADHAT_F405, GARATRONIC_PYBSTICK26_ESP32C3, GARATRONIC_PYBSTICK26_F411, GARATRONIC_PYBSTICK26_RP2040, HYDRABUS, IBK_BLYST_NANO, IDK_BLYST_NANO, LEGO_HUB_NO6, LEGO_HUB_NO7, LILYGO_T3_S3, LILYGO_TTGO_LORA32, LIMIFROG, LOLIN_C3_MINI, LOLIN_S2_MINI, LOLIN_S2_PICO, M5STACK_ATOM, M5STACK_NANOC6, MACHDYNE_WERKZEUG, MAKERDIARY_RT1011_NANO_KIT, MICROBIT, MIKROE_CLICKER2_STM32, MIKROE_QUAIL, MIMXRT1010_EVK, MIMXRT1015_EVK, MIMXRT1020_EVK, MIMXRT1050_EVK, MIMXRT1060_EVK, MIMXRT1064_EVK, MIMXRT1170_EVK, MINISAM_M4, NETDUINO_PLUS_2, NRF52840_MDK_USB_DONGLE, NUCLEO_F091RC, NUCLEO_F401RE, NUCLEO_F411RE, NUCLEO_F412ZG, NUCLEO_F413ZH, NUCLEO_F429ZI, NUCLEO_F439ZI, NUCLEO_F446RE, NUCLEO_F722ZE, NUCLEO_F746ZG, NUCLEO_F756ZG, NUCLEO_F767ZI, NUCLEO_G0B1RE, NUCLEO_G474RE, NUCLEO_H563ZI, NUCLEO_H723ZG, NUCLEO_H743ZI, NUCLEO_H743ZI2, NUCLEO_H753ZI, NUCLEO_H7A3ZI_Q, NUCLEO_L073RZ, NUCLEO_L152RE, NUCLEO_L432KC, NUCLEO_L452RE, NUCLEO_L476RG, NUCLEO_L4A6ZG, NUCLEO_U5A5ZJ_Q, NUCLEO_WB55, NUCLEO_WL55, NULLBITS_BIT_C_PRO, OLIMEX_E407, OLIMEX_ESP32_EVB, OLIMEX_ESP32_POE, OLIMEX_H407, OLIMEX_RT1010, PARTICLE_XENON, PCA10000, PCA10001, PCA10028, PCA10031, PCA10040, PCA10056, PCA10059, PCA10090, PHYBOARD_RT1170, PIMORONI_PICOLIPO, PIMORONI_TINY2040, POLOLU_3PI_2040_ROBOT, POLOLU_ZUMO_2040_ROBOT, PYBD_SF2, PYBD_SF3, PYBD_SF6, PYBLITEV10, PYBV10, PYBV11, RA4M1_CLICKER, RPI_PICO, RPI_PICO2, RPI_PICO2_W, RPI_PICO_W, SAMD21_XPLAINED_PRO, SAMD_GENERIC_D21X18, SAMD_GENERIC_D51X19, SAMD_GENERIC_D51X20, SEEED_ARCH_MIX, SEEED_WIO_TERMINAL, SEEED_XIAO_ESP32C6, SEEED_XIAO_NRF52, SEEED_XIAO_RP2040, SEEED_XIAO_RP2350, SEEED_XIAO_SAMD21, SIL_MANT1S, SIL_RP2040_SHIM, SIL_WESP32, SOLDERED_NULA_MINI, SPARKFUN_IOTNODE_LORAWAN_RP2350, SPARKFUN_IOTREDBOARD_RP2350, SPARKFUN_IOT_REDBOARD_ESP32, SPARKFUN_MICROMOD_STM32, SPARKFUN_PROMICRO, SPARKFUN_PROMICRO_RP2350, SPARKFUN_REDBOARD_TURBO, SPARKFUN_SAMD21_DEV_BREAKOUT, SPARKFUN_SAMD51_THING_PLUS, SPARKFUN_THINGPLUS, SPARKFUN_THINGPLUS_ESP32C5, SPARKFUN_THINGPLUS_RP2350, SPARKFUN_XRP_CONTROLLER, SPARKFUN_XRP_CONTROLLER_BETA, STM32F411DISC, STM32F429DISC, STM32F439, STM32F469DISC, STM32F4DISC, STM32F769DISC, STM32F7DISC, STM32H747I_DISCO, STM32H7B3I_DK, STM32L476DISC, STM32L496GDISC, TEENSY40, TEENSY41, UM_FEATHERS2, UM_FEATHERS2NEO, UM_FEATHERS3, UM_FEATHERS3NEO, UM_NANOS3, UM_OMGS3, UM_PROS3, UM_RGBTOUCH_MINI, UM_TINYC6, UM_TINYPICO, UM_TINYS2, UM_TINYS3, UM_TINYWATCHS3, USBDONGLE_WB55, VCC_GND_F407VE, VCC_GND_F407ZG, VCC_GND_H743VI, VK_RA6M5, W5100S_EVB_PICO, W5500_EVB_PICO, WAVESHARE_RP2040_LCD_0_96, WAVESHARE_RP2040_PLUS, WAVESHARE_RP2040_ZERO, WAVESHARE_RP2350B_CORE, WEACTSTUDIO, WEACTSTUDIO_MINI_STM32U585, WEACTSTUDIO_RP2350B_CORE, WEACT_F411_BLACKPILL
	- `thumbnail` is empty: ACTINIUS_ICARUS, ADAFRUIT_F405_EXPRESS, ADAFRUIT_FEATHER_M0_EXPRESS, ADAFRUIT_FEATHER_M4_EXPRESS, ADAFRUIT_FEATHER_RP2040, ADAFRUIT_ITSYBITSY_M0_EXPRESS, ADAFRUIT_ITSYBITSY_M4_EXPRESS, ADAFRUIT_ITSYBITSY_RP2040, ADAFRUIT_METRO_M4_EXPRESS, ADAFRUIT_METRO_M7, ADAFRUIT_NEOKEY_TRINKEY, ADAFRUIT_QTPY_RP2040, ADAFRUIT_QTPY_SAMD21, ADAFRUIT_TRINKET_M0, ALIF_ENSEMBLE, ARDUINO_GIGA, ARDUINO_NANO_33_BLE_SENSE, ARDUINO_NANO_ESP32, ARDUINO_NANO_RP2040_CONNECT, ARDUINO_NICLA_VISION, ARDUINO_OPTA, ARDUINO_PORTENTA_C33, ARDUINO_PORTENTA_H7, ARDUINO_PRIMO, BLUEIO_TAG_EVIM, B_L072Z_LRWAN1, B_L475E_IOT01A, CERB40, CYTRON_MOTION_2350_PRO, CYTRON_NANOXRP_CONTROLLER, DVK_BL652, EK_RA4M1, EK_RA4W1, EK_RA6M1, EK_RA6M2, ESP32_GENERIC, ESP32_GENERIC_C2, ESP32_GENERIC_C3, ESP32_GENERIC_C5, ESP32_GENERIC_C6, ESP32_GENERIC_P4, ESP32_GENERIC_S2, ESP32_GENERIC_S3, ESP8266_GENERIC, ESPRUINO_PICO, EVK_NINA_B1, EVK_NINA_B3, FEATHER52, GARATRONIC_NADHAT_F405, GARATRONIC_PYBSTICK26_ESP32C3, GARATRONIC_PYBSTICK26_F411, GARATRONIC_PYBSTICK26_RP2040, HYDRABUS, IBK_BLYST_NANO, IDK_BLYST_NANO, LEGO_HUB_NO6, LEGO_HUB_NO7, LILYGO_T3_S3, LILYGO_TTGO_LORA32, LIMIFROG, LOLIN_C3_MINI, LOLIN_S2_MINI, LOLIN_S2_PICO, M5STACK_ATOM, M5STACK_ATOMS3_LITE, MACHDYNE_WERKZEUG, MAKERDIARY_RT1011_NANO_KIT, MICROBIT, MIKROE_CLICKER2_STM32, MIKROE_QUAIL, MIMXRT1010_EVK, MIMXRT1015_EVK, MIMXRT1020_EVK, MIMXRT1050_EVK, MIMXRT1060_EVK, MIMXRT1064_EVK, MIMXRT1170_EVK, MINISAM_M4, NETDUINO_PLUS_2, NRF52840_MDK_USB_DONGLE, NUCLEO_F091RC, NUCLEO_F401RE, NUCLEO_F411RE, NUCLEO_F412ZG, NUCLEO_F413ZH, NUCLEO_F429ZI, NUCLEO_F439ZI, NUCLEO_F446RE, NUCLEO_F722ZE, NUCLEO_F746ZG, NUCLEO_F756ZG, NUCLEO_F767ZI, NUCLEO_G0B1RE, NUCLEO_G474RE, NUCLEO_H563ZI, NUCLEO_H723ZG, NUCLEO_H743ZI, NUCLEO_H743ZI2, NUCLEO_H753ZI, NUCLEO_H7A3ZI_Q, NUCLEO_L073RZ, NUCLEO_L152RE, NUCLEO_L432KC, NUCLEO_L452RE, NUCLEO_L476RG, NUCLEO_L4A6ZG, NUCLEO_U5A5ZJ_Q, NUCLEO_WB55, NUCLEO_WL55, NULLBITS_BIT_C_PRO, OLIMEX_E407, OLIMEX_ESP32_EVB, OLIMEX_ESP32_POE, OLIMEX_H407, OLIMEX_RT1010, PARTICLE_XENON, PCA10000, PCA10001, PCA10028, PCA10031, PCA10040, PCA10056, PCA10059, PCA10090, PHYBOARD_RT1170, PIMORONI_PICOLIPO, PIMORONI_TINY2040, POLOLU_3PI_2040_ROBOT, POLOLU_ZUMO_2040_ROBOT, PYBD_SF2, PYBD_SF3, PYBD_SF6, PYBLITEV10, PYBV10, PYBV11, RA4M1_CLICKER, RPI_PICO, RPI_PICO2, RPI_PICO2_W, RPI_PICO_W, SAMD21_XPLAINED_PRO, SAMD_GENERIC_D21X18, SAMD_GENERIC_D51X19, SAMD_GENERIC_D51X20, SEEED_ARCH_MIX, SEEED_WIO_TERMINAL, SEEED_XIAO_NRF52, SEEED_XIAO_RP2350, SEEED_XIAO_SAMD21, SIL_MANT1S, SIL_RP2040_SHIM, SIL_WESP32, SOLDERED_NULA_MINI, SPARKFUN_IOTNODE_LORAWAN_RP2350, SPARKFUN_IOTREDBOARD_RP2350, SPARKFUN_IOT_REDBOARD_ESP32, SPARKFUN_MICROMOD_STM32, SPARKFUN_PROMICRO, SPARKFUN_PROMICRO_RP2350, SPARKFUN_REDBOARD_TURBO, SPARKFUN_SAMD21_DEV_BREAKOUT, SPARKFUN_SAMD51_THING_PLUS, SPARKFUN_THINGPLUS, SPARKFUN_THINGPLUS_ESP32C5, SPARKFUN_THINGPLUS_RP2350, SPARKFUN_XRP_CONTROLLER, SPARKFUN_XRP_CONTROLLER_BETA, STM32F411DISC, STM32F429DISC, STM32F439, STM32F469DISC, STM32F4DISC, STM32F769DISC, STM32F7DISC, STM32H747I_DISCO, STM32H7B3I_DK, STM32L476DISC, STM32L496GDISC, TEENSY40, TEENSY41, UM_FEATHERS2, UM_FEATHERS2NEO, UM_FEATHERS3, UM_FEATHERS3NEO, UM_NANOS3, UM_OMGS3, UM_PROS3, UM_RGBTOUCH_MINI, UM_TINYPICO, UM_TINYS2, UM_TINYS3, UM_TINYWATCHS3, USBDONGLE_WB55, VCC_GND_F407VE, VCC_GND_F407ZG, VCC_GND_H743VI, VK_RA6M5, W5100S_EVB_PICO, W5500_EVB_PICO, WAVESHARE_RP2040_LCD_0_96, WAVESHARE_RP2040_PLUS, WAVESHARE_RP2040_ZERO, WAVESHARE_RP2350B_CORE, WEACTSTUDIO_MINI_STM32U585, WEACTSTUDIO_RP2350B_CORE, WEACT_F411_BLACKPILL, WIPY, WT51822_S4AT
	- `image` has non-lowercase extension: GARATRONIC_PYBSTICK26_ESP32C3
* Suggestions
	- `thumbnail` is missing: M5STACK_NANOC6, SEEED_XIAO_ESP32C6, SEEED_XIAO_RP2040, UM_TINYC6, WEACTSTUDIO, WEACTSTUDIO_MINI_STM32H743
	- `features_non_filterable` is empty: UM_FEATHERS3, UM_FEATHERS3NEO, UM_PROS3
	- `features` is empty: ACTINIUS_ICARUS, ADAFRUIT_F405_EXPRESS, ARDUINO_PRIMO, BLUEIO_TAG_EVIM, B_L072Z_LRWAN1, B_L475E_IOT01A, CERB40, DVK_BL652, EK_RA4M1, EK_RA4W1, EK_RA6M1, EK_RA6M2, ESPRUINO_PICO, EVK_NINA_B1, EVK_NINA_B3, FEATHER52, GARATRONIC_NADHAT_F405, GARATRONIC_PYBSTICK26_F411, HYDRABUS, IBK_BLYST_NANO, IDK_BLYST_NANO, LEGO_HUB_NO6, LEGO_HUB_NO7, LIMIFROG, MICROBIT, NETDUINO_PLUS_2, NRF52840_MDK_USB_DONGLE, NUCLEO_F091RC, NUCLEO_F401RE, NUCLEO_F411RE, NUCLEO_F412ZG, NUCLEO_F413ZH, NUCLEO_F429ZI, NUCLEO_F439ZI, NUCLEO_F446RE, NUCLEO_F722ZE, NUCLEO_F746ZG, NUCLEO_F756ZG, NUCLEO_F767ZI, NUCLEO_G0B1RE, NUCLEO_G474RE, NUCLEO_H563ZI, NUCLEO_H723ZG, NUCLEO_H743ZI, NUCLEO_H743ZI2, NUCLEO_H753ZI, NUCLEO_H7A3ZI_Q, NUCLEO_L073RZ, NUCLEO_L152RE, NUCLEO_L432KC, NUCLEO_L452RE, NUCLEO_L476RG, NUCLEO_L4A6ZG, NUCLEO_U5A5ZJ_Q, NUCLEO_WB55, NUCLEO_WL55, OLIMEX_E407, OLIMEX_H407, PARTICLE_XENON, PCA10000, PCA10001, PCA10028, PCA10031, PCA10040, PCA10056, PCA10059, PCA10090, PYBD_SF2, PYBD_SF3, PYBLITEV10, PYBV10, PYBV11, RA4M1_CLICKER, SPARKFUN_MICROMOD_STM32, STM32F411DISC, STM32F429DISC, STM32F439, STM32F469DISC, STM32F4DISC, STM32F769DISC, STM32F7DISC, STM32H7B3I_DK, STM32L476DISC, STM32L496GDISC, USBDONGLE_WB55, VCC_GND_F407VE, VCC_GND_F407ZG, VCC_GND_H743VI, WEACTSTUDIO_MINI_STM32U585, WEACT_F411_BLACKPILL, WT51822_S4AT
