### PR TITLE
mimxrt: Fix corruption due to sdcard transfer alignment.

### DIFF
--- a/ports/mimxrt/sdcard.c
+++ b/ports/mimxrt/sdcard.c
@@ -30,6 +30,7 @@
 
 #include "sdcard.h"
 #include "ticks.h"
+#include "fsl_cache.h"
 #include "fsl_iomuxc.h"
 #include "pin.h"
 
@@ -294,17 +295,28 @@ static void sdcard_error_recovery(USDHC_Type *base) {
 static status_t sdcard_transfer_blocking(USDHC_Type *base, usdhc_handle_t *handle, usdhc_transfer_t *transfer, uint32_t timeout_ms) {
     status_t status;
 
-    usdhc_adma_config_t dma_config;
+    usdhc_adma_config_t dma_config = {
+        .dmaMode = kUSDHC_DmaModeAdma2,
+        #if !(defined(FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN) && FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN)
+        .burstLen = kUSDHC_EnBurstLenForINCR,
+        #endif
+        .admaTable = sdcard_adma_descriptor_table,
+        .admaTableWords = DMA_DESCRIPTOR_BUFFER_SIZE,
+    };
+    usdhc_adma_config_t *p_dma_config = &dma_config;
 
-    (void)memset(&dma_config, 0, sizeof(usdhc_adma_config_t));
-    dma_config.dmaMode = kUSDHC_DmaModeAdma2;
-
-    #if !(defined(FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN) && FSL_FEATURE_USDHC_HAS_NO_RW_BURST_LEN)
-    dma_config.burstLen = kUSDHC_EnBurstLenForINCR;
+    #if __DCACHE_PRESENT
+    size_t byte_len = transfer->data->blockCount * transfer->data->blockSize;
+    if ((uintptr_t)transfer->data->rxData % FSL_FEATURE_L1DCACHE_LINESIZE_BYTE != 0 ||
+        byte_len % FSL_FEATURE_L1DCACHE_LINESIZE_BYTE != 0) {
+        // A DMA RX transfer that isn't cache line aligned can be corrupted if the CPU writes the same cache line during
+        // the read, so make a polling transfer instead.
+        //
+        // (Note that the USDHC driver will internally disable DMA if the address isn't 4 byte aligned, so this check only
+        // changes behaviour for addresses which are word aligned but not cache line aligned!)
+        p_dma_config = NULL;
+    }
     #endif
-
-    dma_config.admaTable = sdcard_adma_descriptor_table;
-    dma_config.admaTableWords = DMA_DESCRIPTOR_BUFFER_SIZE;
 
     // Wait while the card is busy before a transfer
     status = kStatus_Timeout;
@@ -313,7 +325,7 @@ static status_t sdcard_transfer_blocking(USDHC_Type *base, usdhc_handle_t *handl
         if (((transfer->data->txData == NULL) && (transfer->data->rxData == NULL)) ||
             (USDHC_GetPresentStatusFlags(base) & (uint32_t)kUSDHC_Data0LineLevelFlag) != 0) {
             // Not busy anymore or no TX-Data
-            status = USDHC_TransferBlocking(base, &dma_config, transfer);
+            status = USDHC_TransferBlocking(base, p_dma_config, transfer);
             if (status != kStatus_Success) {
                 sdcard_error_recovery(base);
             }
@@ -321,6 +333,14 @@ static status_t sdcard_transfer_blocking(USDHC_Type *base, usdhc_handle_t *handl
         }
         ticks_delay_us64(10);
     }
+
+    #if __DCACHE_PRESENT
+    if (p_dma_config && transfer->data->rxData) {
+        // Invalidate any cache lines that were filled while the transfer was in progress
+        L1CACHE_InvalidateDCacheByRange((uintptr_t)transfer->data->rxData, byte_len);
+    }
+    #endif
+
     return status;
 
 }

--- a/tests/extmod_hardware/machine_sdcard_dma_align.py
+++ b/tests/extmod_hardware/machine_sdcard_dma_align.py
@@ -1,36 +1,70 @@
 # Test DMA read operations when the buffer alignment in RAM varies.
 #
+# Runs on both pyb.SDCard and machine.SDCard with default arguments,
+# although some port-specific info is needed (see below)
+#
 # Test requirements:
-# A mostly empty FAT formatted SDCard installed in SD socket
+# A mostly empty FAT formatted SDCard installed in SD socket (a card with other
+# files may be much slower to start the test.)
 import errno
 import os
-import pyb
 import machine
 import micropython
+import sys
 import vfs
 import unittest
 
 from micropython import const
 
+# Use pyb classes on stm32, machine class otherwise
+try:
+    from pyb import SDCard, Timer
+except ImportError:
+    try:
+        from machine import SDCard, Timer
+    except ImportError:
+        print("SKIP")
+        raise SystemExit
+
+READBLOCKS_SUCCESS = (0, True)  # some drivers return True for success, some return 0...
+
 _BLOCK_SZ = const(512)
 _OFFS_WIDTH = const(64)  # Should be at least the cache line size plus the GC block size
 _TEST_BUF_SZ = const(_BLOCK_SZ + _OFFS_WIDTH)
-
-# More repeats = longer test run, more chance of triggering a cache coherence issue
-_REPEATS = const(8)
 
 MOUNT_POINT = "/sd"
 FILE_PATH = "/sd/stm32_align.blk"
 
 # Skip the whole test if there isn't a mountable SDCard
 try:
-    sd = pyb.SDCard()
+    sd = SDCard()
+    fs = vfs.VfsFat(sd)
     vfs.mount(sd, MOUNT_POINT)
     vfs.umount(MOUNT_POINT)
     del sd
 except (OSError, AttributeError):
     print("SKIP")
     raise SystemExit
+
+
+# Set some port-specific parameters for test repeats & interrupt frequency
+# (ports which can issue interrupts at a high frequency don't need to run as many
+# repeats of the test in order to trigger a failure due to cache bugs.)
+if "pyboard" in sys.platform:
+
+    def make_timer(timer_cb):
+        # Pyboard SF6 can do at least this frequency and still run the test,
+        # possibly as high as 40kHz depending on the callback details.
+        return Timer(1, freq=35_000, callback=timer_cb, hard=True)
+
+    REPEATS = 8
+elif "mimxrt" in sys.platform:
+
+    def make_timer(timer_cb):
+        return Timer(-1, period=1, callback=timer_cb, hard=True)
+
+    # virtual timer limited to 1kHz so run more iterations (slow test!)
+    REPEATS = 64
 
 
 def verify_contents(buf, silent=False):
@@ -57,7 +91,7 @@ def verify_contents(buf, silent=False):
 class TestSDAlign(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.sd = pyb.SDCard()
+        cls.sd = SDCard()
         vfs.mount(cls.sd, MOUNT_POINT)
         buf = bytearray(_BLOCK_SZ)
         try:
@@ -77,9 +111,11 @@ class TestSDAlign(unittest.TestCase):
 
         # Now look for the sector which holds the temporary file
         # (assume is in the first 20MB of the SD Card)
+        vfs.umount(MOUNT_POINT)
         for b in range(1, 40960):
-            if not cls.sd.readblocks(b, buf):
-                raise RuntimeError("Failed to call readblocks on SDCard. block:", b)
+            res = cls.sd.readblocks(b, buf)
+            if res not in READBLOCKS_SUCCESS:
+                raise RuntimeError("Failed to call readblocks on SDCard:", res, "block:", b)
             if verify_contents(buf, True):
                 print("Temporary file contents found in block {}".format(b))
                 cls.block = b
@@ -96,22 +132,26 @@ class TestSDAlign(unittest.TestCase):
             print("Deleted temp file")
         except OSError:
             pass
-        vfs.umount(MOUNT_POINT)
+        try:
+            vfs.umount(MOUNT_POINT)
+        except OSError:
+            pass
         del cls.sd
 
     def setUp(self):
         self.offs = 0
 
     @micropython.native
-    def _test_reads_inner(self, buf, repeats=_REPEATS):
+    def _test_reads_inner(self, buf, repeats=REPEATS):
         for offs in range(_OFFS_WIDTH):
             with self.subTest(offs=offs):
                 self.offs = offs
                 slice = memoryview(buf)[offs : offs + _BLOCK_SZ]
                 assert len(slice) == _BLOCK_SZ
                 for r in range(repeats):
-                    self.assertTrue(
+                    self.assertIn(
                         self.sd.readblocks(self.block, slice),
+                        READBLOCKS_SUCCESS,
                         "Read failed for block {} offs {} repeat {}/{}".format(
                             self.block, offs, r, repeats
                         ),
@@ -131,7 +171,7 @@ class TestSDAlign(unittest.TestCase):
         # of hitting one of these cases, but even if the issue is present the test only fails
         # once per ~250 iterations. The other tests inject explicit reads and writes so they fail
         # more or less immediately.
-        self._test_reads_inner(buf, repeats=_REPEATS * 4)
+        self._test_reads_inner(buf, repeats=REPEATS * 4)
 
     def test_interrupted_reads(self):
         # Test reading at all available offsets in a buffer, while an interrupt is
@@ -148,7 +188,7 @@ class TestSDAlign(unittest.TestCase):
                 self.val = buf[self.scan % _TEST_BUF_SZ]
                 self.scan += 1
 
-            t = pyb.Timer(1, freq=30_000, callback=timer_cb, hard=True)
+            t = make_timer(timer_cb)
             self._test_reads_inner(buf)
         finally:
             if t:
@@ -176,8 +216,7 @@ class TestSDAlign(unittest.TestCase):
                 if offs < _TEST_BUF_SZ - 3:
                     buf[offs] = 0x56
 
-            # pybd SF2 at default CPU frequency can manage >30kHz <40kHz
-            t = pyb.Timer(1, freq=35_000, callback=timer_cb, hard=True)
+            t = make_timer(timer_cb)
             self._test_reads_inner(buf)
         finally:
             if t:

--- a/tests/extmod_hardware/machine_sdcard_dma_align.py
+++ b/tests/extmod_hardware/machine_sdcard_dma_align.py
@@ -103,7 +103,7 @@ class TestSDAlign(unittest.TestCase):
                     raise RuntimeError("Corrupt test block in temporary file ", FILE_PATH)
         except OSError as e:
             if e.errno != errno.ENOENT:
-                raise
+                raise e
 
             print("Creating new temp file...")
             with open(FILE_PATH, "wb") as f:


### PR DESCRIPTION
### Summary

Fixes #19010. Follow-up to PR #19140 which fixed this bug on stm32, and this PR is to fix the same bug on mimxrt.

This PR has some overlap with #18451, I apologise that I haven't looked super closely at that PR yet.

First commit is to add a test:

* Adapts the `sdcard_dma_align.py` test from #19140 so it now works on mimxrt as well. This test relies on a high frequency timer interrupt where the CPU reads/writes memory throughout the SD transfer. It's a little less effective on mimxrt because the max timer frequency is only 1kHz - however it still seemed able to trigger the bug.

Then the fix:

* Disable DMA if the buffer is not DCache aligned. This is to prevent corruption caused by CPU writes to the same cache line as the start or end of the buffer. The SDCard block API doesn't return until the operation is done, so disabling DMA shouldn't have much impact apart from a small power consumption increase.
* Invalidate DCache for the DMA buffer region after the transfer completes. This avoids stale cache lines if the CPU has read into the cache while the transfer was in progress (including due to a speculative read). The cache is already correctly cleaned before the transfer (this happens in the NXP driver layer).

### Testing

* Tested `sdcard_dma_align.py` before and after the fix on TEENSY41 & MIMXRT1050. Both boards fail without the fix, and pass with the fix. (An interesting note, the first part of the fix - disabling DMA - doesn't seem to be necessary to pass the test on MIMXRT1050, even running a high number of repeats. I *think* this is because the interrupts only trigger at 1kHz so it's very hard to have one trigger while the start or end cache line is being read, and the driver itself disables DMA internally if a buffer isn't 4-byte aligned so we're aiming for a very small target. This change was, however, very necessary for the test to pass on the Teensy - not entirely sure what the difference is there.)
* Did a special test run where I multiplied the `REPEATS` value by 30 on both boards, checked these extended ~20 minute test runs also pass with the fix applied.
* Ran the updated test on PYBD_SF6 to ensure it still works on stm32 port (it does).

### Trade-offs and Alternatives

* As discussed in #19140, it's not viable to always ensure a DMA buffer is aligned to DCache. Some kind of workaround or special case handler is needed.
* By disabling DMA like this it may be harder to swap to a non-blocking API, as is being trialled in #18451.
* It might be possible to fix this using the same `dma_protect_rx_region()` method that we used on stm32 instead, however (a) that method doesn't scale to multiple concurrent DMA transfers, and (b) I couldn't actually figure out where the MPU is configured on mimxrt! (Although I didn't look for that long.)
* There is support to submit a table of multiple DMA descriptors for a single transfer in the NXP USDHC driver, but it looks like the driver has been designed only for a very specific use case where the descriptors are updated dynamically during the transfer(!) We could maybe write our own USDHC driver so we could chain small aligned "head" and "tail" transfers with a large aligned transfer in the middle, but it would be a lot of work and possibly we'd be the first people to try and use the NXP DMA hardware in this way (which makes me nervous).

### Generative AI

I did not use generative AI tools when creating this PR.