### PR TITLE
esp32: Use ESP-IDF abstraction for CPU cycle count (fix ESP32-C5).

### DIFF
--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -37,6 +37,7 @@
 
 #include "driver/spi_master.h"
 #include "esp_cache.h"
+#include "esp_cpu.h"
 #include "soc/gpio_reg.h"
 
 #define MICROPY_PLATFORM_VERSION "IDF" IDF_VER
@@ -90,13 +91,7 @@ static inline void mp_end_atomic_section(mp_uint_t state) {
 
 mp_uint_t mp_hal_ticks_us(void);
 __attribute__((always_inline)) static inline mp_uint_t mp_hal_ticks_cpu(void) {
-    uint32_t ccount;
-    #if CONFIG_IDF_TARGET_ARCH_RISCV
-    __asm__ __volatile__ ("csrr %0, 0x7E2" : "=r" (ccount)); // Machine Performance Counter Value
-    #else
-    __asm__ __volatile__ ("rsr %0,ccount" : "=a" (ccount));
-    #endif
-    return (mp_uint_t)ccount;
+    return esp_cpu_get_cycle_count();
 }
 
 void mp_hal_delay_us(mp_uint_t);


### PR DESCRIPTION
### Summary

Fixes the crash running `tests/extmod/time_res.py` and `tests/extmod/time_ms_us.py` reported by @Josverl at https://github.com/micropython/micropython/pull/19303#issuecomment-4620867188

Root cause:

- ESP32-C3 & C6 use a RISCV vendor custom performance counter register for cycle counting.

- ESP32-C5 uses the standard RISCV mcycle register. Trying to read the (non-existent) vendor register causes a fault.

- ESP32-P4 is documented to also use the standard mcycle register and not support the custom register, but for some reason the tests don't fault or fail on this CPU...

Rather than adding more inline assembly, this PR delegates to ESP-IDF's abstraction layer which will inline the correct implementation here.

*This work was funded through GitHub Sponsors.*

### Testing

* Ran the full test suite on my ESP32_GENERIC_C5 board (pass, including the time tests).
* Re-ran just the two time tests on C3, C6 and P4 and S3.

### Trade-offs and Alternatives

* For boards apart from ESP32-C5 and possibly ESP32-P4 this should compile to exactly the same binary code, as the ESP-IDF function expands inline to the correct assembly code.
* Generally better to use these kind of Espressif hardware abstractions where available (probably this abstraction wasn't available at the time the first implementations were written).

### Generative AI

I did not use generative AI tools when creating this PR.