### PR TITLE
ports/unix: Add LoongArch64 architecture support.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -327,6 +327,25 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
+  qemu_loong64:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
+    - name: Install packages
+      run: tools/ci.sh unix_qemu_loong64_setup
+    - name: Build
+      run: tools/ci.sh unix_qemu_loong64_build
+    - name: Run main test suite
+      run: tools/ci.sh unix_qemu_loong64_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
   sanitize_address:
     runs-on: ubuntu-latest
     steps:

--- a/extmod/modplatform.h
+++ b/extmod/modplatform.h
@@ -53,6 +53,8 @@
 #else
 #define MICROPY_PLATFORM_ARCH   "riscv"
 #endif
+#elif defined(__loongarch__) && defined(__loongarch64)
+#define MICROPY_PLATFORM_ARCH   "loongarch64"
 #else
 #define MICROPY_PLATFORM_ARCH   ""
 #endif

--- a/ports/unix/README.md
+++ b/ports/unix/README.md
@@ -5,9 +5,10 @@ The "unix" port runs in standard Unix-like environments including Linux, BSD,
 macOS, and Windows Subsystem for Linux.
 
 The x86 and x64 architectures are supported (i.e. x86 32- and 64-bit), as well
-as ARM and MIPS. Extending the unix port to another architecture requires
-writing some assembly code for the exception handling and garbage collection.
-Alternatively, a fallback implementation based on setjmp/longjmp can be used.
+as ARM, MIPS, RISC-V, and LoongArch. Extending the unix port to another
+architecture requires writing some assembly code for the exception handling
+and garbage collection. Alternatively, a fallback implementation based on
+setjmp/longjmp can be used.
 
 Building
 --------

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -106,7 +106,7 @@ typedef long mp_off_t;
 // Always enable GC.
 #define MICROPY_ENABLE_GC           (1)
 
-#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__) || (defined(__riscv) && __riscv_xlen <= 64))
+#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__) || (defined(__riscv) && __riscv_xlen <= 64) || (defined(__loongarch__) && defined(__loongarch64)))
 // Fall back to setjmp() implementation for discovery of GC pointers in registers.
 #define MICROPY_GCREGS_SETJMP (1)
 #endif

--- a/py/nlr.h
+++ b/py/nlr.h
@@ -46,6 +46,7 @@
 #define MICROPY_NLR_NUM_REGS_XTENSAWIN      (17)
 #define MICROPY_NLR_NUM_REGS_RV32I          (14)
 #define MICROPY_NLR_NUM_REGS_RV64I          (14)
+#define MICROPY_NLR_NUM_REGS_LOONG64        (13)
 
 // *FORMAT-OFF*
 
@@ -99,6 +100,13 @@
         #define MICROPY_NLR_RV64I (1)
     #else
         #error Unsupported RISC-V variant.
+    #endif
+#elif defined(__loongarch__)
+    #if defined(__loongarch64)
+        #define MICROPY_NLR_LOONG64 (1)
+        #define MICROPY_NLR_NUM_REGS (MICROPY_NLR_NUM_REGS_LOONG64)
+    #else
+        #error Unsupported Loongarch variant.
     #endif
 #else
     #define MICROPY_NLR_SETJMP (1)

