### PR TITLE
Add rp2 override_invert

### DIFF
--- a/docs/library/machine.Pin.rst
+++ b/docs/library/machine.Pin.rst
@@ -97,6 +97,14 @@ Constructors
        one pin alternate function is supported the this argument is not required.  Not all
        ports implement this argument.
 
+     - ``invert`` enables hardware inversion of both the input and output signal paths.
+       If ``True``, input reads via :meth:`Pin.value` return inverted logic levels, and
+       output levels driven to the pad are inverted.  If ``False``, both paths are set
+       back to normal (non-inverted).  If omitted, the current inversion setting is
+       unchanged.  Not all ports implement this argument.
+
+       Availability: rp2 port.
+
    As specified above, the Pin class allows to set an alternate function for a particular
    pin, but it does not specify any further operations on such a pin.  Pins configured in
    alternate-function mode are usually not used as GPIO but are instead driven by other

--- a/docs/rp2/quickref.rst
+++ b/docs/rp2/quickref.rst
@@ -162,6 +162,25 @@ Use the :ref:`machine.Pin <machine.Pin>` class::
     p4 = Pin(4, Pin.IN, Pin.PULL_UP) # enable internal pull-up resistor
     p5 = Pin(5, Pin.OUT, value=1) # set pin high on creation
 
+Hardware pin inversion
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``invert`` keyword argument to ``Pin()`` and ``Pin.init()`` enables
+hardware inversion of both the input and output paths (using the RP2040/RP2350
+pad ``inover`` and ``outover`` controls).  This is useful for active-low
+signals such as buttons or LEDs without software inversion::
+
+    btn = Pin(15, Pin.IN, Pin.PULL_UP, invert=True)
+    if btn.value():
+        print("pressed")
+
+    led = Pin(16, Pin.OUT, invert=True)
+    led.on()  # drives the pad low
+
+Note that GPIO IRQ triggers operate on a separate hardware path and are not
+affected by ``invert``.  You may need to swap rising/falling triggers
+accordingly.
+
 Programmable IO (PIO)
 ---------------------
 

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -35,8 +35,10 @@
 #include "modmachine.h"
 #include "machine_pin.h"
 
+#include "hardware/gpio.h"
 #include "hardware/irq.h"
 #include "hardware/regs/intctrl.h"
+#include "hardware/regs/io_bank0.h"
 #include "hardware/structs/iobank0.h"
 #include "hardware/structs/padsbank0.h"
 
@@ -228,6 +230,13 @@ static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
                 mp_printf(print, ", alt=%q", af->name);
             }
         }
+        uint inover = (io_bank0_hw->io[self->id].ctrl & IO_BANK0_GPIO0_CTRL_INOVER_BITS)
+            >> IO_BANK0_GPIO0_CTRL_INOVER_LSB;
+        uint outover = (io_bank0_hw->io[self->id].ctrl & IO_BANK0_GPIO0_CTRL_OUTOVER_BITS)
+            >> IO_BANK0_GPIO0_CTRL_OUTOVER_LSB;
+        if (inover == GPIO_OVERRIDE_INVERT && outover == GPIO_OVERRIDE_INVERT) {
+            mp_printf(print, ", invert=True");
+        }
     } else {
         #if MICROPY_HW_PIN_EXT_COUNT
         mode_qst = (self->is_output) ? MP_QSTR_OUT : MP_QSTR_IN;
@@ -238,13 +247,14 @@ static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
 }
 
 enum {
-    ARG_mode, ARG_pull, ARG_value, ARG_alt
+    ARG_mode, ARG_pull, ARG_value, ARG_alt, ARG_invert
 };
 static const mp_arg_t allowed_args[] = {
     {MP_QSTR_mode,  MP_ARG_OBJ,                  {.u_rom_obj = MP_ROM_NONE}},
     {MP_QSTR_pull,  MP_ARG_OBJ,                  {.u_rom_obj = MP_ROM_NONE}},
     {MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
     {MP_QSTR_alt,   MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = GPIO_FUNC_SIO}},
+    {MP_QSTR_invert, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE}},
 };
 
 static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
@@ -259,6 +269,10 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
 
     if (is_ext_pin(self) && args[ARG_alt].u_int != GPIO_FUNC_SIO) {
         mp_raise_ValueError(MP_ERROR_TEXT("alternate functions are not supported for external pins"));
+    }
+
+    if (is_ext_pin(self) && args[ARG_invert].u_obj != mp_const_none) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invert is not supported for external pins"));
     }
 
     // get initial value of pin (only valid for OUT and OPEN_DRAIN modes)
@@ -304,6 +318,14 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
             pull = mp_obj_get_int(args[ARG_pull].u_obj);
         }
         gpio_set_pulls(self->id, pull & GPIO_PULL_UP, pull & GPIO_PULL_DOWN);
+
+        // Configure hardware input/output inversion (gpio_set_inover/gpio_set_outover).
+        if (args[ARG_invert].u_obj != mp_const_none) {
+            uint override = mp_obj_is_true(args[ARG_invert].u_obj)
+                ? GPIO_OVERRIDE_INVERT : GPIO_OVERRIDE_NORMAL;
+            gpio_set_inover(self->id, override);
+            gpio_set_outover(self->id, override);
+        }
     }
     return mp_const_none;
 }

--- a/tests/ports/rp2/pin_invert.py
+++ b/tests/ports/rp2/pin_invert.py
@@ -1,0 +1,20 @@
+# Test hardware input/output inversion via Pin(invert=...).
+
+from machine import Pin
+
+# Input inversion: pull-up, no external wiring required.
+p = Pin(22, Pin.IN, Pin.PULL_UP)
+
+print(p.value())
+p.init(invert=True)
+print(p.value())
+print(p)
+p.init(invert=False)
+print(p.value())
+
+# Output inversion: read back driven level on the same pin.
+p.init(mode=Pin.OUT, invert=True, value=1)
+print(p.value())
+p.init(invert=False, value=1)
+print(p.value())
+print(p)

--- a/tests/ports/rp2/pin_invert.py.exp
+++ b/tests/ports/rp2/pin_invert.py.exp
@@ -1,0 +1,7 @@
+1
+0
+Pin(GPIO22, mode=IN, pull=PULL_UP, invert=True)
+1
+0
+1
+Pin(GPIO22, mode=OUT)


### PR DESCRIPTION


### Summary

For some applications, inversion will be a hardware solution for otherwise inverted logic, avoiding software-side inversion and related issues (buttons, low-side LEDs, etc.), as described in the RST. However, I love the fact that it will also affect alternative functions. For example, hardware-side inversion will allow half-duplex UART communication with open-collector and an N-channel low-side driver without any restrictions, based on the hardware UART.

### Testing

I added a simple test that checks input and output with and without inversion.

### Trade-offs and Alternatives

I am not sure about the code increase; however, this is a local change for the RP2xxx, and will not affect very small controllers. It is worth it because it will make the code for some common hardware designs much easier.
It would be possible to split it further into invert_in and invert_out, but i think the total inversion is much more common than just one direction.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above. I built it locally and ran the test on my hardware. I did run this through a spellchecker, though, but this is handwritten. ;-)