### PR TITLE
tests/run-tests.py: Add --trace-output option for board targets.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -1215,6 +1215,9 @@ the last matching regex is used:
 """,
     )
     cmd_parser.add_argument(
+        "-c", "--trace-output", action="store_true", help="trace test output while running"
+    )
+    cmd_parser.add_argument(
         "-t", "--test-instance", default="unix", help="the MicroPython instance to test"
     )
     cmd_parser.add_argument(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -271,24 +271,52 @@ def run_script_on_remote_target(pyb, args, test_file, is_special, requires_targe
     if had_crash:
         return True, script
 
+    # See if the output should be traced (printed to stdout), but not for feature_check tests.
+    trace_output = args.trace_output and "feature_check" not in test_file
+    if trace_output:
+        print(f"TRACE: {test_file}")
+
+    # Function to collect output data as the test is run.
+    output_mupy = bytearray()
+
+    def data_consumer(data):
+        if data == b"\x04":
+            # End of stream.
+            return
+        if trace_output:
+            # Print out the data as it's received.
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+        output_mupy.extend(data)
+
     try:
         pyb.enter_raw_repl(timeout_overall=TEST_ENTER_RAW_REPL_TIMEOUT)
+
+        # Inject target wiring if needed by the test.
         if requires_target_wiring and pyb.target_wiring_script:
             pyb.exec_(
                 "import sys;sys.modules['target_wiring']=__build_class__(lambda:exec("
                 + repr(pyb.target_wiring_script)
                 + "),'target_wiring')"
             )
-        output_mupy = pyb.exec_(script, timeout=TEST_TIMEOUT)
+
+        # Execute the test, and collect the output.
+        pyb.exec_(script, timeout=TEST_TIMEOUT, data_consumer=data_consumer)
     except pyboard.PyboardError as e:
         had_crash = True
         if not is_special and e.args[0] == "exception":
-            if prepend_start_test and e.args[1] == b"" and b"MemoryError" in e.args[2]:
+            no_output = len(output_mupy) == 0
+            data_consumer(e.args[1])
+            data_consumer(e.args[2])
+            if prepend_start_test and no_output and b"MemoryError" in e.args[2]:
                 output_mupy = b"SKIP-TOO-LARGE\n"
             else:
-                output_mupy = e.args[1] + e.args[2] + b"CRASH"
+                output_mupy += b"CRASH"
         else:
-            output_mupy = bytes(e.args[0], "ascii") + b"\nCRASH"
+            data_consumer(bytes(e.args[0], "ascii") + b"\n")
+            output_mupy += b"CRASH"
+
+    output_mupy = bytes(output_mupy)
 
     if prepend_start_test:
         if output_mupy.startswith(b"START TEST\r\n"):


### PR DESCRIPTION
### Summary

This adds a new `--trace-output` option (short-hand `-c`) to `run-tests.py` which mimics the same option already in `run-multitests.py`.  Using it, the output from the test running on a board is printed to stdout as it is received.

This allows easier debugging of tests, to see the output in real time.  For tests that have complicated run parameters, eg using via-mpy or needing a target wiring script, running them standalone (eg with `mpremote`) is not possible, so using `run-tests.py` becomes mandatory, hence the need to easily see the output without having to view the result file separately at the end.  It's also useful to watch tests that pass but are long running.

### Testing

Tested on PYBD_SF6:
- running normally, still works
- running with `-c`, gives lots of output and everything still passes as before
- deliberately making a test fail, the results file still has the full output, and the crash is also printed to stdout
- deliberately making a test lock up the board, the test runner correctly stops after a few tests have failed to enter the raw repl

### Generative AI

Not used.