### PR TITLE
tests: Rewrite with unittest the select/socket tests that use UDP.

### DIFF
--- a/tests/extmod/select_ipoll.py
+++ b/tests/extmod/select_ipoll.py
@@ -6,14 +6,9 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
-
-def print_poll_output(lst):
-    print([(type(obj), flags) for obj, flags in lst])
-
-
-poller = select.poll()
-
 # Use a new UDP socket for tests, which should be writable but not readable.
+# Some targets (eg PYBV10) have the socket module but are unable to create
+# UDP sockets without a registered NIC.
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(socket.getaddrinfo("127.0.0.1", 8000)[0][-1])
@@ -21,35 +16,51 @@ except OSError:
     print("SKIP")
     raise SystemExit
 
-poller.register(s)
+import unittest
 
-# Basic polling.
-print_poll_output(poller.ipoll(0))
 
-# Pass in flags=1 for one-shot behaviour.
-print_poll_output(poller.ipoll(0, 1))
+class Test(unittest.TestCase):
+    def test_ipoll_single_socket(self):
+        poller = select.poll()
 
-# Socket should be deregistered and poll should return nothing.
-print_poll_output(poller.ipoll(0))
+        # Register socket.
+        poller.register(s)
 
-# Create a second socket.
-s2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-s2.bind(socket.getaddrinfo("127.0.0.1", 8001)[0][-1])
+        # Basic polling.
+        self.assertEqual(list(poller.ipoll(0)), [(s, 4)])
 
-# Register both sockets (to reset the first one).
-poller.register(s)
-poller.register(s2)
+        # Pass in flags=1 for one-shot behaviour.
+        self.assertEqual(list(poller.ipoll(0, 1)), [(s, 4)])
 
-# Basic polling with two sockets.
-print_poll_output(poller.ipoll(0))
+        # Socket should be deregistered and poll should return nothing.
+        self.assertEqual(list(poller.ipoll(0)), [])
 
-# Unregister the first socket, to test polling the remaining one.
-poller.unregister(s)
-print_poll_output(poller.ipoll(0))
+    def test_ipoll_multiple_sockets(self):
+        # Create a second socket.
+        s2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s2.bind(socket.getaddrinfo("127.0.0.1", 8001)[0][-1])
 
-# Unregister the second socket, to test polling none.
-poller.unregister(s2)
-print_poll_output(poller.ipoll(0))
+        poller = select.poll()
 
-s2.close()
+        # Register both sockets.
+        poller.register(s)
+        poller.register(s2)
+
+        # Basic polling with two sockets.
+        self.assertEqual(list(poller.ipoll(0)), [(s2, 4), (s2, 4)])
+
+        # Unregister the first socket, to test polling the remaining one.
+        poller.unregister(s)
+        self.assertEqual(list(poller.ipoll(0)), [(s2, 4)])
+
+        # Unregister the second socket, to test polling none.
+        poller.unregister(s2)
+        self.assertEqual(list(poller.ipoll(0)), [])
+
+        s2.close()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
 s.close()

--- a/tests/extmod/select_ipoll.py.exp
+++ b/tests/extmod/select_ipoll.py.exp
@@ -1,6 +1,0 @@
-[(<class 'socket'>, 4)]
-[(<class 'socket'>, 4)]
-[]
-[(<class 'socket'>, 4), (<class 'socket'>, 4)]
-[(<class 'socket'>, 4)]
-[]

--- a/tests/extmod/select_poll_eintr.py
+++ b/tests/extmod/select_poll_eintr.py
@@ -1,5 +1,8 @@
 # Test interruption of select.poll by EINTR signal, when
 # MICROPY_PY_SELECT_POSIX_OPTIMISATIONS is enabled.
+#
+# Note: this test should run and pass under CPython, but it has a .py.exp file
+# so that port 8000 does not need to be available to get the expected output.
 
 try:
     import time, gc, select, socket, _thread

--- a/tests/extmod/select_poll_eintr.py.exp
+++ b/tests/extmod/select_poll_eintr.py.exp
@@ -1,0 +1,5 @@
+poll
+thread gc start
+thread gc end
+result: []
+dt in range

