### PR TITLE
tools/autobuild: Print consistent msgs for start/pass/fail board build.

### DIFF
--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -49,16 +49,26 @@ function build_board {
     local board=$(echo $board_json | awk -F '/' '{ print $2 }')
 
     # Build the "default" variant. For most boards this is the only thing we build.
-    echo "building $board"
+    echo "$0: Autobuild started for $board"
     local build_dir=/tmp/micropython-build-$board
-    $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir && copy_artefacts $dest_dir $board $fw_tag $build_dir $@
+    if $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir; then
+        copy_artefacts $dest_dir $board $fw_tag $build_dir $@
+        echo "$0: Autobuild succeeded for $board"
+    else
+        echo "$0: Autobuild failed for $board"
+    fi
     rm -rf $build_dir
 
     # Query variants from board.json and build them.
     for variant in `cat $board_json | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('variants', {}).keys()))"`; do
         local variant_build_dir=$build_dir-$variant
-        echo "building $board-$variant"
-        $MICROPY_AUTOBUILD_MAKE BOARD=$board BOARD_VARIANT=$variant BUILD=$variant_build_dir && copy_artefacts $dest_dir $board-$variant $fw_tag $variant_build_dir $@
+        echo "$0: Autobuild started for $board-$variant"
+        if $MICROPY_AUTOBUILD_MAKE BOARD=$board BOARD_VARIANT=$variant BUILD=$variant_build_dir; then
+            copy_artefacts $dest_dir $board-$variant $fw_tag $variant_build_dir $@
+            echo "$0: Autobuild succeeded for $board-$variant"
+        else
+            echo "$0: Autobuild failed for $board-$variant"
+        fi
         rm -rf $variant_build_dir
     done
 }

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -15,13 +15,13 @@
 
 function copy_artefacts {
     local dest_dir=$1
-    local descr=$2
+    local board=$2
     local fw_tag=$3
     local build_dir=$4
     shift 4
 
     for ext in $@; do
-        dest=$dest_dir/$descr$fw_tag.$ext
+        dest=$dest_dir/$board$fw_tag.$ext
         if [ -r $build_dir/firmware.$ext ]; then
             mv $build_dir/firmware.$ext $dest
         elif [ -r $build_dir/micropython.$ext ]; then
@@ -47,19 +47,18 @@ function build_board {
     shift 3
 
     local board=$(echo $board_json | awk -F '/' '{ print $2 }')
-    local descr=$(cat $board_json | python3 -c "import json,sys; print(json.load(sys.stdin).get('id', '$board'))")
 
     # Build the "default" variant. For most boards this is the only thing we build.
-    echo "building $descr $board"
+    echo "building $board"
     local build_dir=/tmp/micropython-build-$board
-    $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir && copy_artefacts $dest_dir $descr $fw_tag $build_dir $@
+    $MICROPY_AUTOBUILD_MAKE BOARD=$board BUILD=$build_dir && copy_artefacts $dest_dir $board $fw_tag $build_dir $@
     rm -rf $build_dir
 
     # Query variants from board.json and build them.
     for variant in `cat $board_json | python3 -c "import json,sys; print(' '.join(json.load(sys.stdin).get('variants', {}).keys()))"`; do
         local variant_build_dir=$build_dir-$variant
-        echo "building variant $descr $board $variant"
-        $MICROPY_AUTOBUILD_MAKE BOARD=$board BOARD_VARIANT=$variant BUILD=$variant_build_dir && copy_artefacts $dest_dir $descr-$variant $fw_tag $variant_build_dir $@
+        echo "building $board-$variant"
+        $MICROPY_AUTOBUILD_MAKE BOARD=$board BOARD_VARIANT=$variant BUILD=$variant_build_dir && copy_artefacts $dest_dir $board-$variant $fw_tag $variant_build_dir $@
         rm -rf $variant_build_dir
     done
 }

--- a/tools/autobuild/build-boards.sh
+++ b/tools/autobuild/build-boards.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # The functions in this file can be run independently to build boards.
-# For example:
+# For example (using bash):
 #
 #   $ source tools/autobuild/build-boards.sh
 #   $ cd ports/rp2
@@ -11,7 +11,7 @@
 #
 #   $ source tools/autobuild/build-boards.sh
 #   $ cd ports/rp2
-#   $ MICROPY_AUTOBUILD_MAKE="make -j8" build_board boards/PICO/board.json -latest /tmp uf2
+#   $ MICROPY_AUTOBUILD_MAKE="make -j8" build_board boards/RPI_PICO/board.json -latest /tmp uf2
 
 function copy_artefacts {
     local dest_dir=$1


### PR DESCRIPTION
### Summary

Consistent messages are now printed to stdout (along with the main output of the build process) when the build starts, and when it succeeds or fails.

For example:

        bash: Autobuild started for RPI_PICO
        ...
        ...
        bash: Autobuild succeeded for RPI_PICO

Or in the case of a failure:

        bash: Autobuild started for RPI_PICO
        ...
        ...
        bash: Autobuild failed for RPI_PICO

That helps searching the output logs for the results of all builds.  And if something failed, it's easy to locate the rest of the build logs for the failure (they will be above the "Autobuild failed" message).

### Testing

Tested locally running the example at the top of the script, namely:
```
MICROPY_AUTOBUILD_MAKE="make -j8" build_board boards/RPI_PICO/board.json -latest /tmp uf2
```
That prints the messages correctly.  Also manually added a build error to check that the fail message was printed correctly.

### Trade-offs and Alternatives

Could instead generate a json file with the build results.  But not sure that's worth the effort, and it would then be hard to find the rest of the build logs corresponding to the failed build (especially when there are >200 boards being built).

### Generative AI

None used.