--- a/py/nlrloong64.c
+++ b/py/nlrloong64.c
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mpstate.h"
+
+#if MICROPY_NLR_LOONG64
+
+__attribute__((used)) unsigned int nlr_push_tail(nlr_buf_t *nlr);
+
+__asm(
+    ".globl nlr_push     \n"
+    "nlr_push:           \n"
+    ".cfi_startproc      \n"
+    "st.d $r1,  $r4, 16  \n" /* Store RA. */
+    "st.d $r23, $r4, 24  \n" /* Store S0. */
+    "st.d $r24, $r4, 32  \n" /* Store S1. */
+    "st.d $r25, $r4, 40  \n" /* Store S2. */
+    "st.d $r26, $r4, 48  \n" /* Store S3. */
+    "st.d $r27, $r4, 56  \n" /* Store S4. */
+    "st.d $r28, $r4, 64  \n" /* Store S5. */
+    "st.d $r29, $r4, 72  \n" /* Store S6. */
+    "st.d $r30, $r4, 80  \n" /* Store S7. */
+    "st.d $r31, $r4, 88  \n" /* Store S8. */
+    "st.d $r22, $r4, 96  \n" /* Store S9. */
+    "st.d $r21, $r4, 104 \n" /* Marked as reserved in the ABI. */
+    "st.d $r3,  $r4, 112 \n" /* Store SP. */
+    "b    nlr_push_tail  \n" /* Jump to the C part. */
+    ".cfi_endproc        \n"
+    );
+
+MP_NORETURN void nlr_jump(void *val) {
+    MP_NLR_JUMP_HEAD(val, top)
+    __asm volatile (
+        "add.d  $r4,  $r0, %0  \n"
+        "ld.d   $r1,  $r4, 16  \n" /* Retrieve RA. */
+        "ld.d   $r23, $r4, 24  \n" /* Retrieve S0. */
+        "ld.d   $r24, $r4, 32  \n" /* Retrieve S1. */
+        "ld.d   $r25, $r4, 40  \n" /* Retrieve S2. */
+        "ld.d   $r26, $r4, 48  \n" /* Retrieve S3. */
+        "ld.d   $r27, $r4, 56  \n" /* Retrieve S4. */
+        "ld.d   $r28, $r4, 64  \n" /* Retrieve S5. */
+        "ld.d   $r29, $r4, 72  \n" /* Retrieve S6. */
+        "ld.d   $r30, $r4, 80  \n" /* Retrieve S7. */
+        "ld.d   $r31, $r4, 88  \n" /* Retrieve S8. */
+        "ld.d   $r22, $r4, 96  \n" /* Retrieve S9. */
+        "ld.d   $r21, $r4, 104 \n"
+        "ld.d   $r3,  $r4, 112 \n" /* Retrieve SP. */
+        "addi.d $r4,  $r0, 1   \n" /* Return 1 for a non-local return. */
+        "ret                   \n" /* Return. */
+        :
+        : "r" (top)
+        : "memory"
+        );
+    MP_UNREACHABLE
+}
+
+#endif

