### PR TITLE
tools/mpy_ld.py: Optimise entry trampoline for x86/x64.

### DIFF
--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -142,7 +142,12 @@ def fit_signed(bits, value):
 
 
 def asm_jump_x86(entry):
-    return struct.pack("<BI", 0xE9, entry)
+    if fit_signed(7, entry):
+        return struct.pack("Bb", 0xEB, entry)
+    elif fit_signed(31, entry):
+        return struct.pack("<Bi", 0xE9, entry)
+    else:
+        raise LinkError("large jumps on x86/x64 are not supported")
 
 
 def asm_jump_thumb(entry):


### PR DESCRIPTION
### Summary

This PR allows natmod entry trampolines to possibly be smaller depending on the offset between the `mpy_init` from the beginning of the text segment.

x64 and x86 shared the same, fixed-size entry point opcode that covered the whole 32-bits offset range.  With changes introduced in 0fd084363a81c369a1487acd62f41f69199a7dae the entry point may change its length once all segments are laid out in the file, so optimised entry point code sequences can be emitted depending on the jump distance.

These changes generate optimised entry point jump opcodes for 8-, and 32- bit offsets.  Depending on the size of the natmod and where the compiler decides to put the `mpy_init` symbol this can help shortening the output file by three bytes.  Clang seems to prefer placing `mpy_init` at the beginning of the text segment on x86, whilst GCC sort of does it on x64.  In both cases, a 2 bytes opcode is used instead of a 6 bytes one.

This is derived from the work being carried out in #19308, as this change won't really fit the parent PR's scope.

### Testing

This should be tested by CI, as x86 and x64 natmod tests should be covered.  In addition, the `features0` natmod is small enough to trigger the generation of a 8-bit jump.  Importing that module on either a x86 or x64 interpreter and running its `factorial` function works as expected.

### Generative AI

I did not use generative AI tools when creating this PR.