### PR TITLE
extmod/vfs: Skip littlefs detection if mp_vfs_blockdev_read_ext() fails.

### DIFF
--- a/extmod/vfs.c
+++ b/extmod/vfs.c
@@ -173,7 +173,9 @@ static mp_obj_t mp_vfs_autodetect(mp_obj_t bdev_obj) {
         mp_vfs_blockdev_init(&blockdev, bdev_obj);
         uint8_t buf[44];
         for (size_t block_num = 0; block_num <= 1; ++block_num) {
-            mp_vfs_blockdev_read_ext(&blockdev, block_num, 8, sizeof(buf), buf);
+            if (mp_vfs_blockdev_read_ext(&blockdev, block_num, 8, sizeof(buf), buf) != 0) {
+                continue;
+            }
             #if MICROPY_VFS_LFS1
             if (memcmp(&buf[32], "littlefs", 8) == 0) {
                 // LFS1

--- a/tests/extmod/vfs_blockdev_invalid.py
+++ b/tests/extmod/vfs_blockdev_invalid.py
@@ -88,6 +88,23 @@ def test(vfs_class, test_data):
             assert error_read is not None
             assert (type(e), str(e)) == error_read
 
+        # Try mounting this block device
+        #
+        # Failing mount operation will return EIO rather than EINVAL, but otherwise
+        # the result should match error_open
+        error_mount = ERROR_EIO if error_open == ERROR_EINVAL else error_open
+        try:
+            vfs.mount(bdev, "/test_ram")
+            assert error_mount is None
+        except Exception as e:
+            assert error_mount is not None
+            assert (type(e), str(e)) == error_mount
+        finally:
+            try:
+                vfs.umount("/test_ram")
+            except OSError:
+                pass
+
 
 try:
     test(


### PR DESCRIPTION
### Summary

I noticed in passing that `buf` can be read uninitialised while checking for littlefs, if `mp_vfs_blockdev_read_ext` fails.

Rather than initialise `buf` (expensive), have opted to check the return value of the read function.

*This work was funded through GitHub Sponsors.*

### Testing

* Flashed a TEENSY41 and an RPI_PICO board, verified the littlefs filesystem still mounted on boot.

### Trade-offs and Alternatives

* Could ignore this, as the chances of this function failing are very low and then the chances of the string `littlefs2` ending up on the stack independently of the internal flash is additionally low (and the first match will return, so a stale copy should never end up being checked on the second iteration.)
* Could zero `buf`, but as mentioned above, this is more expensive than checking the return value.
* Small chance of regression if there's a port block driver which doesn't return 0 here for success, but as the littlefs2 read function *also* calls `mp_vfs_blockdev_read_ext` and returns the result to littlefs2 it seems like such a port block driver would already not work with littlefs.

### Generative AI

I did not use generative AI tools when creating this PR.