### PR TITLE
natmod: Do not share build directory across architectures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build/
 build-*/
 docs/genrst/
+.mpy_ld_cache-*/
 
 # Test failure outputs and intermediate artefacts
 tests/results/*

--- a/examples/natmod/btree/Makefile
+++ b/examples/natmod/btree/Makefile
@@ -2,7 +2,8 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in btree so it can coexist)
-MOD = btree_$(ARCH)
+MOD_BASE = btree
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = btree_c.c
@@ -43,6 +44,9 @@ ifeq ($(ARCH),armv6m)
 # Link with libgcc.a for division helper functions
 LINK_RUNTIME = 1
 endif
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk
 

--- a/examples/natmod/deflate/Makefile
+++ b/examples/natmod/deflate/Makefile
@@ -2,7 +2,8 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in uzlib so it can coexist)
-MOD = deflate_$(ARCH)
+MOD_BASE = deflate
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = deflate.c
@@ -20,5 +21,8 @@ ifeq ($(ARCH),xtensa)
 LINK_RUNTIME = 1
 MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
 endif
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/framebuf/Makefile
+++ b/examples/natmod/framebuf/Makefile
@@ -2,7 +2,8 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in framebuf so it can coexist)
-MOD = framebuf_$(ARCH)
+MOD_BASE = framebuf
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = framebuf.c
@@ -18,5 +19,8 @@ endif
 ifeq ($(ARCH),xtensa)
 MPY_EXTERN_SYM_FILE=$(MPY_DIR)/ports/esp8266/boards/eagle.rom.addr.v6.ld
 endif
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/heapq/Makefile
+++ b/examples/natmod/heapq/Makefile
@@ -2,12 +2,16 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in heapq so it can coexist)
-MOD = heapq_$(ARCH)
+MOD_BASE = heapq
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = heapq.c
 
 # Architecture to build for (x86, x64, armv7m, xtensa, xtensawin, rv32imc, rv64imc)
 ARCH = x64
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/random/Makefile
+++ b/examples/natmod/random/Makefile
@@ -2,7 +2,8 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in random so it can coexist)
-MOD = random_$(ARCH)
+MOD_BASE = random
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = random.c
@@ -18,5 +19,8 @@ ifeq ($(ARCH),$(filter $(ARCH),armv6m armv7m))
 # Link with libm.a for soft-float helper functions
 LINK_RUNTIME = 1
 endif
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/examples/natmod/re/Makefile
+++ b/examples/natmod/re/Makefile
@@ -2,7 +2,8 @@
 MPY_DIR = ../../..
 
 # Name of module (different to built-in re so it can coexist)
-MOD = re_$(ARCH)
+MOD_BASE = re
+MOD = $(MOD_BASE)_$(ARCH)
 
 # Source files (.c or .py)
 SRC = re.c
@@ -14,5 +15,8 @@ ifeq ($(ARCH),armv6m)
 # Link with libgcc.a for division helper functions
 LINK_RUNTIME = 1
 endif
+
+# Strip the architecture name from the internal filename.
+MPY_LD_FLAGS = "--source-name=$(MOD_BASE).mpy"
 
 include $(MPY_DIR)/py/dynruntime.mk

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -237,11 +237,11 @@ $(BUILD)/%.mpy: %.py
 	$(Q)$(MPY_CROSS) $(MPY_CROSS_FLAGS) -o $@ $<
 
 # Build native .mpy from object files
-$(BUILD)/$(MOD).native.mpy: $(SRC_O)
+$(BUILD)/$(MOD).mpy: $(SRC_O)
 	$(ECHO) "LINK $<"
 	$(Q)$(MPY_LD) --arch $(ARCH) --qstrs $(CONFIG_H) $(MPY_LD_FLAGS) -o $@ $^
 
 # Build final .mpy from all intermediate .mpy files
-$(MOD).mpy: $(BUILD)/$(MOD).native.mpy $(SRC_MPY)
+$(MOD).mpy: $(BUILD)/$(MOD).mpy $(SRC_MPY)
 	$(ECHO) "GEN $@"
 	$(Q)$(MPY_TOOL) --merge -o $@ $^

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -1,7 +1,7 @@
 # Makefile fragment for generating native .mpy files from C source
 # MPY_DIR must be set to the top of the MicroPython source tree
 
-BUILD ?= build
+BUILD ?= build-$(ARCH)
 
 ECHO = @echo
 RM = /bin/rm
@@ -39,7 +39,7 @@ MPY_CROSS_FLAGS += -march=$(ARCH)
 SRC_O += $(addprefix $(BUILD)/, $(patsubst %.c,%.o,$(filter %.c,$(SRC))) $(patsubst %.S,%.o,$(filter %.S,$(SRC))))
 SRC_MPY += $(addprefix $(BUILD)/, $(patsubst %.py,%.mpy,$(filter %.py,$(SRC))))
 
-CLEAN_EXTRA += $(MOD).mpy .mpy_ld_cache
+CLEAN_EXTRA += $(MOD).mpy .mpy_ld_cache-$(ARCH)
 
 ################################################################################
 # Architecture configuration

--- a/tools/ar_util.py
+++ b/tools/ar_util.py
@@ -39,6 +39,10 @@ except:
     Archive = None
 
 
+DEFAULT_CACHE_BASE_PATH = ".mpy_ld_cache"
+DEFAULT_CACHE_PREFIX = "ar_"
+
+
 class PickleCache:
     def __init__(self, path, prefix=""):
         self.path = path
@@ -63,11 +67,21 @@ class PickleCache:
             return pickle.load(f)
 
 
-def cached(key, cache):
+PICKLE_CACHE = None
+
+
+def init_cache(path, prefix):
+    global PICKLE_CACHE
+    PICKLE_CACHE = PickleCache(path, prefix)
+
+
+def cached(key, provider):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             cache_key = key(*args, **kwargs)
+            cache = provider()
+            assert cache is not None
             try:
                 d = cache.load(cache_key)
                 if d["key"] != cache_key:
@@ -114,7 +128,7 @@ class CachedArFile:
         sha.update(bytes.fromhex("00000000000000000000000000000001"))
         return sha.hexdigest()
 
-    @cached(key=_cache_key, cache=PickleCache(path=".mpy_ld_cache", prefix="ar_"))
+    @cached(key=_cache_key, provider=lambda: PICKLE_CACHE)
     def load_symbols(self):
         print("Loading", self.fn)
         objs = defaultdict(lambda: {"def": set(), "undef": set(), "weak": set()})

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -1548,6 +1548,9 @@ def do_link(args):
                 load_object_file(env, f, fn)
 
         if args.libs:
+            ar_util.init_cache(
+                f"{ar_util.DEFAULT_CACHE_BASE_PATH}-{args.arch}", ar_util.DEFAULT_CACHE_PREFIX
+            )
             # Load archive info
             archives = []
             for item in args.libs:

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -1386,7 +1386,7 @@ class MPYOutput:
             self.write_uint(n)
 
 
-def build_mpy(env, fmpy, native_qstr_vals, arch_flags):
+def build_mpy(env, fmpy, internal_name, native_qstr_vals, arch_flags):
     # Rewrite the entry trampoline if the proper value isn't known earlier, and
     # ensure the trampoline size remains the same.
     if env.arch.delayed_entry_offset:
@@ -1424,7 +1424,7 @@ def build_mpy(env, fmpy, native_qstr_vals, arch_flags):
     out.write_uint(0)
 
     # MPY: qstr table
-    out.write_qstr(fmpy)  # filename
+    out.write_qstr(internal_name)  # filename
     for q in native_qstr_vals:
         out.write_qstr(q)
 
@@ -1567,7 +1567,14 @@ def do_link(args):
                     load_object_file(env, f, obj_name)
 
         link_objects(env, len(native_qstr_vals))
-        build_mpy(env, args.output, native_qstr_vals, args.arch_flags)
+        if args.source_name:
+            internal_name = args.source_name
+        else:
+            import pathlib
+
+            path = pathlib.Path(args.output)
+            internal_name = path.name
+        build_mpy(env, args.output, internal_name, native_qstr_vals, args.arch_flags)
     except LinkError as er:
         print("LinkError:", er.args[0])
         sys.exit(1)
@@ -1655,6 +1662,9 @@ def main():
     )
     cmd_parser.add_argument("--arch", default="x64", help="architecture")
     cmd_parser.add_argument("--arch-flags", default=None, help="optional architecture flags")
+    cmd_parser.add_argument(
+        "--source-name", default=None, help="override the file name written to the .mpy file"
+    )
     cmd_parser.add_argument("--preprocess", action="store_true", help="preprocess source files")
     cmd_parser.add_argument("--qstrs", default=None, help="file defining additional qstrs")
     cmd_parser.add_argument(


### PR DESCRIPTION
### Summary

This PR modifies the native modules build system to use different directories for different architectures.
  
Previously, the natmod build system would unconditionally put all build data into a single directory (usually "$(PWD)/build" unless overridden), and the static library runtime cache into another directory ("$(PWD)/.mpy_ld_cache").  That works if building is always done for a single architecture or if a full clean is performed before switching architectures, which sometimes is not wanted (collecting the runtime cache may take quite some time depending on the module complexity, for example).  

With these changes, both the build directory and the runtime cache directories are marked with the name of the architecture they target, so for example "$(PWD)/build" becomes "$(PWD)/build_x64" (the same happens to the cache directory name).

That does not come without drawbacks unless the build directory name is overridden in the makefile.  MPY files as part of their preambles will contain the path name provided to `mpy_ld.py` as the first entry in the constant string pool, meaning the output files will be a tiny bit larger.  To offset this, a new option was added to `mpy_ld.py`, `--internal-filename` which - if passed - will write the given string in the module file instead of the default path name.  If said option is not provided, generated MPY files will still carry the raw command line output path, maintaining the same behaviour as before these changes.

That also lets advanced users shrink their MPY files even further (eg. by using single letter names) and/or hide potentially sensitive information provided by the path name if a custom directory is used and said directory contains things like product code names or client names.

This also closes #6585.

### Testing

Besides manual testing performed both for native Unix and QEMU targets, this is should also be tested by CI.

### Trade-offs and Alternatives

Users building a certain module for just one architecture should probably look into overriding the `BUILD` variable if a longer MPY file name is a deal-breaker, or provide their own shorter file name now that the possibility is there.

Right now `mpy-tool.py` does not have such a functionality for already-built MPY files.  I had a quick look at it, but it may require more modifications than what I'm willing to add to this PR.

### Generative AI

I did not use generative AI tools when creating this PR.