### PR TITLE
mimxrt/machine_encoder: Fix the numeric values of UP and DOWN.

### DIFF
--- a/ports/mimxrt/machine_encoder.c
+++ b/ports/mimxrt/machine_encoder.c
@@ -73,8 +73,8 @@ typedef struct _encoder_xbar_signal_t {
 #define XBAR_IN                    (1)
 #define XBAR_OUT                   (0)
 
-#define COUNTER_UP                 (-2)
-#define COUNTER_DOWN               (-3)
+#define COUNTER_UP                 (0)
+#define COUNTER_DOWN               (1)
 #define MODE_ENCODER               (0)
 #define MODE_COUNTER               (1)
 #define MP_ENCODER_ALLOWED_FLAGS   (kENC_HOMETransitionFlag | kENC_INDEXPulseFlag | kENC_PositionCompareFlag | kENC_PositionRollUnderFlag | kENC_PositionRollOverFlag)


### PR DESCRIPTION
### Summary

The values should be 0 for UP and 1 for DOWN to match the documentation. Instead they were -2 and -3, causing a test with a count direction set by a Pin to fail, when the symbols were used instead of numbers..

### Testing

Tested with the machine_encoder.py and machine_counter.py script and the extended machine_counter.py script from PR #19239.

### Generative AI

I did not use generative AI tools when creating this PR.
