### PR TITLE
py/dynruntime.mk: Let natmods be built with Clang.

### DIFF
--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -16,6 +16,7 @@ BERKELEY_DB_CONFIG_FILE ?= \"extmod/berkeley-db/berkeley_db_config_port.h\"
 CFLAGS += -I$(BTREE_DIR)/include
 CFLAGS += -DBERKELEY_DB_CONFIG_FILE=$(BERKELEY_DB_CONFIG_FILE)
 CFLAGS += -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter
+CFLAGS += -Wno-deprecated-non-prototype
 
 SRC += $(addprefix $(realpath $(BTREE_DIR))/,\
 	btree/bt_close.c \
@@ -47,6 +48,13 @@ endif
 
 # Strip the architecture name from the internal filename.
 MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
+
+ifeq ($(ARCH),armv7m)
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+# Link with libclang_rt.builtins.a for memset/memcpy.
+LINK_RUNTIME = 1
+endif
+endif
 
 include $(MPY_DIR)/py/dynruntime.mk
 

--- a/examples/natmod/btree/btree_c.c
+++ b/examples/natmod/btree/btree_c.c
@@ -4,7 +4,7 @@
 
 #include <unistd.h>
 
-#if !defined(__linux__)
+#if !defined(__linux__) || (defined(__clang__) && (defined(__x86_64__) || defined(__i386__) || __ARM_ARCH == 7))
 void *memcpy(void *dst, const void *src, size_t n) {
     return mp_fun_table.memmove_(dst, src, n);
 }

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -11,8 +11,15 @@ SRC = deflate.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc, rv64imc)
 ARCH ?= x64
 
+ifeq ($(ARCH),armv7m)
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+# Link with libclang_rt.a for memset
+LINK_RUNTIME = 1
+endif
+endif
+
 ifeq ($(ARCH),armv6m)
-# Link with libgcc.a for division helper functions
+# Link with libgcc.a or libclang_rt.a for division helper functions
 LINK_RUNTIME = 1
 endif
 

--- a/examples/natmod/deflate/deflate.c
+++ b/examples/natmod/deflate/deflate.c
@@ -3,7 +3,7 @@
 
 #include "py/dynruntime.h"
 
-#if !defined(__linux__)
+#if !defined(__linux__) || (defined(__clang__) && (defined(__x86_64__) || defined(__i386__) || __ARM_ARCH == 7))
 void *memcpy(void *dst, const void *src, size_t n) {
     return mp_fun_table.memmove_(dst, src, n);
 }

--- a/examples/natmod/features2/Makefile
+++ b/examples/natmod/features2/Makefile
@@ -10,6 +10,13 @@ SRC = main.c prod.c test.py
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc, rv64imc)
 ARCH = x64
 
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+ifeq ($(ARCH),$(filter $(ARCH),armv6m armv7m rv32imc))
+# Link with both libc.a and libclang_rt.builtins.a
+LINK_CLANG_LIBC = 1
+endif
+endif
+
 # Link with libm.a and libgcc.a from the toolchain
 LINK_RUNTIME = 1
 

--- a/examples/natmod/framebuf/Makefile
+++ b/examples/natmod/framebuf/Makefile
@@ -11,6 +11,13 @@ SRC = framebuf.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc, rv64imc)
 ARCH ?= x64
 
+ifeq ($(ARCH),armv7m)
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+# Link with libclang_rt.a for memset
+LINK_RUNTIME = 1
+endif
+endif
+
 ifeq ($(ARCH),armv6m)
 # Link with libgcc.a for division helper functions
 LINK_RUNTIME = 1

--- a/examples/natmod/framebuf/framebuf.c
+++ b/examples/natmod/framebuf/framebuf.c
@@ -3,7 +3,7 @@
 
 #include "py/dynruntime.h"
 
-#if !defined(__linux__)
+#if !defined(__linux__) || (defined(__clang__) && (defined(__x86_64__) || defined(__i386__) || __ARM_ARCH == 7))
 void *memcpy(void *dst, const void *src, size_t n) {
     return mp_fun_table.memmove_(dst, src, n);
 }

--- a/examples/natmod/re/Makefile
+++ b/examples/natmod/re/Makefile
@@ -11,6 +11,13 @@ SRC = re.c
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc, rv64imc)
 ARCH = x64
 
