### PR TITLE
esp32/machine_i2c: Set default for new I2C driver at esp-idf >= v5.5.2.

### DIFF
--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -41,12 +41,14 @@
 #if MICROPY_HW_ESP_NEW_I2C_DRIVER
 #include "driver/i2c_master.h"
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2)
+#error The new I2C driver requires esp-idf >= v5.5.2
+#endif
+
 typedef struct _machine_hw_i2c_obj_t {
     mp_obj_base_t base;
     i2c_master_bus_handle_t bus_handle;
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
     i2c_master_dev_handle_t dev_handle;
-    #endif
     uint8_t port : 8;
     gpio_num_t scl : 8;
     gpio_num_t sda : 8;
@@ -58,12 +60,10 @@ static machine_hw_i2c_obj_t machine_hw_i2c_obj[I2C_NUM_MAX];
 
 static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, bool first_init) {
 
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
     if (!first_init && self->dev_handle) {
         i2c_master_bus_rm_device(self->dev_handle);
         self->dev_handle = NULL;
     }
-    #endif
 
     if (!first_init && self->bus_handle) {
         i2c_del_master_bus(self->bus_handle);
@@ -79,14 +79,12 @@ static void machine_hw_i2c_init(machine_hw_i2c_obj_t *self, bool first_init) {
         .flags.enable_internal_pullup = true,
     };
     ESP_ERROR_CHECK(i2c_new_master_bus(&bus_cfg, &self->bus_handle));
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
     i2c_device_config_t dev_cfg = {
         .dev_addr_length = I2C_ADDR_BIT_LEN_7,
         .device_address = 0,  // Will be replaced
         .scl_speed_hz = self->freq,
     };
     ESP_ERROR_CHECK(i2c_master_bus_add_device(self->bus_handle, &dev_cfg, &self->dev_handle));
-    #endif
 }
 
 static uint8_t *create_transfer_buffer(size_t n, mp_machine_i2c_buf_t *bufs, size_t *len_ptr) {
@@ -111,31 +109,8 @@ static uint8_t *create_transfer_buffer(size_t n, mp_machine_i2c_buf_t *bufs, siz
 int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags) {
     machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    // Probe the address to see if any device responds for esp-idf < v5.5.4.
-    // This test uses a fixed scl freq of 100_000.
     esp_err_t err = ESP_OK;
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2)
-    err = i2c_master_probe(self->bus_handle, addr, self->timeout_us / 1000);
-    if (err != ESP_OK) {
-        return -MP_ENODEV;   // No device at address, return immediately
-    }
-    #endif
-
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
-    // Using ".device_address = I2C_DEVICE_ADDRESS_NOT_USED," below
-    // allows to write the address separately using the
-    // i2c_master_execute_defined_operations() API.
-    i2c_device_config_t dev_cfg = {
-        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = addr,
-        .scl_speed_hz = self->freq,
-    };
-    i2c_master_dev_handle_t dev_handle;
-    err = i2c_master_bus_add_device(self->bus_handle, &dev_cfg, &dev_handle);
-    #else
-    #define dev_handle self->dev_handle
-    err = i2c_master_device_change_address(dev_handle, addr, self->timeout_us / 1000);
-    #endif
+    err = i2c_master_device_change_address(self->dev_handle, addr, self->timeout_us / 1000);
     if (err != ESP_OK) {
         return -MP_ENODEV;
     }
@@ -151,7 +126,7 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
         // create a large buffer if needed
         buf = create_transfer_buffer(n - 1, bufs + 1, &len);
         // Do a write then read
-        err = i2c_master_transmit_receive(dev_handle, bufs[0].buf, bufs[0].len, buf, len, self->timeout_us / 1000);
+        err = i2c_master_transmit_receive(self->dev_handle, bufs[0].buf, bufs[0].len, buf, len, self->timeout_us / 1000);
         // Copy the data back if needed starting with the second buffer.
         if (n > 2) {
             len = 0;
@@ -166,7 +141,7 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
         buf = create_transfer_buffer(n, bufs, &len);
         // Transfer data and copy it from/to the buffers as needed.
         if (flags & MP_MACHINE_I2C_FLAG_READ) {
-            err = i2c_master_receive(dev_handle, buf, len, self->timeout_us / 1000);
+            err = i2c_master_receive(self->dev_handle, buf, len, self->timeout_us / 1000);
             if (n > 1) {
                 len = 0;
                 for (size_t i = 0; i < n; ++i) {
@@ -182,12 +157,11 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
                     len += bufs[i].len;
                 }
             }
-            err = i2c_master_transmit(dev_handle, buf, len, self->timeout_us / 1000);
+            err = i2c_master_transmit(self->dev_handle, buf, len, self->timeout_us / 1000);
         }
         if (n > 1) {
             m_del(uint8_t, buf, len);
         }
-    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 2)
     } else if (!(flags & MP_MACHINE_I2C_FLAG_READ)) {
         // Write operation with len=0, bufs->buf = NULL, used by i2c.scan().
         // Use i2c_master_execute_defined_operations() allowing for len == 0.
@@ -196,13 +170,8 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
             { .command = I2C_MASTER_CMD_WRITE, .write = { .ack_check = true, .data = NULL, .total_bytes = 0 } },
             { .command = I2C_MASTER_CMD_STOP },  // Stop is still mandatory
         };
-        err = i2c_master_execute_defined_operations(dev_handle, i2c_ops, 3, self->timeout_us / 1000);
-    #endif
+        err = i2c_master_execute_defined_operations(self->dev_handle, i2c_ops, 3, self->timeout_us / 1000);
     }
