### PR TITLE
Add typing support and enhance testing for runtime features

### DIFF
--- a/ports/stm32/boards/PYBV11/board.json
+++ b/ports/stm32/boards/PYBV11/board.json
@@ -17,7 +17,9 @@
         "DP": "Double-precision float",
         "DP_THREAD": "Double precision float + Threads",
         "NETWORK": "Wiznet 5200 Driver",
-        "THREAD": "Threading"
+        "THREAD": "Threading",
+        "TYPING_2B": "Typing_2b",
+        "TYPING_2C": "Typing_2c"
     },
     "vendor": "George Robotics"
 }

--- a/ports/stm32/boards/PYBV11/mpconfigvariant_TYPING_2B.mk
+++ b/ports/stm32/boards/PYBV11/mpconfigvariant_TYPING_2B.mk
@@ -1,0 +1,1 @@
+FROZEN_MANIFEST = $(BOARD_DIR)/../manifest_typing.py

--- a/ports/stm32/boards/PYBV11/mpconfigvariant_TYPING_2C.mk
+++ b/ports/stm32/boards/PYBV11/mpconfigvariant_TYPING_2C.mk
@@ -1,0 +1,1 @@
+FROZEN_MANIFEST = $(BOARD_DIR)/../manifest_typing.py

--- a/ports/stm32/boards/manifest_typing.py
+++ b/ports/stm32/boards/manifest_typing.py
@@ -1,0 +1,10 @@
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from manifestfile import *
+
+
+include("$(PORT_DIR)/boards/manifest.py")
+include("$(PORT_DIR)/boards/manifest_pyboard.py")
+
+# Typing
+require("bundle-typing", extensions=True)

--- a/ports/unix/variants/coverage/manifest.py
+++ b/ports/unix/variants/coverage/manifest.py
@@ -3,3 +3,5 @@ freeze_as_str("frzstr")
 freeze_as_mpy("frzmpy")
 freeze_mpy("$(MPY_DIR)/tests/assets")
 require("ssl")
+
+require("bundle-typing", extensions=True)

--- a/ports/unix/variants/coverage/manifest.py
+++ b/ports/unix/variants/coverage/manifest.py
@@ -4,4 +4,6 @@ freeze_as_mpy("frzmpy")
 freeze_mpy("$(MPY_DIR)/tests/assets")
 require("ssl")
 
+# used for typing runtime tests
+require("abc")
 require("bundle-typing", extensions=True)

--- a/ports/unix/variants/typing1/manifest.py
+++ b/ports/unix/variants/typing1/manifest.py
@@ -1,0 +1,8 @@
+include("$(PORT_DIR)/variants/manifest.py")
+
+include("$(MPY_DIR)/extmod/asyncio")
+
+
+# Freeze typing modules from local micropython-stubs repo
+require("__future__", opt_level=3)
+module("typing.py", base_path="/home/jos/micropython-stubs/mip", opt=3)

--- a/ports/unix/variants/typing1/mpconfigvariant.h
+++ b/ports/unix/variants/typing1/mpconfigvariant.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"

--- a/ports/unix/variants/typing1/mpconfigvariant.mk
+++ b/ports/unix/variants/typing1/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# This is the default variant when you `make` the Unix port.
+
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py

--- a/ports/unix/variants/typing1/typing/typing.py
+++ b/ports/unix/variants/typing1/typing/typing.py
@@ -1,0 +1,191 @@
+# Minimal MicroPython typing module
+
+
+def cast(type, val):
+    return val
+
+
+def get_origin(type):
+    return None
+
+
+def get_args(type):
+    return ()
+
+
+def no_type_check(func):
+    return func
+
+
+def overload(func):
+    return None
+
+
+def override(func):
+    return func
+
+
+class _AnyCall:
+    def __init__(*args, **kwargs):
+        pass
+
+    def __call__(*args, **kwargs):
+        pass
+
+    def __getitem__(self, arg):
+        return _anyCall
+
+
+_anyCall = _AnyCall()
+
+
+class _SubscriptableType:
+    def __getitem__(self, arg):
+        return _anyCall
+
+
+_Subscriptable = _SubscriptableType()
+
+
+class Any:
+    pass
+
+
+def TypeVar(
+    name,
+    *types,
+    bound: Any | None = None,
+    covariant=False,
+    contravariant=False,
+    infer_variance=False,
+):
+    return None
+
+
+def NewType(name, type):
+    return type
+
+
+class BinaryIO:
+    pass
+
+
+class ClassVar:
+    pass
+
+
+class Final:
+    pass
+
+
+class Hashable:
+    pass
+
+
+class IO:
+    pass
+
+
+class NoReturn:
+    pass
+
+
+class Sized:
+    pass
+
+
+class SupportsInt:
+    pass
+
+
+class SupportsFloat:
+    pass
+
+
+class SupportsComplex:
+    pass
+
+
+class SupportsBytes:
+    pass
+
+
+class SupportsIndex:
+    pass
+
+
+class SupportsAbs:
+    pass
+
+
+class SupportsRound:
+    pass
+
+
+class TextIO:
+    pass
+
+
+class Protocol:
+    pass
+
+
+# CHECK
+class Reversible:
+    pass
+
+
+class NotRequired:
+    pass
+
+
+LiteralString = AnyStr = str
+TypedDict = dict
+final = no_type_check  # PEP 591 final decorator is a no-op in MicroPython runtime.
+TypeAlias = Any
+
+# Deprecated
+Text = str
+# Pattern = str
+# Match = str
+
+AbstractSet = _Subscriptable
+Annotated = _Subscriptable
+AsyncContextManager = _Subscriptable
+AsyncGenerator = _Subscriptable
+AsyncIterable = _Subscriptable
+AsyncIterator = _Subscriptable
+Awaitable = _Subscriptable
+Callable = _Subscriptable
+ChainMap = _Subscriptable
+Collection = _Subscriptable
+Container = _Subscriptable
+ContextManager = _Subscriptable
+Coroutine = _Subscriptable
+Counter = _Subscriptable
+DefaultDict = _Subscriptable
+Deque = _Subscriptable
+Dict = _Subscriptable
+FrozenSet = _Subscriptable
+Generator = _Subscriptable
+Generic = _Subscriptable
+Iterable = _Subscriptable
+Iterator = _Subscriptable
+List = _Subscriptable
+Literal = _Subscriptable
+Mapping = _Subscriptable
+MutableMapping = _Subscriptable
+MutableSequence = _Subscriptable
+MutableSet = _Subscriptable
+NamedTuple = _Subscriptable
+Optional = _Subscriptable
+OrderedDict = _Subscriptable
+ReadOnly = _Subscriptable
+Self = _Subscriptable
+Sequence = _Subscriptable
+Set = _Subscriptable
+Tuple = _Subscriptable
+Type = _Subscriptable
+Union = _Subscriptable
+
+TYPE_CHECKING = False

--- a/ports/unix/variants/typing1/typing_extensions/__init__.py
+++ b/ports/unix/variants/typing1/typing_extensions/__init__.py
@@ -1,0 +1,1 @@
+from typing import *

--- a/ports/unix/variants/typing2a/manifest.py
+++ b/ports/unix/variants/typing2a/manifest.py
@@ -1,0 +1,10 @@
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from manifestfile import *
+
+include("$(PORT_DIR)/variants/manifest.py")
+
+include("$(MPY_DIR)/extmod/asyncio")
+
+require("typing", opt_level=3)
+# require("typing_extensions", opt_level=3)

--- a/ports/unix/variants/typing2a/mpconfigvariant.h
+++ b/ports/unix/variants/typing2a/mpconfigvariant.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"

--- a/ports/unix/variants/typing2a/mpconfigvariant.mk
+++ b/ports/unix/variants/typing2a/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# This is the default variant when you `make` the Unix port.
+
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py

--- a/ports/unix/variants/typing2b/manifest.py
+++ b/ports/unix/variants/typing2b/manifest.py
@@ -1,0 +1,12 @@
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from manifestfile import *
+
+include("$(PORT_DIR)/variants/manifest.py")
+
+include("$(MPY_DIR)/extmod/asyncio")
+
+# to reduce code size:
+#  - default optimization level is 3
+#  - extensions are disabled by default
+require("bundle-typing", extensions=False)

--- a/ports/unix/variants/typing2b/mpconfigvariant.h
+++ b/ports/unix/variants/typing2b/mpconfigvariant.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"

--- a/ports/unix/variants/typing2b/mpconfigvariant.mk
+++ b/ports/unix/variants/typing2b/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# This is the default variant when you `make` the Unix port.
+
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py

--- a/ports/unix/variants/typing2c/manifest.py
+++ b/ports/unix/variants/typing2c/manifest.py
@@ -1,0 +1,12 @@
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from manifestfile import *
+
+include("$(PORT_DIR)/variants/manifest.py")
+
+include("$(MPY_DIR)/extmod/asyncio")
+
+# to reduce code size:
+#  - default optimization level is 3
+#  - extensions are disabled by default
+require("bundle-typing", extensions=True)

--- a/ports/unix/variants/typing2c/mpconfigvariant.h
+++ b/ports/unix/variants/typing2c/mpconfigvariant.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"

--- a/ports/unix/variants/typing2c/mpconfigvariant.mk
+++ b/ports/unix/variants/typing2c/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# This is the default variant when you `make` the Unix port.
+
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py

--- a/ports/unix/variants/typing3/manifest.py
+++ b/ports/unix/variants/typing3/manifest.py
@@ -1,0 +1,3 @@
+include("$(PORT_DIR)/variants/manifest.py")
+
+include("$(MPY_DIR)/extmod/asyncio")

--- a/ports/unix/variants/typing3/mpconfigvariant.h
+++ b/ports/unix/variants/typing3/mpconfigvariant.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Set base feature level.
+#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+
+// Enable extra features for "typing" variant.
+#define MICROPY_PY_TYPING               (1)
+#define MICROPY_PY_TYPING_EXTRA_MODULES (1)
+
+// Enable extra Unix features.
+#include "../mpconfigvariant_common.h"

--- a/ports/unix/variants/typing3/mpconfigvariant.mk
+++ b/ports/unix/variants/typing3/mpconfigvariant.mk
@@ -1,0 +1,3 @@
+# This is the default variant when you `make` the Unix port.
+
+FROZEN_MANIFEST ?= $(VARIANT_DIR)/manifest.py

--- a/tests/cpydiff/core_class_metaclass.py
+++ b/tests/cpydiff/core_class_metaclass.py
@@ -1,0 +1,12 @@
+"""
+categories: Core,Classes
+description: Defining a class with a metaclass is not possible.
+cause: Metaclasses are not supported in MicroPython.
+workaround: None
+"""
+
+from abc import ABCMeta
+
+
+class MyABC(metaclass=ABCMeta):
+    pass

--- a/tests/cpydiff/modules_typing_generics.py
+++ b/tests/cpydiff/modules_typing_generics.py
@@ -1,0 +1,32 @@
+"""
+categories: Modules,typing
+description: User Defined Generics
+cause: MicroPython does not implement User Defined Generics
+workaround: None
+"""
+
+from typing import Dict, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    def __init__(self) -> None:
+        self._store: Dict[str, T] = {}
+
+    def set_item(self, k: str, v: T) -> None:
+        self._store[k] = v
+
+    def get_item(self, k: str) -> T:
+        return self._store[k]
+
+
+family_name_reg = Registry[str]()
+family_age_reg = Registry[int]()
+
+family_name_reg.set_item("husband", "steve")
+family_name_reg.set_item("dad", "john")
+
+family_age_reg.set_item("steve", 30)
+
+print(repr(family_name_reg.__dict__))

--- a/tests/cpydiff/modules_typing_getargs.py
+++ b/tests/cpydiff/modules_typing_getargs.py
@@ -1,0 +1,12 @@
+"""
+categories: Modules,typing
+description: ``get_args()`` function not fully implemented.
+cause: MicroPython does not implement all typing features
+workaround: None
+"""
+
+from typing import get_args
+
+# partial implementation of get_args
+x = get_args(int)
+assert x == (), f"expected () but got {x}"

--- a/tests/cpydiff/modules_typing_getorigin.py
+++ b/tests/cpydiff/modules_typing_getorigin.py
@@ -1,0 +1,13 @@
+"""
+categories: Modules,typing
+description: ``get_origin()`` function not fully implemented.
+cause: MicroPython does not implement all typing features from Python 3.8+
+workaround: None
+"""
+# https://docs.python.org/3/library/typing.html#typing.get_origin
+
+from typing import Dict, get_origin
+
+assert get_origin(Dict[str, int]) is dict, "origin Dict cannot be detected"
+
+assert get_origin(str) is None, "origin str should be None"

--- a/tests/cpydiff/modules_typing_runtime_checkable.py
+++ b/tests/cpydiff/modules_typing_runtime_checkable.py
@@ -1,0 +1,16 @@
+"""
+categories: Modules,typing
+description: ``runtime_checkable()`` is not implemented.
+cause: MicroPython does not implement all typing features from Python 3.8+
+workaround: None
+"""
+
+from typing import runtime_checkable, Protocol
+
+
+@runtime_checkable
+class SwallowLaden(Protocol):
+    def __iter__(self): ...
+
+
+assert isinstance([1, 2, 3], SwallowLaden)

--- a/tests/cpydiff/modules_typing_typeddict.py
+++ b/tests/cpydiff/modules_typing_typeddict.py
@@ -1,0 +1,24 @@
+"""
+categories: Modules,typing
+description: ``TypedDict`` class not allowed for instance or class checks.
+cause: MicroPython does not implement all typing features
+workaround: None
+"""
+
+from typing import TypeVar, TypedDict
+
+
+class Movie(TypedDict):
+    name: str
+    year: int
+
+
+movie: Movie = {"name": "Blade Runner", "year": 1982}
+
+try:
+    if isinstance(movie, Movie):  # type: ignore
+        pass
+    print("TypedDict class not allowed for instance or class checks")
+
+except TypeError as e:
+    print("Handled according to spec")

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1051,6 +1051,8 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
 
         # Look at the output of the test to see if unittest was used.
         uses_unittest = False
+        unittest_ran_match = None
+        unittest_result_match = None
         output_mupy_lines = output_mupy.splitlines()
         if any(
             line == b"ImportError: no module named 'unittest'" for line in output_mupy_lines[-3:]
@@ -1067,13 +1069,13 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
             and output_mupy_lines[-2] == b""
         ):
             # look for unittest summary
-            unittest_ran_match = re.match(rb"Ran (\d+) tests$", output_mupy_lines[-3])
+            unittest_ran_match = re.match(rb"Ran (?P<ran>\d+) tests$", output_mupy_lines[-3])
             unittest_result_match = re.match(
-                b"("
-                rb"(OK)( \(skipped=(\d+)\))?"
-                b"|"
-                rb"(FAILED) \(failures=(\d+), errors=(\d+)\)"
-                b")$",
+                rb"(?:"
+                rb"(?P<ok>OK)(?: \((?P<ok_extras>.+?)\))?"
+                rb"|"
+                rb"(?P<failed>FAILED) \(failures=(?P<failures>\d+), errors=(?P<errors>\d+)(?:, (?P<failed_extras>.+?))?\)"
+                rb")$",
                 output_mupy_lines[-1],
             )
             uses_unittest = unittest_ran_match and unittest_result_match
@@ -1110,19 +1112,53 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         test_passed = False
         extra_info = ""
         if uses_unittest:
-            test_passed = unittest_result_match.group(2) == b"OK"
-            num_test_cases = int(unittest_ran_match.group(1))
-            extra_info = "unittest: {} ran".format(num_test_cases)
-            if test_passed and unittest_result_match.group(4) is not None:
-                num_skipped = int(unittest_result_match.group(4))
-                num_test_cases -= num_skipped
-                extra_info += ", {} skipped".format(num_skipped)
-            elif not test_passed:
-                num_failures = int(unittest_result_match.group(6))
-                num_errors = int(unittest_result_match.group(7))
-                extra_info += ", {} failures, {} errors".format(num_failures, num_errors)
-            extra_info = "(" + extra_info + ")"
-            testcase_count.add(num_test_cases)
+            if unittest_ran_match is None or unittest_result_match is None:
+                unittest_tail = b"\n".join(output_mupy_lines[-3:]).decode(errors="replace")
+                raise RuntimeError(
+                    "Invalid unittest summary format in {}:\n{}".format(test_file, unittest_tail)
+                )
+            else:
+                test_passed = unittest_result_match.group("ok") == b"OK"
+                num_test_cases = int(unittest_ran_match.group("ran"))
+                extra_info = "unittest: {} ran".format(num_test_cases)
+                # Parse fields from the OK(...) or FAILED(...) tail.
+                extras_blob = unittest_result_match.group(
+                    "ok_extras" if test_passed else "failed_extras"
+                )
+                extras = {}
+                if extras_blob:
+                    for part in extras_blob.split(b","):
+                        if b"=" in part:
+                            k, _, v = part.partition(b"=")
+                            k = k.strip()
+                            v = v.strip()
+                            try:
+                                extras[k.decode(errors="replace")] = int(v)
+                            except ValueError:
+                                pass
+                if test_passed:
+                    num_skipped = extras.get("skipped", 0)
+                    if num_skipped:
+                        num_test_cases -= num_skipped
+                        extra_info += ", {} skipped".format(num_skipped)
+                    num_xfail = extras.get("expected failures", 0)
+                    if num_xfail:
+                        extra_info += ", {} xfail".format(num_xfail)
+                else:
+                    num_failures = int(unittest_result_match.group("failures"))
+                    num_errors = int(unittest_result_match.group("errors"))
+                    extra_info += ", {} failures, {} errors".format(num_failures, num_errors)
+                    num_xpass = extras.get("unexpected successes", 0)
+                    if num_xpass:
+                        extra_info += ", {} xpass".format(num_xpass)
+                    num_xfail = extras.get("expected failures", 0)
+                    if num_xfail:
+                        extra_info += ", {} xfail".format(num_xfail)
+                    num_skipped = extras.get("skipped", 0)
+                    if num_skipped:
+                        extra_info += ", {} skipped".format(num_skipped)
+                extra_info = "(" + extra_info + ")"
+                testcase_count.add(num_test_cases)
         else:
             testcase_count.add(len(output_expected.splitlines()))
             test_passed = output_expected == output_mupy

