### PR TITLE
tests/ports/stm32: Use "raise e" instead of raise without an argument.

### DIFF
--- a/tests/ports/stm32/pyb_can_instances.py
+++ b/tests/ports/stm32/pyb_can_instances.py
@@ -78,7 +78,7 @@ class Test(unittest.TestCase):
                             )
                 except OSError as e:
                     if e.errno != errno.ETIMEDOUT:
-                        raise
+                        raise e
                     print("recv timed out")
                 self.assertEqual(n_recv, 1, "Each instance should receive exactly 1 message")
         finally:

--- a/tests/ports/stm32_hardware/sdcard_dma_align.py
+++ b/tests/ports/stm32_hardware/sdcard_dma_align.py
@@ -69,7 +69,7 @@ class TestSDAlign(unittest.TestCase):
                     raise RuntimeError("Corrupt test block in temporary file ", FILE_PATH)
         except OSError as e:
             if e.errno != errno.ENOENT:
-                raise
+                raise e
 
             print("Creating new temp file...")
             with open(FILE_PATH, "wb") as f:


### PR DESCRIPTION
### Summary

The native emitter cannot compile "raise" without an argument.

### Testing

Can now run the stm32-specific tests with the native emitter.


### Generative AI

I did not use generative AI tools when creating this PR.

