### PR TITLE
alif: update Alif security toolkit to v1.110.0

### DIFF
--- a/ports/alif/Makefile
+++ b/ports/alif/Makefile
@@ -93,6 +93,7 @@ $(BUILD)/$(ALIF_TOC_CONFIG): mcu/$(ALIF_TOC_CONFIG).in | $(BUILD)
 
 $(ALIF_TOC_BIN): $(ALIF_TOC_APPS)
 	$(Q)$(PYTHON) $(ALIF_TOOLS)/app-gen-toc.py \
+		--cfg-part $(ALIF_TOOLKIT_CFG_PART) \
 		--filename $(abspath $(BUILD)/$(ALIF_TOC_CONFIG)) \
 		--output-dir $(BUILD) \
 		--firmware-dir $(BUILD) \

--- a/ports/alif/Makefile
+++ b/ports/alif/Makefile
@@ -110,7 +110,8 @@ deploy: $(ALIF_TOC_BIN)
 		--cfg-part $(ALIF_TOOLKIT_CFG_PART) \
 		--port $(PORT) \
 		--pad \
-		--images file:$(BUILD)/application_package.ds
+		--images file:$(BUILD)/application_package.ds \
+		$(ALIF_TOOLKIT_APP_WRITE_MRAM_ARGS) \
 
 .PHONY: deploy-jlink
 deploy-jlink: $(ALIF_TOC_APPS)

--- a/ports/alif/boards/OPENMV_AE3/mpconfigboard.mk
+++ b/ports/alif/boards/OPENMV_AE3/mpconfigboard.mk
@@ -7,6 +7,7 @@ PORT = /dev/ttyUSB0
 
 ALIF_TOOLKIT_CFG_PART = AE302F80F55D5AE
 ALIF_TOOLKIT_CFG_FILE = \"app-device-config-ae3.json\"
+ALIF_TOOLKIT_APP_WRITE_MRAM_ARGS = --switch  # disable baudrate switching (the board cannot do it)
 
 CORE_M55_HP := $(if $(filter M55_HP,$(MCU_CORE)),1,0)
 


### PR DESCRIPTION
### Summary

This updates the `alif-security-toolkit` submodule to the latest version, based on v1.110.0 of that toolkit.

Some minor changes are made to the alif port's build process to get it working with this new toolkit.

### Testing

Built and deployed (over SE serial) both ALIF_ENSEMBLE and OPENMV_AE3 boards (which flashes the firmware and the ToC).  They both deploy correctly and the app runs.

Used `make update-system-package` on both these boards to update tho SEROM, and it worked.

Used `make maintenance` on both these boards to check that the SEROM was updated, and it worked.

### Generative AI

Not used.