### PR TITLE
docs/rp2/quickref: Make machine.PWM a cross-reference link.

### DIFF
--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -226,7 +226,7 @@ are at slice 1, and so on. A certain channel can be assigned to
 different GPIO pins (see Pinout). For instance slice 0, channel A can be assigned
 to both GPIO0 and GPIO16.
 
-Use the ``machine.PWM`` class::
+Use the :ref:`machine.PWM <machine.PWM>` class::
 
     from machine import Pin, PWM
 


### PR DESCRIPTION
### Summary

In the RP2 quick reference, the PWM section refers to the `machine.PWM` class using a plain literal, whereas every other IO section on the page (Pin, UART, ADC, SPI, I2C, etc.) links to the corresponding library page via a `:ref:` role. As reported in #11384, this makes the PWM mention look like a link that isn't actually clickable. This changes it to`:ref:`machine.PWM <machine.PWM>`` so it matches the other sections and resolves to `library/machine.PWM`.

Fixes #11384.

### Testing

- Confirmed the `.. _machine.PWM:` label exists in `docs/library/machine.PWM.rst`, so the reference target is valid (same pattern as the existing ADC/UART links).
- Built the docs locally with `make -C docs html` (`-W --keep-going`) — completed with zero warnings.
- Verified the rendered `build/html/rp2/quickref.html` now emits `<a class="reference internal" href="../library/machine.PWM.html#machine-pwm">machine.PWM</a>`, identical in form to the working `machine.ADC` link on the same page.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
