### PR TITLE
extmod, ports: add new `vfs_rom_ioctl` code to support partial prepare/erase, and implement on alif, samd, stm32

### DIFF
--- a/extmod/vfs.h
+++ b/extmod/vfs.h
@@ -55,11 +55,13 @@
 #define MP_BLOCKDEV_IOCTL_BLOCK_ERASE   (6)
 
 // Constants for vfs.rom_ioctl() function.
+// The 4-arg form of WRITE_PREPARE is only available if GET_MIN_PREPARE returns >0.
 #define MP_VFS_ROM_IOCTL_GET_NUMBER_OF_SEGMENTS     (1) // rom_ioctl(1)
 #define MP_VFS_ROM_IOCTL_GET_SEGMENT                (2) // rom_ioctl(2, <id>)
-#define MP_VFS_ROM_IOCTL_WRITE_PREPARE              (3) // rom_ioctl(3, <id>, <len>)
+#define MP_VFS_ROM_IOCTL_WRITE_PREPARE              (3) // rom_ioctl(3, <id>, <len>) or rom_ioctl(3, <id>, <offset>, <len>)
 #define MP_VFS_ROM_IOCTL_WRITE                      (4) // rom_ioctl(4, <id>, <offset>, <buf>)
 #define MP_VFS_ROM_IOCTL_WRITE_COMPLETE             (5) // rom_ioctl(5, <id>)
+#define MP_VFS_ROM_IOCTL_GET_MIN_PREPARE            (6) // rom_ioctl(6, <id>)
 
 #if MICROPY_VFS_BLOCKDEV_NATIVE
 // Function signatures used when MP_BLOCKDEV_FLAG_NATIVE is set.

--- a/ports/alif/vfs_rom_ioctl.c
+++ b/ports/alif/vfs_rom_ioctl.c
@@ -103,7 +103,15 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
             return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
         }
         uint32_t dest = romfs_base;
-        uint32_t dest_max = dest + mp_obj_get_int(args[2]);
+        uint32_t dest_max;
+        if (n_args == 3) {
+            // Only length given, offset defaults to start of partition.
+            dest_max = dest + mp_obj_get_int(args[2]);
+        } else {
+            // Both offset and length given.
+            dest += mp_obj_get_int(args[2]);
+            dest_max = dest + mp_obj_get_int(args[3]);
+        }
         if (dest_max > romfs_base + romfs_len) {
             return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
         }
@@ -165,6 +173,20 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
             int ret = ospi_flash_write(dest, bufinfo.len, bufinfo.buf);
             mp_event_handle_nowait();
             return MP_OBJ_NEW_SMALL_INT(ret);
+        }
+        #endif
+    }
+
+    if (cmd == MP_VFS_ROM_IOCTL_GET_MIN_PREPARE) {
+        // Get minimum erase size.
+
+        if (mram_is_valid_addr(romfs_base)) {
+            return MP_OBJ_NEW_SMALL_INT(MRAM_SECTOR_SIZE);
+        }
+
+        #if MICROPY_HW_ENABLE_OSPI
+        if (ospi_is_valid_addr(ospi_base, romfs_base)) {
+            return MP_OBJ_NEW_SMALL_INT(MICROPY_HW_FLASH_BLOCK_SIZE_BYTES);
         }
         #endif
     }

--- a/ports/samd/samd_flash.c
+++ b/ports/samd/samd_flash.c
@@ -236,7 +236,15 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
                 return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
             }
             uint32_t dest_addr = MICROPY_HW_ROMFS_BASE;
-            uint32_t bytes_used = mp_obj_get_int(args[2]);
+            uint32_t bytes_used;
+            if (n_args == 3) {
+                // Only length given, offset defaults to start of partition.
+                bytes_used = mp_obj_get_int(args[2]);
+            } else {
+                // Both offset and length given.
+                dest_addr += mp_obj_get_int(args[2]);
+                bytes_used = mp_obj_get_int(args[3]);
+            }
             mp_int_t page_size = flash_get_page_size(&flash_desc); // adf4 API call
             flash_erase(&flash_desc, dest_addr, (bytes_used + page_size - 1) / page_size);
             return MP_OBJ_NEW_SMALL_INT(4);