+ifeq ($(ARCH),armv7m)
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+# Link with libclang_rt.a for memmove
+LINK_RUNTIME = 1
+endif
+endif
+
 ifeq ($(ARCH),armv6m)
 # Link with libgcc.a for division helper functions
 LINK_RUNTIME = 1

--- a/examples/natmod/re/re.c
+++ b/examples/natmod/re/re.c
@@ -32,7 +32,7 @@ void mp_cstack_check(void) {
     }
 }
 
-#if !defined(__linux__)
+#if !defined(__linux__) || (defined(__clang__) && (defined(__x86_64__) || defined(__i386__) || __ARM_ARCH == 7))
 void *memcpy(void *dst, const void *src, size_t n) {
     return mp_fun_table.memmove_(dst, src, n);
 }

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -2,6 +2,7 @@
 # MPY_DIR must be set to the top of the MicroPython source tree
 
 BUILD ?= build-$(ARCH)
+CC = $(CROSS)gcc
 
 ECHO = @echo
 RM = /bin/rm
@@ -123,7 +124,7 @@ else
 $(error architecture '$(ARCH)' not supported)
 endif
 
-ifneq ($(findstring -musl,$(shell $(CROSS)gcc -dumpmachine)),)
+ifneq ($(findstring -musl,$(shell $(CC) -dumpmachine)),)
 USE_MUSL := 1
 endif
 
@@ -132,15 +133,27 @@ ifeq ($(ARCH),$(filter $(ARCH),rv32imc rv64imc))
 # bare metal RISC-V toolchain with Picolibc rather than Newlib, and the default
 # is "nosys" so a value must be provided.  To avoid having per-distro
 # workarounds, always select Picolibc if available.
-PICOLIBC_SPECS := $(shell $(CROSS)gcc --print-file-name=picolibc.specs)
+PICOLIBC_SPECS := $(shell $(CC) --print-file-name=picolibc.specs)
 ifneq ($(PICOLIBC_SPECS),picolibc.specs)
+# LLVM toolchains supporting more than one target seem to ignore the `-march`
+# flag passed when looking up the specs file, so if your system has Picolibc
+# libraries for more than one architectures supported by the compiler the
+# lookup will return the first available file.
+#
+# For example, on Ubuntu 24.02 if you have both `picolibc-aarch64-linux-gnu`
+# and `picolibc-riscv64-unknown-elf` packages installed, the Qualcomm LLVM
+# toolchain (which supports both AArch64 and RISC-V 64) will always return the
+# AArch64 picolibc specs even when building for RISC-V.
+ifeq ($(shell grep -q "$(PICOLIBC_BASE)" "$(PICOLIBC_SPECS)"; echo $$?),0)
 CFLAGS_ARCH += -specs=$(PICOLIBC_SPECS)
 USE_PICOLIBC := 1
+endif
 endif
 endif
 
 MICROPY_FLOAT_IMPL_UPPER = $(shell echo $(MICROPY_FLOAT_IMPL) | tr '[:lower:]' '[:upper:]')
 CFLAGS += $(CFLAGS_ARCH) -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_$(MICROPY_FLOAT_IMPL_UPPER)
+CFLAGS += $(CFLAGS_EXTRA)
 
 ifeq ($(LINK_RUNTIME),1)
 # All of these picolibc-specific directives are here to work around a
@@ -167,15 +180,37 @@ LIBM_NAME := libc.a
 else
 LIBM_NAME := libm.a
 endif
-LIBGCC_PATH := $(realpath $(shell $(CROSS)gcc $(CFLAGS) --print-libgcc-file-name))
-LIBM_PATH := $(realpath $(shell $(CROSS)gcc $(CFLAGS) --print-file-name=$(LIBM_NAME)))
+# Clang will output the path to libclang_rt.builtins.a instead.  The problem is
+# that some symbols are duplicated between the builtins library and libc.a.  In
+# these cases let's leave it to the user to figure out how to handle this for
+# the time being.
+TOOLCHAIN_LIBGCC := $(realpath $(shell $(CC) $(CFLAGS) --print-libgcc-file-name))
+ifneq ($(findstring clang,$(shell $(CC) --version)),clang)
+LIBGCC_PATH = $(TOOLCHAIN_LIBGCC)
+else
+ifneq ($(LINK_CLANG_CLANGRT),0)
+LIBGCC_PATH = $(TOOLCHAIN_LIBGCC)
+else
+LIBGCC_PATH =
+endif
+endif
+LIBM_PATH := $(realpath $(shell $(CC) $(CFLAGS) --print-file-name=$(LIBM_NAME)))
 ifeq ($(USE_PICOLIBC),1)
 ifeq ($(LIBM_PATH),)
 PICOLIBC_ROOT ?= /usr/lib/picolibc/$(PICOLIBC_BASE)/lib
 LIBM_PATH := $(PICOLIBC_ROOT)/$(PICOLIBC_TARGET)/$(LIBM_NAME)
 endif
 endif
