### PR TITLE
stm32: implement WWDG peripheral (windowed watchdog)

### DIFF
--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -25,8 +25,18 @@ Constructors
    Create a WDT object and start it. The timeout must be given in milliseconds.
    Once it is running the timeout cannot be changed and the WDT cannot be stopped either.
 
-   Notes: On the esp8266 a timeout cannot be specified, it is determined by the underlying system.
-   On rp2040 devices, the maximum timeout is 8388 ms.
+   Notes:
+
+   - On the esp8266 port a timeout cannot be specified, it is determined by the underlying
+     system.
+
+   - On rp2040 devices the maximum timeout is 8388 ms.
+
+   - On the stm32 port the default ``id=0`` is the IWDG, which can also be specified by
+     an id of ``"IWDG"``.  Use an id of ``"WWDG"`` to access the WWDG peripheral.
+     For dual-core STM32H7 MCUs there are also ``"IWDG2"`` and ``"WWDG2"``.
+     The WWDG has a very limited maximum timeout across all MCUs, of around 100ms (but
+     it depends heavily on the APB clock).
 
 Methods
 -------

--- a/extmod/machine_wdt.c
+++ b/extmod/machine_wdt.c
@@ -31,7 +31,7 @@
 #include "extmod/modmachine.h"
 
 // The port must provide implementations of these low-level WDT functions.
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms);
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t timeout_ms);
 static void mp_machine_wdt_feed(machine_wdt_obj_t *self);
 #if MICROPY_PY_MACHINE_WDT_TIMEOUT_MS
 static void mp_machine_wdt_timeout_ms_set(machine_wdt_obj_t *self_in, mp_int_t timeout_ms);
@@ -43,7 +43,7 @@ static void mp_machine_wdt_timeout_ms_set(machine_wdt_obj_t *self_in, mp_int_t t
 static mp_obj_t machine_wdt_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     enum { ARG_id, ARG_timeout };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_id, MP_ARG_INT, {.u_int = 0} },
+        { MP_QSTR_id, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(0)} },
         { MP_QSTR_timeout, MP_ARG_INT, {.u_int = 5000} },
     };
 
@@ -52,7 +52,7 @@ static mp_obj_t machine_wdt_make_new(const mp_obj_type_t *type, size_t n_args, s
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     // Create WDT instance.
-    machine_wdt_obj_t *self = mp_machine_wdt_make_new_instance(args[ARG_id].u_int, args[ARG_timeout].u_int);
+    machine_wdt_obj_t *self = mp_machine_wdt_make_new_instance(args[ARG_id].u_obj, args[ARG_timeout].u_int);
 
     return MP_OBJ_FROM_PTR(self);
 }