@@ -252,6 +260,11 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
             mp_get_buffer_raise(args[3], &bufinfo, MP_BUFFER_READ);
             flash_write(&flash_desc, dest_addr, bufinfo.buf, bufinfo.len);
             return MP_OBJ_NEW_SMALL_INT(0);
+        }
+
+        case MP_VFS_ROM_IOCTL_GET_MIN_PREPARE: {
+            // Get minimum erase size.
+            return MP_OBJ_NEW_SMALL_INT(flash_get_page_size(&flash_desc));
         }
 
             #endif

--- a/ports/stm32/flash.c
+++ b/ports/stm32/flash.c
@@ -259,6 +259,16 @@ bool flash_is_valid_addr(uint32_t addr) {
     return base <= addr && addr < end_of_flash;
 }
 
+uint32_t flash_get_max_sector_size(void) {
+    #if FLASH_LAYOUT_IS_HOMOGENEOUS
+    // All sectors are the same size.
+    return FLASH_LAYOUT_SECTOR_SIZE;
+    #else
+    // The last sector is the largest.
+    return flash_layout[MP_ARRAY_SIZE(flash_layout) - 1].sector_size;
+    #endif
+}
+
 int32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size) {
     #if FLASH_LAYOUT_IS_HOMOGENEOUS
     if (addr >= FLASH_LAYOUT_START_ADDR) {

--- a/ports/stm32/flash.h
+++ b/ports/stm32/flash.h
@@ -27,6 +27,7 @@
 #define MICROPY_INCLUDED_STM32_FLASH_H
 
 bool flash_is_valid_addr(uint32_t addr);
+uint32_t flash_get_max_sector_size(void);
 int32_t flash_get_sector_info(uint32_t addr, uint32_t *start_addr, uint32_t *size);
 int flash_erase(uint32_t flash_dest);
 int flash_write(uint32_t flash_dest, const uint32_t *src, uint32_t num_word32);

--- a/ports/stm32/vfs_rom_ioctl.c
+++ b/ports/stm32/vfs_rom_ioctl.c
@@ -110,7 +110,15 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
             return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
         }
         uint32_t dest = romfs_base;
-        uint32_t dest_max = dest + mp_obj_get_int(args[2]);
+        uint32_t dest_max;
+        if (n_args == 3) {
+            // Only length given, offset defaults to start of partition.
+            dest_max = dest + mp_obj_get_int(args[2]);
+        } else {
+            // Both offset and length given.
+            dest += mp_obj_get_int(args[2]);
+            dest_max = dest + mp_obj_get_int(args[3]);
+        }
         if (dest_max > romfs_base + romfs_len) {
             return MP_OBJ_NEW_SMALL_INT(-MP_EINVAL);
         }
@@ -213,6 +221,28 @@ mp_obj_t mp_vfs_rom_ioctl(size_t n_args, const mp_obj_t *args) {
             dest -= xspi_get_xip_base(&xspi_flash2);
             int ret = spi_bdev_writeblocks_raw(MICROPY_HW_ROMFS_XSPI_SPIBDEV_OBJ, bufinfo.buf, 0, dest, bufinfo.len);
             return MP_OBJ_NEW_SMALL_INT(ret);
+        }
+        #endif
+    }
+
+    if (cmd == MP_VFS_ROM_IOCTL_GET_MIN_PREPARE) {
+        // Get minimum erase size.
+
+        #if MICROPY_HW_ROMFS_ENABLE_INTERNAL_FLASH
+        if (flash_is_valid_addr(romfs_base)) {
+            return MP_OBJ_NEW_SMALL_INT(flash_get_max_sector_size());
+        }
+        #endif
+
+        #if MICROPY_HW_ROMFS_ENABLE_EXTERNAL_QSPI
+        if (qspi_is_valid_addr(romfs_base)) {
+            return MP_OBJ_NEW_SMALL_INT(MP_SPIFLASH_ERASE_BLOCK_SIZE);
+        }
+        #endif
+
+        #if MICROPY_HW_ROMFS_ENABLE_EXTERNAL_XSPI
+        if (xspi_is_valid_addr(&xspi_flash2, romfs_base)) {
+            return MP_OBJ_NEW_SMALL_INT(MP_SPIFLASH_ERASE_BLOCK_SIZE);
         }
         #endif
     }