-MPY_LD_FLAGS += $(addprefix -l, $(LIBGCC_PATH) $(LIBM_PATH))
+ifneq ($(LINK_CLANG_LIBC),)
+ifeq ($(findstring clang,$(shell $(CC) --version)),clang)
+LIBC_PATH := $(realpath $(shell $(CC) $(CFLAGS) --print-file-name=libc.a))
+else
+LIBC_PATH =
+endif
+else
+LIBC_PATH =
+endif
+MPY_LD_FLAGS += $(addprefix -l, $(LIBGCC_PATH) $(LIBM_PATH) $(LIBC_PATH))
 endif
 ifneq ($(MPY_EXTERN_SYM_FILE),)
 MPY_LD_FLAGS += --externs "$(realpath $(MPY_EXTERN_SYM_FILE))"
@@ -183,8 +218,6 @@ endif
 ifneq ($(ARCH_FLAGS),)
 MPY_LD_FLAGS += --arch-flags "$(ARCH_FLAGS)"
 endif
-
-CFLAGS += $(CFLAGS_EXTRA)
 
 ################################################################################
 # Build rules
@@ -210,12 +243,12 @@ $(CONFIG_H): $(SRC)
 # Build .o from .c source files
 $(BUILD)/%.o: %.c $(CONFIG_H) Makefile
 	$(ECHO) "CC $<"
-	$(Q)$(CROSS)gcc $(CFLAGS) -o $@ -c $<
+	$(Q)$(CC) $(CFLAGS) -o $@ -c $<
 
 # Build .o from .S source files
 $(BUILD)/%.o: %.S $(CONFIG_H) Makefile
 	$(ECHO) "AS $<"
-	$(Q)$(CROSS)gcc $(CFLAGS) -o $@ -c $<
+	$(Q)$(CC) $(CFLAGS) -o $@ -c $<
 
 # Build .mpy from .py source files
 $(BUILD)/%.mpy: %.py

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -106,38 +106,18 @@ else ifeq ($(ARCH),rv32imc)
 # rv32imc
 CROSS = riscv64-unknown-elf-
 CFLAGS_ARCH += -march=rv32imac -mabi=ilp32 -mno-relax
-# If Picolibc is available then select it explicitly.  Ubuntu 24.04 ships its
-# bare metal RISC-V toolchain with Picolibc rather than Newlib, and the default
-# is "nosys" so a value must be provided.  To avoid having per-distro
-# workarounds, always select Picolibc if available.
-PICOLIBC_SPECS := $(shell $(CROSS)gcc --print-file-name=picolibc.specs)
-ifneq ($(PICOLIBC_SPECS),picolibc.specs)
-CFLAGS_ARCH += -specs=$(PICOLIBC_SPECS)
-USE_PICOLIBC := 1
-PICOLIBC_ARCH := rv32imac
-PICOLIBC_ABI := ilp32
-endif
-
 MICROPY_FLOAT_IMPL ?= none
+PICOLIBC_BASE := riscv64-unknown-elf
+PICOLIBC_TARGET := rv32imac/ilp32
 
 else ifeq ($(ARCH),rv64imc)
 
 # rv64imc
 CROSS = riscv64-unknown-elf-
 CFLAGS_ARCH += -march=rv64imac -mabi=lp64 -mno-relax
-# If Picolibc is available then select it explicitly.  Ubuntu 24.04 ships its
-# bare metal RISC-V toolchain with Picolibc rather than Newlib, and the default
-# is "nosys" so a value must be provided.  To avoid having per-distro
-# workarounds, always select Picolibc if available.
-PICOLIBC_SPECS := $(shell $(CROSS)gcc --print-file-name=picolibc.specs)
-ifneq ($(PICOLIBC_SPECS),picolibc.specs)
-CFLAGS_ARCH += -specs=$(PICOLIBC_SPECS)
-USE_PICOLIBC := 1
-PICOLIBC_ARCH := rv64imac
-PICOLIBC_ABI := lp64
-endif
-
 MICROPY_FLOAT_IMPL ?= none
