### PR TITLE
tests: some tweaks to run/skip on more targets

### DIFF
--- a/tests/extmod/vfs_blockdev_invalid.py
+++ b/tests/extmod/vfs_blockdev_invalid.py
@@ -53,6 +53,7 @@ except MemoryError:
 ERROR_EIO = (OSError, "[Errno 5] EIO")
 ERROR_EINVAL = (OSError, "[Errno 22] EINVAL")
 ERROR_TYPE = (TypeError, "can't convert str to int")
+ALL_ERROR_TYPES = (OSError, TypeError)
 
 
 def test(vfs_class, test_data):
@@ -71,7 +72,7 @@ def test(vfs_class, test_data):
         try:
             with fs.open("test", "r") as f:
                 assert error_open is None
-        except Exception as e:
+        except ALL_ERROR_TYPES as e:
             assert error_open is not None
             assert (type(e), str(e)) == error_open
 
@@ -84,7 +85,7 @@ def test(vfs_class, test_data):
                 assert f.read(1) == "a"
                 assert f.read() == "a" * 63
                 assert error_read is None
-        except Exception as e:
+        except ALL_ERROR_TYPES as e:
             assert error_read is not None
             assert (type(e), str(e)) == error_read
 
@@ -96,7 +97,7 @@ def test(vfs_class, test_data):
         try:
             vfs.mount(bdev, "/test_ram")
             assert error_mount is None
-        except Exception as e:
+        except ALL_ERROR_TYPES as e:
             assert error_mount is not None
             assert (type(e), str(e)) == error_mount
         finally:

--- a/tests/extmod_hardware/machine_sdcard_dma_align.py
+++ b/tests/extmod_hardware/machine_sdcard_dma_align.py
@@ -40,7 +40,7 @@ try:
     vfs.mount(sd, MOUNT_POINT)
     vfs.umount(MOUNT_POINT)
     del sd
-except (OSError, AttributeError):
+except (OSError, ValueError, AttributeError):
     print("SKIP")
     raise SystemExit
 


### PR DESCRIPTION
### Summary

Tweak a few tests so they run/skip on more targets (see commit messages for explanations).

### Testing

Tested on ESP8266_GENERIC and ESP32_GENERIC_C3, these tests now skip.

Will also be tested by CI and Octoprobe.

### Generative AI

Not used.