-    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
-    // Remove the temporary handle.
-    i2c_master_bus_rm_device(dev_handle);
-    #endif
 
     // Map errors
     if (err == ESP_FAIL || err == ESP_ERR_INVALID_STATE) {

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -31,14 +31,6 @@
 #include "extmod/modmachine.h"
 #include "machine_i2c.h"
 
-#if MICROPY_HW_ESP_NEW_I2C_DRIVER
-#include "driver/i2c_master.h"
-#else
-#include "driver/i2c.h"
-#include "esp_clk_tree.h"
-#include "hal/i2c_ll.h"
-#endif
-
 #if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_SOFTI2C
 
 #define I2C_DEFAULT_TIMEOUT_US (50000) // 50ms
@@ -47,6 +39,7 @@
 // option is set.
 
 #if MICROPY_HW_ESP_NEW_I2C_DRIVER
+#include "driver/i2c_master.h"
 
 typedef struct _machine_hw_i2c_obj_t {
     mp_obj_base_t base;
@@ -118,12 +111,15 @@ static uint8_t *create_transfer_buffer(size_t n, mp_machine_i2c_buf_t *bufs, siz
 int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags) {
     machine_hw_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
-    // Probe the address to see if any device responds.
+    // Probe the address to see if any device responds for esp-idf < v5.5.4.
     // This test uses a fixed scl freq of 100_000.
-    esp_err_t err = i2c_master_probe(self->bus_handle, addr, self->timeout_us / 1000);
+    esp_err_t err = ESP_OK;
+    #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 2)
+    err = i2c_master_probe(self->bus_handle, addr, self->timeout_us / 1000);
     if (err != ESP_OK) {
         return -MP_ENODEV;   // No device at address, return immediately
     }
+    #endif
 
     #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     // Using ".device_address = I2C_DEVICE_ADDRESS_NOT_USED," below
@@ -187,20 +183,21 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
                 }
             }
             err = i2c_master_transmit(dev_handle, buf, len, self->timeout_us / 1000);
-            // Use i2c_master_execute_defined_operations() instead of
-            // i2c_master_transmit(), allowing for len == 0.
-            // That will be needed for scan() when dropping i2c_master_probe() is possible,
-            // after https://github.com/espressif/esp-idf/issues/17543 backported to supported versions
-            // i2c_operation_job_t i2c_ops[] = {
-            //     { .command = I2C_MASTER_CMD_START },
-            //     { .command = I2C_MASTER_CMD_WRITE, .write = { .ack_check = true, .data = buf, .total_bytes = len } },
-            //     { .command = I2C_MASTER_CMD_STOP },  // Stop is still mandatory
-            // };
-            // err = i2c_master_execute_defined_operations(dev_handle, i2c_ops, 3, self->timeout_us / 1000);
         }
         if (n > 1) {
             m_del(uint8_t, buf, len);
         }
