### PR TITLE
shared/memzip/make-memzip.py: Make the script run with recent Python versions.

### DIFF
--- a/shared/memzip/make-memzip.py
+++ b/shared/memzip/make-memzip.py
@@ -9,6 +9,8 @@
 
 import argparse
 import os
+import pathlib
+import shutil
 import subprocess
 import sys
 
@@ -63,9 +65,19 @@ def main():
     parser.add_argument(dest="source_dir", default="memzip_files")
     args = parser.parse_args(sys.argv[1:])
 
+    output_zip = pathlib.Path(args.zip_filename)
+    if output_zip.suffix != ".zip":
+        args.zip_filename = output_zip.with_suffix(".zip")
+    output_c = pathlib.Path(args.c_filename)
+    if output_c.suffix != ".c":
+        args.c_filename = output_c.with_suffix(".c")
+
     print("args.zip_filename =", args.zip_filename)
     print("args.c_filename =", args.c_filename)
     print("args.source_dir =", args.source_dir)
+
+    if not shutil.which("zip"):
+        raise FileNotFoundError("zip archiver not available")
 
     create_zip(args.zip_filename, args.source_dir)
     create_c_from_file(args.c_filename, args.zip_filename)

--- a/shared/memzip/make-memzip.py
+++ b/shared/memzip/make-memzip.py
@@ -11,7 +11,6 @@ import argparse
 import os
 import subprocess
 import sys
-import types
 
 
 def create_zip(zip_filename, zip_dir):
@@ -26,7 +25,7 @@ def create_zip(zip_filename, zip_dir):
 
 def create_c_from_file(c_filename, zip_filename):
     with open(zip_filename, "rb") as zip_file:
-        with open(c_filename, "wb") as c_file:
+        with open(c_filename, "wt") as c_file:
             print("#include <stdint.h>", file=c_file)
             print("", file=c_file)
             print("const uint8_t memzip_data[] = {", file=c_file)
@@ -36,10 +35,7 @@ def create_c_from_file(c_filename, zip_filename):
                     break
                 print("   ", end="", file=c_file)
                 for byte in buf:
-                    if isinstance(byte, types.StringType):
-                        print(" 0x{:02x},".format(ord(byte)), end="", file=c_file)
-                    else:
-                        print(" 0x{:02x},".format(byte), end="", file=c_file)
+                    print(" 0x{:02x},".format(byte), end="", file=c_file)
                 print("", file=c_file)
             print("};", file=c_file)
 


### PR DESCRIPTION
### Summary

This PR applies a few fixes to the `shared/memzip/make-memzip.py` utility, namely finishing the Python 3.x migration and improve its resiliency.

The code still wasn't fully aware of how Python unified bytes and strings when it comes to I/O API.  These first commit helps with that, following what has been shown in #7522.

Then turns out that the script had a couple more shortcomings, as passing a zip archive name without the `.zip` extension would make the script fail (`zip` would add the extension itself and the script wouldn't find the file).  A similar change was applied to the generated file, with a `.c` extension added to the output if it was missing from the chosen filename.

This should close #7522.

### Testing

This was tested manually on a Linux/x64 system with both CPython 3.12 and CPython 3.14.  `make-memzip.py -z zipfile -c cfile .` was executed in a directory containing a few small files, and then the generated `cfile.c` file was used to recreate the zip archive present as `zipfile.zip` in the same directory.

`vermin` was also used to confirm the minimum Python version needed to run the script to not be past 3.8.

### Trade-offs and Alternatives

An even more resilient script could be had by reimplementing the bundling done by the `zip` binary using Python's `zipfile` module, but that's probably a bit too much for such a simple utility right now.

### Generative AI

I did not use generative AI tools when creating this PR.