### PR TITLE
py: clean up use of `mp_verbose_flag`

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -49,7 +49,6 @@ static asm_rv32_backend_options_t rv32_options = { 0 };
 
 // Command line options, with their defaults
 static uint emit_opt = MP_EMIT_OPT_NONE;
-mp_uint_t mp_verbose_flag = 0;
 
 #if MICROPY_ENABLE_SOURCE_LINE
 static bool include_source_lines = true;
@@ -340,7 +339,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                     "; mpy-cross emitting mpy v" MP_STRINGIFY(MPY_VERSION) "." MP_STRINGIFY(MPY_SUB_VERSION) "\n");
                 return 0;
             } else if (strcmp(argv[a], "-v") == 0) {
-                mp_verbose_flag++;
+                // This verbose option doesn't currently do anything.
             } else if (strncmp(argv[a], "-O", 2) == 0) {
                 if (unichar_isdigit(argv[a][2])) {
                     MP_STATE_VM(mp_optimise_value) = argv[a][2] & 0xf;
@@ -481,12 +480,6 @@ MP_NOINLINE int main_(int argc, char **argv) {
     }
 
     int ret = compile_and_save(input_file, output_file, source_file);
-
-    #if MICROPY_PY_MICROPYTHON_MEM_INFO
-    if (mp_verbose_flag) {
-        mp_micropython_mem_info(0, NULL);
-    }
-    #endif
 
     mp_deinit();
 

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -142,7 +142,7 @@ static int execute_from_lexer(int source_kind, const void *source, mp_parse_inpu
 
         #if defined(MICROPY_UNIX_COVERAGE)
         // allow to print the parse tree in the coverage build
-        if (mp_verbose_flag >= 3) {
+        if (MP_STATE_VM(mp_verbose_flag) >= 3) {
             printf("----------------\n");
             mp_parse_node_print(&mp_plat_print, parse_tree.root, 0);
             printf("----------------\n");
@@ -661,7 +661,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
                 a += 1;
             #if MICROPY_DEBUG_PRINTERS
             } else if (strcmp(argv[a], "-v") == 0) {
-                mp_verbose_flag++;
+                MP_STATE_VM(mp_verbose_flag)++;
             #endif
             } else if (strncmp(argv[a], "-O", 2) == 0) {
                 if (unichar_isdigit(argv[a][2])) {
@@ -720,7 +720,7 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #endif
 
     #if MICROPY_PY_MICROPYTHON_MEM_INFO
-    if (mp_verbose_flag) {
+    if (MP_STATE_VM(mp_verbose_flag)) {
         mp_micropython_mem_info(0, NULL);
     }
     #endif

--- a/py/compile.c
+++ b/py/compile.c
@@ -3654,7 +3654,7 @@ emit_finished:
 
         #if MICROPY_DEBUG_PRINTERS
         // now that the module context is valid, the raw codes can be printed
-        if (mp_verbose_flag >= 2) {
+        if (MP_STATE_VM(mp_verbose_flag) >= 2) {
             for (scope_t *s = comp->scope_head; s != NULL; s = s->next) {
                 mp_raw_code_t *rc = s->raw_code;
                 if (rc->kind == MP_CODE_BYTECODE) {

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -48,10 +48,6 @@
 #define DEBUG_OP_printf(...) (void)0
 #endif
 
-#if MICROPY_DEBUG_PRINTERS
-mp_uint_t mp_verbose_flag = 0;
-#endif
-
 mp_raw_code_t *mp_emit_glue_new_raw_code(void) {
     mp_raw_code_t *rc = m_new0(mp_raw_code_t, 1);
     rc->kind = MP_CODE_RESERVED;

--- a/py/misc.h
+++ b/py/misc.h
@@ -262,8 +262,6 @@ void vstr_vprintf(vstr_t *vstr, const char *fmt, va_list ap);
 
 int DEBUG_printf(const char *fmt, ...);
 
-extern mp_uint_t mp_verbose_flag;
-
 /** float internals *************/
 
 #if MICROPY_PY_BUILTINS_FLOAT

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -234,6 +234,9 @@ typedef struct _mp_state_vm_t {
     #if MICROPY_EMIT_NATIVE
     uint8_t default_emit_opt; // one of MP_EMIT_OPT_xxx
     #endif
+    #if MICROPY_DEBUG_PRINTERS
+    mp_uint_t mp_verbose_flag;
+    #endif
     #endif
 
     // size of the emergency exception buf, if it's dynamically allocated

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -105,6 +105,9 @@ void mp_init(void) {
     #if MICROPY_EMIT_NATIVE
     MP_STATE_VM(default_emit_opt) = MP_EMIT_OPT_NONE;
     #endif
+    #if MICROPY_DEBUG_PRINTERS
+    MP_STATE_VM(mp_verbose_flag) = 0;
+    #endif
     #endif
 
     // init global module dict

--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -111,7 +111,7 @@ static int parse_compile_execute(const void *source, mp_parse_input_kind_t input
             mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
             #if defined(MICROPY_UNIX_COVERAGE)
             // allow to print the parse tree in the coverage build
-            if (mp_verbose_flag >= 3) {
+            if (MP_STATE_VM(mp_verbose_flag) >= 3) {
                 printf("----------------\n");
                 mp_parse_node_print(&mp_plat_print, parse_tree.root, 0);
                 printf("----------------\n");


### PR DESCRIPTION
### Summary

Remove unused mp_verbose_flag from mpy-cross.  This variable does nothing in mpy-cross because:
- `MICROPY_DEBUG_PRINTERS` is not enabled, so the relevant code in `py/compile.c` that uses `mp_verbose_flag` is unused.
- Even if `MICROPY_DEBUG_PRINTERS` was enabled, nothing happens because mpy-cross has `MP_PLAT_PRINT_STRN` defined to do nothing.
- `MICROPY_PY_MICROPYTHON_MEM_INFO` is not enabled.

So remove it.  But keep the `-v` CLI option to not break existing uses of mpy-cross, and keep it compatible with the CLI options of the unix port.  There is therefore no functional change.

And move mp_verbose_flag to MP_STATE_VM struct.  This stray global variable doesn't really belong in `py/emitglue.c` because it's currently only used by `py/compile.c`.  So move it to the state context struct alongside the related compiler settings.

### Testing

- tested that `mpy-cross` still accepts `-v` but does nothing
- tested 0 through 4 `-v` arguments to unix standard and coverage builds and checked the behaviour was still the same

### Generative AI

Not used.