### PR TITLE
py/makeqstrdefs.py: Filter out unneeded lines from qstr.i.last early on.

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -57,10 +57,30 @@ def preprocess():
     except OSError:
         pass
 
+    # These regex's are used to filter the preprocessed data, keeping only those lines
+    # that are subsequently needed by the `process_file` step.  The regexs are kept
+    # short so they are as efficient as possible. (The stm32 port needs symbols of the
+    # form `micropy_hw_xxx` so they are also kept.)
+    re_line_file = re.compile(rb"^#(?:line)?\s+\d+\s\"")
+    re_mp_info = re.compile(rb"MP_COMP|MP_QSTR|MP_REGI|micropy_hw")
+
     def pp(flags):
         def run(files):
             try:
-                return subprocess.check_output(args.pp + flags + files)
+                filtered_lines = []
+                with subprocess.Popen(args.pp + flags + files, stdout=subprocess.PIPE) as proc:
+                    recent_file = None
+                    for line in proc.stdout:
+                        if line.isspace():
+                            pass
+                        elif re_line_file.match(line):
+                            recent_file = line
+                        elif re_mp_info.search(line):
+                            if recent_file:
+                                filtered_lines.append(recent_file)
+                                recent_file = None
+                            filtered_lines.append(line)
+                return b"".join(filtered_lines)
             except subprocess.CalledProcessError as er:
                 raise PreprocessorError(str(er))
 


### PR DESCRIPTION
### Summary

Generated `qstr.i.last` files (output from the "pp" phase) can be very large due to inclusion of large HAL headers.  Yet only a small amount of this data is actually needed by the "split" phase of `makeqstrdefs.py`.

This commit improves the situation by filtering out unneeded lines as early as possible: in the "pp" phase the C preprocessor runs, its output is parsed via a pipe connection, and only those lines that are needed are written out to the `qstr.i.last` file.  When the "split" phase runs it then sees only the necessary lines (it does further regex filtering to get exactly the lines it needs for the given mode).

Windows already does this filtering (it does not use `makeqstrdefs.py` for the preprocessor phase) in its `ConcatPreProcFiles` function, and that was added long ago in 29c8c8aecb3409e57a43256f8fe5cb25de1e9856.

This change significantly reduces the output build size and improves the build speed:

- stm32 BOARD=PYBV10: build output goes from 152M down to 32M, and build is 10% faster (29s down to 26s).  Building all stm32 boards, the total build size goes from about 11GB down to about 2.5GB.

- rp2 BOARD=RPI_PICO: build output goes from 87M down to 39M, and build is about 5% faster (23s down to 21.6s).

- esp32 BOARD=ESP32_GENERIC: build output goes from 307M down to 230M, and build is about 6% faster (101s down to 95s).

### Testing

Tested all three ports above, that the files in build/genhdr are equivalent (except of course `qstr.i.last`), and that PYBV10 is binary equivalent before and after this change.

### Trade-offs and Alternatives

Tried using gzip in #19312, but the approach here is far better.

Now need to keep the regex's in sync, between the "pp" and "split" phases.

### Generative AI

Not used.