--- a/py/py.cmake
+++ b/py/py.cmake
@@ -61,6 +61,7 @@ set(MICROPY_SOURCE_PY
     ${MICROPY_PY_DIR}/nativeglue.c
     ${MICROPY_PY_DIR}/nlr.c
     ${MICROPY_PY_DIR}/nlraarch64.c
+    ${MICROPY_PY_DIR}/nlrloong64.c
     ${MICROPY_PY_DIR}/nlrmips.c
     ${MICROPY_PY_DIR}/nlrpowerpc.c
     ${MICROPY_PY_DIR}/nlrrv32.c

--- a/py/py.mk
+++ b/py/py.mk
@@ -93,6 +93,7 @@ PY_CORE_O_BASENAME = $(addprefix py/,\
 	nlrxtensa.o \
 	nlrrv32.o \
 	nlrrv64.o \
+	nlrloong64.o \
 	nlrsetjmp.o \
 	malloc.o \
 	gc.o \

--- a/shared/runtime/gchelper_generic.c
+++ b/shared/runtime/gchelper_generic.c
@@ -189,6 +189,32 @@ static void gc_helper_get_regs(gc_helper_regs_t arr) {
     arr[11] = s11;
 }
 
+#elif defined(__loongarch__) && defined(__loongarch64)
+
+// Fallback implementation for LOONG64, prefer gchelper_loong64.s.
+static void gc_helper_get_regs(gc_helper_regs_t arr) {
+    register uintptr_t s0 asm ("r23");
+    register uintptr_t s1 asm ("r24");
+    register uintptr_t s2 asm ("r25");
+    register uintptr_t s3 asm ("r26");
+    register uintptr_t s4 asm ("r27");
+    register uintptr_t s5 asm ("r28");
+    register uintptr_t s6 asm ("r29");
+    register uintptr_t s7 asm ("r30");
+    register uintptr_t s8 asm ("r31");
+    register uintptr_t s9 asm ("r22");
+    arr[0] = s0;
+    arr[1] = s1;
+    arr[2] = s2;
+    arr[3] = s3;
+    arr[4] = s4;
+    arr[5] = s5;
+    arr[6] = s6;
+    arr[7] = s7;
+    arr[8] = s8;
+    arr[9] = s9;
+}
+
 #else
 
 #error "Architecture not supported for gc_helper_get_regs. Set MICROPY_GCREGS_SETJMP to use the fallback implementation."

--- a/shared/runtime/gchelper_loong64.s
+++ b/shared/runtime/gchelper_loong64.s
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2026 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,32 +23,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-#ifndef MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
-#define MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
 
-#include <stdint.h>
+    .global gc_helper_get_regs_and_sp
+    .type   gc_helper_get_regs_and_sp, @function
 
-#if MICROPY_GCREGS_SETJMP
-#include <setjmp.h>
-typedef jmp_buf gc_helper_regs_t;
-#else
+gc_helper_get_regs_and_sp:
 
-#if defined(__x86_64__)
-typedef uintptr_t gc_helper_regs_t[6];
-#elif defined(__i386__)
-typedef uintptr_t gc_helper_regs_t[4];
-#elif defined(__thumb2__) || defined(__thumb__) || defined(__arm__)
-typedef uintptr_t gc_helper_regs_t[10];
-#elif defined(__aarch64__)
-typedef uintptr_t gc_helper_regs_t[11]; // x19-x29
-#elif defined(__riscv) && (__riscv_xlen <= 64)
-typedef uintptr_t gc_helper_regs_t[12]; // S0-S11
-#elif defined(__loongarch__) && defined(__loongarch64)
-typedef uintptr_t gc_helper_regs_t[10]; // S0-S9
-#endif
+    /* Store registers into the given array. */
 
-#endif
+    st.d  $r23, $r4, 0   /* Save S0.  */
+    st.d  $r24, $r4, 8   /* Save S1.  */
+    st.d  $r25, $r4, 16  /* Save S2.  */
+    st.d  $r26, $r4, 24  /* Save S3.  */
+    st.d  $r27, $r4, 32  /* Save S4.  */
+    st.d  $r28, $r4, 40  /* Save S5.  */
+    st.d  $r29, $r4, 48  /* Save S6.  */
+    st.d  $r30, $r4, 56  /* Save S7.  */
+    st.d  $r31, $r4, 64  /* Save S8.  */
+    st.d  $r22, $r4, 72  /* Save S9.  */
 
-void gc_helper_collect_regs_and_stack(void);
+    /* Return the stack pointer. */
 
-#endif // MICROPY_INCLUDED_LIB_UTILS_GCHELPER_H
+    add.d $r4, $r0, $r3
+    jirl  $r0, $r1, 0
+
+    .size gc_helper_get_regs_and_sp, .-gc_helper_get_regs_and_sp

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -607,6 +607,12 @@ CI_UNIX_OPTS_QEMU_RISCV64=(
     MICROPY_STANDALONE=1
 )
 
+CI_UNIX_OPTS_QEMU_LOONG64=(
+    CROSS_COMPILE=loongarch64-linux-gnu-
+    VARIANT=coverage
+    MICROPY_STANDALONE=1
+)
+
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
     # Macro MP_ASAN allows detecting ASan on gcc<=13
     CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -DMP_ASAN=1"
@@ -965,6 +971,36 @@ function ci_unix_qemu_riscv64_run_tests {
     MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py --exclude 'thread/stress_aes.py'
     MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-natmodtests.py extmod/btree*.py extmod/deflate*.py extmod/framebuf*.py extmod/heapq*.py extmod/random_basic*.py extmod/re*.py
     popd
+}
+
+function ci_unix_qemu_loong64_setup {
+    sudo apt-get update
+    sudo apt-get install gcc-14-loongarch64-linux-gnu g++-14-loongarch64-linux-gnu libc6-loong64-cross libltdl-dev
+    sudo apt-get install qemu-user-static
+    qemu-loongarch64-static --version
+    sudo mkdir -p /usr/gnemul
+    sudo ln -s /usr/loongarch64-linux-gnu /usr/gnemul/qemu-loongarch64
+    sudo ln -s /usr/bin/loongarch64-linux-gnu-gcc-14 /usr/bin/loongarch64-linux-gnu-gcc
+    sudo ln -s /usr/bin/loongarch64-linux-gnu-g++-14 /usr/bin/loongarch64-linux-gnu-g++
+}
+
+function ci_unix_qemu_loong64_build {
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_LOONG64[@]}"
+    ci_unix_build_ffi_lib_helper loongarch64-linux-gnu-gcc
+}
+
+function ci_unix_qemu_loong64_run_tests {
+    # Issues with LOONG64 tests:
+    # - thread/stress_aes.py takes around 90 seconds
+    file ./ports/unix/build-coverage/micropython
+    # Loongarch64 isn't defined in the CI image's binfmt list.
+    cat << 'EOF' > ./ports/unix/build-coverage/micropython-runner
+#!/bin/sh
+MPY_PATH=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+qemu-loongarch64-static "$MPY_PATH"/micropython $@
+EOF
+    chmod +x ./ports/unix/build-coverage/micropython-runner
+    (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython-runner MICROPY_TEST_TIMEOUT=180 ./run-tests.py)
 }
 
 function ci_unix_repr_b_build {


### PR DESCRIPTION
### Summary

This PR introduces support for the LoongArch64 architecture to the Unix port.

Inspired by #18564 and #18604, and with roughly a hour of free time, LoongArch64 could now be added to the list of supported architectures.  This is essentially a rehash of the RV64 code with the unsupported `__attribute__((naked))` workaround introduced in `py/nlrmips.c`, saving and restoring a subset of the RV64 registers, and having to look up the new opcodes syntax.  The assembly code could have probably been machine-translated given how similar it is.

LoongArch64 support, if merged, will stay at the same level as MIPS64 unless there are users asking for more.  Which in this case would only mean natmod support, and only if there's strong demand (some of the relocation types mentioned in the ABI documents make AArch64 look simplistic...).

Like MIPS 64 and RISC-V 64, LoongArch64 is fully supported by Linux, GCC, and LibFFI.  It is an officially supported platform by the Alpine and Debian Linux distributions, so there might be some interest in getting MicroPython to work a tiny bit better on this architecture.

It's not a big deal if this PR is found to be out of scope w.r.t. the current MicroPython direction, it was an interesting exercise and it took more time to come up with appropriate git commit descriptions than figuring out how to make this work. 

Some pointers:

ELF ABI: https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
Assembler opcodes: https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.pdf
Toolchain preprocessor definitions: https://loongson.github.io/LoongArch-Documentation/LoongArch-toolchain-conventions-EN.pdf

### Testing

This should be already tested by the updated CI workflow present in this PR.  `tests/thread/stress_aes.py` is still flaky, but that's the case with all other QEMU-based runners.  When the job is executed during off-peak hours (eg. 4AM or 5AM) the test completes in the allotted amount of time.

### Trade-offs and Alternatives

Although a new architecture usually means non-trivial amount of maintenance at the beginning, this should require the same amount of maintenance as the Unix port's RV64 variant.  It's basically the same execution model but with different assembler syntax, after all.

### Generative AI

I did not use generative AI tools when creating this PR.