### PR TITLE
extmod/vfs_posix: Add size field to ilistdir() entries.

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -215,6 +215,7 @@ typedef struct _vfs_posix_ilistdir_it_t {
     mp_fun_1_t finaliser;
     bool is_str;
     DIR *dir;
+    vstr_t path;
 } vfs_posix_ilistdir_it_t;
 
 static mp_obj_t vfs_posix_ilistdir_it_iternext(mp_obj_t self_in) {
@@ -241,8 +242,8 @@ static mp_obj_t vfs_posix_ilistdir_it_iternext(mp_obj_t self_in) {
             continue;
         }
 
-        // make 3-tuple with info about this entry
-        mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(3, NULL));
+        // make 4-tuple with info about this entry
+        mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(4, NULL));
 
         if (self->is_str) {
             t->items[0] = mp_obj_new_str_from_cstr(fn);
@@ -273,6 +274,20 @@ static mp_obj_t vfs_posix_ilistdir_it_iternext(mp_obj_t self_in) {
         t->items[2] = MP_OBJ_NEW_SMALL_INT(0);
         #endif
 
+        // Materialise the full path while the GIL is held; vstr may allocate.
+        size_t base_len = self->path.len;
+        vstr_add_str(&self->path, fn);
+        const char *full_path = vstr_null_terminated_str(&self->path);
+        struct stat st;
+        mp_int_t size = 0;
+        MP_THREAD_GIL_EXIT();
+        if (stat(full_path, &st) == 0) {
+            size = st.st_size;
+        }
+        MP_THREAD_GIL_ENTER();
+        self->path.len = base_len;
+        t->items[3] = mp_obj_new_int_from_uint(size);
+
         return MP_OBJ_FROM_PTR(t);
     }
 }
@@ -284,6 +299,7 @@ static mp_obj_t vfs_posix_ilistdir_it_del(mp_obj_t self_in) {
         closedir(self->dir);
         MP_THREAD_GIL_ENTER();
     }
+    vstr_clear(&self->path);
     return mp_const_none;
 }
 
@@ -293,9 +309,15 @@ static mp_obj_t vfs_posix_ilistdir(mp_obj_t self_in, mp_obj_t path_in) {
     iter->iternext = vfs_posix_ilistdir_it_iternext;
     iter->finaliser = vfs_posix_ilistdir_it_del;
     iter->is_str = mp_obj_get_type(path_in) == &mp_type_str;
+    iter->dir = NULL;
+    vstr_init(&iter->path, 0);
     const char *path = vfs_posix_get_path_str(self, path_in);
     if (path[0] == '\0') {
         path = ".";
+    }
+    vstr_add_str(&iter->path, path);
+    if (iter->path.buf[iter->path.len - 1] != '/') {
+        vstr_add_char(&iter->path, '/');
     }
     MP_THREAD_GIL_EXIT();
     iter->dir = opendir(path);


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Previously the POSIX ilistdir() iterator returned 3-tuples (name, type, inode), while the MCU VFS implementations (FAT, LFS, ROM) return 4-tuples that also include the entry size. This caused mpremote's ls/tree commands to display zero for all file sizes when talking to a MicroPython Unix port.

This change makes vfs_posix return 4-tuples (name, type, inode, size), matching the other VFS implementations. The size is retrieved via a stat() call on each entry, with the directory path cached in the iterator state to avoid recomputation. If stat() fails the size is reported as 0, consistent with how MCU ports treat missing size info.

Fixes #18661.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

- Standard unix port builds cleanly.
- `tests/extmod/vfs_basic.py`, `vfs_posix_paths.py`, `vfs_posix_enoent.py`,
  `vfs_posix_ilistdir_filter.py`, and `vfs_posix_ilistdir_del.py` all
  pass.
- The full `tests/extmod/` suite is unaffected by this change (the only
  failure, `select_poll_fd.py`, also fails on master and is unrelated).
- Verified manually that sizes are correct for files, that bytes-mode
  paths still return `bytes` names, that mounted `vfs.VfsPosix` works,
  and that a nonexistent directory still raises `OSError`.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
