### PR TITLE
mimxrt: Fix flash erase operations on Hyperflash boards.

### DIFF
--- a/ports/mimxrt/flash.c
+++ b/ports/mimxrt/flash.c
@@ -30,7 +30,7 @@ void flash_init(void) {
     // Upload the custom flash configuration
     // And fix the entry for PAGEPROGRAM_QUAD
     // Update the flash CLK
-    flexspi_nor_update_lut_clk(MICROPY_HW_FLASH_CLK);
+    flexspi_update_lut_clk(MICROPY_HW_FLASH_CLK);
 
     // Configure FLEXSPI IP FIFO access.
     BOARD_FLEX_SPI->MCR0 &= ~(FLEXSPI_MCR0_ARDFEN_MASK);

--- a/ports/mimxrt/hal/flexspi_hyper_flash.c
+++ b/ports/mimxrt/hal/flexspi_hyper_flash.c
@@ -9,7 +9,11 @@
 #include "fsl_clock.h"
 #include "flexspi_hyper_flash.h"
 
-void flexspi_nor_update_lut_clk(uint32_t freq_index) {
+void flexspi_update_lut_clk(uint32_t freq_index) {
+    // This should be performed by the boot ROM but for some reason it is not.
+    FLEXSPI_UpdateLUT(BOARD_FLEX_SPI, 0,
+        qspiflash_config.memConfig.lookupTable,
+        ARRAY_SIZE(qspiflash_config.memConfig.lookupTable));
 }
 
 // Copy of a few (pseudo-)functions from fsl_clock.h, which were nor reliably

--- a/ports/mimxrt/hal/flexspi_hyper_flash.h
+++ b/ports/mimxrt/hal/flexspi_hyper_flash.h
@@ -47,7 +47,7 @@ extern flexspi_nor_config_t qspiflash_config;
 
 status_t flexspi_nor_hyperflash_cfi(FLEXSPI_Type *base);
 void flexspi_hyper_flash_init(void);
-void flexspi_nor_update_lut_clk(uint32_t freq_index);
+void flexspi_update_lut_clk(uint32_t freq_index);
 status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address);
 status_t flexspi_nor_flash_erase_block(FLEXSPI_Type *base, uint32_t address);
 status_t flexspi_nor_flash_page_program(FLEXSPI_Type *base, uint32_t address, const uint32_t *src, uint32_t size);

--- a/ports/mimxrt/hal/flexspi_nor_flash.c
+++ b/ports/mimxrt/hal/flexspi_nor_flash.c
@@ -89,7 +89,7 @@ static ps_div_t div_table_mhz[] = {
 };
 #endif
 
-__attribute__((section(".ram_functions"))) void flexspi_nor_update_lut_clk(uint32_t freq_index) {
+__attribute__((section(".ram_functions"))) void flexspi_update_lut_clk(uint32_t freq_index) {
     // Create a local copy of the LookupTable. Modify the entry for WRITESTATUSREG
     // Add an entry for PAGEPROGRAM_QUAD.
     uint32_t lookuptable_copy[64];

--- a/ports/mimxrt/hal/flexspi_nor_flash.h
+++ b/ports/mimxrt/hal/flexspi_nor_flash.h
@@ -45,7 +45,7 @@
 extern flexspi_nor_config_t qspiflash_config;
 
 status_t flexspi_nor_get_vendor_id(FLEXSPI_Type *base, uint8_t *vendorId);
-void flexspi_nor_update_lut_clk(uint32_t freq_index);
+void flexspi_update_lut_clk(uint32_t freq_index);
 status_t flexspi_nor_enable_quad_mode(FLEXSPI_Type *base);
 status_t flexspi_nor_flash_erase_sector(FLEXSPI_Type *base, uint32_t address);
 status_t flexspi_nor_flash_erase_block(FLEXSPI_Type *base, uint32_t address);


### PR DESCRIPTION
### Summary

Possibly also fixes flash write (untested). Closes #19250

Regression introduced in b251aec0f (#15983), where the FLEXSPI_UpdateLUT() call was removed from boards configured for Hyperflash.

This commit restores the old version, but doesn't add any of the additional LUT improvements & clock changes subsequently added for the NOR flash driver.

### Testing

* After erasing flash chip (I used `pyocd erase --chip`) and flashing MicroPython, the failure mode can be easily triggered by running `mpremote exec "import _boot"`. A mimxrt board with working flash filesystem reports `OSError EPERM`, but a board with the bug reports `OSError 84`.
* The same method was used to git bisect the regression.
* Also verified manually that it's possible to write files on the internal flash of MIXMRT1050_EVK board after this fix is applied.
* Currently I think this board is the only MicroPython board that uses Hyperflash, and also it doesn't support the UF2 bootloader, so other boards & configurations should not have a risk of regression.

### Generative AI

I did not use generative AI tools when creating this PR.