--- a/tests/typing_runtime/check_all_modules.py
+++ b/tests/typing_runtime/check_all_modules.py
@@ -1,0 +1,64 @@
+# probe module availability
+# test import only
+
+import collections
+import sys
+import unittest
+
+
+try:
+    from typing import TYPE_CHECKING
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+
+class TestModuleIncluded(unittest.TestCase):
+    def test_typing(self):
+        import typing
+
+        self.assertIsNotNone(typing)
+
+    def test_typing_extensions(self):
+        try:
+            import typing_extensions
+
+            self.assertIsNotNone(typing_extensions)
+        except ImportError:
+            self.skipTest("module not available")
+
+    def test_future(self):
+        try:
+            import __future__
+
+            self.assertIsNotNone(__future__)
+        except ImportError:
+            self.skipTest("module not available")
+
+    def test_abc(self):
+        try:
+            import abc
+
+            self.assertIsNotNone(abc)
+        except ImportError:
+            self.skipTest("module not available")
+
+    def test_collections(self):
+        try:
+            import collections
+
+            self.assertIsNotNone(collections)
+        except ImportError:
+            self.skipTest("module not available")
+
+    def test_collections_abc(self):
+        try:
+            import collections.abc
+
+            self.assertIsNotNone(collections.abc)
+        except ImportError:
+            self.skipTest("module not available")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_abc.py
+++ b/tests/typing_runtime/check_module_abc.py
@@ -1,0 +1,57 @@
+# module abc
+# runtime parity checks .
+
+import sys
+import unittest
+
+
+try:
+    import abc
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+
+class TestAbcRuntime(unittest.TestCase):
+    # Basic abc helpers should be callable.
+
+    @unittest.expectedFailure
+    def test_abc_helper_functions(self):
+        token = abc.get_cache_token()
+
+        class C(abc.ABC):
+            @abc.abstractmethod
+            def f(self): ...
+
+        cls = abc.update_abstractmethods(C)
+        self.assertTrue(type(token) is int)
+        self.assertTrue(cls is C)
+
+    # Abstract class pattern with concrete implementations should execute.
+    def test_abstract_class_usage(self):
+        class Shape(abc.ABC):
+            @abc.abstractmethod
+            def get_area(self): ...
+
+        class Square(Shape):
+            def __init__(self, side):
+                self.side = side
+
+            def get_area(self):
+                return self.side * self.side
+
+        sq = Square(5)
+        self.assertEqual(sq.get_area(), 25)
+
+    @unittest.expectedFailure
+    # TODO: cpydiff: metaclass=ABCMeta behavior differs between CPython and MicroPython.
+    def test_abcmeta_metaclass_bot_supported(self):
+        code = "class MyABC(metaclass=ABCMeta):\n    pass\n"
+
+        ns = {"ABCMeta": abc.ABCMeta}
+        exec(code, ns, ns)
+        self.assertTrue("MyABC" in ns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_collections.py
+++ b/tests/typing_runtime/check_module_collections.py
@@ -1,0 +1,66 @@
+# collections module runtime checks.
+
+try:
+    import collections
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import sys
+import unittest
+
+try:
+    from collections import MutableMapping as collections_py  # type: ignore
+except ImportError:
+    collections_py = None
+
+
+class TestCollectionsRuntime(unittest.TestCase):
+    def test_collections_C_module_symbols_exist(self):
+        # collections should expose expected module-level symbols.
+        expected = ("OrderedDict", "deque", "namedtuple")
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(collections, name), "missing: {}".format(name))
+
+    @unittest.skipIf(collections_py is None, "MutableMapping not implemented in this runtime")
+    def test_collections_py_module_MutableMapping(self):
+        # MutableMapping is implemented in a .py module that needs to be explicitly included in a firmware.
+        expected = ("MutableMapping",)
+        for name in expected:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(collections, name), "missing: {}".format(name))
+
+    # namedtuple factory path should create tuple-like classes and instances.
+    def test_namedtuple_factory_path(self):
+        point_t = collections.namedtuple("Point", ("x", "y"))
+        point = point_t(1, 2)
+
+        self.assertEqual(point[0], 1)
+        self.assertEqual(point[1], 2)
+
+    # deque and OrderedDict basic operations should work.
+    def test_deque_and_ordereddict_basic_ops(self):
+        dq = collections.deque((), 8)
+        dq.append(1)
+        dq.append(2)
+        self.assertEqual(dq.popleft(), 1)
+
+        od = collections.OrderedDict()
+        od["a"] = 1
+        od["b"] = 2
+        self.assertEqual(list(od.keys()), ["a", "b"])
+
+    @unittest.expectedFailure
+    # TODO: cpydiff namedtuple rename/defaults keyword args are not supported on MicroPython.
+    # TypeError: function doesn't take keyword arguments
+    def test_namedtuple_keyword_arguments_runtime_difference(self):
+        nt = collections.namedtuple("NT", ["a", "a"], rename=True)
+        self.assertEqual(nt._fields, ("a", "_1"))
+
+        nt2 = collections.namedtuple("NT2", "a b c", defaults=(1, 2))
+        self.assertEqual(nt2(1), nt2(a=1, b=1, c=2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_collections_abc.py
+++ b/tests/typing_runtime/check_module_collections_abc.py
@@ -1,0 +1,62 @@
+# module: collections.abc
+# runtime parity checks.
+
+try:
+    import collections.abc as cabc
+    import typing
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import Protocol
+from collections.abc import Iterable, Callable, Awaitable, Sequence, Mapping
+
+
+class TestCollectionsAbcRuntime(unittest.TestCase):
+    # Mapping and Sequence annotation signatures should execute.
+    def test_mapping_sequence_annotations(self):
+        if cabc is None:
+            return
+
+        class Employee:
+            pass
+
+        def notify_by_email(employees: Sequence[Employee], overrides: Mapping[str, str]) -> None:
+            self.assertTrue(type(overrides) is dict)
+            self.assertTrue(type(employees) is list)
+
+        notify_by_email([Employee()], {"a": "b"})
+
+    # Callable and Awaitable annotations should be usable in async callback signatures.
+    def test_callable_awaitable_annotations(self):
+        if cabc is None:
+            return
+
+        async def on_update(value: str) -> None:
+            return None
+
+        callback: Callable[[str], Awaitable[None]] = on_update
+        self.assertTrue(callback is on_update)
+
+    # Iterable and Protocol callback pattern should execute.
+    def test_iterable_protocol_callback_path(self):
+        class Combiner(Protocol):
+            def __call__(self, *vals: bytes, maxlen=None): ...
+
+        def batch_proc(data: Iterable[bytes], cb_results: Combiner) -> bytes:
+            for item in data:
+                _ = item
+            out = cb_results(b"a", b"b")
+            return out[0]
+
+        def good_cb(*vals: bytes, maxlen=None):
+            return list(vals)
+
+        result = batch_proc([b"x", b"y"], good_cb)
+        self.assertEqual(result, b"a")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_future.py
+++ b/tests/typing_runtime/check_module_future.py
@@ -1,0 +1,74 @@
+# Tests for the MicroPython __future__ module runtime flags.
+
+try:
+    import __future__ as future_mod
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+import unittest
+
+
+class TestFutureModule(unittest.TestCase):
+    # __future__ exports known feature-switch names as module attributes.
+    def test_expected_feature_flags_exist(self):
+        expected_names = (
+            "nested_scopes",
+            "generators",
+            "division",
+            "absolute_import",
+            "with_statement",
+            "print_function",
+            "unicode_literals",
+            "annotations",
+        )
+
+        for name in expected_names:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(future_mod, name), "missing: {}".format(name))
+
+    # In this runtime module, each known flag is a bool set to True.
+    def test_feature_flags_are_true_booleans(self):
+        expected_names = (
+            "nested_scopes",
+            "generators",
+            "division",
+            "absolute_import",
+            "with_statement",
+            "print_function",
+            "unicode_literals",
+            "annotations",
+        )
+
+        for name in expected_names:
+            with self.subTest(name=name):
+                value = getattr(future_mod, name)
+                self.assertTrue(type(value) is bool)
+                self.assertTrue(value)
+
+    # Guard against accidental symbol leakage in the module namespace.
+    def test_random_symbols_are_not_present(self):
+        self.assertFalse(hasattr(future_mod, "FooBas"))
+        self.assertFalse(hasattr(future_mod, "SNAFU"))
+
+    # __future__.annotations and typing.cast should not enforce runtime conversion.
+    def test_future_annotations_with_cast_runtime_behavior(self):
+        ns = {}
+        code = (
+            "from __future__ import annotations\n"
+            "from typing import cast\n"
+            "x = 1\n"
+            "y = cast(str, x)\n"
+            "ok = False\n"
+            "try:\n"
+            "    y.upper()\n"
+            "except AttributeError:\n"
+            "    ok = True\n"
+        )
+        exec(code, ns, ns)
+        self.assertTrue(ns["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_typing.py
+++ b/tests/typing_runtime/check_module_typing.py
@@ -1,0 +1,425 @@
+# Runtime tests that mirror feat_typing execution patterns.
+
+try:
+    import typing
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+
+def xfail_on_error(func):
+    """Report test as skipped ("xfail: ...") if it raises, or as ok if it
+    passes. Use instead of @unittest.expectedFailure when an unexpected pass
+    should NOT be reported as a failure (xpass)."""
+
+    def wrapper(self):
+        try:
+            func(self)
+        except Exception as e:
+            raise unittest.SkipTest("xfail: {}".format(e))
+
+    return wrapper
+
+
+class TestTypingRuntime(unittest.TestCase):
+    # This fails for the 'Mocked' typing modules
+    # Check star import and private symbol presence when available.
+    # def test_star_import_and_private_symbol(self):
+    #     ns = {}
+    #     exec("from typing import *", {}, ns)
+    #     self.assertTrue("List" in ns)
+    #     self.assertTrue(hasattr(typing, "_AnyCall"))
+
+    # Check Self usage in method callback annotations.
+    def test_self_in_callback_annotation(self):
+        class BaseClass:
+            def register(self, callback: typing.Callable[[typing.Self], None]) -> None:
+                callback(self)
+
+        state = {"called": False}
+
+        def cb(x):
+            state["called"] = x is not None
+
+        base = BaseClass()
+        base.register(cb)
+        self.assertTrue(state["called"])
+
+    # Check decorator stacking with no_type_check.
+    def test_no_type_check_with_stacked_decorators(self):
+        def my_deco(func):
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        @typing.no_type_check
+        @my_deco
+        def foo(x=""):
+            return "ok" + x
+
+        self.assertEqual(foo("!"), "ok!")
+
+    # typing spec (directives): no_type_check can be applied to classes without runtime breakage.
+    def test_no_type_check_class_decorator_runtime(self):
+        @typing.no_type_check
+        class Payload:
+            value: int = "runtime"
+
+            def __init__(self):
+                self.value = "ok"
+
+        item = Payload()
+        self.assertEqual(item.value, "ok")
+
+    # Check that annotations do not enforce runtime argument types here.
+    def test_annotated_calls_are_runtime_permissive(self):
+        ns = {}
+        code = (
+            "from typing import Any, Dict, List\n"
+            "def func_with_hints(c: int, b: str, a: int | None, lst: List[float] = [0.0]) -> Any:\n"
+            "    return 42\n"
+            "x = func_with_hints(1, '1', None, lst=3.14)\n"
+        )
+        exec(code, {}, ns)
+        self.assertEqual(ns["x"], 42)
+
+    # Check typing_extensions TYPE_CHECKING interop used in feat_typing.
+    def test_typing_extensions_type_checking_import(self):
+        try:
+            from typing_extensions import TYPE_CHECKING as te_type_checking
+        except ImportError:
+            te_type_checking = typing.TYPE_CHECKING
+
+        self.assertTrue(type(te_type_checking) is bool)
+
+    # typing spec (directives): TYPE_CHECKING-gated blocks should not execute at runtime.
+    def test_type_checking_gated_branch_is_runtime_false(self):
+        flag = 0
+        if typing.TYPE_CHECKING:
+            flag = 1
+
+        self.assertEqual(flag, 0)
+
+    # AnyStr annotations should allow str+str and bytes+bytes, and fail on mixed runtime concat.
+    def test_anystr_runtime_mixed_concat_behavior(self):
+        def concat(a: typing.AnyStr, b: typing.AnyStr) -> typing.AnyStr:
+            return a + b
+
+        self.assertEqual(concat("foo", "bar"), "foobar")
+        self.assertEqual(concat(b"foo", b"bar"), b"foobar")
+
+        with self.assertRaises(TypeError):
+            concat("foo", b"bar")
+
+    # NewType runtime value path should produce an int-compatible value.
+    def test_newtype_runtime_value_path(self):
+        user_id = typing.NewType("UserId", int)
+
+        if typing.NewType("UserId2", int) is int:
+            value = user_id(524313)
+            self.assertTrue(isinstance(value, int))
+            self.assertEqual(value, 524313)
+            return
+
+        value = user_id(524313)
+        self.assertTrue(isinstance(value, int))
+        self.assertEqual(value, 524313)
+
+    # Overload declaration pattern should be runtime-safe with a concrete implementation.
+    def test_overload_declaration_pattern(self):
+        @typing.overload
+        def bar(x: int) -> str: ...
+
+        @typing.overload
+        def bar(x: str) -> int: ...
+
+        def bar(x):
+            return x
+
+        self.assertEqual(bar(42), 42)
+        self.assertEqual(bar("x"), "x")
+
+    # typing.Generator annotation path should execute and yield as expected.
+    def test_typing_generator_runtime_path(self):
+        def echo_round() -> typing.Generator[int, float, str]:
+            sent = yield 0
+            while sent >= 0:
+                sent = yield round(sent)
+            return "Done"
+
+        g = echo_round()
+        self.assertEqual(next(g), 0)
+
+    # NoReturn annotations should allow normal runtime raising behavior.
+    def test_noreturn_runtime_path(self):
+        def hard_stop() -> typing.NoReturn:
+            raise RuntimeError("stop execution here")
+
+        with self.assertRaises(RuntimeError):
+            hard_stop()
+
+    # Final can be used as annotation without changing runtime value behavior.
+    def test_final_runtime_path(self):
+        const: typing.Final = 42
+        self.assertEqual(const, 42)
+
+    # IO marker classes should be instantiable in this runtime typing module.
+    def test_io_marker_classes_runtime_path(self):
+        io_obj = typing.IO()
+        text_obj = typing.TextIO()
+        binary_obj = typing.BinaryIO()
+
+        self.assertTrue(isinstance(io_obj, typing.IO))
+        self.assertTrue(isinstance(text_obj, typing.TextIO))
+        self.assertTrue(isinstance(binary_obj, typing.BinaryIO))
+
+
+class TestTypingMod(unittest.TestCase):
+    # typing spec (library interface): module should expose expected public symbols.
+    def test_all_defined_names_exist(self):
+        expected_names = (
+            "cast",
+            "get_origin",
+            "get_args",
+            "no_type_check",
+            "overload",
+            "override",
+            "TypeVar",
+            "NewType",
+            "Any",
+            "BinaryIO",
+            "ClassVar",
+            "Final",
+            "Hashable",
+            "IO",
+            "NoReturn",
+            "Sized",
+            "SupportsInt",
+            "SupportsFloat",
+            "SupportsComplex",
+            "SupportsBytes",
+            "SupportsIndex",
+            "SupportsAbs",
+            "SupportsRound",
+            "TextIO",
+            "Protocol",
+            "AnyStr",
+            "TypedDict",
+            "AbstractSet",
+            "AsyncContextManager",
+            "AsyncGenerator",
+            "AsyncIterable",
+            "AsyncIterator",
+            "Awaitable",
+            "Callable",
+            "ChainMap",
+            "Collection",
+            "Container",
+            "ContextManager",
+            "Coroutine",
+            "Counter",
+            "DefaultDict",
+            "Deque",
+            "Dict",
+            "FrozenSet",
+            "Generator",
+            "Generic",
+            "Iterable",
+            "Iterator",
+            "List",
+            "Literal",
+            "Mapping",
+            "MutableMapping",
+            "MutableSequence",
+            "MutableSet",
+            "NamedTuple",
+            "Optional",
+            "OrderedDict",
+            "Self",
+            "Sequence",
+            "Set",
+            "Tuple",
+            "Type",
+            "Union",
+            "TYPE_CHECKING",
+        )
+
+        for name in expected_names:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(typing, name), "missing: {}".format(name))
+
+    # typing spec (library interface): reject accidental non-spec symbols.
+    @xfail_on_error
+    def test_random_symbols_are_not_present(self):
+        self.assertFalse(hasattr(typing, "FooBar"), "unexpected symbol typing.FooBar found")
+        self.assertFalse(hasattr(typing, "SNAFU"), "unexpected symbol typing.SNAFU found")
+
+    # typing spec (directives/aliases): TYPE_CHECKING, AnyStr, TypedDict aliases.
+    def test_constants_and_simple_aliases(self):
+        self.assertTrue(typing.TYPE_CHECKING is False)
+        self.assertTrue(typing.AnyStr is str)
+        self.assertTrue(typing.TypedDict is dict)
+
+    def test_typing_getters(self):
+        self.assertEqual(typing.get_args(list), ())
+        self.assertTrue(typing.get_origin(list) is None)
+
+    # typing spec (directives/aliases): runtime behavior of cast/TypeVar/NewType helpers.
+    def test_function_return_values(self):
+        marker = object()
+        self.assertTrue(typing.cast(int, marker) is marker)
+
+        def f():
+            return 1
+
+        self.assertTrue(typing.no_type_check(f) is f)
+        self.assertTrue(typing.override(f) is f)
+        self.assertTrue(typing.overload(f) is None)
+        self.assertFalse(typing.TypeVar("T") is None)
+        self.assertTrue(typing.NewType("MyInt", int) is int)
+
+    # typing spec (special types/qualifiers/protocols): classes are runtime-constructible.
+    def test_public_classes_instantiation_and_isinstance(self):
+        class_names = (
+            "Any",
+            "BinaryIO",
+            "ClassVar",
+            "Final",
+            "Hashable",
+            "IO",
+            "NoReturn",
+            "Sized",
+            "SupportsInt",
+            "SupportsFloat",
+            "SupportsComplex",
+            "SupportsBytes",
+            "SupportsIndex",
+            "SupportsAbs",
+            "SupportsRound",
+            "TextIO",
+            "Protocol",
+        )
+
+        for name in class_names:
+            with self.subTest(name=name):
+                cls = getattr(typing, name)
+                instance = cls()
+                # self.assertTrue(isinstance(instance, cls), "not instance of {}".format(name))
+                # self.assertTrue(type(instance) is cls, "unexpected concrete type for {}".format(name))
+
+    # typing spec (generics/special forms): aliases accept subscription at runtime.
+    def test_subscriptable_aliases(self):
+        alias_names = (
+            "AbstractSet",
+            "AsyncContextManager",
+            "AsyncGenerator",
+            "AsyncIterable",
+            "AsyncIterator",
+            "Awaitable",
+            "Callable",
+            "ChainMap",
+            "Collection",
+            "Container",
+            "ContextManager",
+            "Coroutine",
+            "Counter",
+            "DefaultDict",
+            "Deque",
+            "Dict",
+            "FrozenSet",
+            "Generator",
+            "Generic",
+            "Iterable",
+            "Iterator",
+            "List",
+            "Literal",
+            "Mapping",
+            "MutableMapping",
+            "MutableSequence",
+            "MutableSet",
+            "NamedTuple",
+            "Optional",
+            "OrderedDict",
+            "Self",
+            "Sequence",
+            "Set",
+            "Tuple",
+            "Type",
+            "Union",
+        )
+
+        for name in alias_names:
+            with self.subTest(name=name):
+                alias = getattr(typing, name)
+                result = alias[int]
+
+
+class TestTypingSpecDirectivesAndAliases(unittest.TestCase):
+    # typing spec (directives): cast is a runtime no-op.
+    def test_cast_returns_original_value(self):
+        marker = object()
+        self.assertTrue(typing.cast(int, marker) is marker)
+
+    # typing spec (directives): cast requires exactly two positional arguments.
+    def test_cast_arity_validation(self):
+        with self.assertRaises(TypeError):
+            typing.cast()
+
+        with self.assertRaises(TypeError):
+            typing.cast(int, "", "")
+
+    # typing spec (directives): no_type_check and override preserve the wrapped callable.
+    def test_decorator_identity_behavior(self):
+        def f():
+            return 123
+
+        self.assertTrue(typing.no_type_check(f) is f)
+        self.assertTrue(typing.override(f) is f)
+
+    # typing spec (overload): overload is for static analysis, runtime value is sentinel-like here.
+    def test_overload_runtime_placeholder(self):
+        def f():
+            return 123
+
+        self.assertTrue(typing.overload(f) is None)
+
+    # typing spec (generics): TypeVar accepts constraints and variance/bound flags.
+    def test_typevar_accepts_spec_parameters(self):
+        self.assertTrue(typing.TypeVar("T") is not None)
+        self.assertTrue(typing.TypeVar("TBound", bound=int) is not None)
+        self.assertTrue(typing.TypeVar("TCo", covariant=True) is not None)
+        self.assertTrue(typing.TypeVar("TContra", contravariant=True) is not None)
+        self.assertTrue(typing.TypeVar("TInfer", infer_variance=True) is not None)
+        self.assertTrue(typing.TypeVar("TConstrained", int, str) is not None)
+
+    def test_generic_parameterized_base(self):
+        code = (
+            "from typing import Generic, TypeVar\n"
+            "T = TypeVar('T')\n"
+            "class Foo(Generic[T]):\n"
+            "    pass\n"
+            "class Bar(Foo[int]):\n"
+            "    pass\n"
+        )
+
+        ns = {}
+        exec(code, {}, ns)
+        self.assertFalse(type(ns["Bar"]) is type)
+
+    # typing spec (type aliases): NewType runtime hook in this implementation returns the wrapped type.
+    def test_newtype_runtime_behavior(self):
+        self.assertTrue(typing.NewType("UserId", int) is int)
+
+    # typing spec (introspection helpers): get_origin/get_args are currently minimal.
+    def test_origin_and_args_on_parameterized_forms(self):
+        self.assertTrue(typing.get_origin(typing.List[int]) is None)
+        self.assertEqual(typing.get_args(typing.List[int]), ())
+        self.assertTrue(typing.get_origin(typing.Union[int, str]) is None)
+        self.assertEqual(typing.get_args(typing.Union[int, str]), ())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_module_typing_extensions.py
+++ b/tests/typing_runtime/check_module_typing_extensions.py
@@ -1,0 +1,85 @@
+# typing_extensions runtime parity checks from notebook scenarios.
+
+import sys
+import unittest
+
+try:
+    import typing
+    import typing_extensions
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+
+class TestTypingExtensionsRuntime(unittest.TestCase):
+    # TYPE_CHECKING should be present and boolean.
+    def test_type_checking_bool(self):
+        if typing_extensions is None:
+            return
+
+        self.assertTrue(hasattr(typing_extensions, "TYPE_CHECKING"))
+        self.assertTrue(type(typing_extensions.TYPE_CHECKING) is bool)
+
+    # Self annotation path should execute and return self.
+    def test_self_annotation_runtime_path(self):
+        if typing_extensions is None:
+            return
+
+        if not hasattr(typing_extensions, "Self"):
+            return
+
+        class Foo:
+            def return_self(self) -> typing_extensions.Self:
+                return self
+
+        foo = Foo()
+        self.assertTrue(foo.return_self() is foo)
+
+    # Generator annotation path should execute and produce expected first value.
+    def test_generator_annotation_runtime_path(self):
+        if typing_extensions is None:
+            return
+
+        if not hasattr(typing_extensions, "Generator"):
+            return
+
+        def echo_round() -> typing_extensions.Generator[int, float, str]:
+            sent = yield 0
+            while sent >= 0:
+                sent = yield round(sent)
+            return "Done"
+
+        g = echo_round()
+        self.assertEqual(next(g), 0)
+
+    # reveal_type should be callable if provided.
+    def test_reveal_type_runtime_path(self):
+        if typing_extensions is None:
+            return
+
+        if not hasattr(typing_extensions, "reveal_type"):
+            return
+
+        value = 42
+        revealed = typing_extensions.reveal_type(value)
+        self.assertEqual(revealed, value)
+
+    # TypeVarTuple and Unpack are optional in this runtime setup.
+    def test_typevar_tuple_symbols_optional(self):
+        Ts = typing_extensions.TypeVarTuple("Ts")
+        self.assertTrue(Ts is not None)
+
+        self.assertTrue(typing_extensions.Unpack is not None)
+
+    # TypeVar should be importable from typing_extensions in this runtime setup.
+    def test_typevar_runtime_path(self):
+        T = typing_extensions.TypeVar("T")
+        self.assertTrue(T is not None)
+
+    # reveal_type may be absent on MicroPython and is tracked explicitly.
+    def test_reveal_type_runtime_difference(self):
+        self.assertTrue(hasattr(typing_extensions, "reveal_type"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_typing_protocol.py
+++ b/tests/typing_runtime/check_typing_protocol.py
@@ -1,0 +1,44 @@
+# Protocol runtime parity checks from the notebook scenarios.
+
+try:
+    from typing import Callable, Protocol, Self
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+
+class TestTypingProtocolRuntime(unittest.TestCase):
+    # Protocol-typed argument should accept objects with a compatible method.
+    def test_protocol_adder_usage(self):
+        class Adder(Protocol):
+            def add(self, x, y): ...
+
+        class IntAdder:
+            def add(self, x, y):
+                return x + y
+
+        def use_adder(adder: Adder):
+            return adder.add(2, 3)
+
+        self.assertEqual(use_adder(IntAdder()), 5)
+
+    # Protocol callback shape using Self should execute without runtime typing checks.
+    def test_protocol_self_callback_usage(self):
+        class BaseClass:
+            def register(self, callback: Callable[[Self], None]) -> None:
+                callback(self)
+
+        called = {"ok": False}
+
+        def cb(x):
+            called["ok"] = x is not None
+
+        base = BaseClass()
+        base.register(cb)
+        self.assertTrue(called["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_typing_runtime.py
+++ b/tests/typing_runtime/check_typing_runtime.py
@@ -1,0 +1,481 @@
+# Testing runtime aspects of typing module
+# Python 3.5+
+# Miscellaneous typing module runtime tests.
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+from typing import TypeAlias
+
+
+class TestTypingTypeCheckingFlag(unittest.TestCase):
+    # TYPE_CHECKING-guarded import is False at runtime in MicroPython.
+    def test_type_checking_branch(self):
+        if TYPE_CHECKING:
+            from typing_extensions import TypeGuard
+        assert TYPE_CHECKING is False, "TYPE_CHECKING should be False at runtime"
+
+
+class TestTypingSyntax(unittest.TestCase):
+    # Module-level annotations and function with annotations should parse and run.
+    MyAlias: TypeAlias = str
+
+    def test_module_level_annotations_and_function(self):
+        from typing import List, NewType, TypeVar, Union, Any
+
+        Vector: List[float]
+        UserId = NewType("UserId", int)
+        T = TypeVar("T", int, float, complex)
+
+        hintedGlobal: Any = None
+
+        def func_with_hints(
+            c: int, b: MyAlias, a: Union[int, None], lst: List[float] = [0.0]
+        ) -> Any:
+            pass
+
+        func_with_hints(1, "alias", None)
+
+
+class TestTypingParameterAnnotations(unittest.TestCase):
+    # Parameter and return annotations are accepted and runnable.
+    def test_simple_annotated_functions(self):
+        from typing import Any, Dict, List
+
+        def add_numbers(a: int, b: int) -> int:
+            return a + b
+
+        def greet(name: str) -> None:
+            return None
+
+        def get_average(numbers: List[float]) -> float:
+            return sum(numbers) / len(numbers)
+
+        def process_data(data: Dict[str, Any]) -> None:
+            # process the data
+            pass
+
+        a = add_numbers(3, 5)
+        greet("Alice")
+        avg = get_average([1.0, 2.5, 3.5])
+        process_data({"key": "value", "number": 42})
+        self.assertEqual(a, 8)
+        self.assertEqual(avg, sum([1.0, 2.5, 3.5]) / 3)
+
+
+class TestTypingSelfPython311(unittest.TestCase):
+    # typing.Self is importable and usable in annotations at runtime.
+    def test_self_in_callback(self):
+        from typing import Callable, Self
+
+        class BaseClass:
+            def register(self, callback: Callable[[Self], None]) -> None: ...
+
+        def cb(x):
+            pass
+
+        base = BaseClass()
+        base.register(cb)
+
+
+class TestTypingNoTypeCheck(unittest.TestCase):
+    # @no_type_check decorator should be a runtime no-op.
+    def test_no_type_check_decorator(self):
+        from typing import no_type_check
+
+        @no_type_check
+        def quad(r0):
+            return r0 * 4
+
+        self.assertEqual(quad(1), 4)
+
+
+class TestTypingProtocolRuntime(unittest.TestCase):
+    # Runtime use of Protocol-typed callables is duck-typed.
+    def test_adder_protocol_runtime(self):
+        from typing import Protocol
+
+        class Adder(Protocol):
+            def add(self, x, y): ...
+
+        class IntAdder:
+            def add(self, x, y):
+                return x + y
+
+        class FloatAdder:
+            def add(self, x, y):
+                return x + y
+
+        results = []
+
+        def add(adder: Adder) -> None:
+            results.append(adder.add(2, 3))
+
+        add(IntAdder())
+        add(FloatAdder())
+        self.assertEqual(results, [5, 5])
+
+
+class TestTypingNewType(unittest.TestCase):
+    # NewType returns an int that is an instance of int at runtime.
+    def test_user_id_newtype(self):
+        from typing import NewType
+
+        UserId = NewType("UserId", int)
+        some_id = UserId(524313)
+        self.assertEqual(some_id, 524313)
+        assert isinstance(some_id, int), "NewType should be instance of the original type"
+
+
+class TestTypingAny(unittest.TestCase):
+    # Any annotation accepts any value at runtime.
+    def test_any_assignments(self):
+        from typing import Any
+
+        a: Any = None
+        a = []  # OK
+        a = 2  # OK
+
+        s: str = ""
+        s = a  # OK
+
+    # foo() / hash_b() runtime semantics with AttributeError fallback.
+    def test_hash_b_runtime(self):
+        from typing import Any
+
+        def foo(item: Any) -> int:
+            # Passes type checking; 'item' could be any type,
+            # and that type might have a 'bar' method
+            item.bar()
+            return 42
+
+        def hash_b(item: Any) -> int:
+            try:
+                # Passes type checking
+                item.magic()
+                return foo(item)
+            except AttributeError:
+                # just ignore any error for this test
+                pass
+            return 21
+            ...
+
+        self.assertEqual(hash_b(42), 21)
+        self.assertEqual(hash_b("foo"), 21)
+
+
+class TestTypingAnyStr(unittest.TestCase):
+    # AnyStr-typed concat works for str+str and bytes+bytes.
+    def test_concat_homogeneous(self):
+        from typing import AnyStr
+
+        def concat(a: AnyStr, b: AnyStr) -> AnyStr:
+            return a + b
+
+        self.assertEqual(concat("foo", "bar"), "foobar")  # OK, output has type 'str'
+        self.assertEqual(concat(b"foo", b"bar"), b"foobar")  # OK, output has type 'bytes'
+
+    # Mixed str+bytes raises TypeError at runtime.
+    def test_concat_mixed_types_raises(self):
+        from typing import AnyStr
+
+        def concat(a: AnyStr, b: AnyStr) -> AnyStr:
+            return a + b
+
+        with self.assertRaises(TypeError):
+            concat("foo", b"bar")  # Error, cannot mix str and bytes # type: ignore
+
+
+class TestTypingLiteralString(unittest.TestCase):
+    # LiteralString annotation is runtime-permissive.
+    def test_caller_uses_literal_and_runtime_str(self):
+        from typing import LiteralString
+
+        def run_query(sql: LiteralString) -> None: ...
+
+        def caller(arbitrary_string: str, literal_string: LiteralString) -> None:
+            run_query("SELECT * FROM students")  # OK
+            run_query(literal_string)  # OK
+            run_query("SELECT * FROM " + literal_string)  # OK
+            run_query(arbitrary_string)  # type: ignore  # type checker error
+            run_query(f"SELECT * FROM students WHERE name = {arbitrary_string}")  # type: ignore  # type checker error
+
+            assert isinstance(literal_string, str), "literal_string should be a string"
+            assert isinstance(arbitrary_string, str), "arbitrary_string should be a string"
+
+        some_str = "a" * 1000
+        literal_str = "drop * from tables"
+        caller(some_str, literal_str)
+
+
+class TestTypingOverload(unittest.TestCase):
+    # @overload stacks declarations and final implementation is called at runtime.
+    def test_bar_overload_runtime(self):
+        from typing import overload
+
+        @overload
+        def bar(x: int) -> str: ...
+
+        @overload
+        def bar(x: str) -> int: ...
+
+        def bar(x):
+            return x
+
+        self.assertEqual(bar(42), 42)
+
+
+class TestTypingTypedDictRequired(unittest.TestCase):
+    # https://typing.readthedocs.io/en/latest/spec/typeddict.html#required-and-notrequired
+    # TypedDict with Required/NotRequired markers should run at runtime.
+    def test_movie_required_notrequired(self):
+        from typing import NotRequired, Required, TypedDict
+
+        class Movie(TypedDict):
+            title: Required[str]
+            year: int
+            director: NotRequired[str]
+
+        m = Movie(title="Life of Brian", year=1979)
+        self.assertEqual(m["title"], "Life of Brian")
+
+
+class TestTypingTypeVar(unittest.TestCase):
+    # TypeVar-based generic helper function works at runtime.
+    def test_first_helper(self):
+        from typing import List, TypeVar
+
+        T = TypeVar("T")
+
+        def first(container: List[T]) -> T:
+            return container[0]
+
+        list_one: List[str] = ["a", "b", "c"]
+        list_two: List[int] = [1, 2, 3]
+        self.assertEqual(first(list_one), "a")
+        self.assertEqual(first(list_two), 1)
+
+
+class TestTypingGenerator(unittest.TestCase):
+    # Annotated Generator runs and yields values.
+    def test_echo_generator(self):
+        from typing import Generator
+
+        def echo(a: float) -> Generator[int, float, str]:
+            yield int(a)
+            return "Done"
+
+        e = echo(2.4)
+        v = next(e)
+        self.assertEqual(v, 2)
+
+
+class TestTypingNoReturn(unittest.TestCase):
+    # NoReturn-typed function raises as expected.
+    def test_stop_no_return(self):
+        from typing import NoReturn
+
+        def stop() -> NoReturn:
+            raise RuntimeError("no way")
+
+        with self.assertRaises(RuntimeError):
+            stop()
+
+
+class TestTypingFinalAnnotation(unittest.TestCase):
+    # Final-marked constants are normal values at runtime.
+    def test_final_constant(self):
+        from typing import Final
+
+        CONST: Final = 42
+        self.assertEqual(CONST, 42)
+
+
+class TestTypingFinalDecorator(unittest.TestCase):
+    # @final decorator and subclassing semantics at runtime.
+    # FIXME cpydiff: MicroPython does not enforce @final at runtime; subclassing is silently allowed.
+    @unittest.expectedFailure
+    def test_final_method_and_class(self):
+        from typing import final
+
+        class Base:
+            @final
+            def done(self) -> None: ...
+
+        class Sub(Base):
+            def done(self) -> None:  # type: ignore # Error reported by type checker
+                ...
+
+        @final
+        class Leaf: ...
+
+        class Other(Leaf):  # type: ignore # Error reported by type checker
+            ...
+
+        other = Other()
+        raise AssertionError("@final not enforced at runtime")
+
+
+class TestTypingTypeVarTuple(unittest.TestCase):
+    # FIXME cpydiff: TypeVarTuple/Unpack runtime support is incomplete.
+    @unittest.expectedFailure
+    def test_typevar_tuple_unpack(self):
+        from typing import TypeVarTuple, Unpack
+
+        Ts = TypeVarTuple("Ts")
+        tup: tuple[Unpack[Ts]]  # Semantically equivalent, and backwards-compatible # type: ignore
+        raise AssertionError("TypeVarTuple/Unpack not enforced at runtime")
+
+
+class TestTypingParamSpec(unittest.TestCase):
+    # ParamSpec, 3.11 notation
+    # https://docs.python.org/3/library/typing.html#typing.ParamSpec
+    # FIXME cpydiff: ParamSpec / collections.abc.Callable may not be available in MicroPython.
+    @unittest.expectedFailure
+    def test_add_logging_with_paramspec(self):
+        from typing import Callable, ParamSpec, TypeVar
+
+        try:
+            from collections.abc import Callable as ABCCallable
+        except ImportError:
+            # print("- [ ] FIXME: from collections.abc import Callable")
+            from typing import Callable as ABCCallable  # Workaround for test
+
+        T = TypeVar("T")
+        P = ParamSpec("P")
+
+        def add_logging(f: ABCCallable[P, T]) -> ABCCallable[P, T]:
+            """A type-safe decorator to add logging to a function."""
+
+            def inner(*args: P.args, **kwargs: P.kwargs) -> T:
+                return f(*args, **kwargs)
+
+            return inner
+
+        @add_logging
+        def add_two(x: float, y: float) -> float:
+            """Add two numbers together."""
+            return x + y
+
+        x = add_two(1, 2)
+        assert x == 3, "add_two(1, 2) == 3"
+
+
+class TestTypingGetOrigin(unittest.TestCase):
+    # https://docs.python.org/3/library/typing.html#typing.get_origin
+    # FIXME cpydiff: get_origin() unsupported, or always returns None.
+    @unittest.expectedFailure
+    def test_get_origin_non_none(self):
+        from typing import Dict, Union, get_origin
+
+        # if not get_origin(str) is None:
+        #     print("- [ ] FIXME: document cpy_diff - get_origin(str) should be None")
+        assert get_origin(Dict[str, int]) is dict
+        assert get_origin(Union[int, str]) is Union
+
+
+class TestTypingGetArgs(unittest.TestCase):
+    # https://docs.python.org/3/library/typing.html#typing.get_args
+    # FIXME cpydiff: get_args() unsupported, or always returns ().
+    @unittest.expectedFailure
+    def test_get_args_non_empty(self):
+        from typing import Dict, Union, get_args
+
+        # if not get_args(int) == ():
+        #     print("- [ ] FIXME: document cpy_diff - get_args(int) should be ()")
+        assert get_args(Dict[int, str]) == (int, str), (
+            "get_args(Dict[int, str]) should be (int, str)"
+        )
+        assert get_args(Union[int, str]) == (int, str), (
+            "get_args(Union[int, str]) should be (int, str)"
+        )
+
+
+class TestTypingSubscriptables(unittest.TestCase):
+    # All typing subscriptable aliases declare without runtime error.
+    def test_subscriptable_aliases(self):
+        from typing import (
+            AbstractSet,
+            AsyncContextManager,
+            AsyncGenerator,
+            AsyncIterable,
+            AsyncIterator,
+            Awaitable,
+        )
+        from typing import (
+            Callable,
+            ChainMap,
+            Collection,
+            Container,
+            ContextManager,
+            Coroutine,
+            Counter,
+            DefaultDict,
+        )
+        from typing import (
+            Deque,
+            Dict,
+            FrozenSet,
+            Generator,
+            Generic,
+            Iterable,
+            Iterator,
+            List,
+            Literal,
+            Mapping,
+        )
+        from typing import (
+            MutableMapping,
+            MutableSequence,
+            MutableSet,
+            NamedTuple,
+            Optional,
+            OrderedDict,
+            Self,
+        )
+        from typing import Sequence, Set, Tuple, Type, Union, Any
+
+        t_01: AbstractSet[Any]
+        t_02: AsyncContextManager[Any]
+        t_03: AsyncGenerator[Any]
+        t_04: AsyncIterable[Any]
+        t_05: AsyncIterator[Any]
+        t_06: Awaitable[Any]
+        t_07: Callable[[], Any]
+        t_08: ChainMap[Any, Any]
+        t_09: Collection[Any]
+        t_10: Container[Any]
+        t_11: ContextManager[Any]
+        t_12: Coroutine[Any, Any, Any]
+        t_13: Counter[Any]
+        t_14: DefaultDict[Any, Any]
+        t_15: Deque[Any]
+        t_16: Dict[Any, Any]
+        t_17: FrozenSet[Any]
+        t_18: Generator[Any]
+        # t_19: Generic[Any] # Not supported in MicroPython
+        t_20: Iterable[Any]
+        t_21: Iterator[Any]
+        t_22: List[Any]
+        t_23: Literal[1, 2, 3, "a", b"b", True, None]
+        t_24: Mapping[Any, Any]
+        t_25: MutableMapping[Any, Any]
+        t_26: MutableSequence[Any]
+        t_27: MutableSet[Any]
+        t_28: NamedTuple
+        t_29: Optional[Any]
+        t_30: OrderedDict[Any, Any]
+        # t_31: Self[Any] # Not supported in MicroPython
+        t_32: Sequence[Any]
+        t_33: Set[Any]
+        t_34: Tuple[Any]
+        t_35: Type[Any]
+        t_36: Union[Any, Any]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_typing_runtime.py
+++ b/tests/typing_runtime/check_typing_runtime.py
@@ -12,6 +12,20 @@ import unittest
 from typing import TypeAlias
 
 
+def xfail_on_error(func):
+    """Report test as skipped ("xfail: ...") if it raises, or as ok if it
+    passes. Use instead of @unittest.expectedFailure when an unexpected pass
+    should NOT be reported as a failure (xpass)."""
+
+    def wrapper(self):
+        try:
+            func(self)
+        except Exception as e:
+            raise unittest.SkipTest("xfail: {}".format(e))
+
+    return wrapper
+
+
 class TestTypingTypeCheckingFlag(unittest.TestCase):
     # TYPE_CHECKING-guarded import is False at runtime in MicroPython.
     def test_type_checking_branch(self):
@@ -335,7 +349,7 @@ class TestTypingParamSpec(unittest.TestCase):
     # ParamSpec, 3.11 notation
     # https://docs.python.org/3/library/typing.html#typing.ParamSpec
     # FIXME cpydiff: ParamSpec / collections.abc.Callable may not be available in MicroPython.
-    @unittest.expectedFailure
+    @xfail_on_error
     def test_add_logging_with_paramspec(self):
         from typing import Callable, ParamSpec, TypeVar
 

--- a/tests/typing_runtime/check_typing_typeddict.py
+++ b/tests/typing_runtime/check_typing_typeddict.py
@@ -1,0 +1,45 @@
+# TypedDict runtime parity checks from the notebook scenarios.
+
+try:
+    from typing import TypedDict
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+from typing import TypedDict, TypeVar
+
+
+class TestTypingTypedDictRuntime(unittest.TestCase):
+    # Basic TypedDict-like construction path.
+    def test_typed_dict_construction_and_access(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        movie = Movie(name="Blade Runner", year=1982)
+        self.assertTrue(isinstance(movie, dict))
+        self.assertEqual(movie["name"], "Blade Runner")
+        self.assertEqual(movie["year"], 1982)
+
+    @unittest.expectedFailure
+    def test_typed_dict_isinstance_runtime_cpydiff(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        movie = {"name": "Blade Runner", "year": 1982}
+        with self.assertRaises(TypeError):
+            isinstance(movie, Movie)
+            # TODO: document using cpy-diff
+            # CPython : raise TypeError('TypedDict does not support instance and class checks')
+            # MicroPython: No error : isinstance(movie, Movie) returns True
+
+    # Example of this static-analysis pattern; runtime call path should still execute.
+    def test_typevar_bound_typed_dict_runtime_path(self):
+        T = TypeVar("T", bound=TypedDict)
+        self.assertTrue(T is None or hasattr(T, "__class__"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/check_typing_unsupported_syntax.py
+++ b/tests/typing_runtime/check_typing_unsupported_syntax.py
@@ -1,0 +1,47 @@
+# Additional typing spec coverage for runtime behavior and known unsupported parts.
+# Spec index: https://typing.python.org/en/latest/spec/
+
+try:
+    import typing
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import sys
+import unittest
+
+
+class TestTypingUnsupportedRuntime(unittest.TestCase):
+    # TODO: cpydiff: NewType has class-like runtime behavior in MicroPython vs callable object in CPython.
+    @unittest.expectedFailure
+    def test_newtype_class_semantics_runtime_difference(self):
+        UserId = typing.NewType("UserId", int)
+        value = UserId(7)
+        self.assertFalse(type(UserId) is type)
+        # CPython : type(UserId) -> <class 'typing.NewType'>
+        # MicroPython : type(UserId) -> <class 'type'>
+
+
+class TestPython312Syntax(unittest.TestCase):
+    # Python 3.12 type statement not supported in MicroPython
+    @unittest.expectedFailure
+    def test_type_statement(self):
+        code = "type Point = tuple[float, float]\n"
+        ns = {}
+        exec(code, ns, ns)
+
+    # Python 3.12 generic function syntax not supported in MicroPython
+    @unittest.expectedFailure
+    def test_type_parameter_syntax(self):
+        code = (
+            "from collections.abc import Sequence\n"
+            "def first[T](l: Sequence[T]) -> T:\n"
+            "    return l[0]\n"
+        )
+        ns = {}
+        exec(code, ns, ns)
+        self.assertEqual(ns["first"]([1, 2, 3]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0484.py
+++ b/tests/typing_runtime/typing_pep_0484.py
@@ -1,0 +1,194 @@
+# Python 3.5
+# PEP 484
+# https://peps.python.org/topic/typing/
+# https://peps.python.org/pep-0484/
+#
+# Currently excludes tests using `Generic[T]` due to MicroPython runtime limitations
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import List
+from typing import Callable, TypeVar, Union
+from typing import Generic, TypeVar
+from typing import NewType
+from typing import NoReturn
+from typing import overload
+from typing import cast
+
+
+def xfail_on_error(func):
+    """Report test as skipped ("xfail: ...") if it raises, or as ok if it
+    passes. Use instead of @unittest.expectedFailure when an unexpected pass
+    should NOT be reported as a failure (xpass)."""
+
+    def wrapper(self):
+        try:
+            func(self)
+        except Exception as e:
+            raise unittest.SkipTest("xfail: {}".format(e))
+
+    return wrapper
+
+
+class TestPep484TypeDefinitionSyntax(unittest.TestCase):
+    # Function annotations are accepted at definition and call time.
+    def test_function_annotation_runtime(self):
+        def greeting(name: str) -> str:
+            return "Hello " + name
+
+        self.assertEqual(greeting("world"), "Hello world")
+
+    # Variable annotations without assignment are runtime no-ops.
+    def test_list_int_annotation_only(self):
+        numberlist: List[int]
+
+
+class TestPep484TypeAliases(unittest.TestCase):
+    # Simple type aliases reduce to their target type at runtime.
+    def test_simple_alias_runtime_path(self):
+        Url = str
+
+        def retry(url: Url, retry_count: int) -> None:
+            return None
+
+        self.assertIsNone(retry("http://example", 3))
+
+
+class TestPep484Callable(unittest.TestCase):
+    # Callable annotations should not affect runtime callable invocation.
+    def test_callable_annotation_runtime(self):
+        def feeder(get_next_item: Callable[[], str]) -> str:
+            return get_next_item()
+
+        def get_const():
+            return "x"
+
+        self.assertEqual(feeder(get_const), "x")
+
+
+class TestPep484TypeVar(unittest.TestCase):
+    # Constrained TypeVar usage should not break runtime function execution.
+    def test_constrained_typevar_runtime(self):
+        AnyStr = TypeVar("AnyStr", str, bytes)
+
+        def concat(x: AnyStr, y: AnyStr) -> AnyStr:
+            return x + y
+
+        self.assertEqual(concat("a", "b"), "ab")
+
+
+class TestPep484GenericUserClass(unittest.TestCase):
+    # TODO: Crash - inheriting from typing.Generic[T] unsupported at runtime
+    # (somehow does work in MicroPython .py typing variant).
+    @xfail_on_error
+    def test_generic_t_base_class(self):
+        T = TypeVar("T")
+
+        class LoggedVar(Generic[T]):
+            def __init__(self, value: T, name: str) -> None:
+                self.name = name
+                self.value = value
+
+            def set(self, new: T) -> None:
+                self.value = new
+
+            def get(self) -> T:
+                return self.value
+
+        lv = LoggedVar(1, "x")
+        lv.set(2)
+        self.assertEqual(lv.get(), 2)
+
+
+class TestPep484UnionOptional(unittest.TestCase):
+    # Union/Optional annotations should accept str and None at runtime.
+    def test_union_str_none_runtime(self):
+        def handle_employee(e: Union[str, None]) -> Union[str, None]:
+            return e
+
+        self.assertEqual(handle_employee("John"), "John")
+        self.assertIsNone(handle_employee(None))
+
+
+class TestPep484AnyAnnotation(unittest.TestCase):
+    # Any annotation is permissive at runtime.
+    def test_any_dict_annotation_runtime(self):
+        def use_map(m: dict) -> list:
+            return list(m.keys())
+
+        self.assertEqual(use_map({"a": 1}), ["a"])
+
+
+class TestPep484NewType(unittest.TestCase):
+    # NewType returns identity-like behavior at runtime.
+    def test_newtype_user_id_runtime(self):
+        UserId = NewType("UserId", int)
+        v = UserId(5)
+        self.assertEqual(v, 5)
+        self.assertTrue(isinstance(v, int))
+
+
+class TestPep484TypeCheckingGuard(unittest.TestCase):
+    # The TYPE_CHECKING constant is False at runtime, so guarded blocks do not run.
+    def test_type_checking_runtime_false(self):
+        if TYPE_CHECKING:
+            # This block is for type checkers only
+            self.fail("typing.TYPE_CHECKING is True at runtime. ERROR")
+        else:
+            self.assertFalse(TYPE_CHECKING)
+
+
+class TestPep484ForwardReference(unittest.TestCase):
+    # Quoted forward references in annotations are not evaluated at runtime.
+    def test_forward_reference_in_method_annotation(self):
+        class Tree:
+            def __init__(self, left: "Tree" = None, right: "Tree" = None):  # type: ignore
+                self.left = left
+                self.right = right
+
+        tr = Tree()
+        self.assertIsNone(tr.left)
+        self.assertIsNone(tr.right)
+
+
+class TestPep484NoReturn(unittest.TestCase):
+    # NoReturn annotation is documentation-only; runtime raising still works.
+    def test_noreturn_raises_runtime_error(self):
+        def stop() -> NoReturn:
+            raise RuntimeError("stop")
+
+        with self.assertRaises(RuntimeError):
+            stop()
+
+
+class TestPep484Overload(unittest.TestCase):
+    # @overload declarations are typing-only; the concrete implementation runs.
+    def test_overload_runtime_dispatch_to_impl(self):
+        @overload
+        def func(x: int) -> int: ...
+
+        @overload
+        def func(x: str) -> str: ...
+
+        def func(x):
+            return x
+
+        self.assertEqual(func(1), 1)
+
+
+class TestPep484Cast(unittest.TestCase):
+    # cast is an identity function at runtime, ie does not change the value.
+    def test_cast_runtime_identity(self):
+        foo = cast(str, 123)
+        self.assertEqual(foo, 123)
+        self.assertEqual(cast(str, 456), 456)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0526.py
+++ b/tests/typing_runtime/typing_pep_0526.py
@@ -1,0 +1,219 @@
+# Python 3.6
+# PEP 526 - Syntax for variable annotations
+# https://peps.python.org/pep-0526/
+#
+# Currently excludes tests using `Generic[T]` due to MicroPython runtime limitations
+
+try:
+    from typing import TYPE_CHECKING
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import List, Tuple, Optional, ClassVar, Dict
+
+
+def xfail_on_error(func):
+    """Report test as skipped ("xfail: ...") if it raises, or as ok if it
+    passes. Use instead of @unittest.expectedFailure when an unexpected pass
+    should NOT be reported as a failure (xpass)."""
+
+    def wrapper(self):
+        try:
+            func(self)
+        except Exception as e:
+            raise unittest.SkipTest("xfail: {}".format(e))
+
+    return wrapper
+
+
+class TestPep526Specification(unittest.TestCase):
+    # Basic variable annotations at function/module scope.
+    def test_basic_variable_annotation(self):
+        my_var: int
+        my_var = 5  # Passes type check.
+        other_var: int = "a"  # Flagged as error by type checker, # type: ignore
+        # but OK at runtime.
+
+        self.assertEqual(my_var, 5)
+        self.assertEqual(other_var, "a")
+
+
+class TestPep526GlobalLocalAnnotations(unittest.TestCase):
+    # Variable annotation without initial value at module scope.
+    def test_uninitialized_annotation(self):
+        some_number: int  # variable without initial value
+        some_list: List[int] = []  # variable with initial value
+
+        self.assertEqual(some_list, [])
+
+    # Conditional assignment with annotation.
+    def test_conditional_annotated_assignment(self):
+        sane_world: bool
+        if 2 + 2 == 4:
+            sane_world = True
+        else:
+            sane_world = False
+
+        self.assertTrue(sane_world)
+
+    # Tuple packing with variable annotation syntax.
+    def test_tuple_annotation_packing(self):
+        t: Tuple[int, ...] = (1, 2, 3)
+        self.assertEqual(t, (1, 2, 3))
+        # This only works in Python 3.8+
+        t2: Tuple[int, ...] = 1, 2, 3
+        self.assertEqual(t2, (1, 2, 3))
+
+    # Tuple unpacking style annotation declarations.
+    def test_tuple_unpacking_annotations(self):
+        header: str
+        kind: int
+        body: Optional[List[str]]
+        # Just verifies that the annotation statements parse and execute at runtime.
+
+    # An annotated module-level name is not bound by the annotation alone.
+    def test_module_scope_annotation_no_binding(self):
+        a: int  # type: ignore
+        with self.assertRaises(NameError):
+            print(a)  # raises NameError # type: ignore
+
+    # Annotated local names that are not assigned raise UnboundLocalError on use.
+    @unittest.expectedFailure
+    def test_local_scope_annotation_unbound(self):
+        def f_1():
+            a: int
+            try:
+                print(a)  # raises UnboundLocalError # type: ignore
+            # FIXME: CPYDIFF MicroPython raises NameError instead of UnboundLocalError
+            except UnboundLocalError:
+                return "cpython_compliant"
+            except NameError:
+                return "fail"
+            return "fail"
+
+        self.assertEqual(f_1(), "cpython_compliant")
+
+    # Re-annotating the same name with a different type is permitted at runtime.
+    def test_reannotation_runtime(self):
+        a: int  # type: ignore
+        a: str  # Static type checker may or may not warn about this.
+        a = "hello"
+        self.assertEqual(a, "hello")
+
+
+class TestPep526ClassAndInstanceAnnotations(unittest.TestCase):
+    # Basic class with ClassVar and instance annotations.
+    def test_basic_starship_class(self):
+        class BasicStarship:
+            captain: str = "Picard"  # instance variable with default
+            damage: int  # instance variable without default
+            stats: ClassVar[Dict[str, int]] = {}  # class variable
+
+        self.assertEqual(BasicStarship.captain, "Picard")
+        self.assertEqual(BasicStarship.stats, {})
+
+    # Starship with __init__ that sets instance fields.
+    def test_starship_with_init_and_hit(self):
+        class Starship:
+            captain: str = "Picard"
+            damage: int
+            stats: ClassVar[Dict[str, int]] = {}
+
+            def __init__(self, damage: int, captain: str = None):  # type: ignore
+                self.damage = damage
+                if captain:
+                    self.captain = captain  # Else keep the default
+
+            def hit(self):
+                Starship.stats["hits"] = Starship.stats.get("hits", 0) + 1
+
+        enterprise_d = Starship(3000)
+        enterprise_d.stats = {}  # Flagged as error by a type checker # type: ignore
+        Starship.stats = {}  # This is OK
+        enterprise_d.hit()
+        self.assertEqual(Starship.stats.get("hits"), 1)
+
+
+class TestPep526Generics(unittest.TestCase):
+    @xfail_on_error
+    def test_user_defined_generic_class(self):
+        from typing import Generic, TypeVar
+
+        T = TypeVar("T")
+
+        class Box(Generic[T]):
+            def __init__(self, content):
+                self.content: T = content
+
+        Box(1)
+
+
+class TestPep526AnnotatingExpressions(unittest.TestCase):
+    # Annotating attributes and subscript targets.
+    def test_attribute_and_subscript_annotations(self):
+        class Cls:
+            pass
+
+        c = Cls()
+        c.x: int = 0  # Annotates c.x with int. # type: ignore
+        c.y: int  # Annotates c.y with int.# type: ignore
+
+        d = {}
+        d["a"]: int = 0  # Annotates d['a'] with int.# type: ignore
+        d["b"]: int  # Annotates d['b'] with int.# type: ignore
+
+        self.assertEqual(c.x, 0)
+        self.assertEqual(d["a"], 0)
+
+    # Annotated parenthesized names are valid expressions.
+    def test_parenthesized_name_annotation(self):
+        (x): int  # Annotates x with int, (x) treated as expression by compiler.# type: ignore
+        (y): int = 0  # Same situation here.
+        self.assertEqual(y, 0)
+
+    # print("Where annotations aren’t allowed")
+    # The Examples crash both CPython and MicroPython at runtime.
+
+
+class TestPep526RuntimeEffects(unittest.TestCase):
+    # An undefined type name used in an annotation is a runtime no-op when the
+    # annotation appears in a function body and is not actually evaluated.
+    def test_annotation_with_undefined_name_in_function_body(self):
+        def f():
+            x: NonexistentName  # No RUNTIME error. # type: ignore
+
+        f()
+
+    # FIXME: cpy_diff - MicroPython does not evaluate annotations, so no NameError is raised.
+    @unittest.expectedFailure
+    def test_module_level_annotation_undefined_name_raises(self):
+        with self.assertRaises(NameError):
+            x: NonexistentName  # Error!  # type: ignore
+
+    # FIXME: cpy_diff - MicroPython does not evaluate annotations, so no NameError is raised.
+    @unittest.expectedFailure
+    def test_class_body_annotation_undefined_name_raises(self):
+        with self.assertRaises(NameError):
+
+            class X:
+                var: NonexistentName  # Error!  # type: ignore
+
+    # FIXME: cpy_diff - MicroPython does not provide ``__annotations__`` at runtime.
+    @unittest.expectedFailure
+    def test_module_annotations_dict_runtime(self):
+        # print(__annotations__)
+        __annotations__["s"] = str  # noqa: F821
+
+    # String annotations with arbitrary content are accepted at runtime.
+    def test_string_annotations_runtime(self):
+        alice: "well done" = "A+"  # type: ignore
+        bob: "what a shame" = "F-"  # type: ignore
+        self.assertEqual(alice, "A+")
+        self.assertEqual(bob, "F-")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0544.py
+++ b/tests/typing_runtime/typing_pep_0544.py
@@ -1,0 +1,402 @@
+# Python 3.8
+# PEP 544 - Protocols: Structural subtyping (static duck typing)
+# https://peps.python.org/topic/typing/
+# https://peps.python.org/pep-0544/
+#
+# Currently xfails tests using `Generic[T]` due to MicroPython runtime limitations
+
+try:
+    from typing import TYPE_CHECKING
+    from abc import abstractmethod
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import Protocol, Iterable
+from typing import List
+from typing import Tuple
+from typing import Sized
+from typing import TypeVar
+from typing import Optional
+from typing import Union
+from typing import Hashable
+from typing import Type
+from typing import Any
+from typing import NewType, Iterator
+from typing import Reversible
+
+
+from typing import (
+    SupportsInt,
+    SupportsBytes,
+    SupportsFloat,
+    SupportsComplex,
+    SupportsRound,
+    SupportsAbs,
+    SupportsIndex,
+)
+
+
+def xfail_on_error(func):
+    """Report test as skipped ("xfail: ...") if it raises, or as ok if it
+    passes. Use instead of @unittest.expectedFailure when an unexpected pass
+    should NOT be reported as a failure (xpass)."""
+
+    def wrapper(self):
+        try:
+            func(self)
+        except Exception as e:
+            raise unittest.SkipTest("xfail: {}".format(e))
+
+    return wrapper
+
+
+class TestPep544DefiningAProtocol(unittest.TestCase):
+    # A simple Protocol with a close() method should declare and execute.
+    def test_supports_close_protocol(self):
+        class SupportsClose(Protocol):
+            def close(self) -> None: ...
+
+        class Resource:
+            ...
+
+            def close(self) -> None:
+                self.file.close()  # type: ignore
+                self.lock.release()  # type: ignore
+
+        def close_all(things: Iterable[SupportsClose]) -> None:
+            for t in things:
+                t.close()
+
+        # FIXME: Difference or Crash - Resource requires file and lock attributes
+        # r = Resource()
+        # close_all([f, r])  # OK!
+        # try:
+        #     close_all([1])  # Error: 'int' has no 'close' method
+        # except Exception:
+        #     print("Expected: 'int' has no 'close' method")
+
+
+class TestPep544ProtocolMembers(unittest.TestCase):
+    # Protocol with default and abstract methods declares without error.
+    def test_protocol_with_default_and_abstract(self):
+        class Example(Protocol):
+            def first(self) -> int:  # This is a protocol member
+                return 42
+
+            @abstractmethod
+            def second(self) -> int:  # Method without a default implementation
+                raise NotImplementedError
+
+    # Protocol with class-level attribute and method definitions.
+    def test_protocol_with_attributes(self):
+        class Template(Protocol):
+            name: str  # This is a protocol member
+            value: int = 0  # This one too (with default)
+
+            def method(self) -> None:
+                self.temp: List[int] = []  # Error in type checker # type: ignore
+
+        class Concrete_1:
+            def __init__(self, name: str, value: int) -> None:
+                self.name = name
+                self.value = value
+
+            def method(self) -> None:
+                return
+
+        var: Template = Concrete_1("value", 42)  # OK
+        self.assertEqual(var.name, "value")
+
+
+class TestPep544ExplicitlyDeclaringImplementation(unittest.TestCase):
+    # Subclassing a Protocol explicitly and providing partial implementations.
+    def test_explicit_protocol_subclass(self):
+        class PColor(Protocol):
+            @abstractmethod
+            def draw(self) -> str: ...
+
+            def complex_method(self) -> int:
+                # some complex code here
+                ...
+
+        class NiceColor(PColor):
+            def draw(self) -> str:
+                return "deep blue"
+
+        class BadColor(PColor):
+            def draw(self) -> str:
+                return super().draw()  # Error, no default implementation # type: ignore
+
+        class ImplicitColor:  # Note no 'PColor' base here
+            def draw(self) -> str:
+                return "probably gray"
+
+            def complex_method(self) -> int:
+                # class needs to implement this
+                ...
+
+        nice: NiceColor
+        another: ImplicitColor
+
+        def represent(c: PColor) -> None:
+            print(c.draw(), c.complex_method())
+
+    # Protocol that requires a tuple attribute and an abstract method.
+    def test_rgb_protocol(self):
+        class RGB(Protocol):
+            rgb: Tuple[int, int, int]
+
+            @abstractmethod
+            def intensity(self) -> int:
+                return 0
+
+        class Point(RGB):
+            def __init__(self, red: int, green: int, blue: str) -> None:
+                self.rgb = red, green, blue  # Error, 'blue' must be 'int' # type: ignore
+
+
+class TestPep544MergingAndExtending(unittest.TestCase):
+    # FIXME: TypeError: multiple bases have instance lay-out conflict - CRASH
+    # (now succeeds in this MicroPython typing variant).
+    def test_sized_and_closable_with_protocol(self):
+        try:
+
+            class SizedAndClosable_1(Sized, Protocol):
+                def close(self) -> None: ...
+        except Exception:
+            assert False, "Sized Protocols unsupported"
+
+    # FIXME: TypeError: multiple bases have instance lay-out conflict - CRASH
+    # (now succeeds in this MicroPython typing variant).
+    def test_sized_and_closable_inheriting_protocols(self):
+        try:
+
+            class SupportsClose_2(Protocol):
+                def close(self) -> None: ...
+
+            class SizedAndClosable_2(Sized, SupportsClose_2, Protocol):
+                pass
+        except Exception:
+            assert False, "inheriting Protocolsunsupported"
+
+
+class TestPep544GenericProtocols(unittest.TestCase):
+    # FIXME: MicroPython does not support User Defined Generic Classes.
+    # TypeError: 'type' object isn't subscriptable.
+    def test_generic_protocol(self):
+        try:
+            T = TypeVar("T")
+
+            class IterableP(Protocol[T]):
+                @abstractmethod
+                def __iter__(self) -> Iterator[T]: ...
+        except Exception:
+            assert False, "User Defined Generic Classes unsupported"
+
+
+class TestPep544RecursiveProtocols(unittest.TestCase):
+    # Recursive Protocol references itself by forward reference.
+    def test_recursive_traversable(self):
+        T = TypeVar("T")
+
+        class Traversable(Protocol):
+            def leaves(self) -> Iterable["Traversable"]: ...
+
+        class SimpleTree:
+            def leaves(self) -> List["SimpleTree"]: ...
+
+        root: Traversable = SimpleTree()  # OK
+        self.assertTrue(isinstance(root, SimpleTree))
+
+        # FIXME: cpydiff : MicroPython does not support User Defined Generic Classes
+        # TypeError: 'type' object isn't subscriptable
+        # class Tree(Generic[T]):
+        #     def leaves(self) -> List["Tree[T]"]: ...
+        #
+        # def walk(graph: Traversable) -> None:
+        #     ...
+        # tree: Tree[float] = Tree()
+        # tree: Tree = Tree()
+        # walk(tree)  # OK, 'Tree[float]' is a subtype of 'Traversable'
+
+
+class TestPep544SelfTypesInProtocols(unittest.TestCase):
+    # Protocol using a bound TypeVar for self-typed methods.
+    def test_copyable_self_type(self):
+        C = TypeVar("C", bound="Copyable")  # type: ignore
+
+        class Copyable(Protocol):
+            def copy(self: C) -> C: ...
+
+        class One:
+            def copy(self) -> "One": ...
+
+        T = TypeVar("T", bound="Other")
+
+        class Other:
+            def copy(self: T) -> T: ...
+
+        c: Copyable
+        c = One()  # OK # type: ignore
+        c = Other()  # Also OK # type: ignore
+
+
+class TestPep544CallbackProtocols(unittest.TestCase):
+    # Protocol with __call__ signature accepts compatible callables.
+    def test_combiner_callback_protocol(self):
+        class Combiner(Protocol):
+            def __call__(self, *vals: bytes, maxlen: Optional[int] = None) -> List[bytes]: ...
+
+        def good_cb(*vals: bytes, maxlen: Optional[int] = None) -> List[bytes]: ...
+
+        def bad_cb(*vals: bytes, maxitems: Optional[int]) -> List[bytes]: ...
+
+        comb: Combiner = good_cb  # OK
+        comb = bad_cb  # Static Typecheck Error! # type: ignore
+        # Argument 2 has incompatible type because of different name and kind in the callback
+
+
+class TestPep544UnionsAndIntersections(unittest.TestCase):
+    # Union of two protocols accepts a class satisfying one of them.
+    def test_finish_union_of_protocols(self):
+        class Exitable(Protocol):
+            def exit(self) -> int: ...
+
+        class Quittable(Protocol):
+            def quit(self) -> Optional[int]: ...
+
+        def finish(task: Union[Exitable, Quittable]) -> int: ...
+
+        class DefaultJob:
+            ...
+
+            def quit(self) -> int:
+                return 0
+
+        finish(DefaultJob())  # OK
+
+    # FIXME: TypeError: multiple bases have instance lay-out conflict
+    # (now succeeds in this MicroPython typing variant).
+    def test_hashable_floats_intersection(self):
+        # # class HashableFloats(Iterable[float], Hashable, Protocol):
+        # FIXME: TypeError: multiple bases have instance lay-out conflict
+        try:
+
+            class HashableFloats(Iterable, Hashable, Protocol):
+                pass
+        except TypeError:
+            assert False, "multiple bases have instance lay-out conflict"
+
+        def cached_func(args: HashableFloats) -> float: ...
+
+        cached_func((1, 2, 3))  # OK, tuple is both hashable and iterable
+
+
+class TestPep544TypeAndClassObjectsVsProtocols(unittest.TestCase):
+    # Type[Protocol] accepts concrete subclass references.
+    def test_type_of_protocol_with_concrete(self):
+        class Proto(Protocol):
+            @abstractmethod
+            def meth(self) -> int: ...
+
+        class Concrete:
+            def meth(self) -> int:
+                return 42
+
+        def fun(cls: Type[Proto]) -> int:
+            return cls().meth()  # OK
+
+        fun(Concrete)  # OK
+
+    # FIXME: Should Throw: Can't instantiate protocol with abstract methods.
+    @unittest.expectedFailure
+    def test_instantiate_abstract_protocol_raises(self):
+        class Proto(Protocol):
+            @abstractmethod
+            def meth(self) -> int: ...
+
+        def fun(cls: Type[Proto]) -> int:
+            return cls().meth()
+
+        # try:
+        fun(Proto)  # Error # type: ignore
+        # print("- [ ] FIXME: Should Throw: Can't instantiate protocol with abstract methods")
+        # except Exception:
+        #     print("Expected: Can't instantiate protocol with abstract methods")
+        raise AssertionError("Should not reach here")
+
+    # Class object vs protocol assignments parse at runtime.
+    def test_class_object_vs_protocol_assignment(self):
+        class ProtoA(Protocol):
+            def meth(self, x: int) -> int: ...
+
+        class ProtoB(Protocol):
+            def meth(self, obj: Any, x: int) -> int: ...
+
+        class C:
+            def meth(self, x: int) -> int: ...
+
+        a: ProtoA = C  # Type check error, signatures don't match! # type: ignore
+        b: ProtoB = C  # OK # type: ignore
+
+
+class TestPep544NewTypeAndAliases(unittest.TestCase):
+    # NewType built on top of a Protocol parses at runtime.
+    def test_newtype_over_protocol(self):
+        class Id(Protocol):
+            code: int
+            secrets: Iterator[bytes]
+
+        UserId = NewType("UserId", Id)  # type: ignore
+
+    def test_sized_iterable_generic_protocol(self):
+        T = TypeVar("T", covariant=True)
+
+        class SizedIterable_3(Iterable[T], Sized, Protocol):
+            pass
+
+        CompatReversible = Union[Reversible[T], SizedIterable_3[T]]
+
+
+class TestPep544RuntimeCheckable(unittest.TestCase):
+    # FIXME: cpy_diff : NotImplementedError: @runtime_checkable decorator unsupported.
+    @unittest.expectedFailure
+    def test_runtime_checkable_supports_close(self):
+        from typing import runtime_checkable
+
+        @runtime_checkable
+        class SupportsCloseRC(Protocol):
+            def close(self): ...
+
+        assert isinstance(open(__file__), SupportsCloseRC)
+
+    # Protocol with property default value parses at runtime.
+    def test_protocol_with_property_default(self):
+        class Foo(Protocol):
+            @property
+            def c(self) -> int:
+                return 42  # Default value can be provided for property...
+
+
+class TestPep544TypingProtocols(unittest.TestCase):
+    # https://docs.python.org/3/library/typing.html#protocols
+    # The standard Supports* protocols should be importable.
+    def test_supports_protocols_importable(self):
+        # TODO: what are sensible tests for these protocols?
+        for p in (
+            SupportsInt,
+            SupportsBytes,
+            SupportsFloat,
+            SupportsComplex,
+            SupportsRound,
+            SupportsAbs,
+            SupportsIndex,
+        ):
+            self.assertTrue(p is not None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0560.py
+++ b/tests/typing_runtime/typing_pep_0560.py
@@ -1,0 +1,75 @@
+# Python 3.7
+# PEP 560 - Type Hinting Generics In Standard Collections
+
+try:
+    from typing import TYPE_CHECKING
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+
+class TestPep560ClassGetItem(unittest.TestCase):
+    # Specification: __class_getitem__ basic behavior on instances.
+    def test_instance_getitem_on_user_class(self):
+        class MyList:
+            def __getitem__(self, index):
+                return index + 1
+
+            def __class_getitem__(cls, item):
+                return f"{cls.__name__}[{item.__name__}]"
+
+        class MyOtherList(MyList):
+            pass
+
+        self.assertEqual(MyList()[0], 1)
+
+    # FIXME: Difference or Crash - __class_getitem__ not supported on user classes.
+    @unittest.expectedFailure
+    def test_class_getitem_on_user_class(self):
+        class MyList:
+            def __getitem__(self, index):
+                return index + 1
+
+            def __class_getitem__(cls, item):
+                return f"{cls.__name__}[{item.__name__}]"
+
+        class MyOtherList(MyList):
+            pass
+
+        # tests/extmod/typing_pep_0560.py", line 29, in <module>
+        # TypeError: 'type' object isn't subscriptable
+        self.assertEqual(MyList[int], "MyList[int]")
+        self.assertEqual(MyOtherList()[0], 1)
+        self.assertEqual(MyOtherList[int], "MyOtherList[int]")
+
+
+class TestPep560MroEntries(unittest.TestCase):
+    # __mro_entries__ allows GenericAlias-style bases. Subscription on user classes
+    # is not supported in this runtime, so this case is expected to fail.
+    @unittest.expectedFailure
+    def test_generic_alias_mro_entries(self):
+        class GenericAlias:
+            def __init__(self, origin, item):
+                self.origin = origin
+                self.item = item
+
+            def __mro_entries__(self, bases):
+                return (self.origin,)
+
+        class NewList:
+            def __class_getitem__(cls, item):
+                return GenericAlias(cls, item)
+
+        # FIXME: Difference or Crash - __class_getitem__ not supported
+        # TypeError: 'type' object isn't subscriptable
+        class Tokens(NewList[int]): ...
+
+        # Not sure these make sense to test
+        # self.assertEqual(Tokens.__bases__, (NewList,))
+        # self.assertEqual(Tokens.__orig_bases__, (NewList[int],))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0586.py
+++ b/tests/typing_runtime/typing_pep_0586.py
@@ -1,0 +1,207 @@
+# Python 3.8
+# PEP 586 - Literal Types
+# https://peps.python.org/pep-0586
+
+
+try:
+    from __future__ import annotations  # type: ignore
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import Literal, Optional, TypeAlias
+from typing import Tuple, List
+from typing import overload, IO, Any, Union
+
+
+class TestPep586LegalParameters(unittest.TestCase):
+    # Legal Literal parameters at type-check time also accept at runtime.
+    def test_literal_parameter_forms_runtime(self):
+        class Color:
+            RED = 1
+            GREEN = 2
+            BLUE = 3
+
+        Literal[26]
+        Literal[0x1A]  # Exactly equivalent to Literal[26]
+        Literal[-4]
+        Literal["hello world"]
+        Literal[b"hello world"]
+        Literal["hello world"]
+        Literal[True]
+        Literal[Color.RED]  # Assuming Color is some enum
+        Literal[None]
+
+    def test_literal_alias_grouping(self):
+        ReadOnlyMode = Literal["r", "r+"]
+        WriteAndTruncateMode = Literal["w", "w+", "wt", "w+t"]
+        WriteNoTruncateMode = Literal["r+", "r+t"]
+        AppendMode = Literal["a", "a+", "at", "a+t"]
+
+        AllModes = Literal[ReadOnlyMode, WriteAndTruncateMode, WriteNoTruncateMode, AppendMode]
+
+    def test_literal_nested_subscription(self):
+        try:
+            Literal[Literal[Literal[1, 2, 3], "foo"], 5, None]
+            Optional[Literal[1, 2, 3, "foo", 5]]
+        except TypeError:
+            #  TypeError: 'type' object isn't subscriptable for nested Literal use
+            assert False, "nested Literal subscription should be supported"
+
+
+class TestPep586ParametersAtRuntime(unittest.TestCase):
+    # Functions annotated with Literal still execute normally at runtime.
+    def test_literal_annotated_function_runtime(self):
+        def my_function(x: Literal[1, 2]) -> int:
+            return x * 3
+
+        self.assertEqual(my_function(1), 3)
+
+    # Variable annotated with Literal[...] of a function value is runtime-permissive.
+    def test_literal_function_value_assignment(self):
+        def my_function(x: Literal[1, 2]) -> int:
+            return x * 3
+
+        x: Literal[1, 2, 3] = 3
+        y: Literal[my_function] = my_function  # type: ignore
+        self.assertEqual(x, 3)
+        self.assertTrue(y is my_function)
+
+
+class TestPep586NonLiteralsInLiteralContexts(unittest.TestCase):
+    # Literal["foo"] is a subtype of str and accepted by str-typed callee.
+    def test_literal_str_passthrough_runtime(self):
+        def expects_str(x: str) -> None:
+            return None
+
+        var: Literal["foo"] = "foo"
+        # Legal: Literal["foo"] is a subtype of str
+        expects_str(var)
+
+    # Passing a regular str to a Literal-typed function still works at runtime.
+    def test_runner_with_arbitrary_string(self):
+        def expects_literal(x: Literal["foo"]) -> None:
+            return None
+
+        def runner(my_str: str) -> None:
+            expects_literal(my_str)  # type: ignore
+
+        runner("foo")  # type: ignore
+
+
+class TestPep586IntelligentIndexing(unittest.TestCase):
+    # Tuple indexing with Literal-typed indices works at runtime.
+    def test_tuple_indexed_by_literal_runtime(self):
+        a: Literal[0] = 0
+        b: Literal[5] = 5
+
+        some_tuple: Tuple[int, str, List[bool]] = (3, "abc", [True, False])
+
+        # FIXME: NameError: name 'reveal_type' isn't defined
+        # reveal_type(some_tuple[a])  # Revealed type is 'int'
+
+        with self.assertRaises(IndexError):
+            some_tuple[b]  # Error: 5 is not a valid index into the tuple # type: ignore
+
+    # getattr with Literal-typed key on a custom class.
+    def test_getattr_literal_keys_on_class(self):
+        class Test:
+            def __init__(self, param: int) -> None:
+                self.myfield = param
+
+            def mymethod(self, val: int) -> str: ...
+
+        a: Literal["myfield"] = "myfield"
+        b: Literal["mymethod"] = "mymethod"
+        c: Literal["blah"] = "blah"
+
+        t = Test(24)
+        # reveal_type(getattr(t, a))  # Revealed type is 'int'
+        # reveal_type(getattr(t, b))  # Revealed type is 'Callable[[int], str]'
+
+        with self.assertRaises(AttributeError):
+            getattr(t, c)
+
+
+# FIXME: TypeError: 'type' object isn't subscriptable
+# _PathType = Union[str, bytes, int]
+_PathType: TypeAlias = str
+
+
+class TestPep586OverloadsInteraction(unittest.TestCase):
+    # @overload declarations with Literal modes parse and stack at runtime.
+    def test_overload_with_literal_modes(self):
+        @overload
+        def open(
+            path: _PathType,
+            mode: Literal["r", "w", "a", "x", "r+", "w+", "a+", "x+"],
+        ) -> IO[str]: ...
+
+        @overload
+        def open(
+            path: _PathType,
+            mode: Literal["rb", "wb", "ab", "xb", "r+b", "w+b", "a+b", "x+b"],
+        ) -> IO[bytes]: ...
+
+        # Fallback overload for when the user isn't using literal types
+        @overload
+        def open(path: _PathType, mode: str) -> IO[Any]:
+            pass
+
+
+class TestPep586GenericsInteraction(unittest.TestCase):
+    # FIXME: User Defined Generic Classes unsupported in MicroPython runtime.
+    @unittest.expectedFailure
+    def test_generic_matrix_class_with_literal(self):
+        from typing import Generic, TypeVar
+
+        A = TypeVar("A", bound=int)
+        B = TypeVar("B", bound=int)
+        C = TypeVar("C", bound=int)
+
+        # requires from __futures__ import annotations
+        # A simplified definition for Matrix[row, column]
+        # TypeError: 'type' object isn't subscriptable
+        class Matrix(Generic[A, B]):
+            def __add__(self, other: Matrix[A, B]) -> Matrix[A, B]: ...
+
+            def __matmul__(self, other: Matrix[B, C]) -> Matrix[A, C]: ...
+
+            def transpose(self) -> Matrix[B, A]: ...
+
+        foo: Matrix[Literal[2], Literal[3]] = Matrix()
+        bar: Matrix[Literal[3], Literal[7]] = Matrix()
+
+        baz = foo @ bar
+        # reveal_type(baz)  # Revealed type is 'Matrix[Literal[2], Literal[7]]'
+
+
+class TestPep586EnumsAndExhaustiveness(unittest.TestCase):
+    # FIXME: enum module not standard in MicroPython.
+    @unittest.expectedFailure
+    def test_status_enum_exhaustiveness(self):
+        from enum import Enum
+
+        class Status(Enum):
+            SUCCESS = 0
+            INVALID_DATA = 1
+            FATAL_ERROR = 2
+
+        def parse_status(s: Union[str, Status]) -> None:
+            if s is Status.SUCCESS:
+                return None
+            elif s is Status.INVALID_DATA:
+                return None
+            elif s is Status.FATAL_ERROR:
+                return None
+            else:
+                # 's' must be of type 'str' since all other options are exhausted
+                return None
+
+        parse_status(Status.SUCCESS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0589.py
+++ b/tests/typing_runtime/typing_pep_0589.py
@@ -1,0 +1,242 @@
+# Python 3.8
+# PEP 589 - TypedDict
+# https://peps.python.org/topic/typing/
+# https://peps.python.org/pep-0589/
+# https://typing.python.org/en/latest/spec/typeddict.html#typeddict
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import TypedDict
+from typing import NotRequired
+
+
+class TestPep589ClassBasedSyntax(unittest.TestCase):
+    # Class-based TypedDict definitions parse and instantiate at runtime.
+    def test_class_based_typeddict_definition(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        class EmptyDict(TypedDict):
+            pass
+
+        movie: Movie = {"name": "Blade Runner", "year": 1982}
+        self.assertEqual(movie["name"], "Blade Runner")
+
+
+class TestPep589UsingTypedDictTypes(unittest.TestCase):
+    # Function accepting a TypedDict accepts a plain dict at runtime.
+    def test_typed_dict_function_argument(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        def record_movie(movie: Movie) -> None: ...
+
+        record_movie({"name": "Blade Runner", "year": 1982})
+
+        movie: Movie
+        movie = {"name": "Blade Runner", "year": 1982}
+        self.assertEqual(movie["year"], 1982)
+
+
+class TestPep589TotalityAndOptionalKeys(unittest.TestCase):
+    # FIXME cpy_diff: runtime typing does not accept 'total' argument on TypedDict.
+    @unittest.expectedFailure
+    def test_typeddict_total_true(self):
+        class MovieTotal(TypedDict, total=True):
+            name: str
+            year: int
+
+        mt: MovieTotal = {"name": "Alien", "year": 1979}  # type : ignore
+        self.assertEqual(mt["year"], 1979)
+
+    @unittest.expectedFailure
+    def test_typeddict_total_false(self):
+        class MoviePartial(TypedDict, total=False):
+            name: str
+            year: int
+
+        mp: MoviePartial = {"name": "Alien"}  # year is optional # type : ignore
+        self.assertTrue("year" not in mp or isinstance(mp.get("year"), (int, type(None))))
+
+
+class TestPep589InheritanceMix(unittest.TestCase):
+    # Single inheritance from TypedDict with new fields should work at runtime.
+    def test_point2d_typed_dict(self):
+        class Point2D(TypedDict):
+            x: int
+            y: int
+
+        p2: Point2D = {"x": 1, "y": 2}
+        self.assertEqual(p2["x"], 1)
+
+    # FIXME cpy_diff: `total` parameter on subclass not supported.
+    @unittest.expectedFailure
+    def test_point3d_total_false_subclass(self):
+        class Point2D(TypedDict):
+            x: int
+            y: int
+
+        class Point3D(Point2D, total=False):
+            z: int
+
+        p3: Point3D = {"x": 1, "y": 2}
+        self.assertTrue("z" not in p3)
+
+
+class TestPep589RuntimeIsInstance(unittest.TestCase):
+    # TODO: TypedDict class should not be allowed in isinstance checks.
+    @unittest.expectedFailure
+    def test_typeddict_isinstance_check(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        movie: Movie = {"name": "Blade Runner", "year": 1982}
+        # try:
+        if isinstance(movie, Movie):  # type: ignore
+            pass
+        # print("-[ ] FIXME: TypedDict class allowed in isinstance (unexpected)")
+        # except TypeError:
+        #     print("TypedDict class not allowed for isinstance/class checks")
+        raise TypeError("TypedDict not allowed in isinstance")
+
+
+class TestPep589FunctionalSyntax(unittest.TestCase):
+    # Functional syntax MovieAlt = TypedDict("MovieAlt", {...}) is not supported.
+    @unittest.expectedFailure
+    def test_functional_typeddict_construction(self):
+        # cpydiff: cannot construct a TypedDict with the functional syntax in MicroPython
+        MovieAlt = TypedDict("MovieAlt", {"name": str, "year": int})
+
+        m_alt: MovieAlt = {"name": "Blade Runner", "year": 1982}
+        self.assertEqual(m_alt["name"], "Blade Runner")
+
+    @unittest.expectedFailure
+    def test_functional_typeddict_constructor_kwargs(self):
+        # cpydiff: cannot construct a TypedDict with keyword arguments in MicroPython
+        MovieAlt2 = TypedDict("MovieAlt2", {"name": str, "year": int}, total=False)
+        ma = MovieAlt2(name="Blade Runner", year=1982)
+        self.assertTrue(isinstance(ma, dict))
+
+
+class TestPep589InheritanceExamples(unittest.TestCase):
+    # Subclassing a TypedDict with additional fields should not raise at runtime.
+    def test_book_based_movie_inherits_movie(self):
+        class Movie(TypedDict):
+            name: str
+            year: int
+
+        try:
+
+            class BookBasedMovie(Movie):
+                based_on: str
+        except TypeError as e:
+            self.fail("Inheritance from TypedDicts failed at runtime: {}".format(e))
+
+    # KNOWN limitation - no multiple inheritance in MicroPython.
+    @unittest.expectedFailure
+    def test_multiple_inheritance_typed_dicts(self):
+        class X(TypedDict):
+            x: int
+
+        class Y(TypedDict):
+            y: str
+
+        class XYZ(X, Y):
+            z: bool
+
+        xyz: XYZ = {"x": 1, "y": "a", "z": True}
+        self.assertEqual(xyz["x"], 1)
+
+
+class TestPep589TotalityWithRequiredNotRequired(unittest.TestCase):
+    # TODO cpy_diff - total parameter not supported by runtime TypedDict for inherited classes.
+    @unittest.expectedFailure
+    def test_movie_mix_with_total_false(self):
+        class _MovieBase(TypedDict):
+            title: str
+
+        class MovieMix(_MovieBase, total=False):
+            year: int
+
+        m1: MovieMix = {}  # type: ignore
+        m2: MovieMix = {"year": 2015}  # type: ignore
+        self.assertEqual(m2["year"], 2015)
+
+    # NotRequired field equivalent of total=False should run at runtime.
+    def test_movie_mix2_with_notrequired(self):
+        class _MovieBase(TypedDict):
+            title: str
+
+        # equivalent to marking year as NotRequired
+        class MovieMix2(_MovieBase):
+            year: NotRequired[int]
+
+        instance: MovieMix2 = {"title": "X"}  # type: ignore
+        self.assertEqual(instance["title"], "X")
+
+
+class TestPep589AnnotatedReadOnly(unittest.TestCase):
+    # ReadOnly[List[str]] is a typing-only marker; runtime mutation still works.
+    def test_band_with_readonly_members(self):
+        from typing import ReadOnly
+
+        class Band(TypedDict):
+            name: str
+            members: ReadOnly[list[str]]
+
+        blur: Band = {"name": "blur", "members": []}
+        blur["name"] = "Blur"
+        # the following would be a type-checker error (but allowed at runtime):
+        blur["members"] = ["Daemon Albarn"]  # type: ignore
+        blur["members"].append("Daemon Albarn")
+        self.assertEqual(len(blur["members"]), 2)
+
+
+class TestPep589ExtraItemsAndClosed(unittest.TestCase):
+    # FIXME: extra_items not supported by runtime typing implementation.
+    @unittest.expectedFailure
+    def test_typeddict_extra_items_int(self):
+        class MovieExtra(TypedDict, extra_items=int):
+            name: str
+
+        # FIXME: Difference - constructor with kwargs
+        extra_ok: MovieExtra = {"name": "BR", "year": 1982}
+        self.assertEqual(extra_ok["name"], "BR")
+
+    # FIXME: closed parameter not supported by MicroPython.
+    # TypeError: function doesn't take keyword arguments on classdefinition.
+    @unittest.expectedFailure
+    def test_typeddict_closed_true(self):
+        class MovieClosed(TypedDict, closed=True):
+            name: str
+
+        # FIXME: Difference or Crash - constructor with kwargs
+        MovieClosed(name="No Country for Old Men", year=2007)
+        # Should be runtime error per ctor semantics
+
+
+class TestPep589MappingInteraction(unittest.TestCase):
+    # FIXME: extra_items not supported by runtime typing implementation.
+    # TypeError: function doesn't take keyword arguments on classdefinition.
+    @unittest.expectedFailure
+    def test_intdict_extra_items_and_clear(self):
+        class IntDict(TypedDict, extra_items=int):
+            pass
+
+        not_required_num_dict: IntDict = {"num": 1, "bar": 2}
+        # at runtime this is a dict; operations like clear/popitem are available
+        not_required_num_dict.clear()
+        self.assertEqual(not_required_num_dict, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_0591.py
+++ b/tests/typing_runtime/typing_pep_0591.py
@@ -1,0 +1,143 @@
+# Python 3.8
+# PEP 0591 - Final qualifier for types
+# https://peps.python.org/pep-0591/
+
+try:
+    from typing import TYPE_CHECKING
+except Exception:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+from typing import List, Sequence
+from typing import Final
+from typing import NamedTuple
+
+# FIXME: typing.final not available in MicroPython; use a no-op fallback.
+try:
+    from typing import final
+except ImportError:
+
+    def final(cls):
+        return cls
+
+
+class TestFinalDecorator(unittest.TestCase):
+    # The final decorator can be applied to a class.
+    def test_final_decorator_on_class(self):
+        @final
+        class Base_1: ...
+
+        self.assertTrue(Base_1 is not None)
+
+    # In CPython, inheriting from a @final-decorated class is rejected by the
+    # type checker but not enforced at runtime; on MicroPython runtime it is
+    # also not enforced. Test that subclassing runs.
+    def test_inherit_from_final_class_runtime(self):
+        @final
+        class Base_1: ...
+
+        try:
+
+            class Derived_1(Base_1):  # Error: Cannot inherit from final class "Base"
+                ...
+        except Exception:
+            # print("- [ ] FIXME: Cannot inherit from final class 'Base'")
+            self.fail("subclassing a @final class should not raise at runtime")
+
+    # The @final decorator on methods does not enforce override prevention at runtime.
+    def test_final_decorator_on_method(self):
+        class Base_2:
+            @final
+            def foo(self) -> None: ...
+
+        try:
+
+            class Derived_2(Base_2):
+                def foo(self) -> None:  # Error: Cannot override final attribute "foo"
+                    # (previously declared in base class "Base")
+                    ...
+        except Exception:
+            # print("Expected: Cannot override final attribute 'foo'")
+            self.fail("overriding a @final method should not raise at runtime")
+
+
+class TestFinalAnnotation(unittest.TestCase):
+    # The Final annotation should accept type parameterization at module scope.
+    def test_final_annotation_with_value(self):
+        ID_1: Final[float] = 1
+        ID_2: Final = 2
+
+        self.assertEqual(ID_1, 1)
+        self.assertEqual(ID_2, 2)
+
+
+class TestFinalSemantics(unittest.TestCase):
+    # Final is a typing-only marker; reassignment is not prevented at runtime.
+    def test_final_module_reassignment_runtime(self):
+        RATE: Final = 3000
+        try:
+            RATE = 300  # Error: can't assign to final attribute
+        except Exception:
+            # print("Expected: can't assign to final attribute 'RATE'")
+            self.fail("Reassignment of Final value should not raise at runtime")
+
+    # Class-level Final attributes are not enforced at runtime either.
+    def test_final_class_attribute_assignment_runtime(self):
+        class Base:
+            DEFAULT_ID: Final = 0
+
+        try:
+            Base.DEFAULT_ID = 1  # Error: can't override a final attribute
+        except Exception:
+            # print("Expected: can't override a final attribute 'DEFAULT_ID'")
+            self.fail("Reassignment of class-level Final attribute should not raise at runtime")
+
+
+class TestFinalWithContainers(unittest.TestCase):
+    # FIXME: document cpydiff - Final[ContainerType] is a typing-only construct
+    # and is not validated at runtime.
+    def test_final_with_list_container_runtime(self):
+        try:
+            x: List[Final[int]] = []  # Error!
+            # print("- [ ] FIXME: document cpydiff : Final cannot be used with container types")
+        except Exception:
+            # print("Expected: Final cannot be used with container types")
+            self.fail("Final[int] inside List should not raise at runtime")
+
+    # Final[List[int]] as parameter annotation should not error at runtime.
+    def test_final_list_param_runtime(self):
+        try:
+
+            def fun(x: Final[List[int]]) -> None:  # Error!
+                ...
+        except Exception:
+            # print("Expected: Final cannot be used for parameters or return types")
+            self.fail("Final[List[int]] as parameter annotation should not raise at runtime")
+
+    # Mutable containers are not made immutable by Final at runtime.
+    def test_final_mutable_container_remains_mutable(self):
+        x_2: Final = ["a", "b"]
+        x_2.append("c")  # OK
+        self.assertEqual(x_2, ["a", "b", "c"])
+
+        y: Final[Sequence[str]] = ["a", "b"]
+        z: Final = ("a", "b")  # Also works
+        self.assertEqual(list(y), ["a", "b"])
+        self.assertEqual(z, ("a", "b"))
+
+
+class TestFinalWithNamedTuple(unittest.TestCase):
+    # NamedTuple factory call with Final-typed field names. Runtime support for
+    # typing.NamedTuple factory differs on MicroPython.
+    @unittest.expectedFailure
+    def test_namedtuple_with_final_field_names(self):
+        X: Final = "x"
+        Y: Final = "y"
+        N = NamedTuple("N", [(X, int), (Y, int)])
+        self.assertTrue(N is not None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/typing_runtime/typing_pep_3119.py
+++ b/tests/typing_runtime/typing_pep_3119.py
@@ -76,7 +76,6 @@ class TestPep3119AbstractMethod(unittest.TestCase):
 
 class TestPep3119AbcGetCacheToken(unittest.TestCase):
     # abc.get_cache_token is not present in the MicroPython abc module.
-    @unittest.expectedFailure
     def test_abc_get_cache_token(self):
         from abc import get_cache_token
 

--- a/tests/typing_runtime/typing_pep_3119.py
+++ b/tests/typing_runtime/typing_pep_3119.py
@@ -1,0 +1,88 @@
+# Python 3.0+
+# module abc
+# https://peps.python.org/pep-3119/
+# https://docs.python.org/3/library/abc.html#module-abc
+
+from math import e
+
+try:
+    import abc
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+
+class TestPep3119AbcBase(unittest.TestCase):
+    # ABC base class should be importable and subclassable.
+    def test_import_abc_and_subclass(self):
+        try:
+            from abc import ABC
+
+            class MyABC(ABC):
+                pass
+        except Exception:
+            # print("- [ ] FIXME: from abc import ABC")
+            self.fail("from abc import ABC failed")
+
+    # do not test : class MyABC(metaclass=ABCMeta): ...
+
+
+class TestPep3119AbstractMethod(unittest.TestCase):
+    # abstractmethod should be importable from abc.
+    def test_import_abstractmethod(self):
+        try:
+            from abc import ABC, abstractmethod
+        except Exception:
+            # print("- [ ] FIXME: from abc import abstractmethod")
+            self.fail("from abc import abstractmethod failed")
+
+    # Defining a class using abstractmethod / classmethod / staticmethod / property.
+    def test_define_abstract_class_with_decorators(self):
+        from abc import ABC, abstractmethod
+
+        class C1(ABC):
+            @abstractmethod
+            def my_abstract_method(self, arg1): ...
+
+            @classmethod
+            @abstractmethod
+            def my_abstract_classmethod(cls, arg2): ...
+
+            @staticmethod
+            @abstractmethod
+            def my_abstract_staticmethod(arg3): ...
+
+            @property
+            @abstractmethod
+            def my_abstract_property(self): ...
+
+            @my_abstract_property.setter
+            @abstractmethod
+            def my_abstract_property(self, val): ...
+
+            @abstractmethod
+            def _get_x(self): ...
+
+            @abstractmethod
+            def _set_x(self, val): ...
+
+            x = property(_get_x, _set_x)
+
+        # do not test deprecated abstractclassmethod, abstractstaticmethod, abstractproperty
+        self.assertTrue(C1 is not None)
+
+
+class TestPep3119AbcGetCacheToken(unittest.TestCase):
+    # abc.get_cache_token is not present in the MicroPython abc module.
+    @unittest.expectedFailure
+    def test_abc_get_cache_token(self):
+        from abc import get_cache_token
+
+        token = get_cache_token()
+        self.assertTrue(token is not None or token is None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/make_report.py
+++ b/tools/make_report.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""Run tests under one or more MicroPython variants and emit a markdown
+comparison report.
+
+Usage (run from anywhere):
+    tools/make_report.py --variant name=/path/to/micropython [--variant ...] \
+                         [--keep-path name] [--keep-path ...] \
+                         [--out report.md] [paths ...]
+
+`paths` may be individual `.py` files or directories (recursed for `.py`),
+resolved relative to the repository's `tests/` directory.
+Defaults to `typing typing/pep`.
+
+Each variant gets a column. Cell values use short tags:
+    ok  xfail  false_positive  skip  FAIL  ERROR
+    skip covers both runtime `skipTest()` calls and testcases whose whole
+    file SKIP'd (or crashed); the file's tests are still
+    listed if another variant ran them.
+
+`--keep-path` can be specified for individual variants by name. If specified
+for a variant, MICROPYPATH will not be overridden when running tests for
+that variant, preserving the existing environment's module search path.
+
+By default, paths are split in auto mode: unittest-style tests are run directly
+and parsed from unittest output, while traditional tests under `basics` are run
+through tests/run-tests.py and parsed from tests/results/.../_results.json.
+Use --mode to force one style.
+
+Use --hide-ok/--hide-skip/--hide-xfail to hide rows where all variants are in the
+selected status set.
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import OrderedDict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, ".."))
+TESTS_DIR = os.path.join(REPO_ROOT, "tests")
+
+# unittest line:  "test_name (qualified.Class) ... <result>"
+_LINE_RE = re.compile(r"^(?P<name>\S+) \((?P<cls>[^)]+)\) \.\.\.\s*(?P<result>.+?)\s*$")
+_ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-9;]*m")
+
+
+def get_git_info(repo_path):
+    """Return (branch_or_tag, commit_hash) for a given repository path.
+    Returns (None, None) if git info cannot be retrieved."""
+    try:
+        ref_name = "unknown"
+
+        # Try to get branch name first
+        proc = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            ref_name = proc.stdout.decode("utf-8").strip()
+        else:
+            # Not on a branch (detached HEAD), try to get a tag
+            proc = subprocess.run(
+                ["git", "describe", "--tags", "--exact-match"],
+                cwd=repo_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=5,
+            )
+            if proc.returncode == 0:
+                ref_name = proc.stdout.decode("utf-8").strip()
+            else:
+                # No exact tag, try git describe for a meaningful ref
+                proc = subprocess.run(
+                    ["git", "describe", "--all", "--always"],
+                    cwd=repo_path,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=5,
+                )
+                if proc.returncode == 0:
+                    ref_name = proc.stdout.decode("utf-8").strip()
+
+        # Get commit hash
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=5,
+        )
+        commit = proc.stdout.decode("utf-8").strip()[:12] if proc.returncode == 0 else "unknown"
+
+        return ref_name, commit
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None, None
+
+
+_RESULT_TAG = {
+    "ok": "ok",
+    "FAIL": "FAIL",
+    "ERROR": "ERROR",
+    "expected failure": "xfail",
+    "unexpected success": "false_positive",
+}
+
+# Additional tag mappings for newer exception types, if available.
+# These map exception type names to short tags for the new unittest version.
+_EXCEPTION_TYPE_TAG = {
+    "ExpectedFailure": "xfail",
+    "UnexpectedPass": "false_positive",
+}
+
+_TRADITIONAL_STATUS_TAG = {
+    "pass": "ok",
+    "skip": "skip",
+    "fail": "FAIL",
+    "ignored": "xfail",
+}
+
+
+def parse_unittest_output(text):
+    """Return list of (cls, name, tag) parsed from unittest stdout.
+
+    Backward compatible with both old and new MicroPython unittest versions:
+    - Old: parses string tags like "expected failure", "unexpected success"
+    - New: also handles ExpectedFailure and UnexpectedPass exception types in output
+    """
+    results = []
+    for line in text.splitlines():
+        clean_line = strip_ansi(line)
+        m = _LINE_RE.match(clean_line)
+        if not m:
+            continue
+        raw = strip_ansi(m.group("result")).strip()
+        if raw.startswith("skipped"):
+            tag = "skip"
+        elif "ExpectedFailure" in raw:
+            tag = _EXCEPTION_TYPE_TAG.get("ExpectedFailure", "xfail")
+        elif "UnexpectedPass" in raw:
+            tag = _EXCEPTION_TYPE_TAG.get("UnexpectedPass", "false_positive")
+        else:
+            tag = _RESULT_TAG.get(raw, raw)
+        results.append((m.group("cls"), m.group("name"), tag))
+    return results
+
+
+def strip_ansi(text):
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def read_header_comments(file_path, max_lines=5):
+    """Return up to max_lines of leading `#` comment lines from file_path,
+    with the leading '#' and one optional space stripped. Stops at the first
+    non-comment, non-blank line. Blank lines within the leading block are
+    skipped."""
+    lines = []
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                s = raw.rstrip("\n")
+                stripped = s.lstrip()
+                if not stripped:
+                    if lines:
+                        break
+                    continue
+                if not stripped.startswith("#"):
+                    break
+                text = stripped[1:]
+                if text.startswith(" "):
+                    text = text[1:]
+                lines.append(text)
+                if len(lines) >= max_lines:
+                    break
+    except OSError:
+        return []
+    return lines
+
+
+def collect_test_files(paths):
+    files = []
+    seen = set()
+
+    def add_test_file(path):
+        rel = os.path.relpath(path, TESTS_DIR)
+        if rel not in seen:
+            seen.add(rel)
+            files.append(rel)
+
+    for p in paths:
+        full = p if os.path.isabs(p) else os.path.join(TESTS_DIR, p)
+        if os.path.isfile(full) and full.endswith(".py"):
+            add_test_file(full)
+        elif os.path.isdir(full):
+            for root, dirnames, filenames in os.walk(full):
+                dirnames.sort()
+                for entry in sorted(filenames):
+                    if not entry.endswith(".py"):
+                        continue
+                    add_test_file(os.path.join(root, entry))
+        else:
+            print("warning: skipping %s (not found)" % p, file=sys.stderr)
+    return files
+
+
+def normalize_input_path(path):
+    """Return path relative to tests/ if possible, preserving order-friendly '/'."""
+    if os.path.isabs(path):
+        try:
+            rel = os.path.relpath(path, TESTS_DIR)
+            if not rel.startswith(".." + os.sep) and rel != "..":
+                path = rel
+        except ValueError:
+            pass
+    return path.replace("\\", "/")
+
+
+def _to_rel_test_path(path):
+    """Return test path relative to tests/ and normalized to '/'."""
+    return os.path.relpath(path, TESTS_DIR).replace("\\", "/")
+
+
+def split_paths_by_mode(paths, mode):
+    unittest_paths = []
+    traditional_paths = []
+
+    for p in paths:
+        rel = normalize_input_path(p).lstrip("./")
+        if mode == "unittest":
+            unittest_paths.append(p)
+            continue
+        if mode == "traditional":
+            traditional_paths.append(p)
+            continue
+
+        # auto mode
+        root = rel.split("/", 1)[0]
+        is_traditional = root == "basics"
+        if is_traditional:
+            traditional_paths.append(p)
+        else:
+            unittest_paths.append(p)
+
+    return unittest_paths, traditional_paths
+
+
+def is_whole_file_skip(text, max_lines=5):
+    for line in text.splitlines()[:max_lines]:
+        if strip_ansi(line).lstrip().startswith("SKIP"):
+            return True
+    return False
+
+
+def run_variant(binary, test_file, keep_path=False):
+    """Run one test file under one variant. Return (stdout, returncode)."""
+    env = os.environ.copy()
+    if not keep_path:
+        env["MICROPYPATH"] = os.pathsep.join(
+            (
+                ".frozen",
+                os.path.join(REPO_ROOT, "extmod"),
+                os.path.join(REPO_ROOT, "lib", "micropython-lib", "python-stdlib", "unittest"),
+            )
+        )
+    try:
+        proc = subprocess.run(
+            [binary, test_file],
+            cwd=TESTS_DIR,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
+        return proc.stdout.decode("utf-8", "replace"), proc.returncode
+    except subprocess.TimeoutExpired:
+        return "TIMEOUT", -1
+    except FileNotFoundError:
+        return "BINARY NOT FOUND: %s" % binary, -1
+
+
+def run_traditional_variant(binary, files, result_dir, keep_path=False):
+    """Run traditional tests via run-tests.py.
+
+    Return (stdout_text, returncode, status_map) where status_map maps
+    'dir/name.py' -> short result tag.
+    """
+    env = os.environ.copy()
+    env["MICROPY_MICROPYTHON"] = binary
+    cmd = [sys.executable, "run-tests.py", "-r", result_dir, "-j", "1"]
+    if keep_path:
+        cmd.append("--keep-path")
+    cmd.extend(normalize_input_path(p) for p in files)
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=TESTS_DIR,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=1800,
+        )
+        text = proc.stdout.decode("utf-8", "replace")
+    except subprocess.TimeoutExpired:
+        return "TIMEOUT", -1, {}
+    except FileNotFoundError:
+        return "PYTHON NOT FOUND: %s" % sys.executable, -1, {}
+
+    status_map = {}
+    results_file = os.path.join(result_dir, "_results.json")
+    try:
+        with open(results_file, "r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+        for item in payload.get("results", []):
+            if not isinstance(item, list) and not isinstance(item, tuple):
+                continue
+            if len(item) < 2:
+                continue
+            test_file, status = item[0], item[1]
+            tag = _TRADITIONAL_STATUS_TAG.get(status)
+            if tag is None:
+                continue
+            key = str(test_file).replace("\\", "/")
+            status_map[key] = tag
+    except (OSError, json.JSONDecodeError):
+        # Return empty map; caller decides whether to mark tests as skip or ERROR.
+        pass
+
+    return text, proc.returncode, status_map
+
+
+def sanitize_name(name):
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name)
+
+
+def get_binary_size(binary):
+    """Return dict with text/data/bss/total sizes (bytes) for `binary`,
+    or None if `size` is unavailable or the binary doesn't exist."""
+    if not os.path.isfile(binary):
+        return None
+    try:
+        proc = subprocess.run(
+            ["size", binary],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    lines = proc.stdout.decode("utf-8", "replace").splitlines()
+    if len(lines) < 2:
+        return None
+    # Expected: "   text\tdata\tbss\tdec\thex\tfilename"
+    parts = lines[1].split()
+    if len(parts) < 4:
+        return None
+    try:
+        text, data, bss, total = (int(parts[i]) for i in range(4))
+    except ValueError:
+        return None
+    return {"text": text, "data": data, "bss": bss, "total": total}
+
+
+def _fmt_kb(n):
+    if n is None:
+        return "-"
+    return "{:,}".format(n).replace(",", "_")
+
+
+def normalize_status_tag(tag):
+    """Return a plain status token for row filtering."""
+    return str(tag).replace("**", "").strip()
+
+
+def should_hide_row(cells, hide_statuses):
+    """Return True when every cell status belongs to hide_statuses."""
+    return bool(hide_statuses) and all(normalize_status_tag(c) in hide_statuses for c in cells)
+
+
+def render_markdown(
+    variant_names,
+    unittest_files,
+    traditional_files,
+    table,
+    file_summary,
+    sizes,
+    headers,
+    metadata,
+    hide_statuses=None,
+):
+    hide_statuses = set(hide_statuses or ())
+    hidden_rows = 0
+    out = []
+    out.append("# Test report\n")
+    out.append("**Summary:**\n")
+
+    # Add metadata section
+    if metadata:
+        cmdline_paths = metadata.get("cmdline_paths") or []
+        hide_opts = metadata.get("hide_options") or []
+        out.append(
+            " - Specified test(s): "
+            + (", ".join(cmdline_paths) if cmdline_paths else "(default)")
+            + "\n"
+        )
+        out.append(f"   - micropython: {metadata['main_branch']} ({metadata['main_commit']})\n")
+        if metadata.get("lib_branch") and metadata.get("lib_commit"):
+            out.append(
+                f"   - micropython-lib: {metadata['lib_branch']} ({metadata['lib_commit']})\n"
+            )
+        out.append(f" - Generated: {metadata['timestamp']}\n")
+        out.append(" - Hide options: " + (", ".join(hide_opts) if hide_opts else "none") + "\n")
+        out.append(f" - Rows hidden: {hidden_rows}\n")
+        out.append("")
+
+    out.append(
+        "| Variant | PASS | xfail | skip | FAIL | False Positive | ERROR | total | text | data | bss | size | Δsize |"
+    )
+    out.append("|:---|" + "---:|" * 12)
+    baseline_size = None
+    if variant_names:
+        first_size = (sizes.get(variant_names[0]) or {}).get("total")
+        baseline_size = first_size
+    for v in variant_names:
+        c = file_summary[v]
+        s = sizes.get(v) or {}
+        total_size = s.get("total")
+        if total_size is None or baseline_size is None:
+            delta = "-"
+        elif v == variant_names[0]:
+            delta = "ref"
+        else:
+            d = total_size - baseline_size
+            delta = ("{:+,}".format(d)).replace(",", "_")
+        out.append(
+            "| %s | %d | %d | %d | %d | %d | %d | %d | %s | %s | %s | %s | %s |"
+            % (
+                v,
+                c["ok"],
+                c["xfail"],
+                c["skip"],
+                c["FAIL"],
+                c["false_positive"],
+                c["ERROR"],
+                c["total"],
+                _fmt_kb(s.get("text")),
+                _fmt_kb(s.get("data")),
+                _fmt_kb(s.get("bss")),
+                _fmt_kb(s.get("total")),
+                delta,
+            )
+        )
+    out.append("")
+
+    out.append(
+        "\n"
+        "Legend:\n"
+        " - **ok**=passed, **xfail**=expected failure, **skip**=test skipped\n"
+        " - **FAIL**=test failed, **False Positive**=unexpected success\n"
+        " - **ERROR**=test errored (also used when the test module crashed).\n"
+        " - Firmware sizes are reported in bytes from `size <binary>`.\n"
+    )
+
+    for f in unittest_files:
+        rows = [(k, v) for k, v in table.items() if k[0] == f]
+        if not rows:
+            continue
+        rendered_rows = []
+        for (_f, cls, name), per in rows:
+            cells = [per.get(v, "skip") for v in variant_names]
+            if should_hide_row(cells, hide_statuses):
+                hidden_rows += 1
+                continue
+            rendered_rows.append((cls, name, cells))
+        if not rendered_rows:
+            continue
+        out.append("## " + f)
+        hdr_lines = headers.get(f) or []
+        if hdr_lines:
+            for hl in hdr_lines:
+                out.append("    " + hl)
+            out.append("")
+        header = "| Class | Test | " + " | ".join(variant_names) + " |"
+        sep = "|" + "---|" * (2 + len(variant_names))
+        out.append(header)
+        out.append(sep)
+        for cls, name, cells in rendered_rows:
+            out.append("| %s | %s | %s |" % (cls, name, " | ".join(cells)))
+        out.append("")
+
+    grouped = {}
+    for f in traditional_files:
+        folder = os.path.dirname(f).replace("\\", "/")
+        if not folder:
+            folder = "."
+        grouped.setdefault(folder, []).append(f)
+
+    for folder in sorted(grouped):
+        files = sorted(grouped[folder])
+        if folder in (".", "./"):
+            folder_label = "tests"
+        else:
+            folder_label = f"tests/{folder}"
+        rendered_rows = []
+        for f in files:
+            key = (f, "traditional", "result")
+            per = table.get(key)
+            if not per:
+                continue
+            cells = [per.get(v, "skip") for v in variant_names]
+            if should_hide_row(cells, hide_statuses):
+                hidden_rows += 1
+                continue
+            rendered_rows.append((os.path.basename(f), cells))
+        if not rendered_rows:
+            continue
+        out.append("## Folder: " + folder_label)
+        header = "| Test | " + " | ".join(variant_names) + " |"
+        sep = "|" + "---|" * (1 + len(variant_names))
+        out.append(header)
+        out.append(sep)
+        for test_name, cells in rendered_rows:
+            out.append("| %s | %s |" % (test_name, " | ".join(cells)))
+        out.append("")
+    if metadata:
+        out[6] = f" - Rows hidden: {hidden_rows}\n"
+
+    return "\n".join(out)
+
+
+def bold_failures(text):
+    return re.sub(r"\b(FAIL|ERROR|false_positive)\b", r"**\1**", text)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--variant",
+        action="append",
+        required=True,
+        help="name=path to a micropython binary (may be repeated)",
+    )
+    ap.add_argument(
+        "--keep-path",
+        action="append",
+        default=[],
+        help="variant name for which to keep MICROPYPATH (do not override it)",
+    )
+    ap.add_argument(
+        "--mode",
+        choices=("auto", "unittest", "traditional"),
+        default="auto",
+        help="test processing mode (default: auto)",
+    )
+    ap.add_argument("--hide-ok", action="store_true", help="hide rows where all variants are ok")
+    ap.add_argument(
+        "--hide-skip", action="store_true", help="hide rows where all variants are skip"
+    )
+    ap.add_argument(
+        "--hide-xfail", action="store_true", help="hide rows where all variants are xfail"
+    )
+    ap.add_argument("--out", default="-", help="markdown output file (default: stdout)")
+    ap.add_argument(
+        "paths",
+        nargs="*",
+        default=["typing", "typing/pep"],
+        help="test files or directories (relative to tests/)",
+    )
+    args = ap.parse_args()
+
+    variants = OrderedDict()
+    for spec in args.variant:
+        if "=" not in spec:
+            ap.error("--variant must be name=path")
+        name, _, path = spec.partition("=")
+        if not os.path.isabs(path):
+            path = os.path.abspath(os.path.join(REPO_ROOT, path))
+        variants[name] = path
+
+    # Build a set of variant names for which to keep the path
+    keep_path_variants = set(args.keep_path)
+
+    unittest_paths, traditional_paths = split_paths_by_mode(args.paths, args.mode)
+
+    if args.mode == "auto":
+        # Always include both suites in auto mode.
+        for default_path in ("typing_runtime", "typing", "typing/pep"):
+            full = os.path.join(TESTS_DIR, default_path)
+            if os.path.isdir(full) or (os.path.isfile(full) and full.endswith(".py")):
+                unittest_paths.append(default_path)
+        basics_dir = os.path.join(TESTS_DIR, "basics")
+        if os.path.isdir(basics_dir):
+            traditional_paths.append("basics")
+
+    unittest_paths = list(
+        OrderedDict((normalize_input_path(p), None) for p in unittest_paths).keys()
+    )
+    traditional_paths = list(
+        OrderedDict((normalize_input_path(p), None) for p in traditional_paths).keys()
+    )
+
+    unittest_files = collect_test_files(unittest_paths)
+    traditional_files = collect_test_files(traditional_paths)
+
+    table = OrderedDict()  # (file, cls, name) -> {variant: tag}
+    file_status = {}  # (file, variant) -> "ran" | "skip" | "crash"
+    file_summary = {
+        v: dict.fromkeys(("ok", "xfail", "false_positive", "skip", "FAIL", "ERROR", "total"), 0)
+        for v in variants
+    }
+    sizes = {v: get_binary_size(p) for v, p in variants.items()}
+
+    for f in unittest_files:
+        for vname, vbin in variants.items():
+            keep_path = vname in keep_path_variants
+            text, rc = run_variant(vbin, f, keep_path=keep_path)
+            if is_whole_file_skip(text):
+                file_status[(f, vname)] = "skip"
+                continue
+            if rc != 0:
+                file_status[(f, vname)] = "crash"
+            else:
+                file_status[(f, vname)] = "ran"
+            cases = parse_unittest_output(text)
+            for cls, name, tag in cases:
+                if cls.startswith("__main__."):
+                    cls = cls.replace("__main__.", "")
+                key = (f, cls, name)
+                if key not in table:
+                    table[key] = {}
+                # Count using the original tag before bolding
+                if tag in file_summary[vname]:
+                    file_summary[vname][tag] += 1
+                file_summary[vname]["total"] += 1
+                # Apply bold formatting for display
+                tag = bold_failures(tag)
+                table[key][vname] = tag
+
+    # Second pass: testcases that some variants ran but others did not are
+    # counted as `skip` (whole-file SKIP) or `ERROR` (variant crashed) so
+    # per-variant totals match the global row count.
+    for key, per in table.items():
+        f = key[0]
+        for vname in variants:
+            if vname in per:
+                continue
+            status = file_status.get((f, vname), "skip")
+            tag = "ERROR" if status == "crash" else "skip"
+            per[vname] = bold_failures(tag)
+            file_summary[vname][tag] += 1
+            file_summary[vname]["total"] += 1
+
+    for vname, vbin in variants.items():
+        if not traditional_paths:
+            break
+        keep_path = vname in keep_path_variants
+        result_dir = os.path.join(TESTS_DIR, "results", "make_report_" + sanitize_name(vname))
+        os.makedirs(result_dir, exist_ok=True)
+        _text, rc, status_map = run_traditional_variant(
+            vbin,
+            traditional_files,
+            result_dir=result_dir,
+            keep_path=keep_path,
+        )
+
+        for f in traditional_files:
+            tag = status_map.get(f)
+            if tag is None:
+                tag = "ERROR" if rc != 0 else "skip"
+            key = (f, "traditional", "result")
+            if key not in table:
+                table[key] = {}
+            table[key][vname] = bold_failures(tag)
+            if tag in file_summary[vname]:
+                file_summary[vname][tag] += 1
+            file_summary[vname]["total"] += 1
+
+    headers = {f: read_header_comments(os.path.join(TESTS_DIR, f)) for f in unittest_files}
+
+    # Gather metadata
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    main_branch, main_commit = get_git_info(REPO_ROOT)
+    lib_path = os.path.join(REPO_ROOT, "lib", "micropython-lib")
+    lib_branch, lib_commit = get_git_info(lib_path) if os.path.isdir(lib_path) else (None, None)
+
+    metadata = {
+        "timestamp": timestamp,
+        "main_branch": main_branch or "unknown",
+        "main_commit": main_commit or "unknown",
+        "lib_branch": lib_branch,
+        "lib_commit": lib_commit,
+        "cmdline_paths": args.paths,
+        "hide_options": [],
+    }
+
+    hide_statuses = set()
+    if args.hide_ok:
+        hide_statuses.add("ok")
+        metadata["hide_options"].append("--hide-ok")
+    if args.hide_skip:
+        hide_statuses.add("skip")
+        metadata["hide_options"].append("--hide-skip")
+    if args.hide_xfail:
+        hide_statuses.add("xfail")
+        metadata["hide_options"].append("--hide-xfail")
+
+    md = render_markdown(
+        list(variants),
+        unittest_files,
+        traditional_files,
+        table,
+        file_summary,
+        sizes,
+        headers,
+        metadata,
+        hide_statuses=hide_statuses,
+    )
+    if args.out == "-":
+        print(md)
+    else:
+        with open(args.out, "w") as fh:
+            fh.write(md)
+        print("Wrote %s (%d rows)" % (args.out, len(table)), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/make_report.py
+++ b/tools/make_report.py
@@ -4,6 +4,7 @@ comparison report.
 
 Usage (run from anywhere):
     tools/make_report.py --variant name=/path/to/micropython [--variant ...] \
+                         [--board name=/dev/ttyACM0 [--board ...]] \
                          [--keep-path name] [--keep-path ...] \
                          [--out report.md] [paths ...]
 
@@ -16,6 +17,13 @@ Each variant gets a column. Cell values use short tags:
     skip covers both runtime `skipTest()` calls and testcases whose whole
     file SKIP'd (or crashed); the file's tests are still
     listed if another variant ran them.
+
+`--board name=PORT` adds a column that runs the tests on a bare-metal target
+(e.g. `--board RPI_PICO2=/dev/ttyACM0`). Unittest-style tests are run on the
+board individually via `mpremote` and reported per testcase (directly
+comparable to variant columns); traditional tests under `basics` are run via
+`tests/run-tests.py -t PORT` and reported at file-level granularity. The test's
+required modules must already be present on the board's filesystem.
 
 `--keep-path` can be specified for individual variants by name. If specified
 for a variant, MICROPYPATH will not be overridden when running tests for
@@ -258,7 +266,14 @@ def is_whole_file_skip(text, max_lines=5):
 
 
 def run_variant(binary, test_file, keep_path=False):
-    """Run one test file under one variant. Return (stdout, returncode)."""
+    """Run one test file under one variant. Return (stdout, returncode).
+
+    Unless `keep_path` is set, MICROPYPATH is overridden with the essential
+    paths only (deliberately excluding any typing/stub libs in the caller's
+    environment) so a plain variant acts as a true baseline. Use `keep_path`
+    for variants that should keep the environment's MICROPYPATH (e.g. a
+    "mip-installed" baseline).
+    """
     env = os.environ.copy()
     if not keep_path:
         env["MICROPYPATH"] = os.pathsep.join(
@@ -284,29 +299,58 @@ def run_variant(binary, test_file, keep_path=False):
         return "BINARY NOT FOUND: %s" % binary, -1
 
 
-def run_traditional_variant(binary, files, result_dir, keep_path=False):
-    """Run traditional tests via run-tests.py.
+def run_variant_on_board(port, test_file, timeout=300):
+    """Run one unittest file on a bare-metal board via `mpremote`.
+
+    Returns (stdout, returncode), mirroring `run_variant` so the same
+    unittest-output parsing applies. The test's required modules must already
+    be present on the board's filesystem.
+    """
+    cmd = ["mpremote", "connect", port, "run", test_file]
+    try:
+        proc = subprocess.run(
+            cmd,
+            cwd=TESTS_DIR,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+        )
+        return proc.stdout.decode("utf-8", "replace"), proc.returncode
+    except subprocess.TimeoutExpired:
+        return "TIMEOUT", -1
+    except FileNotFoundError:
+        return "mpremote NOT FOUND", -1
+
+
+def run_traditional_variant(binary, files, result_dir, keep_path=False, device=None):
+    """Run tests via run-tests.py and return per-file results.
+
+    When `device` is given, tests run on a bare-metal target via the
+    run-tests.py `-t` option (and `binary` is ignored). Otherwise tests run
+    on the local `binary` via the MICROPY_MICROPYTHON environment variable.
 
     Return (stdout_text, returncode, status_map) where status_map maps
     'dir/name.py' -> short result tag.
     """
     env = os.environ.copy()
-    env["MICROPY_MICROPYTHON"] = binary
     cmd = [sys.executable, "run-tests.py", "-r", result_dir, "-j", "1"]
+    if device is not None:
+        cmd.extend(["-t", device])
+    else:
+        env["MICROPY_MICROPYTHON"] = binary
     if keep_path:
         cmd.append("--keep-path")
     cmd.extend(normalize_input_path(p) for p in files)
 
     try:
+        # Stream run-tests.py output directly to the terminal so the user sees
+        # progress (board runs over serial can be slow).
         proc = subprocess.run(
             cmd,
             cwd=TESTS_DIR,
             env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
             timeout=1800,
         )
-        text = proc.stdout.decode("utf-8", "replace")
     except subprocess.TimeoutExpired:
         return "TIMEOUT", -1, {}
     except FileNotFoundError:
@@ -332,7 +376,7 @@ def run_traditional_variant(binary, files, result_dir, keep_path=False):
         # Return empty map; caller decides whether to mark tests as skip or ERROR.
         pass
 
-    return text, proc.returncode, status_map
+    return "", proc.returncode, status_map
 
 
 def sanitize_name(name):
@@ -540,13 +584,106 @@ def bold_failures(text):
     return re.sub(r"\b(FAIL|ERROR|false_positive)\b", r"**\1**", text)
 
 
+def run_unittest_files(runners, unittest_files, keep_path_names, table, file_status, file_summary):
+    """Run each unittest file under every runner and record per-testcase rows.
+
+    `runners` is a list of (name, kind, target) where kind is "variant"
+    (target is a local binary path) or "board" (target is a serial port run
+    via mpremote). Both produce the same unittest output, parsed identically.
+    """
+    for f in unittest_files:
+        for rname, kind, target in runners:
+            keep_path = rname in keep_path_names
+            if kind == "board":
+                print("  [%s] %s ..." % (rname, f), file=sys.stderr)
+                text, rc = run_variant_on_board(target, f)
+            else:
+                text, rc = run_variant(target, f, keep_path=keep_path)
+            if is_whole_file_skip(text):
+                file_status[(f, rname)] = "skip"
+                continue
+            file_status[(f, rname)] = "crash" if rc != 0 else "ran"
+            for cls, name, tag in parse_unittest_output(text):
+                if cls.startswith("__main__."):
+                    cls = cls.replace("__main__.", "")
+                key = (f, cls, name)
+                table.setdefault(key, {})
+                if tag in file_summary[rname]:
+                    file_summary[rname][tag] += 1
+                file_summary[rname]["total"] += 1
+                table[key][rname] = bold_failures(tag)
+
+
+def fill_missing_cells(columns, table, file_status, file_summary):
+    """Fill cells for columns that did not produce a row for a testcase.
+
+    A missing cell is counted as `skip` (whole-file SKIP) or `ERROR` (the
+    column crashed running that file) so per-column totals match row counts.
+    """
+    for key, per in table.items():
+        f = key[0]
+        for cname in columns:
+            if cname in per:
+                continue
+            status = file_status.get((f, cname), "skip")
+            tag = "ERROR" if status == "crash" else "skip"
+            per[cname] = bold_failures(tag)
+            file_summary[cname][tag] += 1
+            file_summary[cname]["total"] += 1
+
+
+def run_traditional_files(runners, traditional_files, keep_path_names, table, file_summary):
+    """Run traditional (non-unittest) tests via run-tests.py for every runner.
+
+    These are reported at file-level granularity in a single rollup row per
+    file. Boards run on-target via `run-tests.py -t PORT`.
+    """
+    if not traditional_files:
+        return
+    for rname, kind, target in runners:
+        keep_path = rname in keep_path_names
+        result_dir = os.path.join(TESTS_DIR, "results", "make_report_" + sanitize_name(rname))
+        os.makedirs(result_dir, exist_ok=True)
+        print(
+            "\n=== Running %d traditional test(s) for %s %r ==="
+            % (len(traditional_files), kind, rname),
+            file=sys.stderr,
+        )
+        device = target if kind == "board" else None
+        binary = None if kind == "board" else target
+        _text, rc, status_map = run_traditional_variant(
+            binary,
+            traditional_files,
+            result_dir=result_dir,
+            keep_path=keep_path,
+            device=device,
+        )
+        for f in traditional_files:
+            tag = status_map.get(f)
+            if tag is None:
+                tag = "ERROR" if rc != 0 else "skip"
+            key = (f, "traditional", "result")
+            table.setdefault(key, {})
+            table[key][rname] = bold_failures(tag)
+            if tag in file_summary[rname]:
+                file_summary[rname][tag] += 1
+            file_summary[rname]["total"] += 1
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument(
         "--variant",
         action="append",
-        required=True,
+        default=[],
         help="name=path to a micropython binary (may be repeated)",
+    )
+    ap.add_argument(
+        "--board",
+        action="append",
+        default=[],
+        help="name=serialport for a bare-metal target run via run-tests.py -t "
+        "(e.g. RPI_PICO2=/dev/ttyACM0; may be repeated)",
     )
     ap.add_argument(
         "--keep-path",
@@ -571,10 +708,14 @@ def main():
     ap.add_argument(
         "paths",
         nargs="*",
-        default=["typing", "typing/pep"],
-        help="test files or directories (relative to tests/)",
+        default=[],
+        help="test files or directories (relative to tests/). If omitted, a "
+        "default suite (typing_runtime, typing, typing/pep, basics) is used.",
     )
     args = ap.parse_args()
+
+    if not args.variant and not args.board:
+        ap.error("at least one --variant or --board is required")
 
     variants = OrderedDict()
     for spec in args.variant:
@@ -585,20 +726,30 @@ def main():
             path = os.path.abspath(os.path.join(REPO_ROOT, path))
         variants[name] = path
 
+    boards = OrderedDict()
+    for spec in args.board:
+        if "=" not in spec:
+            ap.error("--board must be name=serialport")
+        name, _, port = spec.partition("=")
+        if name in variants:
+            ap.error("--board name %r collides with a --variant name" % name)
+        boards[name] = port
+
+    # Columns are all variants followed by all boards.
+    columns = list(variants) + list(boards)
+
     # Build a set of variant names for which to keep the path
     keep_path_variants = set(args.keep_path)
 
-    unittest_paths, traditional_paths = split_paths_by_mode(args.paths, args.mode)
-
-    if args.mode == "auto":
-        # Always include both suites in auto mode.
-        for default_path in ("typing_runtime", "typing", "typing/pep"):
+    # Only fall back to the full default suite when the user gave no paths.
+    user_paths = list(args.paths)
+    if not user_paths:
+        for default_path in ("typing_runtime", "typing", "typing/pep", "basics"):
             full = os.path.join(TESTS_DIR, default_path)
             if os.path.isdir(full) or (os.path.isfile(full) and full.endswith(".py")):
-                unittest_paths.append(default_path)
-        basics_dir = os.path.join(TESTS_DIR, "basics")
-        if os.path.isdir(basics_dir):
-            traditional_paths.append("basics")
+                user_paths.append(default_path)
+
+    unittest_paths, traditional_paths = split_paths_by_mode(user_paths, args.mode)
 
     unittest_paths = list(
         OrderedDict((normalize_input_path(p), None) for p in unittest_paths).keys()
@@ -614,74 +765,20 @@ def main():
     file_status = {}  # (file, variant) -> "ran" | "skip" | "crash"
     file_summary = {
         v: dict.fromkeys(("ok", "xfail", "false_positive", "skip", "FAIL", "ERROR", "total"), 0)
-        for v in variants
+        for v in columns
     }
     sizes = {v: get_binary_size(p) for v, p in variants.items()}
 
-    for f in unittest_files:
-        for vname, vbin in variants.items():
-            keep_path = vname in keep_path_variants
-            text, rc = run_variant(vbin, f, keep_path=keep_path)
-            if is_whole_file_skip(text):
-                file_status[(f, vname)] = "skip"
-                continue
-            if rc != 0:
-                file_status[(f, vname)] = "crash"
-            else:
-                file_status[(f, vname)] = "ran"
-            cases = parse_unittest_output(text)
-            for cls, name, tag in cases:
-                if cls.startswith("__main__."):
-                    cls = cls.replace("__main__.", "")
-                key = (f, cls, name)
-                if key not in table:
-                    table[key] = {}
-                # Count using the original tag before bolding
-                if tag in file_summary[vname]:
-                    file_summary[vname][tag] += 1
-                file_summary[vname]["total"] += 1
-                # Apply bold formatting for display
-                tag = bold_failures(tag)
-                table[key][vname] = tag
+    # Runners: local variants first, then bare-metal boards. Both produce
+    # per-testcase unittest rows so their columns are directly comparable.
+    runners = [(n, "variant", p) for n, p in variants.items()]
+    runners += [(n, "board", p) for n, p in boards.items()]
 
-    # Second pass: testcases that some variants ran but others did not are
-    # counted as `skip` (whole-file SKIP) or `ERROR` (variant crashed) so
-    # per-variant totals match the global row count.
-    for key, per in table.items():
-        f = key[0]
-        for vname in variants:
-            if vname in per:
-                continue
-            status = file_status.get((f, vname), "skip")
-            tag = "ERROR" if status == "crash" else "skip"
-            per[vname] = bold_failures(tag)
-            file_summary[vname][tag] += 1
-            file_summary[vname]["total"] += 1
-
-    for vname, vbin in variants.items():
-        if not traditional_paths:
-            break
-        keep_path = vname in keep_path_variants
-        result_dir = os.path.join(TESTS_DIR, "results", "make_report_" + sanitize_name(vname))
-        os.makedirs(result_dir, exist_ok=True)
-        _text, rc, status_map = run_traditional_variant(
-            vbin,
-            traditional_files,
-            result_dir=result_dir,
-            keep_path=keep_path,
-        )
-
-        for f in traditional_files:
-            tag = status_map.get(f)
-            if tag is None:
-                tag = "ERROR" if rc != 0 else "skip"
-            key = (f, "traditional", "result")
-            if key not in table:
-                table[key] = {}
-            table[key][vname] = bold_failures(tag)
-            if tag in file_summary[vname]:
-                file_summary[vname][tag] += 1
-            file_summary[vname]["total"] += 1
+    run_unittest_files(
+        runners, unittest_files, keep_path_variants, table, file_status, file_summary
+    )
+    fill_missing_cells(columns, table, file_status, file_summary)
+    run_traditional_files(runners, traditional_files, keep_path_variants, table, file_summary)
 
     headers = {f: read_header_comments(os.path.join(TESTS_DIR, f)) for f in unittest_files}
 
@@ -713,7 +810,7 @@ def main():
         metadata["hide_options"].append("--hide-xfail")
 
     md = render_markdown(
-        list(variants),
+        columns,
         unittest_files,
         traditional_files,
         table,

--- a/tools/make_report.py
+++ b/tools/make_report.py
@@ -265,17 +265,15 @@ def is_whole_file_skip(text, max_lines=5):
     return False
 
 
-def run_variant(binary, test_file, keep_path=False):
-    """Run one test file under one variant. Return (stdout, returncode).
-
-    Unless `keep_path` is set, MICROPYPATH is overridden with the essential
-    paths only (deliberately excluding any typing/stub libs in the caller's
-    environment) so a plain variant acts as a true baseline. Use `keep_path`
-    for variants that should keep the environment's MICROPYPATH (e.g. a
-    "mip-installed" baseline).
-    """
+def get_env(keep_path):
     env = os.environ.copy()
-    if not keep_path:
+    if keep_path:
+        if not env.get("MICROPYPATH"):
+            raise RuntimeError(
+                "--keep-path specified but MICROPYPATH is not set in the environment; test may fail due to missing modules"
+            )
+    else:
+        # Build MICROPYPATH for the test to use.
         env["MICROPYPATH"] = os.pathsep.join(
             (
                 ".frozen",
@@ -283,6 +281,12 @@ def run_variant(binary, test_file, keep_path=False):
                 os.path.join(REPO_ROOT, "lib", "micropython-lib", "python-stdlib", "unittest"),
             )
         )
+    return env
+
+
+def run_variant(binary, test_file, keep_path=False):
+    """Run one test file under one variant. Return (stdout, returncode)."""
+    env = get_env(keep_path)
     try:
         proc = subprocess.run(
             [binary, test_file],
@@ -332,7 +336,7 @@ def run_traditional_variant(binary, files, result_dir, keep_path=False, device=N
     Return (stdout_text, returncode, status_map) where status_map maps
     'dir/name.py' -> short result tag.
     """
-    env = os.environ.copy()
+    env = get_env(keep_path)
     cmd = [sys.executable, "run-tests.py", "-r", result_dir, "-j", "1"]
     if device is not None:
         cmd.extend(["-t", device])
@@ -451,18 +455,16 @@ def render_markdown(
         cmdline_paths = metadata.get("cmdline_paths") or []
         hide_opts = metadata.get("hide_options") or []
         out.append(
-            " - Specified test(s): "
-            + (", ".join(cmdline_paths) if cmdline_paths else "(default)")
-            + "\n"
+            " - Specified test(s): " + (", ".join(cmdline_paths) if cmdline_paths else "(default)")
         )
-        out.append(f"   - micropython: {metadata['main_branch']} ({metadata['main_commit']})\n")
+        out.append(f"   - micropython: {metadata['main_branch']} ({metadata['main_commit']})")
         if metadata.get("lib_branch") and metadata.get("lib_commit"):
             out.append(
-                f"   - micropython-lib: {metadata['lib_branch']} ({metadata['lib_commit']})\n"
+                f"   - micropython-lib: {metadata['lib_branch']} ({metadata['lib_commit']})"
             )
-        out.append(f" - Generated: {metadata['timestamp']}\n")
-        out.append(" - Hide options: " + (", ".join(hide_opts) if hide_opts else "none") + "\n")
-        out.append(f" - Rows hidden: {hidden_rows}\n")
+        out.append(f" - Generated: {metadata['timestamp']}")
+        out.append(" - Hide options: " + (", ".join(hide_opts) if hide_opts else "none") + "")
+        # out.append(f" - Rows hidden: {hidden_rows}")
         out.append("")
 
     out.append(
@@ -574,7 +576,7 @@ def render_markdown(
         for test_name, cells in rendered_rows:
             out.append("| %s | %s |" % (test_name, " | ".join(cells)))
         out.append("")
-    if metadata:
+    if metadata and hidden_rows > 0:
         out[6] = f" - Rows hidden: {hidden_rows}\n"
 
     return "\n".join(out)
@@ -584,7 +586,9 @@ def bold_failures(text):
     return re.sub(r"\b(FAIL|ERROR|false_positive)\b", r"**\1**", text)
 
 
-def run_unittest_files(runners, unittest_files, keep_path_names, table, file_status, file_summary):
+def run_unittest_files(
+    runners, unittest_files, keep_path_names: list[str], table, file_status, file_summary
+):
     """Run each unittest file under every runner and record per-testcase rows.
 
     `runners` is a list of (name, kind, target) where kind is "variant"

--- a/tools/manifestfile.py
+++ b/tools/manifestfile.py
@@ -305,6 +305,9 @@ class ManifestFile:
             for dirpath, _, filenames in os.walk(package_path or ".", followlinks=True):
                 for file in filenames:
                     file = os.path.relpath(os.path.join(dirpath, file), ".")
+                    # Skip manifest.py files
+                    if os.path.basename(file) == "manifest.py":
+                        continue
                     _, ext = os.path.splitext(file)
                     if ext.lower() in exts:
                         self._add_file(


### PR DESCRIPTION
### Summary

This is a companion Draft-PR to https://github.com/micropython/micropython-lib/pull/1051

The goal is to Introduce typing modules to MicroPython, to enabling support for various static typing features. 
This PR manly consists of test for both supported an unsupported typing functionalities

It also includes:

- Changes to `tests/run-tests.py` to support `unittest@0.11.0`
- a new reporting tool `tools/make-report.py`
- Addition of the `typing` modules to the `unix-coverage` variant.
- several minor fixes.
- Several **temporary** variants to aid in measurement and testing:
   - **temporary** `unix-typing_XX` variants to help gauge the size impact of freezing typing modules 
   - **temporary** `PYBV11-typing_XX` variants to help gauge the size impact of freezing typing modules 

I expect that this PR may be split and changed

### Testing
The main part of this PR are tests , and test tools.

Tests were added to verify the runtime behavior of type annotations across various features. These tests were executed on the Unix port, and against multiple raw-iron boards.

### Trade-offs and Alternatives

Inclusion of typing modules may increase code size, but it significantly enhances the functionality and usability of MicroPython for type hinting and static analysis.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked and corrected the
code and is responsible for the code and the description above.