--- a/tests/extmod/select_poll_udp.py
+++ b/tests/extmod/select_poll_udp.py
@@ -2,12 +2,12 @@
 
 try:
     import socket, select
-
-    select.poll  # Raises AttributeError for CPython implementations without poll()
-except (ImportError, AttributeError):
+except ImportError:
     print("SKIP")
     raise SystemExit
 
+# Some targets (eg PYBV10) have the socket module but are unable to create
+# UDP sockets without a registered NIC.
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(socket.getaddrinfo("127.0.0.1", 8000)[0][-1])
@@ -15,19 +15,33 @@ except OSError:
     print("SKIP")
     raise SystemExit
 
-poll = select.poll()
+import unittest
 
-# UDP socket should not be readable
-poll.register(s, select.POLLIN)
-print(len(poll.poll(0)))
 
-# UDP socket should be writable
-poll.modify(s, select.POLLOUT)
-print(poll.poll(0)[0][1] == select.POLLOUT)
+class Test(unittest.TestCase):
+    def test_poll(self):
+        poll = select.poll()
 
-# same test for select.select, but just skip it if the function isn't available
-if hasattr(select, "select"):
-    r, w, e = select.select([s], [], [], 0)
-    assert not r and not w and not e
+        # UDP socket should not be readable.
+        poll.register(s, select.POLLIN)
+        res = poll.poll(0)
+        self.assertEqual(len(res), 0)
+
+        # UDP socket should be writable.
+        poll.modify(s, select.POLLOUT)
+        res = poll.poll(0)
+        self.assertEqual(res[0][1], select.POLLOUT)
+
+    @unittest.skipUnless(hasattr(select, "select"), "no select")
+    def test_select(self):
+        # UDP socket should only be writable.
+        r, w, e = select.select([s], [s], [s], 0)
+        self.assertEqual(r, [])
+        self.assertEqual(w, [s])
+        self.assertEqual(e, [])
+
+
+if __name__ == "__main__":
+    unittest.main()
 
 s.close()

--- a/tests/extmod/socket_udp_nonblock.py
+++ b/tests/extmod/socket_udp_nonblock.py
@@ -6,6 +6,8 @@ except ImportError:
     print("SKIP")
     raise SystemExit
 
+# Some targets (eg PYBV10) have the socket module but are unable to create
+# UDP sockets without a registered NIC.
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     s.bind(socket.getaddrinfo("127.0.0.1", 8000)[0][-1])
@@ -13,11 +15,19 @@ except OSError:
     print("SKIP")
     raise SystemExit
 
-s.settimeout(0)
+import unittest
 
-try:
-    s.recv(1)
-except OSError as er:
-    print("EAGAIN:", er.errno == errno.EAGAIN)
+
+class Test(unittest.TestCase):
+    def test_nonblocking(self):
+        s.settimeout(0)
+
+        with self.assertRaises(OSError) as ctx:
+            s.recv(1)
+        self.assertEqual(ctx.exception.errno, errno.EAGAIN)
+
+
+if __name__ == "__main__":
+    unittest.main()
 
 s.close()


### PR DESCRIPTION
### Summary

Three tests are rewritten using unittest, so that they don't need to be run under CPython to get the expected output.  Because running under CPython requires port 8000 to be available, which it may not (at least for tests in the extmod directory having a port available should not be a requirement).

And one test had a .py.exp file added, for the same reason (so CPython doesn't need to be run).

This was motivated by some failures in Octoprobe, where tests failed because CPython could not run the test to get the expected output, because port 8000 was in use (the tests otherwise run on target boards, not the host micropython).

### Testing

To be tested by CI, and Octoprobe.

### Trade-offs and Alternatives

This gives a bit of churn, but unittest is arguably a better choice for finicky tests like these, it makes it easy to understand what it's testing, and extend it in the future.

Running the tests on local micropython executables still requires port 8000 to be available, but that's a harder problem to solve, and isn't an issue with Octoprobe (which only tests hardware targets).

### Generative AI

Not used.