### PR TITLE
esp32/network_wlan: Add channel bandwidth configuration parameter.

### DIFF
--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -146,6 +146,7 @@ Methods
    txpower        Maximum transmit power in dBm (integer or float)
    pm             WiFi Power Management setting (see below for allowed values)
    protocol       (ESP32 Only.) WiFi Low level 802.11 protocol. See `WLAN.PROTOCOL_DEFAULT`.
+   bandwidth      (ESP32 Only.) WiFi channel bandwidth. See `WLAN.BANDWIDTH_20` and others.
    =============  ===========
 
 Constants
@@ -189,6 +190,26 @@ network interface parameter:
       documentation`_ for more details.
 
       Long range mode is not supported on ESP32-C2.
+
+.. data:: WLAN.BANDWIDTH_20
+        WLAN.BANDWIDTH_40
+        WLAN.BANDWIDTH_80
+        WLAN.BANDWIDTH_160
+        WLAN.BANDWIDTH_80_80
+
+      Allowed values for the ``WLAN.config(bandwidth=...)`` network interface parameter:
+
+      * ``BANDWIDTH_20``: specifies a 20MHz wide WiFi channel when in STA and AP mode
+      * ``BANDWIDTH_40``: specifies a 40MHz wide WiFi channel when in STA and AP mode
+      * ``BANDWIDTH_80``: specifies a 80MHz wide WiFi channel when in AP mode, may not
+        be available on all ESP32 models
+      * ``BANDWIDTH_160``: specifies a 160MHz wide WiFi channel when in AP mode, may not
+        be available on all ESP32 models
+      * ``BANDWIDTH_80_80``: specifies a multi-antenna 80MHz + 80MHz wide WiFi channel
+        setup when in AP mode, may not be available on all ESP32 models.
+
+      When in STA mode, bandwidth can only be changed when the adapter is not connected to a
+      network.  In AP mode it can be changed at any time.
 
 .. _ESP-IDF Wi-Fi Protocols: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/wifi.html#wi-fi-protocol-mode
 .. _Espressif proprietary "long-range" mode:

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -610,6 +610,10 @@ static mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
                         }
                         break;
                     }
+                    case MP_QSTR_bandwidth: {
+                        esp_exceptions(esp_wifi_set_bandwidth(self->if_id, mp_obj_get_int(kwargs->table[i].value)));
+                        break;
+                    }
                     case MP_QSTR_hostname:
                     case MP_QSTR_dhcp_hostname: {
                         // TODO: Deprecated. Use network.hostname(name) instead.
@@ -706,6 +710,12 @@ static mp_obj_t network_wlan_config(size_t n_args, const mp_obj_t *args, mp_map_
             wifi_second_chan_t second;
             esp_exceptions(esp_wifi_get_channel(&channel, &second));
             val = MP_OBJ_NEW_SMALL_INT(channel);
+            break;
+        }
+        case MP_QSTR_bandwidth: {
+            wifi_bandwidth_t bandwidth;
+            esp_exceptions(esp_wifi_get_bandwidth(self->if_id, &bandwidth));
+            val = MP_OBJ_NEW_SMALL_INT(bandwidth);
             break;
         }
         case MP_QSTR_ifname: {
@@ -807,6 +817,12 @@ static const mp_rom_map_elem_t wlan_if_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PM_NONE), MP_ROM_INT(WIFI_PS_NONE) },
     { MP_ROM_QSTR(MP_QSTR_PM_PERFORMANCE), MP_ROM_INT(WIFI_PS_MIN_MODEM) },
     { MP_ROM_QSTR(MP_QSTR_PM_POWERSAVE), MP_ROM_INT(WIFI_PS_MAX_MODEM) },
+
+    { MP_ROM_QSTR(MP_QSTR_BANDWIDTH_20), MP_ROM_INT(WIFI_BW20) },
+    { MP_ROM_QSTR(MP_QSTR_BANDWIDTH_40), MP_ROM_INT(WIFI_BW40) },
+    { MP_ROM_QSTR(MP_QSTR_BANDWIDTH_80), MP_ROM_INT(WIFI_BW80) },
+    { MP_ROM_QSTR(MP_QSTR_BANDWIDTH_160), MP_ROM_INT(WIFI_BW160) },
+    { MP_ROM_QSTR(MP_QSTR_BANDWIDTH_80_80), MP_ROM_INT(WIFI_BW80_BW80) },
 };
 static MP_DEFINE_CONST_DICT(wlan_if_locals_dict, wlan_if_locals_dict_table);
 


### PR DESCRIPTION
### Summary

This commit adds a configuration parameter to set and retrieve the WiFi channel bandwidth.

The configuration only applies when the adapter is in single-band mode (ie. either 2.4 GHz or 5 GHz, not both at the same time), which is not an issue at the moment since there's no provision to put the adapter in multi-band mode.

Rather than accepting the bandwidth as a raw MHz value, five new constants are introduced, following the same nomenclature as the ESP-IDF SDK.  This is required since there's one constant that indicates a multi-antenna bandwidth setup and therefore not representable as a single integer value.

All constants involved are present in ESP-IDF 5.3 and later.

This addresses #6036.

### Testing

Network connectivity tests were performed on ESP32, ESP32C3, and ESP32S3, checking whether changing bandwidth between 20MHz and 40MHz would not impact connection in STA mode, and whether a bandwidth change in AP mode would be reported by a network analyser running on a phone.

On older boards, setting constants above 40MHz may not trigger an error but automatically cap bandwidth to either 20MHz or 40MHz depending on the board.

The firmware was also built for ESP32P4 to make sure this feature should not be gated behind a define in hosted mode.

### Trade-offs and Alternatives

There's a small size increase, but that cannot really be avoided.  The fact that there's one bandwidth setting for multi-antenna setups also forces usage of constants.

The constant names could probably be more descriptive, like `WLAN.BANDWIDTH_20` rather than `WLAN.BW20`, but I followed the SDK here and shorter names mean taking up less space.  If more descriptive constant names are preferred, changing them is not a problem.

### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

I originally planned to also support multi-mode WiFi since a supported target has it (ESP32C5), but then I realised there's no way to set the adapter into multi-mode to begin with.  That requires some minor changes to protocol, channel, and bandwidth retrieval/setting procedures.

I can add multi-mode support and apply the necessary changes in another PR but somebody else has to test it as I do not have the suitable hardware (although I can make sure it builds :)) and put that behind a define if multi-mode is not available on the target.