--- a/ports/cc3200/mods/machine_wdt.c
+++ b/ports/cc3200/mods/machine_wdt.c
@@ -84,8 +84,8 @@ void pybwdt_sl_alive (void) {
 /******************************************************************************/
 // MicroPython bindings
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
-    if (id != 0) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t timeout_ms) {
+    if (id != MP_OBJ_NEW_SMALL_INT(0)) {
         mp_raise_OSError(MP_ENODEV);
     }
     if (timeout_ms < PYBWDT_MIN_TIMEOUT_MS) {

--- a/ports/esp32/machine_wdt.c
+++ b/ports/esp32/machine_wdt.c
@@ -39,8 +39,8 @@ static machine_wdt_obj_t wdt_default = {
     {&machine_wdt_type}, 0
 };
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
-    if (id != 0) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t timeout_ms) {
+    if (id != MP_OBJ_NEW_SMALL_INT(0)) {
         mp_raise_ValueError(NULL);
     }
 

--- a/ports/esp8266/machine_wdt.c
+++ b/ports/esp8266/machine_wdt.c
@@ -36,20 +36,19 @@ typedef struct _machine_wdt_obj_t {
 
 static machine_wdt_obj_t wdt_default = {{&machine_wdt_type}};
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t timeout_ms) {
+    if (id != MP_OBJ_NEW_SMALL_INT(0)) {
+        mp_raise_ValueError(NULL);
+    }
+
     // The timeout on ESP8266 is fixed, so raise an exception if the argument is not the default.
     if (timeout_ms != 5000) {
         mp_raise_ValueError(NULL);
     }
 
-    switch (id) {
-        case 0:
-            ets_loop_dont_feed_sw_wdt = 1;
-            system_soft_wdt_feed();
-            return &wdt_default;
-        default:
-            mp_raise_ValueError(NULL);
-    }
+    ets_loop_dont_feed_sw_wdt = 1;
+    system_soft_wdt_feed();
+    return &wdt_default;
 }
 
 static void mp_machine_wdt_feed(machine_wdt_obj_t *self) {

--- a/ports/mimxrt/machine_wdt.c
+++ b/ports/mimxrt/machine_wdt.c
@@ -38,8 +38,9 @@ typedef struct _machine_wdt_obj_t {
 
 static const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
     // Verify the WDT id.
+    mp_int_t id = mp_obj_get_int(id_obj);
     if (id != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
     }

--- a/ports/rp2/machine_wdt.c
+++ b/ports/rp2/machine_wdt.c
@@ -38,8 +38,9 @@ typedef struct _machine_wdt_obj_t {
 
 static const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
     // Verify the WDT id.
+    mp_int_t id = mp_obj_get_int(id_obj);
     if (id != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
     }

--- a/ports/samd/machine_wdt.c
+++ b/ports/samd/machine_wdt.c
@@ -76,9 +76,10 @@ static void set_timeout(uint32_t timeout) {
     #endif
 }
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
     #if defined(MCU_SAMD51)
     // Verify the WDT id. SAMD51 only, saving a few bytes for SAMD21
+    mp_int_t id = mp_obj_get_int(id_obj);
     if (id != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
     }

--- a/ports/stm32/boards/stm32f0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f0xx_hal_conf_base.h
@@ -84,6 +84,7 @@
 #include "stm32f0xx_hal_usart.h"
 #include "stm32f0xx_hal_wwdg.h"
 #include "stm32f0xx_ll_adc.h"
+#include "stm32f0xx_ll_bus.h"
 #include "stm32f0xx_ll_rtc.h"
 #include "stm32f0xx_ll_usart.h"
 

--- a/ports/stm32/boards/stm32f4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f4xx_hal_conf_base.h
@@ -97,6 +97,7 @@
 #include "stm32f4xx_hal_usart.h"
 #include "stm32f4xx_hal_wwdg.h"
 #include "stm32f4xx_ll_adc.h"
+#include "stm32f4xx_ll_bus.h"
 #include "stm32f4xx_ll_pwr.h"
 #include "stm32f4xx_ll_rtc.h"
 #include "stm32f4xx_ll_usart.h"

--- a/ports/stm32/boards/stm32f7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32f7xx_hal_conf_base.h
@@ -93,6 +93,7 @@
 #include "stm32f7xx_hal_usart.h"
 #include "stm32f7xx_hal_wwdg.h"
 #include "stm32f7xx_ll_adc.h"
+#include "stm32f7xx_ll_bus.h"
 #include "stm32f7xx_ll_pwr.h"
 #include "stm32f7xx_ll_rtc.h"
 #include "stm32f7xx_ll_usart.h"

--- a/ports/stm32/boards/stm32g0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32g0xx_hal_conf_base.h
@@ -94,6 +94,7 @@
 #include "stm32g0xx_hal_uart.h"
 #include "stm32g0xx_hal_usart.h"
 #include "stm32g0xx_hal_wwdg.h"
+#include "stm32g0xx_ll_bus.h"
 #include "stm32g0xx_ll_lpuart.h"
 #include "stm32g0xx_ll_rtc.h"
 #include "stm32g0xx_ll_usart.h"

--- a/ports/stm32/boards/stm32g4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32g4xx_hal_conf_base.h
@@ -119,6 +119,7 @@
 #include "stm32g4xx_hal_usart.h"
 #include "stm32g4xx_hal_wwdg.h"
 #include "stm32g4xx_ll_adc.h"
+#include "stm32g4xx_ll_bus.h"
 #include "stm32g4xx_ll_rtc.h"
 #include "stm32g4xx_ll_usart.h"
 #include "stm32g4xx_ll_lpuart.h"

--- a/ports/stm32/boards/stm32h5xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h5xx_hal_conf_base.h
@@ -96,6 +96,7 @@
 #include "stm32h5xx_hal_usart.h"
 #include "stm32h5xx_hal_wwdg.h"
 #include "stm32h5xx_ll_adc.h"
+#include "stm32h5xx_ll_bus.h"
 #include "stm32h5xx_ll_lpuart.h"
 #include "stm32h5xx_ll_pwr.h"
 #include "stm32h5xx_ll_rcc.h"

--- a/ports/stm32/boards/stm32h7xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32h7xx_hal_conf_base.h
@@ -94,6 +94,7 @@
 #include "stm32h7xx_hal_usart.h"
 #include "stm32h7xx_hal_wwdg.h"
 #include "stm32h7xx_ll_adc.h"
+#include "stm32h7xx_ll_bus.h"
 #include "stm32h7xx_ll_lpuart.h"
 #include "stm32h7xx_ll_pwr.h"
 #include "stm32h7xx_ll_rcc.h"

--- a/ports/stm32/boards/stm32l0xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l0xx_hal_conf_base.h
@@ -85,6 +85,7 @@
 #include "stm32l0xx_hal_usart.h"
 #include "stm32l0xx_hal_wwdg.h"
 #include "stm32l0xx_ll_adc.h"
+#include "stm32l0xx_ll_bus.h"
 #include "stm32l0xx_ll_lpuart.h"
 #include "stm32l0xx_ll_rtc.h"
 #include "stm32l0xx_ll_usart.h"

--- a/ports/stm32/boards/stm32l1xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l1xx_hal_conf_base.h
@@ -91,6 +91,7 @@
 #include "stm32l1xx_hal_wwdg.h"
 #include "stm32l1xx_hal_exti.h"
 #include "stm32l1xx_ll_adc.h"
+#include "stm32l1xx_ll_bus.h"
 #include "stm32l1xx_ll_pwr.h"
 #include "stm32l1xx_ll_rtc.h"
 #include "stm32l1xx_ll_usart.h"

--- a/ports/stm32/boards/stm32l4xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32l4xx_hal_conf_base.h
@@ -93,6 +93,7 @@
 #include "stm32l4xx_hal_usart.h"
 #include "stm32l4xx_hal_wwdg.h"
 #include "stm32l4xx_ll_adc.h"
+#include "stm32l4xx_ll_bus.h"
 #include "stm32l4xx_ll_lpuart.h"
 #include "stm32l4xx_ll_rtc.h"
 #include "stm32l4xx_ll_usart.h"

--- a/ports/stm32/boards/stm32u5xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32u5xx_hal_conf_base.h
@@ -163,6 +163,7 @@
 #include "stm32u5xx_hal_ramcfg.h"
 #include "stm32u5xx_hal_mdf.h"
 #include "stm32u5xx_hal_xspi.h"
+#include "stm32u5xx_ll_bus.h"
 #include "stm32u5xx_ll_usart.h"
 #include "stm32u5xx_ll_lpuart.h"
 #include "stm32u5xx_ll_rtc.h"

--- a/ports/stm32/machine_wdt.c
+++ b/ports/stm32/machine_wdt.c
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2016-2023 Damien P. George
+ * Copyright (c) 2016-2026 Damien P. George
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,13 +31,76 @@
 
 #if defined(STM32H7)
 #define IWDG (IWDG1)
+#define WWDG (WWDG1)
 #endif
+
+#if defined(WWDG_CFR_WDGTB_2)
+#define WWDG_PRESCALER_MAX (7U)
+#else
+#define WWDG_PRESCALER_MAX (3U)
+#endif
+#define WWDG_COUNTER_MAX (64U)
 
 typedef struct _machine_wdt_obj_t {
     mp_obj_base_t base;
+    __IO uint32_t *feed_register;
+    uint32_t feed_value;
 } machine_wdt_obj_t;
 
-static const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
+static const machine_wdt_obj_t machine_iwdt = {{&machine_wdt_type}, &IWDG->KR, 0xaaaa};
+static machine_wdt_obj_t machine_wwdt = {{&machine_wdt_type}, &WWDG->CR, 0};
+
+#if defined(STM32H7)
+// This is not provided by the HAL, so define it here.
+static uint32_t HAL_RCC_GetPCLK3Freq(void) {
+    return LL_RCC_CALC_PCLK3_FREQ(HAL_RCC_GetHCLKFreq(), LL_RCC_GetAPB3Prescaler());
+}
+#endif
+
+static machine_wdt_obj_t *make_wwdt(mp_int_t timeout_ms) {
+    // WWDG is clocked from PCLKx divided by 4096.
+    uint32_t pclk;
+    #if defined(STM32H7)
+    pclk = HAL_RCC_GetPCLK3Freq();
+    #else
+    pclk = HAL_RCC_GetPCLK1Freq();
+    #endif
+
+    // Compute the number of ticks corresponding to the requested millisecond timeout.
+    uint64_t timeout_ticks = (uint64_t)timeout_ms * (uint64_t)(pclk / 1000U) / 4096ULL;
+
+    // Increase the prescaler to try and get timeout_ticks below its maximum value.
+    uint32_t prescaler = 0;
+    while (prescaler < WWDG_PRESCALER_MAX && timeout_ticks > WWDG_COUNTER_MAX) {
+        ++prescaler;
+        timeout_ticks = (timeout_ticks + 1) / 2;
+    }
+
+    // Check that the timeout is within range of the peripheral limits.
+    if (timeout_ticks <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("WDT timeout too short"));
+    } else if (timeout_ticks > WWDG_COUNTER_MAX) {
+        unsigned int max_timeout_ms = WWDG_COUNTER_MAX * 4096U * (1U << WWDG_PRESCALER_MAX) / (HAL_RCC_GetPCLK1Freq() / 1000U);
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT timeout too long, max %ums"), max_timeout_ms);
+    }
+
+    // Compute the value that will feed the WWDG.
+    machine_wwdt.feed_value = WWDG_CR_WDGA | (0x3f + timeout_ticks) << WWDG_CR_T_Pos;
+
+    // Initialise and start the WWDG.
+    #if defined(STM32H7)
+    LL_APB3_GRP1_EnableClock(LL_APB3_GRP1_PERIPH_WWDG1);
+    #if defined(RCC_GCR_WW1RSC)
+    LL_RCC_WWDG1_EnableSystemReset();
+    #endif
+    #else
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_WWDG);
+    #endif
+    WWDG->CFR = prescaler << WWDG_CFR_WDGTB_Pos | 0x7f << WWDG_CFR_W_Pos;
+    WWDG->CR = machine_wwdt.feed_value;
+
+    return &machine_wwdt;
+}
 
 static machine_wdt_obj_t *make_iwdt(mp_int_t timeout_ms) {
     // compute prescaler
@@ -70,7 +133,7 @@ static machine_wdt_obj_t *make_iwdt(mp_int_t timeout_ms) {
     // start the watch dog
     IWDG->KR = 0xcccc;
 
-    return (machine_wdt_obj_t *)&machine_wdt;
+    return (machine_wdt_obj_t *)&machine_iwdt;
 }
 
 static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
@@ -78,6 +141,8 @@ static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_i
         qstr qst = mp_obj_str_get_qstr(id_obj);
         if (qst == MP_QSTR_IWDG) {
             return make_iwdt(timeout_ms);
+        } else if (qst == MP_QSTR_WWDG) {
+            return make_wwdt(timeout_ms);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%q) doesn't exist"), qst);
         }
@@ -92,6 +157,5 @@ static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_i
 }
 
 static void mp_machine_wdt_feed(machine_wdt_obj_t *self) {
-    (void)self;
-    IWDG->KR = 0xaaaa;
+    *self->feed_register = self->feed_value;
 }

--- a/ports/stm32/machine_wdt.c
+++ b/ports/stm32/machine_wdt.c
@@ -32,6 +32,13 @@
 #if defined(STM32H7)
 #define IWDG (IWDG1)
 #define WWDG (WWDG1)
+#if defined(DUAL_CORE)
+#define DUAL_WDG (1)
+#endif
+#endif
+
+#ifndef DUAL_WDG
+#define DUAL_WDG (0)
 #endif
 
 #if defined(WWDG_CFR_WDGTB_2)
@@ -50,6 +57,11 @@ typedef struct _machine_wdt_obj_t {
 static const machine_wdt_obj_t machine_iwdt = {{&machine_wdt_type}, &IWDG->KR, 0xaaaa};
 static machine_wdt_obj_t machine_wwdt = {{&machine_wdt_type}, &WWDG->CR, 0};
 
+#if DUAL_WDG
+static const machine_wdt_obj_t machine_iwdt2 = {{&machine_wdt_type}, &IWDG2->KR, 0xaaaa};
+static machine_wdt_obj_t machine_wwdt2 = {{&machine_wdt_type}, &WWDG2->CR, 0};
+#endif
+
 #if defined(STM32H7)
 // This is not provided by the HAL, so define it here.
 static uint32_t HAL_RCC_GetPCLK3Freq(void) {
@@ -57,11 +69,18 @@ static uint32_t HAL_RCC_GetPCLK3Freq(void) {
 }
 #endif
 
-static machine_wdt_obj_t *make_wwdt(mp_int_t timeout_ms) {
+static machine_wdt_obj_t *make_wwdt(machine_wdt_obj_t *self, WWDG_TypeDef *wwdg, mp_int_t timeout_ms) {
     // WWDG is clocked from PCLKx divided by 4096.
     uint32_t pclk;
     #if defined(STM32H7)
-    pclk = HAL_RCC_GetPCLK3Freq();
+    #if DUAL_WDG
+    if (wwdg == WWDG2) {
+        pclk = HAL_RCC_GetPCLK1Freq();
+    } else
+    #endif
+    {
+        pclk = HAL_RCC_GetPCLK3Freq();
+    }
     #else
     pclk = HAL_RCC_GetPCLK1Freq();
     #endif
@@ -85,24 +104,34 @@ static machine_wdt_obj_t *make_wwdt(mp_int_t timeout_ms) {
     }
 
     // Compute the value that will feed the WWDG.
-    machine_wwdt.feed_value = WWDG_CR_WDGA | (0x3f + timeout_ticks) << WWDG_CR_T_Pos;
+    self->feed_value = WWDG_CR_WDGA | (0x3f + timeout_ticks) << WWDG_CR_T_Pos;
 
-    // Initialise and start the WWDG.
+    // Enable WWDG clock.
     #if defined(STM32H7)
-    LL_APB3_GRP1_EnableClock(LL_APB3_GRP1_PERIPH_WWDG1);
-    #if defined(RCC_GCR_WW1RSC)
-    LL_RCC_WWDG1_EnableSystemReset();
+    #if DUAL_WDG
+    if (wwdg == WWDG2) {
+        LL_APB3_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_WWDG2);
+        LL_RCC_WWDG2_EnableSystemReset();
+    } else
     #endif
+    {
+        LL_APB3_GRP1_EnableClock(LL_APB3_GRP1_PERIPH_WWDG1);
+        #if defined(RCC_GCR_WW1RSC)
+        LL_RCC_WWDG1_EnableSystemReset();
+        #endif
+    }
     #else
     LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_WWDG);
     #endif
-    WWDG->CFR = prescaler << WWDG_CFR_WDGTB_Pos | 0x7f << WWDG_CFR_W_Pos;
-    WWDG->CR = machine_wwdt.feed_value;
 
-    return &machine_wwdt;
+    // Initialise and start the WWDG.
+    wwdg->CFR = prescaler << WWDG_CFR_WDGTB_Pos | 0x7f << WWDG_CFR_W_Pos;
+    wwdg->CR = self->feed_value;
+
+    return self;
 }
 
-static machine_wdt_obj_t *make_iwdt(mp_int_t timeout_ms) {
+static machine_wdt_obj_t *make_iwdt(const machine_wdt_obj_t *self, IWDG_TypeDef *iwdg, mp_int_t timeout_ms) {
     // compute prescaler
     int32_t timeout = timeout_ms;
     uint32_t prescaler;
@@ -119,37 +148,43 @@ static machine_wdt_obj_t *make_iwdt(mp_int_t timeout_ms) {
     timeout -= 1;
 
     // set the reload register
-    while (IWDG->SR & 2) {
+    while (iwdg->SR & 2) {
     }
-    IWDG->KR = 0x5555;
-    IWDG->RLR = timeout;
+    iwdg->KR = 0x5555;
+    iwdg->RLR = timeout;
 
     // set the prescaler
-    while (IWDG->SR & 1) {
+    while (iwdg->SR & 1) {
     }
-    IWDG->KR = 0x5555;
-    IWDG->PR = prescaler;
+    iwdg->KR = 0x5555;
+    iwdg->PR = prescaler;
 
     // start the watch dog
-    IWDG->KR = 0xcccc;
+    iwdg->KR = 0xcccc;
 
-    return (machine_wdt_obj_t *)&machine_iwdt;
+    return (machine_wdt_obj_t *)self;
 }
 
 static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
     if (mp_obj_is_str(id_obj)) {
         qstr qst = mp_obj_str_get_qstr(id_obj);
         if (qst == MP_QSTR_IWDG) {
-            return make_iwdt(timeout_ms);
+            return make_iwdt(&machine_iwdt, IWDG, timeout_ms);
         } else if (qst == MP_QSTR_WWDG) {
-            return make_wwdt(timeout_ms);
+            return make_wwdt(&machine_wwdt, WWDG, timeout_ms);
+        #if DUAL_WDG
+        } else if (qst == MP_QSTR_IWDG2) {
+            return make_iwdt(&machine_iwdt2, IWDG2, timeout_ms);
+        } else if (qst == MP_QSTR_WWDG2) {
+            return make_wwdt(&machine_wwdt2, WWDG2, timeout_ms);
+        #endif
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%q) doesn't exist"), qst);
         }
     } else {
         mp_int_t id = mp_obj_get_int(id_obj);
         if (id == 0) {
-            return make_iwdt(timeout_ms);
+            return make_iwdt(&machine_iwdt, IWDG, timeout_ms);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
         }

--- a/ports/stm32/machine_wdt.c
+++ b/ports/stm32/machine_wdt.c
@@ -39,7 +39,8 @@ typedef struct _machine_wdt_obj_t {
 
 static const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
+    mp_int_t id = mp_obj_get_int(id_obj);
     if (id != 0) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
     }

--- a/ports/stm32/machine_wdt.c
+++ b/ports/stm32/machine_wdt.c
@@ -39,12 +39,7 @@ typedef struct _machine_wdt_obj_t {
 
 static const machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}};
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
-    mp_int_t id = mp_obj_get_int(id_obj);
-    if (id != 0) {
-        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
-    }
-
+static machine_wdt_obj_t *make_iwdt(mp_int_t timeout_ms) {
     // compute prescaler
     int32_t timeout = timeout_ms;
     uint32_t prescaler;
@@ -76,6 +71,24 @@ static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_i
     IWDG->KR = 0xcccc;
 
     return (machine_wdt_obj_t *)&machine_wdt;
+}
+
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
+    if (mp_obj_is_str(id_obj)) {
+        qstr qst = mp_obj_str_get_qstr(id_obj);
+        if (qst == MP_QSTR_IWDG) {
+            return make_iwdt(timeout_ms);
+        } else {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%q) doesn't exist"), qst);
+        }
+    } else {
+        mp_int_t id = mp_obj_get_int(id_obj);
+        if (id == 0) {
+            return make_iwdt(timeout_ms);
+        } else {
+            mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
+        }
+    }
 }
 
 static void mp_machine_wdt_feed(machine_wdt_obj_t *self) {

--- a/ports/zephyr/machine_wdt.c
+++ b/ports/zephyr/machine_wdt.c
@@ -45,8 +45,8 @@ static machine_wdt_obj_t wdt_default = {
     {&machine_wdt_type}, NULL, -1
 };
 
-static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_int_t id, mp_int_t timeout_ms) {
-    if (id != 0) {
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id, mp_int_t timeout_ms) {
+    if (id != MP_OBJ_NEW_SMALL_INT(0)) {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid WDT id"));
     }
 


### PR DESCRIPTION
### Summary

The stm32 port already supports `machine.WDT()`, which accesses the IWDG peripheral (independent watchdog).

This PR adds support for the STM32 WWDG peripheral (windowed watchdog), through the same, standard `machine.WDT()` class interface.  It's accessed as peripheral id=1.

So now it's possible to have 2 watchdogs, like this:
```py
import machine

w1 = machine.WDT(timeout=5000)  # IWDG
w2 = machine.WDT(1, timeout=100)  #WWDG
w1.feed()
w2.feed()
```

The maximum timeout is quite limited on this watchdog due to the limited prescaler values, for example:
- STM32F4 at 168MHz: 49ms max timeout (at 96MHz it's 87ms max)
- STM32F7 at 216MHz: 38ms max timeout
- STM32N6 at 800MHz: 167ms max timeout
- STM32WB at 64MHz: 524ms max timeout

So it needs to be used with care.

### Testing

Tested on:
- PYBV10
- PYB_SF6
- NUCLEO_WB55
- OPENMV_N6

### Trade-offs and Alternatives

The hardest decision here is how to name/access the peripherals.  All existing ports have only one watchdog exposed, and it's the default when you do `machine.WDT()` -- that's equivalent to `machine.WDT(0)`.

But now with more than one watchdog, how to name them?  The stm32 datasheets call them IWDG and WWDG on everything except H7 which has two of each: IWDG1, IWDG2, WWDG1 and WWDG2 (only IWDG1/WWDG1 are currently implemented on H7).

Note that mimxrt also has multiple watchdogs: WDOG1, WDOG2 (and WDOG3 if it exists on the MCU).  Currently only WDOG1 is exposed (as `machine.WDT(0)`).

To be consistent with other stm32 peripheral naming, the IWDG1/IWDG2 should probably be accessed via id=1 and id=2 respectively.  Then WWDG1/WWDG2 could be id=3 and id=4... although that's not very intuitive.  Instead they could be named by a string like `machine.WDT("WWDG1")` etc.  The default `machine.WDT()` would still access IWDG(1), but I guess it should also be available via the string `"IWDG"`/`"IWDG1"`.

### Generative AI

Not used.