--- a/tools/mpremote/mpremote/commands.py
+++ b/tools/mpremote/mpremote/commands.py
@@ -561,6 +561,29 @@ def do_rtc(state, args):
         print(state.transport.eval("machine.RTC().datetime()"))
 
 
+def _do_romfs_query_partition(transport, rom_id):
+    transport.exec(f"dev=vfs.rom_ioctl(2,{rom_id})")
+    if transport.eval("isinstance(dev,int) and dev<0"):
+        raise CommandError(f"ROMFS{rom_id} partition not found on device")
+
+    has_object = transport.eval("hasattr(dev,'ioctl')")
+    if has_object:
+        rom_block_count = transport.eval("dev.ioctl(4,0)")
+        rom_block_size = transport.eval("dev.ioctl(5,0)")
+        rom_size = rom_block_count * rom_block_size
+    else:
+        rom_size = transport.eval("len(dev)")
+        rom_block_size = transport.eval(f"vfs.rom_ioctl(6,{rom_id})")
+        if rom_block_size <= 0:
+            rom_block_size = rom_size
+
+    print(
+        f"ROMFS{rom_id} partition has size {rom_size} bytes ({rom_size // rom_block_size} blocks of {rom_block_size} bytes each)"
+    )
+
+    return has_object, rom_size, rom_block_size
+
+
 def _do_romfs_query(state, args):
     state.ensure_raw_repl()
     state.did_action()
@@ -576,18 +599,7 @@ def _do_romfs_query(state, args):
         return
 
     for rom_id in range(num_rom_partitions):
-        state.transport.exec(f"dev=vfs.rom_ioctl(2,{rom_id})")
-        has_object = state.transport.eval("hasattr(dev,'ioctl')")
-        if has_object:
-            rom_block_count = state.transport.eval("dev.ioctl(4,0)")
-            rom_block_size = state.transport.eval("dev.ioctl(5,0)")
-            rom_size = rom_block_count * rom_block_size
-            print(
-                f"ROMFS{rom_id} partition has size {rom_size} bytes ({rom_block_count} blocks of {rom_block_size} bytes each)"
-            )
-        else:
-            rom_size = state.transport.eval("len(dev)")
-            print(f"ROMFS{rom_id} partition has size {rom_size} bytes")
+        _do_romfs_query_partition(state.transport, rom_id)
         romfs = state.transport.eval("bytes(memoryview(dev)[:12])")
         print(f"  Raw contents: {romfs.hex(':')} ...")
         if not romfs.startswith(b"\xd2\xcd\x31"):
@@ -644,20 +656,7 @@ def _do_romfs_deploy(state, args):
     state.transport.exec("import vfs")
     if not state.transport.eval("hasattr(vfs,'rom_ioctl')"):
         raise CommandError("ROMFS is not enabled on this device")
