### PR TITLE
rp2: Build with nano.specs, add linker cref table

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -538,6 +538,7 @@ target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
     -Wl,--wrap=runtime_init_clocks
     -Wl,--print-memory-usage
+    -Wl,--cref
 )
 
 if(DEFINED PICO_FLASH_SIZE_BYTES)

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -532,6 +532,13 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
     -Wall
     -Werror
     -g  # always include debug information in the ELF
+
+    # pico-sdk already passes --specs=nosys.specs to stub out syscall handlers,
+    # passing nano.specs as well means that newlib-nano libc functions will be used
+    # (note this is mostly a linker option, but should be passed to the compiler as
+    # well to add the newlib-nano header to the search path. Currently this happens
+    # inconsistently as pico-sdk files aren't built with this option.)
+    --specs=nano.specs
 )
 
 target_link_options(${MICROPY_TARGET} PRIVATE
@@ -539,6 +546,8 @@ target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--wrap=runtime_init_clocks
     -Wl,--print-memory-usage
     -Wl,--cref
+    # see note about nano.specs, above
+    --specs=nano.specs
 )
 
 if(DEFINED PICO_FLASH_SIZE_BYTES)

--- a/ports/rp2/mbedtls/mbedtls_config_port.h
+++ b/ports/rp2/mbedtls/mbedtls_config_port.h
@@ -34,6 +34,7 @@
 time_t rp2_rtctime_seconds(time_t *timer);
 #define MBEDTLS_PLATFORM_TIME_MACRO rp2_rtctime_seconds
 #define MBEDTLS_PLATFORM_MS_TIME_ALT mbedtls_ms_time
+#define MBEDTLS_PLATFORM_GMTIME_R_ALT 1
 
 // Set MicroPython-specific options.
 #define MICROPY_MBEDTLS_CONFIG_BARE_METAL (1)

--- a/ports/rp2/mbedtls/mbedtls_port.c
+++ b/ports/rp2/mbedtls/mbedtls_port.c
@@ -47,4 +47,13 @@ mbedtls_ms_time_t mbedtls_ms_time(void) {
     current_ms = rp2_rtctime_seconds(tv) * 1000;
     return current_ms;
 }
+
+struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt, struct tm *tm_buf) {
+    // Default mbedTLS platform implementation calls gmtime() here. This is
+    // unnecessary as this function signature already matches gmtime_r(), and
+    // additionally on newlib-nano gmtime() tries to malloc the reent buffer on
+    // demand - which will fail.
+    return gmtime_r(tt, tm_buf);
+}
+
 #endif


### PR DESCRIPTION
### Summary

Passes `--specs=nano.specs` on the gcc compiler & linker command line for rp2, meaning newlib-nano is used instead of regular newlib. As mentioned by @Gadgetoid in #11143. This reduces both the binary size and (significantly) the static RAM usage. Should also save some RAM at runtime, particularly the stack footprint of libc printf.

Includes a commit to add the `--cref` linker argument, which adds a cross-reference table in the linker map file. This is useful to figure out how/why certain symbols are linked.

The specific libc pieces which are linked in the default rp2 build seem to be malloc/free/realloc and some printf support.

* The malloc/free/realloc looks like it's pulled in via `pico_util` queue.c and time.c, and operator new & delete (unclear why these are pulled in at all!) Can find via `__wrap_free` in the cross-reference table. This feels like with a small amount of work it could be removed, maybe...? Particularly as the default rp2 build has no C heap available.
* snprintf looks like it's being pulled in via some mbedTLS features, `shared/readline`, and `shared/netutils`. Can find via `__wrap_snprintf` in the cross-reference table. This feels like it'd be harder to remove the dependency for.

I don't think any of these use cases require "full" newlib support.

The best description I know for gcc specs and nano vs normal newlib is https://metebalci.com/blog/demystifying-arm-gnu-toolchain-specs-nano-and-nosys/

### Testing

* Ran the default unit tests on RPI_PICO2.

### Trade-offs and Alternatives

* Keeping default newlib is the safer path, particularly if there are any C usermodules that happen to depend on "full" libc features. However, MicroPython itself doesn't depend on much libc at all.

### Generative AI

I did not use generative AI tools when creating this PR.