### PR TITLE
nrf, samd: Run events at least once in mp_hal_delay_ms.

### DIFF
--- a/ports/nrf/mphalport.c
+++ b/ports/nrf/mphalport.c
@@ -303,12 +303,13 @@ void mp_hal_delay_us(mp_uint_t us) {
 void mp_hal_delay_ms(mp_uint_t ms) {
     uint32_t now;
     if (ms == 0) {
+        mp_handle_pending(MP_HANDLE_PENDING_CALLBACKS_AND_EXCEPTIONS);
         return;
     }
     now = mp_hal_ticks_ms();
-    while (mp_hal_ticks_ms() - now < ms) {
+    do {
         MICROPY_EVENT_POLL_HOOK
-    }
+    } while (mp_hal_ticks_ms() - now < ms);
 }
 
 #else

--- a/ports/samd/mphalport.c
+++ b/ports/samd/mphalport.c
@@ -70,9 +70,11 @@ void mp_hal_clr_pin_mux(mp_hal_pin_obj_t pin) {
 
 void mp_hal_delay_ms(mp_uint_t ms) {
     uint32_t t0 = systick_ms;
-    while (systick_ms - t0 < ms) {
-        mp_event_wait_ms(1);
-    }
+    uint32_t elapsed = 0;
+    do {
+        mp_event_wait_ms(ms - elapsed);
+        elapsed = systick_ms - t0;
+    } while (elapsed < ms);
 }
 
 void mp_hal_delay_us(mp_uint_t us) {

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -42,7 +42,12 @@
 #define MICROPY_PY_PENDSV_EXIT    restore_irq_pri(atomic_state)
 
 // Port level Wait-for-Event macro.
-#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) __WFE()
+#define MICROPY_INTERNAL_WFE(TIMEOUT_MS) \
+    do { \
+        if (TIMEOUT_MS != 0) { \
+            __WFE(); \
+        } \
+    } while (0)
 
 #define MICROPY_HW_USB_CDC_TX_TIMEOUT (500)
 


### PR DESCRIPTION
### Summary

Per the docs for `time.sleep()` and `time.sleep_ms()`, events must be run at least once in `mp_hal_delay_ms()`.

This gets the `tests/micropython/schedule_sleep.py` test working when using the native emitter.

### Testing

Tested on ARDUINO_NANO_33_BLE_SENSE (nrf) and ADAFRUIT_ITSYBITSY_M0_EXPRESS (samd), using:
```
$ ./run-tests -t a0 --via-mpy --emit native micropython/schedule_sleep.py
```
It now passes instead of locking up.

Existing tests still pass OK.

### Generative AI

Not used.