### PR TITLE
py/runtime: Only build mp_raise_recursion_depth when STACK_CHECK is on.

### DIFF
--- a/py/qstrdefs.h
+++ b/py/qstrdefs.h
@@ -53,7 +53,9 @@ Q({:#x})
 Q({:#b})
 Q( )
 Q(\n)
+#if MICROPY_STACK_CHECK
 Q(maximum recursion depth exceeded)
+#endif
 Q(<module>)
 Q(<lambda>)
 Q(<listcomp>)

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1779,7 +1779,7 @@ MP_NORETURN void mp_raise_OSError_with_filename(int errno_, const char *filename
     nlr_raise(mp_obj_exception_make_new(&mp_type_OSError, 2, 0, args));
 }
 
-#if MICROPY_STACK_CHECK || MICROPY_ENABLE_PYSTACK
+#if MICROPY_STACK_CHECK
 MP_NORETURN void mp_raise_recursion_depth(void) {
     mp_raise_type_arg(&mp_type_RuntimeError, MP_OBJ_NEW_QSTR(MP_QSTR_maximum_space_recursion_space_depth_space_exceeded));
 }


### PR DESCRIPTION
### Summary

This helper function is used only by the C stack control functions (in `py/cstack.c` and `py/stackctrl.c`) and not by pystack.  Similarly the qstr message is only used by this `mp_raise_recursion_depth()` function.

(`mp_raise_recursion_depth()` is also used by the VM in strict stacless mode when pystack is disabled, but for that configuration one should anyway be enabling C stack checking.)

### Testing

Will be tested by CI.

### Generative AI

Not used.