### PR TITLE
tools/mpremote: add a baudrate argument

### DIFF
--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -19,6 +19,7 @@ class CommandError(Exception):
 
 def do_connect(state, args=None):
     dev = args.device[0] if args else "auto"
+    baud = args.baud if args else 115200
     do_disconnect(state)
 
     try:
@@ -42,7 +43,7 @@ def do_connect(state, args=None):
             for p in sorted(serial.tools.list_ports.comports()):
                 if p.vid is not None and p.pid is not None:
                     try:
-                        state.transport = SerialTransport(p.device, baudrate=115200)
+                        state.transport = SerialTransport(p.device, baudrate=baud)
                         return
                     except TransportError as er:
                         if not er.args[0].startswith("failed to access"):
@@ -54,14 +55,14 @@ def do_connect(state, args=None):
             dev = None
             for p in serial.tools.list_ports.comports():
                 if p.serial_number == serial_number:
-                    state.transport = SerialTransport(p.device, baudrate=115200)
+                    state.transport = SerialTransport(p.device, baudrate=baud)
                     return
             raise TransportError("no device with serial number {}".format(serial_number))
         else:
             # Connect to the given device.
             if dev.startswith("port:"):
                 dev = dev[len("port:") :]
-            state.transport = SerialTransport(dev, baudrate=115200)
+            state.transport = SerialTransport(dev, baudrate=baud)
             return
     except TransportError as er:
         msg = er.args[0]

--- a/tools/mpremote/mpremote/main.py
+++ b/tools/mpremote/mpremote/main.py
@@ -101,6 +101,13 @@ def _bool_flag(cmd_parser, name, short_name, default, description):
 def argparse_connect():
     cmd_parser = argparse.ArgumentParser(description="connect to given device")
     cmd_parser.add_argument(
+        "-b",
+        "--baud",
+        type=int,
+        default=115200,
+        help="baudrate of the serial console",
+    )
+    cmd_parser.add_argument(
         "device", nargs=1, help="Either list, auto, id:x, port:x, or any valid device name/path"
     )
     return cmd_parser


### PR DESCRIPTION
### Summary

Add an argument to select the serial console baudrate, for the unusual systems that do not use 115200.

This can be compbined as usual with other arguments, such as `mpremote connect -b 1000000 run script.py`.

### Testing

With an in-house device a all boards I have use sensible baudrates, but still:

```
mpremote connect -b 156200 /dev/ttyUSB1
mpremote connect -b 156200 /dev/ttyUSB1 run ~/test.py
```

### Trade-offs and Alternatives

This does not work along with aliases like `a1 -b 115200` or `u1 -b 115200` but might be quite rare to need this.

### Generative AI

no no