+    #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 2)
+    } else if (!(flags & MP_MACHINE_I2C_FLAG_READ)) {
+        // Write operation with len=0, bufs->buf = NULL, used by i2c.scan().
+        // Use i2c_master_execute_defined_operations() allowing for len == 0.
+        i2c_operation_job_t i2c_ops[] = {
+            { .command = I2C_MASTER_CMD_START },
+            { .command = I2C_MASTER_CMD_WRITE, .write = { .ack_check = true, .data = NULL, .total_bytes = 0 } },
+            { .command = I2C_MASTER_CMD_STOP },  // Stop is still mandatory
+        };
+        err = i2c_master_execute_defined_operations(dev_handle, i2c_ops, 3, self->timeout_us / 1000);
+    #endif
     }
     #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     // Remove the temporary handle.
@@ -208,7 +205,7 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
     #endif
 
     // Map errors
-    if (err == ESP_FAIL) {
+    if (err == ESP_FAIL || err == ESP_ERR_INVALID_STATE) {
         return -MP_ENODEV;
     }
     if (err == ESP_ERR_TIMEOUT) {
@@ -221,6 +218,10 @@ int machine_hw_i2c_transfer(mp_obj_base_t *self_in, uint16_t addr, size_t n, mp_
 }
 
 #else
+
+#include "driver/i2c.h"
+#include "esp_clk_tree.h"
+#include "hal/i2c_ll.h"
 
 #if SOC_I2C_SUPPORT_XTAL
 #if CONFIG_XTAL_FREQ > 0

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -146,6 +146,9 @@
 #define MICROPY_PY_MACHINE_I2C_TARGET_INCLUDEFILE "ports/esp32/machine_i2c_target.c"
 #define MICROPY_PY_MACHINE_I2C_TARGET_MAX   (2)
 #endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 2) && !defined(MICROPY_HW_ESP_NEW_I2C_DRIVER)
+#define MICROPY_HW_ESP_NEW_I2C_DRIVER       (1)
+#endif
 #define MICROPY_PY_MACHINE_SOFTI2C          (1)
 #define MICROPY_PY_MACHINE_SPI              (1)
 #define MICROPY_PY_MACHINE_SOFTSPI          (1)
@@ -216,9 +219,6 @@
 #endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
-#ifndef MICROPY_HW_ESP_NEW_I2C_DRIVER
-#define MICROPY_HW_ESP_NEW_I2C_DRIVER       (0)
-#endif
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)
 #define MICROPY_SSL_MBEDTLS                 (MICROPY_PY_SSL)
 #define MICROPY_PY_WEBSOCKET                (MICROPY_PY_NETWORK)


### PR DESCRIPTION
### Summary

With v5.5.2 and up the the additional bus probing is not needed any more. It was needed because transfers to a non-existing address caused an error message to be printed instead of just returning an error code. With esp-idf v5.5.2 it returns just an error code. For 0-length writes as being used by i2c.scan(), an additional code path using i2c_master_execute_defined_operations() is needed to avoid an error message.
By default the new I2C driver is enabled for esp-idf version >= 5.5.2.

There is a slight inconsistency: reading 0 bytes from a non-existing address return an empty bytes object and does not raise an error. Writing 0 bytes to a non-existing address returns an error. That case is used by i2c.scan().

### Testing

Tested with a Generic ESP32 and esp-idf v5.5.1, v5.5.2 and v5.5.4. Tested as well using the new driver with v5.5.1.
Tested V5.5.2 with Generic ESP32, ESP32S2, ESP32S3, ESP32C2, ESP32C3, ESP32C5, ESP32C6, ESP32P4. Driving an external device as I2C controller.

### Trade-offs and Alternatives

There is still a problem with I2CTarget mode. But that exists back to v5.4.2 and did not get worse with v5.5.2 and v5.5.4

### Generative AI

I did not use generative AI tools when creating this PR.
