### PR TITLE
tests: Fix test runs with `MICROPY_ERROR_REPORTING_NONE`.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -67,14 +67,26 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
-  standard_terse:
+  standard_error_terse:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
     - name: Build
-      run: tools/ci.sh unix_standard_terse_build
+      run: tools/ci.sh unix_standard_error_terse_build
     - name: Run main test suite
-      run: tools/ci.sh unix_standard_terse_run_tests
+      run: tools/ci.sh unix_standard_error_terse_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
+  standard_error_none:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Build
+      run: tools/ci.sh unix_standard_error_none_build
+    - name: Run main test suite
+      run: tools/ci.sh unix_standard_error_none_run_tests
     - name: Print failures
       if: failure()
       run: tests/run-tests.py --print-failures

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -204,6 +204,7 @@ typedef enum {
     VTYPE_BUILTIN_CAST = 0x70 | MP_NATIVE_TYPE_OBJ,
 } vtype_kind_t;
 
+#if MICROPY_ERROR_REPORTING != MICROPY_ERROR_REPORTING_NONE
 static qstr vtype_to_qstr(vtype_kind_t vtype) {
     switch (vtype) {
         case VTYPE_PYOBJ:
@@ -227,6 +228,7 @@ static qstr vtype_to_qstr(vtype_kind_t vtype) {
             return MP_QSTR_None;
     }
 }
+#endif
 
 typedef struct _stack_info_t {
     vtype_kind_t vtype;

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -320,7 +320,11 @@ const mp_fun_table_t mp_fun_table = {
     gc_realloc,
     mp_printf,
     mp_vprintf,
+    #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_NONE
+    NULL,
+    #else
     mp_raise_msg,
+    #endif
     mp_obj_get_type,
     mp_obj_new_str,
     mp_obj_new_bytes,

--- a/tests/basics/deque_micropython.py
+++ b/tests/basics/deque_micropython.py
@@ -45,12 +45,12 @@ print(d.popleft(), d.popleft())
 try:
     d.popleft()
 except IndexError as e:
-    print(repr(e))
+    print(str(e) or 'empty', len(d))
 
 try:
     d.pop()
 except IndexError as e:
-    print(repr(e))
+    print(str(e) or 'empty', len(d))
 
 d.append(5)
 d.append(6)
@@ -58,12 +58,12 @@ print(len(d))
 try:
     d.append(7)
 except IndexError as e:
-    print(repr(e))
+    print(str(e) or 'full', len(d))
 
 try:
     d.appendleft(8)
 except IndexError as e:
-    print(repr(e))
+    print(str(e) or 'full', len(d))
 
 print(len(d))
 
@@ -72,4 +72,4 @@ print(len(d))
 try:
     d.popleft()
 except IndexError as e:
-    print(repr(e))
+    print(str(e) or 'empty', len(d))

--- a/tests/basics/deque_micropython.py.exp
+++ b/tests/basics/deque_micropython.py.exp
@@ -6,12 +6,12 @@ None
 1
 2
 3 4
-IndexError('empty',)
-IndexError('empty',)
+empty 0
+empty 0
 2
-IndexError('full',)
-IndexError('full',)
+full 2
+full 2
 2
 5 6
 0
-IndexError('empty',)
+empty 0

--- a/tests/basics/generator_pend_throw.py
+++ b/tests/basics/generator_pend_throw.py
@@ -46,7 +46,7 @@ g = gen_next()
 try:
     next(g)
 except Exception as e:
-    print("raised", repr(e))
+    print("raised {} {}".format(type(e), str(e) or "generator already executing"))
 
 
 # Verify that you can't pend_throw from within the running coroutine.
@@ -59,7 +59,7 @@ g = gen_pend_throw()
 try:
     next(g)
 except Exception as e:
-    print("raised", repr(e))
+    print("raised {} {}".format(type(e), str(e) or "generator already executing"))
 
 
 # Verify that the pend_throw exception can be ignored.

--- a/tests/basics/generator_pend_throw.py.exp
+++ b/tests/basics/generator_pend_throw.py.exp
@@ -3,8 +3,8 @@
 raised ValueError()
 ret was: None
 raised OSError()
-raised ValueError('generator already executing',)
-raised ValueError('generator already executing',)
+raised <class 'ValueError'> generator already executing
+raised <class 'ValueError'> generator already executing
 0
 ignore CancelledError
 1

--- a/tests/basics/int_64_basics.py
+++ b/tests/basics/int_64_basics.py
@@ -145,12 +145,12 @@ if r is not None:
 try:
     print((1 << 48) >> -4)
 except ValueError as e:
-    print(e)
+    print(str(e) or "negative shift count")
 
 try:
     print((1 << 48) << -6)
 except ValueError as e:
-    print(e)
+    print(str(e) or "negative shift count")
 
 # Test that the most extreme 64 bit integer values all parse with int()
 print(int("-9223372036854775807"))

--- a/tests/basics/subclass_native_exc_new.py
+++ b/tests/basics/subclass_native_exc_new.py
@@ -26,7 +26,7 @@ try:
     raise BadException("bad message")
 except Exception as bad:
     # Should be TypeError 'exceptions must derive from BaseException'
-    print(type(bad), bad.args[0])
+    print(type(bad), bad.args or ("exceptions must derive from BaseException",))
 
 try:
     def gen():
@@ -35,4 +35,4 @@ try:
     gen().throw(BadException)
 except Exception as genbad:
     # Should be TypeError 'exceptions must derive from BaseException'
-    print(type(genbad), genbad.args[0])
+    print(type(genbad), genbad.args or ("exceptions must derive from BaseException",))

--- a/tests/basics/subclass_native_exc_new.py.exp
+++ b/tests/basics/subclass_native_exc_new.py.exp
@@ -1,6 +1,6 @@
 GoodException __new__
 <class 'Dummy'> good message
 BadException __new__
-<class 'TypeError'> exceptions must derive from BaseException
+<class 'TypeError'> ('exceptions must derive from BaseException',)
 BadException __new__
-<class 'TypeError'> exceptions must derive from BaseException
+<class 'TypeError'> ('exceptions must derive from BaseException',)

--- a/tests/extmod/asyncio_cancel_self.py
+++ b/tests/extmod/asyncio_cancel_self.py
@@ -25,4 +25,4 @@ async def main():
 try:
     asyncio.run(main())
 except RuntimeError as er:
-    print(er)
+    print(str(er) or "can't cancel self")

--- a/tests/extmod/cryptolib_aes128_ctr.py
+++ b/tests/extmod/cryptolib_aes128_ctr.py
@@ -13,7 +13,7 @@ try:
     _new(b"x" * 16, b"x" * 16)
 except ValueError as e:
     # is CTR support disabled?
-    if e.args[0] == "mode":
+    if len(e.args) == 0 or e.args[0] == "mode":
         print("SKIP")
         raise SystemExit
     raise e

--- a/tests/extmod/ssl_cadata.py
+++ b/tests/extmod/ssl_cadata.py
@@ -15,4 +15,4 @@ except AttributeError:
     print("SKIP")
     raise SystemExit
 except ValueError as er:
-    print(repr(er))
+    print(str(er) or "invalid cert")

--- a/tests/extmod/ssl_cadata.py.exp
+++ b/tests/extmod/ssl_cadata.py.exp
@@ -1,1 +1,1 @@
-ValueError('invalid cert',)
+invalid cert

--- a/tests/extmod/ssl_keycert.py
+++ b/tests/extmod/ssl_keycert.py
@@ -13,7 +13,7 @@ key = b"0\x82\x019\x02\x01\x00\x02A\x00\xf9\xe0}\xbd\xd7\x9cI\x18\x06\xc3\xcb\xb
 try:
     ssl.wrap_socket(io.BytesIO(), key=b"!")
 except ValueError as er:
-    print(repr(er))
+    print(str(er) or "invalid key")
 
 # Valid key, no cert
 try:
@@ -26,4 +26,4 @@ except TypeError as er:
 try:
     ssl.wrap_socket(io.BytesIO(), key=key, cert=b"!")
 except ValueError as er:
-    print(repr(er))
+    print(str(er) or "invalid cert")

--- a/tests/extmod/ssl_keycert.py.exp
+++ b/tests/extmod/ssl_keycert.py.exp
@@ -1,3 +1,3 @@
-ValueError('invalid key',)
+invalid key
 TypeError
-ValueError('invalid cert',)
+invalid cert

--- a/tests/extmod/ssl_keycert_pkcs8.py
+++ b/tests/extmod/ssl_keycert_pkcs8.py
@@ -21,4 +21,4 @@ keypkcs8 = b'0\x82\x01U\x02\x01\x000\r\x06\t*\x86H\x86\xf7\r\x01\x01\x01\x05\x00
 try:
     ssl.wrap_socket(io.BytesIO(), key=keypkcs8, cert=b"!")
 except ValueError as er:
-    print(repr(er))
+    print(str(er) or "invalid cert")

--- a/tests/extmod/ssl_keycert_pkcs8.py.exp
+++ b/tests/extmod/ssl_keycert_pkcs8.py.exp
@@ -1,1 +1,1 @@
-ValueError('invalid cert',)
+invalid cert

--- a/tests/feature_check/target_info.py
+++ b/tests/feature_check/target_info.py
@@ -40,6 +40,6 @@ except NameError:
 try:
     (lambda: 0)(0)
 except TypeError as er:
-    error_reporting = {0: "none", 27: "terse", 54: "normal", 56: "detailed"}[len(er.value)]
+    error_reporting = {0: "none", 27: "terse", 54: "normal", 56: "detailed"}[len(er.value or "")]
 
 print(platform, arch, arch_flags, build, thread, float_prec, len("α") == 1, error_reporting)

--- a/tests/float/math_fun.py
+++ b/tests/float/math_fun.py
@@ -43,7 +43,7 @@ for function_name, function, test_vals in functions:
             ans = "{:.5g}".format(function(value))
         except ValueError as e:
             ans = str(e)
-            if ans.startswith("expected a "):
+            if ans.startswith("expected a ") or ans == "":
                 # CPython 3.14 changed messages to be more detailed; convert them back to simple ones
                 ans = "math domain error"
         print("{}({:.5g}) = {}".format(function_name, value, ans))

--- a/tests/float/math_fun_special.py
+++ b/tests/float/math_fun_special.py
@@ -51,7 +51,7 @@ for function_name, function, test_vals in functions:
             ans = "{:.4g}".format(function(value))
         except ValueError as e:
             ans = str(e)
-            if ans.startswith("expected a "):
+            if ans.startswith("expected a ") or ans == "":
                 # CPython 3.14 changed messages to be more detailed; convert them back to simple ones
                 ans = "math domain error"
         # a tiny error in REPR_C value for 1.5204998778 causes a wrong rounded value

--- a/tests/micropython/import_mpy_invalid.py
+++ b/tests/micropython/import_mpy_invalid.py
@@ -63,7 +63,7 @@ for i in range(len(user_files)):
     try:
         __import__(mod)
     except ValueError as er:
-        print(mod, "ValueError", er)
+        print(mod, "ValueError", str(er) or "incompatible .mpy file")
 
 # unmount and undo path addition
 vfs.umount("/userfs")

--- a/tests/micropython/import_mpy_native.py
+++ b/tests/micropython/import_mpy_native.py
@@ -122,7 +122,7 @@ for i in range(len(user_files)):
         __import__(mod)
         print(mod, "OK")
     except ValueError as er:
-        print(mod, "ValueError", er)
+        print(mod, "ValueError", str(er) or "incompatible .mpy arch")
 
 # unmount and undo path addition
 vfs.umount("/userfs")

--- a/tests/micropython/viper_error.py
+++ b/tests/micropython/viper_error.py
@@ -1,19 +1,19 @@
 # test syntax and type errors specific to viper code generation
 
 
-def test(code):
+def test(code, msg):
     try:
         exec(code)
     except (SyntaxError, ViperTypeError, NotImplementedError) as e:
-        print(repr(e))
+        print(type(e), str(e) or msg)
 
 
 # viper: annotations must be identifiers
-test("@micropython.viper\ndef f(a:1): pass")
-test("@micropython.viper\ndef f() -> 1: pass")
+test("@micropython.viper\ndef f(a:1): pass", "annotation must be an identifier")
+test("@micropython.viper\ndef f() -> 1: pass", "annotation must be an identifier")
 
 # unknown type
-test("@micropython.viper\ndef f(x:unknown_type): pass")
+test("@micropython.viper\ndef f(x:unknown_type): pass", "unknown type 'unknown_type'")
 
 # local used before type known
 test(
@@ -22,7 +22,8 @@ test(
 def f():
     print(x)
     x = 1
-"""
+""",
+    "local 'x' used before type known",
 )
 
 # type mismatch storing to local
@@ -33,7 +34,8 @@ def f():
     x = 1
     y = []
     x = y
-"""
+""",
+    "local 'x' has type 'int' but source is 'object'",
 )
 
 # can't implicitly convert type to bool
@@ -44,51 +46,52 @@ def f():
     x = ptr(0)
     if x:
         pass
-"""
+""",
+    "can't implicitly convert 'ptr' to 'bool'",
 )
 
 # incorrect return type
-test("@micropython.viper\ndef f() -> int: return []")
+test("@micropython.viper\ndef f() -> int: return []", "return expected 'int' but got 'object'")
 
 # can't do unary op of incompatible type
-test("@micropython.viper\ndef f(x:ptr): -x")
+test("@micropython.viper\ndef f(x:ptr): -x", "can't do unary op of 'ptr'")
 
 # can't do binary op between incompatible types
-test("@micropython.viper\ndef f(): 1 + []")
-test("@micropython.viper\ndef f(x:int, y:uint): x < y")
+test("@micropython.viper\ndef f(): 1 + []", "can't do binary op between 'int' and 'object'")
+test("@micropython.viper\ndef f(x:int, y:uint): x < y", "comparison of int and uint")
 
 # can't load
-test("@micropython.viper\ndef f(): 1[0]")
-test("@micropython.viper\ndef f(): 1[x]")
+test("@micropython.viper\ndef f(): 1[0]", "can't load from 'int'")
+test("@micropython.viper\ndef f(): 1[x]", "can't load from 'int'")
 
 # can't store
-test("@micropython.viper\ndef f(): 1[0] = 1")
-test("@micropython.viper\ndef f(): 1[x] = 1")
-test("@micropython.viper\ndef f(x:int): x[0] = x")
-test("@micropython.viper\ndef f(x:ptr32): x[0] = None")
-test("@micropython.viper\ndef f(x:ptr32): x[x] = None")
+test("@micropython.viper\ndef f(): 1[0] = 1", "can't store to 'int'")
+test("@micropython.viper\ndef f(): 1[x] = 1", "can't store to 'int'")
+test("@micropython.viper\ndef f(x:int): x[0] = x", "can't store to 'int'")
+test("@micropython.viper\ndef f(x:ptr32): x[0] = None", "can't store 'None'")
+test("@micropython.viper\ndef f(x:ptr32): x[x] = None", "can't store 'None'")
 
 # must raise an object
-test("@micropython.viper\ndef f(): raise 1")
+test("@micropython.viper\ndef f(): raise 1", "must raise an object")
 
 # unary ops not implemented
-test("@micropython.viper\ndef f(x:int): not x")
+test("@micropython.viper\ndef f(x:int): not x", "'not' not implemented")
 
 # binary op not implemented
-test("@micropython.viper\ndef f(x:uint, y:uint): res = x // y")
-test("@micropython.viper\ndef f(x:uint, y:uint): res = x % y")
-test("@micropython.viper\ndef f(x:int): res = x in x")
+test("@micropython.viper\ndef f(x:uint, y:uint): res = x // y", "div/mod not implemented for uint")
+test("@micropython.viper\ndef f(x:uint, y:uint): res = x % y", "div/mod not implemented for uint")
+test("@micropython.viper\ndef f(x:int): res = x in x", "binary op  not implemented")
 
 # raise with 0 or 2 args not implemented
-test("@micropython.viper\ndef f():\n try:\n  x\n except:\n  raise\n")
-test("@micropython.viper\ndef f(): raise Exception from Exception")
+test("@micropython.viper\ndef f():\n try:\n  x\n except:\n  raise\n", "native raise")
+test("@micropython.viper\ndef f(): raise Exception from Exception", "native raise")
 
 # yield (from) not implemented
-test("@micropython.viper\ndef f(): yield")
-test("@micropython.viper\ndef f(): yield from f")
+test("@micropython.viper\ndef f(): yield", "native yield")
+test("@micropython.viper\ndef f(): yield from f", "native yield")
 
 # passing a ptr to a Python function not implemented
-test("@micropython.viper\ndef f(): print(ptr(1))")
+test("@micropython.viper\ndef f(): print(ptr(1))", "conversion to object")
 
 # cast of a casting identifier not implemented
-test("@micropython.viper\ndef f(): int(int)")
+test("@micropython.viper\ndef f(): int(int)", "casting")

--- a/tests/micropython/viper_error.py.exp
+++ b/tests/micropython/viper_error.py.exp
@@ -1,28 +1,28 @@
-SyntaxError('annotation must be an identifier',)
-SyntaxError('annotation must be an identifier',)
-ViperTypeError("unknown type 'unknown_type'",)
-ViperTypeError("local 'x' used before type known",)
-ViperTypeError("local 'x' has type 'int' but source is 'object'",)
-ViperTypeError("can't implicitly convert 'ptr' to 'bool'",)
-ViperTypeError("return expected 'int' but got 'object'",)
-ViperTypeError("can't do unary op of 'ptr'",)
-ViperTypeError("can't do binary op between 'int' and 'object'",)
-ViperTypeError('comparison of int and uint',)
-ViperTypeError("can't load from 'int'",)
-ViperTypeError("can't load from 'int'",)
-ViperTypeError("can't store to 'int'",)
-ViperTypeError("can't store to 'int'",)
-ViperTypeError("can't store to 'int'",)
-ViperTypeError("can't store 'None'",)
-ViperTypeError("can't store 'None'",)
-ViperTypeError('must raise an object',)
-ViperTypeError("'not' not implemented",)
-ViperTypeError('div/mod not implemented for uint',)
-ViperTypeError('div/mod not implemented for uint',)
-ViperTypeError('binary op  not implemented',)
-NotImplementedError('native raise',)
-NotImplementedError('native raise',)
-NotImplementedError('native yield',)
-NotImplementedError('native yield',)
-NotImplementedError('conversion to object',)
-NotImplementedError('casting',)
+<class 'SyntaxError'> annotation must be an identifier
+<class 'SyntaxError'> annotation must be an identifier
+<class 'ViperTypeError'> unknown type 'unknown_type'
+<class 'ViperTypeError'> local 'x' used before type known
+<class 'ViperTypeError'> local 'x' has type 'int' but source is 'object'
+<class 'ViperTypeError'> can't implicitly convert 'ptr' to 'bool'
+<class 'ViperTypeError'> return expected 'int' but got 'object'
+<class 'ViperTypeError'> can't do unary op of 'ptr'
+<class 'ViperTypeError'> can't do binary op between 'int' and 'object'
+<class 'ViperTypeError'> comparison of int and uint
+<class 'ViperTypeError'> can't load from 'int'
+<class 'ViperTypeError'> can't load from 'int'
+<class 'ViperTypeError'> can't store to 'int'
+<class 'ViperTypeError'> can't store to 'int'
+<class 'ViperTypeError'> can't store to 'int'
+<class 'ViperTypeError'> can't store 'None'
+<class 'ViperTypeError'> can't store 'None'
+<class 'ViperTypeError'> must raise an object
+<class 'ViperTypeError'> 'not' not implemented
+<class 'ViperTypeError'> div/mod not implemented for uint
+<class 'ViperTypeError'> div/mod not implemented for uint
+<class 'ViperTypeError'> binary op  not implemented
+<class 'NotImplementedError'> native raise
+<class 'NotImplementedError'> native raise
+<class 'NotImplementedError'> native yield
+<class 'NotImplementedError'> native yield
+<class 'NotImplementedError'> conversion to object
+<class 'NotImplementedError'> casting

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -197,8 +197,8 @@ platform_tests_to_skip = {
 
 # Tests to skip when MICROPY_ERROR_REPORTING is at a certain level.
 error_reporting_tests_to_skip = {
-    # Skip at level MICROPY_ERROR_REPORTING_NONE.
-    "none": (
+    # Skip at level MICROPY_ERROR_REPORTING_TERSE.
+    "terse": (
         "cmdline/repl_paste.py",
         # This test needs updates before being removed from this list.
         "extmod/vfs_blockdev_invalid.py",
@@ -209,8 +209,10 @@ error_reporting_tests_to_skip = {
         "misc/sys_settrace_features.py",
     ),
 }
-# Skip at level MICROPY_ERROR_REPORTING_TERSE.
-error_reporting_tests_to_skip["terse"] = error_reporting_tests_to_skip["none"]
+# Skip at level MICROPY_ERROR_REPORTING_NONE.
+error_reporting_tests_to_skip["none"] = error_reporting_tests_to_skip["terse"] + (
+    "extmod/asyncio_gather_notimpl.py",
+)
 
 # Tests with known intermittent failures. These tests still run, but failures
 # are reclassified as "ignored" instead of "fail" so they don't affect the CI

--- a/tests/stress/bytecode_limit.py
+++ b/tests/stress/bytecode_limit.py
@@ -23,7 +23,7 @@ for n in number_of_body_copies:
         print("SKIP")
         raise SystemExit
     except RuntimeError as er:
-        results.append(repr(er))
+        results.append("RuntimeError('{}')".format(str(er) or "bytecode overflow"))
 print(results)
 
 # Test changing size of code info (source line/bytecode mapping) due to changing

--- a/tests/stress/bytecode_limit.py.exp
+++ b/tests/stress/bytecode_limit.py.exp
@@ -1,4 +1,4 @@
 cond false
 cond false
-["RuntimeError('bytecode overflow',)", "RuntimeError('bytecode overflow',)", 'ok', 'ok']
+["RuntimeError('bytecode overflow')", "RuntimeError('bytecode overflow')", 'ok', 'ok']
 [123]

--- a/tests/stress/qstr_limit.py
+++ b/tests/stress/qstr_limit.py
@@ -13,7 +13,7 @@ for l in range(254, 259):
     try:
         exec(var + "=1", g)
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
         continue
     print(var in g)
 
@@ -27,7 +27,7 @@ for l in range(254, 259):
     try:
         exec("f({}=1)".format(make_id(l)))
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
 
 # type construction
 for l in range(254, 259):
@@ -35,7 +35,7 @@ for l in range(254, 259):
     try:
         print(type(id, (), {}))
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
 
 
 # hasattr, setattr, getattr
@@ -49,11 +49,11 @@ for l in range(254, 259):
     try:
         setattr(a, id, 123)
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
     try:
         print(hasattr(a, id), getattr(a, id))
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
 
 # format with keys
 for l in range(254, 259):
@@ -61,7 +61,7 @@ for l in range(254, 259):
     try:
         print(("{" + id + "}").format(**{id: l}))
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
 
 # import module
 # (different OS's have different results so only run those that are consistent)
@@ -71,7 +71,7 @@ for l in (100, 101, 256, 257, 258):
     except ImportError:
         print("ok", l)
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)
 
 # import package
 for l in (100, 101, 102, 128, 129):
@@ -80,4 +80,4 @@ for l in (100, 101, 102, 128, 129):
     except ImportError:
         print("ok", l)
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print(str(er) or "name too long", l)

--- a/tests/stress/qstr_limit.py.exp
+++ b/tests/stress/qstr_limit.py.exp
@@ -1,38 +1,38 @@
 True
 True
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 258
+name too long 256
+name too long 257
+name too long 258
 {'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst': 1}
 {'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu': 1}
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 258
+name too long 256
+name too long 257
+name too long 258
 <class 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst'>
 <class 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstu'>
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 258
+name too long 256
+name too long 257
+name too long 258
 True 123
 True 123
-RuntimeError name too long 256
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 257
-RuntimeError name too long 258
-RuntimeError name too long 258
+name too long 256
+name too long 256
+name too long 257
+name too long 257
+name too long 258
+name too long 258
 254
 255
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 258
+name too long 256
+name too long 257
+name too long 258
 ok 100
 ok 101
-RuntimeError name too long 256
-RuntimeError name too long 257
-RuntimeError name too long 258
+name too long 256
+name too long 257
+name too long 258
 ok 100
 ok 101
 ok 102
-RuntimeError name too long 128
-RuntimeError name too long 129
+name too long 128
+name too long 129

--- a/tests/stress/qstr_limit_str_modulo.py
+++ b/tests/stress/qstr_limit_str_modulo.py
@@ -18,4 +18,4 @@ for l in range(254, 259):
     try:
         print(("%(" + id + ")d") % {id: l})
     except RuntimeError as er:
-        print("RuntimeError", er, l)
+        print("RuntimeError", str(er) or "name too long", l)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -721,11 +721,19 @@ function ci_unix_standard_v2_run_tests {
     ci_unix_run_tests_full_helper standard
 }
 
-function ci_unix_standard_terse_build {
+function ci_unix_standard_error_terse_build {
     ci_unix_build_helper VARIANT=standard CFLAGS_EXTRA="-DMICROPY_ERROR_REPORTING=MICROPY_ERROR_REPORTING_TERSE"
 }
 
-function ci_unix_standard_terse_run_tests {
+function ci_unix_standard_error_terse_run_tests {
+    make -C ports/unix VARIANT=standard test
+}
+
+function ci_unix_standard_error_none_build {
+    ci_unix_build_helper VARIANT=standard CFLAGS_EXTRA="-DMICROPY_ERROR_REPORTING=MICROPY_ERROR_REPORTING_NONE" MICROPY_ROM_TEXT_COMPRESSION=0
+}
+
+function ci_unix_standard_error_none_run_tests {
     make -C ports/unix VARIANT=standard test
 }
 


### PR DESCRIPTION
### Summary

This PR contains fixes for MicroPython core and tests to make the Unix port pass tests when built with no error detail being generated in case of exceptions (ie. `MICROPY_ERROR_REPORTING_NONE`).

This PR depends on #19324 being merged first, otherwise things won't build when the support commits are removed.

### Testing

There's a temporary CI job used to keep track of which tests still fail, and will be taken out once things work.  Unless there's the need for an extra job running the test suite with this configuration, that is.

### Generative AI

I did not use generative AI tools when creating this PR.
