### PR TITLE
py/makeqstrdefs.py: Gzip the qstr.i.last generated output.

### DIFF
--- a/ports/stm32/boards/plli2svalues.py
+++ b/ports/stm32/boards/plli2svalues.py
@@ -4,6 +4,7 @@ processors supporting an I2S PLL in the clock tree.
 Those processors are listed below in the mcu_support_plli2s[] list.
 """
 
+import gzip
 import re
 from collections import namedtuple
 
@@ -129,7 +130,7 @@ def generate_c_table(plli2s_table, hse, pllm):
 def search_header(filename, re_define, lookup):
     regex_define = re.compile(re_define)
     val = None
-    with open(filename) as f:
+    with gzip.open(filename, "rt") as f:
         for line in f:
             line = line.strip()
             m = regex_define.match(line)

--- a/ports/stm32/boards/pllvalues.py
+++ b/ports/stm32/boards/pllvalues.py
@@ -4,6 +4,7 @@ the CPU frequency to a given value.  The algorithm here appears as C code
 for the machine.freq() function.
 """
 
+import gzip
 import re
 
 
@@ -231,7 +232,7 @@ def search_header_for_hsx_values(filename):
     regex_def = re.compile(
         r"static.* +(micropy_hw_hs[ei]_value) = +([0-9 +-/\*()]+);",
     )
-    with open(filename) as f:
+    with gzip.open(filename, "rt") as f:
         for line in f:
             line = line.strip()
             m = regex_def.match(line)

--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -5,7 +5,7 @@ qstr. Each qstr is transformed into a qstr definition of the form 'Q(...)'.
 This script works with Python 3.3+.
 """
 
-import io
+import gzip
 import os
 import re
 import subprocess
@@ -71,7 +71,7 @@ def preprocess():
     except NotImplementedError:
         cpus = 1
     p = multiprocessing.dummy.Pool(cpus)
-    with open(args.output[0], "wb") as out_file:
+    with gzip.open(args.output[0], "wb", compresslevel=1) as out_file:
         for flags, sources in (
             (args.cflags, csources),
             (args.cxxflags, cxxsources),
@@ -230,7 +230,7 @@ if __name__ == "__main__":
         pass
 
     if args.command == "split":
-        with io.open(args.input_filename, encoding="utf-8") as infile:
+        with gzip.open(args.input_filename, "rt", encoding="utf-8") as infile:
             process_file(infile)
 
     if args.command == "cat":


### PR DESCRIPTION
### Summary

Generated `qstr.i.last` files can be very, very large due to inclusion of large HAL headers.  The data is very repetitive text so compressing it can significantly reduce the size of the file, and hence reduce the size of the build directory and decrease wear of the filesystem.

With a clean build from scratch, using gzip level 1 changes the build output by the following amounts:
- stm32 PYBV10: 130M -> 48M (`qstr.i.last` reduced by 82M)
- rp2 RPI_PICO: 85M -> 47M (`qstr.i.last` reduced by 38M)
- esp32 ESP32_GENERIC: 304M -> 244M (`qstr.i.last` reduced by 60M)

This can amount to significant savings when building all boards for a port, eg saving up to 6GB building all stm32 boards.

It saves less on a rebuild because `qstr.i.last` only contains preprocessor output from files that changed since the previous build.

Built time is increased slightly due to the compression: about 0.5-1 second slower (out of a total 30s build time, which includes 4s generating `qstr.i.last`) for stm32 PYBV10, which is around 3% slower.

Using `compresslevel=9` saves about 2M more but almost doubles the time taken to generate `qstr.i.last` (going from 4s up to 8s or more).  So using `compresslevel=1` is the best trade off here.

### Testing

Tested building the above ports and measured output size.

CI will test the rest.

### Trade-offs and Alternatives

Costs a small amount of time to compress/decompress, but using level 1 keeps this time down to a minimum.

The `qstr.i.last` data is no longer readable in an editor, without first decompressing it (which is pretty easy to do if you ever need to view this data).

### Generative AI

Not used.