+PICOLIBC_BASE := riscv64-unknown-elf
+PICOLIBC_TARGET := rv64imac/lp64
 
 else
 $(error architecture '$(ARCH)' not supported)
@@ -147,12 +127,24 @@ ifneq ($(findstring -musl,$(shell $(CROSS)gcc -dumpmachine)),)
 USE_MUSL := 1
 endif
 
+ifeq ($(ARCH),$(filter $(ARCH),rv32imc rv64imc))
+# If Picolibc is available then select it explicitly.  Ubuntu 24.04 ships its
+# bare metal RISC-V toolchain with Picolibc rather than Newlib, and the default
+# is "nosys" so a value must be provided.  To avoid having per-distro
+# workarounds, always select Picolibc if available.
+PICOLIBC_SPECS := $(shell $(CROSS)gcc --print-file-name=picolibc.specs)
+ifneq ($(PICOLIBC_SPECS),picolibc.specs)
+CFLAGS_ARCH += -specs=$(PICOLIBC_SPECS)
+USE_PICOLIBC := 1
+endif
+endif
+
 MICROPY_FLOAT_IMPL_UPPER = $(shell echo $(MICROPY_FLOAT_IMPL) | tr '[:lower:]' '[:upper:]')
 CFLAGS += $(CFLAGS_ARCH) -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_$(MICROPY_FLOAT_IMPL_UPPER)
 
 ifeq ($(LINK_RUNTIME),1)
 # All of these picolibc-specific directives are here to work around a
-# limitation of Ubuntu 22.04's RISC-V bare metal toolchain.  In short, the
+# limitation of Ubuntu 24.04's RISC-V bare metal toolchain.  In short, the
 # specific version of GCC in use (10.2.0) does not seem to take into account
 # extra paths provided by an explicitly passed specs file when performing name
 # resolution via `--print-file-name`.
@@ -163,7 +155,7 @@ ifeq ($(LINK_RUNTIME),1)
 # flags that are passed to GCC.  The `PICOLIBC_ROOT` environment variable is
 # checked to override the starting point for the library file search, and if
 # it is not set then the default value is used, assuming that this is running
-# on an Ubuntu 22.04 machine.
+# on an Ubuntu 24.04 machine.
 #
 # This should be revised when the CI base image is updated to a newer Ubuntu
 # version (that hopefully contains a newer RISC-V compiler) or to another Linux
