### PR TITLE
tools: Formally recommend the micropython-uncrustify package.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
         name: MicroPython codeformat.py for changed C files
         entry: tools/codeformat.py -v -c -f
         language: python
+        additional_dependencies:
+          - micropython-uncrustify==1.0.0.post1
       - id: verifygitlog
         name: MicroPython git commit message format checker
         entry: tools/verifygitlog.py --check-file --ignore-rebase

--- a/CODECONVENTIONS.md
+++ b/CODECONVENTIONS.md
@@ -72,36 +72,28 @@ be used for MicroPython. Different uncrustify versions produce slightly
 different formatting, and the configuration file formats are often
 incompatible. v0.73 or newer *will not work*.
 
-Depending on your operating system version, it may be possible to install a pre-compiled
-uncrustify version:
+Depending on your operating system version, it may be possible to install a
+compatible pre-compiled uncrustify version. Otherwise, a compatible version is
+available via the PyPI package archive:
 
-Ubuntu, Debian
---------------
-
-Ubuntu versions 21.10 or 22.04LTS, and Debian versions bullseye or bookworm all
-include v0.72 so can be installed directly:
+Pip
+---
 
 ```
-$ apt install uncrustify
+pip install micropython-uncrustify
 ```
 
-Arch Linux
-----------
+This installs a native compiled uncrustify binary as a Python executable, so it
+can be installed into a virtualenv.
 
-The current Arch uncrustify version is too new. There is an [old Arch package
-for v0.72](https://archive.archlinux.org/packages/u/uncrustify/) that can be
-installed from the Arch Linux archive ([more
-information](https://wiki.archlinux.org/title/Downgrading_packages#Arch_Linux_Archive)). Use
-the [IgnorePkg feature](https://wiki.archlinux.org/title/Pacman#Skip_package_from_being_upgraded)
-to prevent it re-updating.
-
-Brew
+Pipx
 ----
 
-This command may work, please raise a new Issue if it doesn't:
+It's also possible to install via [pipx](https://pipx.pypa.io/) if not using a
+virtualenv:
 
 ```
-curl -L https://github.com/Homebrew/homebrew-core/raw/2b07d8192623365078a8b855a164ebcdf81494a6/Formula/uncrustify.rb > uncrustify.rb && brew install uncrustify.rb && rm uncrustify.rb
+pipx install micropython-uncrustify
 ```
 
 Code spell checking
@@ -127,6 +119,9 @@ To have code formatting and commit message conventions automatically checked,
 a configuration file is provided for the [pre-commit](https://pre-commit.com/)
 tool.
 
+Pre-commit will automatically install the correct version of dependencies
+such as codespell, uncrustify, etc.
+
 First install `pre-commit`, either from your system package manager or via
 `pip`. When installing `pre-commit` via pip, it is recommended to use a
 virtual environment. Other sources, such as Brew are also available, see
@@ -138,10 +133,6 @@ $ pacman -Sy python-precommit  # Arch Linux
 $ brew install pre-commit      # Brew
 $ pip install pre-commit       # PyPI
 ```
-
-Next, install [uncrustify (see above)](#uncrustify). Other dependencies are managed by
-pre-commit automatically, but uncrustify needs to be installed and available on
-the PATH.
 
 Then, inside the MicroPython repository, register the git hooks for pre-commit
 by running:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -42,8 +42,7 @@ function ci_picotool_setup {
 # c code formatting
 
 function ci_c_code_formatting_setup {
-    sudo apt-get update
-    sudo apt-get install uncrustify
+    pip install micropython-uncrustify==1.0.0.post1
     uncrustify --version
 }
 


### PR DESCRIPTION
### Summary

This is a follow-up to https://github.com/micropython/micropython/pull/15221#issuecomment-4559996188. micropython-uncrustify has been the unofficial best option for a while, this updates the docs and pre-commit/CI checks to match.

Before this PR, using pre-commit successfully required manually installing uncrustify. After this PR, pre-commit should automatically install `micropython-uncrustify` - similar to the other tools it depends on.

Thanks @dlech for publishing the micropython-uncrustify package!

### Testing

* Ran pre-commit locally
* The code formatting job will run against this PR

### Trade-offs and Alternatives

* Eventually it'd be good to have a MicroPython pyproject.toml (or similar) which captures the supported development versions of a bunch of these tools. For now have specified the correct micropython-uncrustify version in both ci.sh and pre-commit config, which at least gives us a path to updating uncrustify at some point in the future (although I'm not sure we ever will).

### Generative AI

I did not use generative AI tools when creating this PR.