### PR TITLE
py/stream: Use MP_SEEK_xxx constants instead of SEEK_xxx.

### DIFF
--- a/extmod/vfs_fat_file.c
+++ b/extmod/vfs_fat_file.c
@@ -103,15 +103,15 @@ static mp_uint_t file_obj_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg,
         struct mp_stream_seek_t *s = (struct mp_stream_seek_t *)(uintptr_t)arg;
 
         switch (s->whence) {
-            case 0: // SEEK_SET
+            case MP_SEEK_SET:
                 f_lseek(&self->fp, s->offset);
                 break;
 
-            case 1: // SEEK_CUR
+            case MP_SEEK_CUR:
                 f_lseek(&self->fp, f_tell(&self->fp) + s->offset);
                 break;
 
-            case 2: // SEEK_END
+            case MP_SEEK_END:
                 f_lseek(&self->fp, f_size(&self->fp) + s->offset);
                 break;
         }

--- a/extmod/vfs_rom_file.c
+++ b/extmod/vfs_rom_file.c
@@ -110,11 +110,11 @@ static mp_uint_t vfs_rom_file_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t 
     switch (request) {
         case MP_STREAM_SEEK: {
             struct mp_stream_seek_t *s = (struct mp_stream_seek_t *)arg;
-            if (s->whence == 0) { // SEEK_SET
+            if (s->whence == MP_SEEK_SET) {
                 self->file_offset = (size_t)s->offset;
-            } else if (s->whence == 1) { // SEEK_CUR
+            } else if (s->whence == MP_SEEK_CUR) {
                 self->file_offset += s->offset;
-            } else { // SEEK_END
+            } else { // MP_SEEK_END
                 self->file_offset = self->file_size + s->offset;
             }
             if (self->file_offset > self->file_size) {

--- a/ports/pic16bit/unistd.h
+++ b/ports/pic16bit/unistd.h
@@ -3,9 +3,6 @@
 
 // XC16 compiler doesn't seem to have unistd.h file
 
-#define SEEK_SET 0
-#define SEEK_CUR 1
-
 typedef int ssize_t;
 
 #endif // MICROPY_INCLUDED_PIC16BIT_UNISTD_H

--- a/ports/powerpc/unistd.h
+++ b/ports/powerpc/unistd.h
@@ -28,9 +28,6 @@
 
 // powerpc gcc compiler doesn't seem to have unistd.h file
 
-#define SEEK_SET 0
-#define SEEK_CUR 1
-
 typedef int ssize_t;
 
 #endif // MICROPY_INCLUDED_POWERPC_UNISTD_H

--- a/py/stream.c
+++ b/py/stream.c
@@ -461,13 +461,13 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream___exit___obj, 4, 4, mp_stream___ex
 static mp_obj_t stream_seek(size_t n_args, const mp_obj_t *args) {
     // TODO: Could be uint64
     mp_off_t offset = mp_obj_get_int(args[1]);
-    int whence = SEEK_SET;
+    int whence = MP_SEEK_SET;
     if (n_args == 3) {
         whence = mp_obj_get_int(args[2]);
     }
 
     // In POSIX, it's error to seek before end of stream, we enforce it here.
-    if (whence == SEEK_SET && offset < 0) {
+    if (whence == MP_SEEK_SET && offset < 0) {
         mp_raise_OSError(MP_EINVAL);
     }
 
@@ -484,7 +484,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(mp_stream_seek_obj, 2, 3, stream_seek);
 
 static mp_obj_t stream_tell(mp_obj_t self) {
     mp_obj_t offset = MP_OBJ_NEW_SMALL_INT(0);
-    mp_obj_t whence = MP_OBJ_NEW_SMALL_INT(SEEK_CUR);
+    mp_obj_t whence = MP_OBJ_NEW_SMALL_INT(MP_SEEK_CUR);
     const mp_obj_t args[3] = {self, offset, whence};
     return stream_seek(3, args);
 }


### PR DESCRIPTION
### Summary

The `MP_SEEK_xxx` constants are defined in `py/stream.h` exactly for use by `py/stream.c` so that it doesn't depend on the C library.  So use them.

Also remove definitions of `SEEK_xxx` in custom `unistd.h` files because they are no longer needed.

This issue was reported when porting MicroPython to the P2: https://forums.parallax.com/discussion/comment/1572778/#Comment_1572778

### Testing

Ran unix coverage tests locally.  CI will also test.

### Generative AI

None used.