@@ -179,14 +171,8 @@ LIBGCC_PATH := $(realpath $(shell $(CROSS)gcc $(CFLAGS) --print-libgcc-file-name
 LIBM_PATH := $(realpath $(shell $(CROSS)gcc $(CFLAGS) --print-file-name=$(LIBM_NAME)))
 ifeq ($(USE_PICOLIBC),1)
 ifeq ($(LIBM_PATH),)
-# The CROSS toolchain prefix usually ends with a dash, but that may not be
-# always the case.  If the prefix ends with a dash it has to be taken out as
-# Picolibc's architecture directory won't have it in its name.  GNU Make does
-# not have any facility to perform character-level text manipulation so we
-# shell out to sed.
-CROSS_PREFIX := $(shell echo $(CROSS) | sed -e 's/-$$//')
-PICOLIBC_ROOT ?= /usr/lib/picolibc/$(CROSS_PREFIX)/lib
-LIBM_PATH := $(PICOLIBC_ROOT)/$(PICOLIBC_ARCH)/$(PICOLIBC_ABI)/$(LIBM_NAME)
+PICOLIBC_ROOT ?= /usr/lib/picolibc/$(PICOLIBC_BASE)/lib
+LIBM_PATH := $(PICOLIBC_ROOT)/$(PICOLIBC_TARGET)/$(LIBM_NAME)
 endif
 endif
 MPY_LD_FLAGS += $(addprefix -l, $(LIBGCC_PATH) $(LIBM_PATH))

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -459,14 +459,10 @@ class LinkEnv:
         for sec in self.sections:
             log(LOG_LEVEL_2, "  {:08x} {} size={}".format(sec.addr, sec.name, len(sec.data)))
 
-    def find_addr(self, name):
+    def find_sym(self, name):
         if name in self.known_syms:
-            s = self.known_syms[name]
-            return s.section.addr + s["st_value"]
+            return self.known_syms[name]
         raise LinkError("unknown symbol: {}".format(name))
-
-    def find_entry_addr(self):
-        return self.find_addr("mpy_init")
 
 
 def build_got_generic(env):
@@ -1194,6 +1190,18 @@ def load_object_file(env, f, felf):
         raise LinkError("\n".join(dup_errors))
 
 
+def generate_entry_point_jump(env):
+    entry_point = env.find_sym("mpy_init")
+    address = entry_point.section.addr + entry_point["st_value"]
+    alignment = entry_point.section.alignment
+    if alignment == 1:
+        return env.arch.asm_jump(address)
+    last_jump_length = len(env.arch.asm_jump(address))
+    aligned_jump = align_to(last_jump_length, alignment)
+    jump = env.arch.asm_jump(address + aligned_jump - last_jump_length)
+    return jump.ljust(align_to(len(jump), alignment), b"\0")
+
+
 def link_objects(env, native_qstr_vals_len):
     # Build GOT information
     if env.arch.name == "EM_XTENSA":
@@ -1289,8 +1297,7 @@ def link_objects(env, native_qstr_vals_len):
         raise LinkError("\n".join(undef_errors))
 
     # Generate the entry trampoline assuming the offset is already known.
-    env.entry_point = env.find_entry_addr()
-    jump = env.arch.asm_jump(env.entry_point)
+    jump = generate_entry_point_jump(env)
     env.entry_trampoline_len = len(jump)
 
     # Align sections, assign their addresses, and create full_text
@@ -1390,7 +1397,7 @@ def build_mpy(env, fmpy, internal_name, native_qstr_vals, arch_flags):
     # Rewrite the entry trampoline if the proper value isn't known earlier, and
     # ensure the trampoline size remains the same.
     if env.arch.delayed_entry_offset:
-        jump = env.arch.asm_jump(env.find_entry_addr())
+        jump = generate_entry_point_jump(env)
         env.full_text[: len(jump)] = jump
         assert len(jump) == env.entry_trampoline_len
 

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -128,6 +128,7 @@ R_RISCV_TLSDESC_HI20 = 62
 R_RISCV_TLSDESC_LOAD_LO12 = 63
 R_RISCV_TLSDESC_ADD_LO12 = 64
 R_RISCV_TLSDESC_CALL = 65
+R_ARM_GOT_PREL = 96
 
 ################################################################################
 # Architecture configuration
@@ -254,28 +255,28 @@ ARCH_DATA = {
         "EM_ARM",
         MP_NATIVE_ARCH_ARMV6M << 2,
         4,
-        (R_ARM_GOT_BREL,),
+        (R_ARM_GOT_BREL, R_ARM_GOT_PREL),
         asm_jump_thumb,
     ),
     "armv7m": ArchData(
         "EM_ARM",
         MP_NATIVE_ARCH_ARMV7M << 2,
         4,
-        (R_ARM_GOT_BREL,),
+        (R_ARM_GOT_BREL, R_ARM_GOT_PREL),
         asm_jump_thumb2,
     ),
     "armv7emsp": ArchData(
         "EM_ARM",
         MP_NATIVE_ARCH_ARMV7EMSP << 2,
         4,
-        (R_ARM_GOT_BREL,),
+        (R_ARM_GOT_BREL, R_ARM_GOT_PREL),
         asm_jump_thumb2,
     ),
     "armv7emdp": ArchData(
         "EM_ARM",
         MP_NATIVE_ARCH_ARMV7EMDP << 2,
         4,
-        (R_ARM_GOT_BREL,),
+        (R_ARM_GOT_BREL, R_ARM_GOT_PREL),
         asm_jump_thumb2,
     ),
     "xtensa": ArchData(
@@ -681,10 +682,14 @@ def do_relocation_text(env, text_addr, r):
         # Relcation pointing to GOT
         reloc = addr = env.got_entries[s.name].offset
 
-    elif env.arch.name == "EM_X86_64" and r_info_type in (
-        R_X86_64_GOTPCREL,
-        R_X86_64_REX_GOTPCRELX,
-    ):
+    elif (
+        env.arch.name == "EM_X86_64"
+        and r_info_type
+        in (
+            R_X86_64_GOTPCREL,
+            R_X86_64_REX_GOTPCRELX,
+        )
+    ) or (env.arch.name == "EM_ARM" and r_info_type == R_ARM_GOT_PREL):
         # Relcation pointing to GOT
         got_entry = env.got_entries[s.name]
         addr = env.got_section.addr + got_entry.offset

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -1510,19 +1510,13 @@ def do_preprocess(args):
         args.output = args.files[0][:-1] + "config.h"
     static_qstrs, qstr_vals = extract_qstrs(args.files)
     with open(args.output, "w") as f:
-        print(
-            "#include <stdint.h>\n"
-            "typedef uintptr_t mp_uint_t;\n"
-            "typedef intptr_t mp_int_t;\n"
-            "typedef uintptr_t mp_off_t;",
-            file=f,
-        )
+        print("#include <stdint.h>\ntypedef uintptr_t mp_off_t;", file=f)
         for i, q in enumerate(static_qstrs):
             print("#define %s (%u)" % (q, i + 1), file=f)
         for i, q in enumerate(sorted(qstr_vals)):
             print("#define %s (mp_native_qstr_table[%d])" % (q, i + 1), file=f)
         print("extern const uint16_t mp_native_qstr_table[];", file=f)
-        print("extern const mp_uint_t mp_native_obj_table[];", file=f)
+        print("extern const uintptr_t mp_native_obj_table[];", file=f)
 
 
 def do_link(args):


### PR DESCRIPTION
### Summary

This PR modifies the build rules for native modules in order to remove the dependence on GCC for creating native MPY files.

Whilst the Unix port of MicroPython can be built with Clang by overriding the `CC` variable, natmods require a bit more work.  GCC builds compilers that are tailored for a single architecture, but Clang takes the opposite approach, so a single binary may target more than one architecture.  Architecture selection is, by definition, not compatible between those two compilers.

These changes attempt to make things easier to handle when using Clang. Native modules can now be built with something like this: `make CC=clang ARCH=<arch> CFLAGS_EXTRA='--target=<clang-target-arch>'`.  So, for example building an x86 native module the command line will look something like this: `make CC=clang ARCH=x86 CFLAGS_EXTRA='--target=i686-unknown-linux-gnu'`.

Clang and GCC, however, have different tolerances for deviations from the chosen C standard.  Whilst GCC doesn't really mind whether a typedef is defined multiple times as long as it is defined to the same value, Clang does raise a warning which is then interpreted as an error.

Unfortunately #ifdef/#ifndef does not work with typedefs, and the way native modules are built meant that `py/mpconfig.h` would first include the native module's generated configuration file and then proceed with the rest of the configuration.  However, both files attempt to provide aliases for both `mp_int_t` and `mp_uint_t`, and that doesn't really work.  Thus, the only sane way to work around it is to rely on the presence of a definition that indicates that `mp_int_t` and `mp_uint_t` are already there to begin with, letting builds proceed on both GCC and Clang.

### Testing

All natmods in `examples/natmod` were attempted to be built for x86 using the command line mentioned in the summary section.  Results are as follows:

- `btree`: fails to compile because `__bt_close`, `__bt_sync`, and `bt_meta` do not have a prototype
- `deflate`: ~fails to link because `memset` is not defined~ builds on both x86 and x64
- `features0`: builds on x86, x64, and armv7m
- `features1`: builds on x86, x64, and armv7m
- `features2`: builds on x86, x64, and armv7m
- `features3`: builds on x86, x64, and armv7m
- `features4`: builds on x86, x64, and armv7m
- `framebuf`: ~fails to link because `memset` is not defined~ builds on both x86 and x64
- `heapq`: builds on x86, x64, and armv7m
- `random`: builds
- `re`: ~fails to link because `memset` is not defined~ builds on both x86 and x64.

~Importing `features0` in a Clang-built x86 interpreter, though, crashes due to "something" happening when calling `mp_call_function_0`.  The same happens on an x86 interpreter built with GCC, and on x64 too.  Fun for the whole architecture family.~ With Clang the entry trampoline gets emitted incorrectly, so that had to be patched somehow.

The same procedure was done successfully without overriding `CC`, `CFLAGS_EXTRA`, and `LDFLAGS_EXTRA`, still building with `ARCH=x86`.  Then natmods were built for `xtensawin` but specifying `CROSS=xtensa-esp32s3-elf-` to make sure the new compiler was picked up correctly.

### Trade-offs and Alternatives

None I can see, although the crashes and link failures need to be sorted out first.
### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

This is marked as draft due to the obvious shortcomings of the PR in its current state.  Still working on it, `tools/mpy_ld.py` doesn't like something about the object files emitted by clang - maybe it's the section ordering or something else, but at least I have a rough idea on where to look.