-    transport.exec(f"dev=vfs.rom_ioctl(2,{rom_id})")
-    if transport.eval("isinstance(dev,int) and dev<0"):
-        raise CommandError(f"ROMFS{rom_id} partition not found on device")
-    has_object = transport.eval("hasattr(dev,'ioctl')")
-    if has_object:
-        rom_block_count = transport.eval("dev.ioctl(4,0)")
-        rom_block_size = transport.eval("dev.ioctl(5,0)")
-        rom_size = rom_block_count * rom_block_size
-        print(
-            f"ROMFS{rom_id} partition has size {rom_size} bytes ({rom_block_count} blocks of {rom_block_size} bytes each)"
-        )
-    else:
-        rom_size = transport.eval("len(dev)")
-        print(f"ROMFS{rom_id} partition has size {rom_size} bytes")
+    has_object, rom_size, rom_block_size = _do_romfs_query_partition(transport, rom_id)
 
     # Check if ROMFS image is valid
     if not romfs.startswith(VfsRomWriter.ROMFS_HEADER):
@@ -670,16 +669,27 @@ def _do_romfs_deploy(state, args):
         sys.exit(1)
 
     # Prepare ROMFS partition for writing.
-    print(f"Preparing ROMFS{rom_id} partition for writing")
     transport.exec("import vfs\ntry:\n vfs.umount('/rom')\nexcept:\n pass")
     chunk_size = 4096
     if has_object:
         for offset in range(0, len(romfs), rom_block_size):
+            print(f"\rPreparing at offset {offset}", end="")
             transport.exec(f"dev.ioctl(6,{offset // rom_block_size})")
         chunk_size = min(chunk_size, rom_block_size)
     else:
-        rom_min_write = transport.eval(f"vfs.rom_ioctl(3,{rom_id},{len(romfs)})")
+        if rom_block_size < rom_size:
+            offset = 0
+            while offset < len(romfs):
+                print(f"\rPreparing at offset {offset}", end="")
+                remain = min(len(romfs) - offset, 32768)
+                prepare = (remain + rom_block_size - 1) // rom_block_size * rom_block_size
+                rom_min_write = transport.eval(f"vfs.rom_ioctl(3,{rom_id},{offset},{prepare})")
+                offset += prepare
+        else:
+            print("\rPreparing at offset 0", end="")
+            rom_min_write = transport.eval(f"vfs.rom_ioctl(3,{rom_id},{len(romfs)})")
         chunk_size = max(chunk_size, rom_min_write)
+    print()
 
     # Detect capabilities of the device to use the fastest method of transfer.
     has_bytes_fromhex = transport.eval("hasattr(bytes,'fromhex')")


### PR DESCRIPTION
### Summary

At the moment, ROMFS on some ports (eg alif, samd, stm32) supports only a single large partition that must be prepared/erase in one go.  This PR enhances these ports so that their ROMFS partition can be prepared/erased in blocks (down to the erase size of the underlying flash).  This has two advantages:
1. It no longer has a timeout in `mpremote` when deploying very large (>8MB) ROM filesystems.  This timeout would occur if the prepare stage took > 10 seconds.  But now it's split up into many smaller prepare calls, each taking less than 1 second, so does not timeout anymore.
2. It opens the possibility to do partial updates of the ROMFS partition, eg support multiple sub-partitions and update them one at a time, or update the start of the partition last to protect against power loss during the update.  Both of those can be important for OTA updates that go into ROMFS.

Changes in this PR:
- add new MP_VFS_ROM_IOCTL_GET_MIN_PREPARE ioctl
- add new 4-arg version of existing MP_VFS_ROM_IOCTL_WRITE_PREPARE ioctl
- implement the above two on alif, samd and stm32 ports
- update `mpremote` to use the new ioctls when they are supported by a target

The change is fully backwards compatible with boards that don't support the newer ioctls.

### Testing

Tested on ALIF_ENSEMBLE, ADAFRUIT_ITSYBITSY_M0_EXPRESS, RPI_PICO2 and PYBD_SF6:
- using new `mpremote` with old firmware (before these changes)
- `romfs query` and `romfs deploy`
- multiple ROMFS partitions on ALIF_ENSEMBLE
- using old `mpremote` with new firmware

### Trade-offs and Alternatives

This adds a small amount of extra code to ports that use the new features.  But ports that don't have the space do not have to implement it.

The impact to mpremote is minimal (some code was refactored there).

### Generative AI

Not used.