### PR TITLE
esp8266/network_wlan: Allow bytes() objects as MAC address.

### DIFF
--- a/ports/esp8266/network_wlan.c
+++ b/ports/esp8266/network_wlan.c
@@ -559,7 +559,10 @@ static mp_obj_t esp_config(size_t n_args, const mp_obj_t *args, mp_map_t *kwargs
                         if (bufinfo.len != 6) {
                             mp_raise_ValueError(MP_ERROR_TEXT("invalid buffer length"));
                         }
-                        wifi_set_macaddr(self->if_id, bufinfo.buf);
+                        // The MAC address must be in a word-aligned DRAM buffer.
+                        uint8_t mac[6];
+                        memcpy(mac, bufinfo.buf, sizeof(mac));
+                        wifi_set_macaddr(self->if_id, mac);
                         break;
                     }
                     case MP_QSTR_ssid:


### PR DESCRIPTION
### Summary

This PR fixes a crash occurring when setting the WLAN MAC address using a bytes() object containing the new MAC address bytes.  This also fixes cases where the address is put in ROM or is an unaligned slice of a larger buffer.

The ESP8266's network stack seems to want the MAC address buffer being in a particular memory area and with a specific alignment, which cannot be always guaranteed.  Luckily stack-allocated buffers do have the necessary requirements when it comes to location and alignment, so the MAC address is first copied into such a buffer and then that's passed to the network stack.

This fixes #11357.

### Testing

The sample code fragments provided in #11357 were executed on a generic ESP8266 board, correctly setting the WLAN MAC address instead of crashing.
### Trade-offs and Alternatives

This makes the firmware 76 bytes larger, which I believe is unavoidable in this case.
### Generative AI

I did not use generative AI tools when creating this PR.