### PR TITLE
tools/mpy_ld.py: Ignore R_XTENSA_NDIFF32 relocations.

### DIFF
--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -121,6 +121,7 @@ R_RISCV_SET32 = 56
 R_RISCV_32_PCREL = 57
 R_RISCV_PLT32 = 59
 R_XTENSA_PDIFF32 = 59
+R_XTENSA_NDIFF32 = 62
 R_RISCV_SET_ULEB128 = 60
 R_RISCV_SUB_ULEB128 = 61
 R_RISCV_TLSDESC_HI20 = 62
@@ -714,11 +715,11 @@ def do_relocation_text(env, text_addr, r):
     elif env.arch.name == "EM_XTENSA" and r_info_type in (
         R_XTENSA_DIFF32,
         R_XTENSA_PDIFF32,
+        R_XTENSA_NDIFF32,
         R_XTENSA_ASM_EXPAND,
     ):
         if not hasattr(s, "section") or s.section.name.startswith(".text"):
-            # it looks like R_XTENSA_[P]DIFF32 into .text is already correctly relocated,
-            # and expand relaxations cannot occur in non-executable sections.
+            # Ignore relaxation relocations.
             return
         assert 0
 


### PR DESCRIPTION

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

This PR introduces support for the negative counterpart of `R_XTENSA_PDIFF32`, ignoring the relocation instead of aborting processing.

There are more relaxation relocations that could be ignored but so far `R_XTENSA_NDIFF32` was the only one that was encountered in the wild.  Others can be added at a later stage if updated Xtensa toolchains start emitting them or if users file bug reports about linking errors due to unsupported relocation types.

This addresses #8781.

### Testing

In #8781 the relocation in question was encountered when linking a native module using the ESP32S3-specific binaries from ESP-IDF.  However, I wasn't able to trigger the generation of that relocation when rebuilding all example natmods with `CROSS=xtensa-esp32s3-elf-`.

Still, the relocation was emitted via this small assembler file:

```s
	.text
	.literal_position
	.literal .LC0, mp_fun_table
	.align 4
	.type fun, @function
fun:
	entry sp, 32
	l32r a0, .LC0
	.reloc fun, R_XTENSA_NDIFF32
	retw.n
	.size fun, .-fun
	.global mpy_init
	.type mpy_init, @function
mpy_init:
	entry sp, 32
	retw.n
	.size mpy_init, .-mpy_init
	.section .rodata
	.align 4
	.type fun_obj, @object
	.size fun_obj, 8
fun_obj:
	.word 0
	.word fun
```

Which was built with `xtensa-esp32s3-elf-as -o reloc.o reloc.s`, and then attempted to converted into a MPY file via `tools/mpy_ld.py -o out.mpy -march=xtensawin reloc.o`.   Without this change, linking will fail due to an unknown relocation (of type `R_XTENSA_NDIFF32`).

### Generative AI

I did not use generative AI tools when creating this PR.
