### PR TITLE
rp2: Revert newlib nano on RP2350, move nano libc to RAM on RP2040.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -532,22 +532,31 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
     -Wall
     -Werror
     -g  # always include debug information in the ELF
-
-    # pico-sdk already passes --specs=nosys.specs to stub out syscall handlers,
-    # passing nano.specs as well means that newlib-nano libc functions will be used
-    # (note this is mostly a linker option, but should be passed to the compiler as
-    # well to add the newlib-nano header to the search path. Currently this happens
-    # inconsistently as pico-sdk files aren't built with this option.)
-    --specs=nano.specs
 )
+
+if(PICO_RP2040)
+    # Enable nano.specs for RP2040 only.
+    #
+    # Pico-sdk already enables nosys.specs to stub out syscall handlers,
+    # passing nano.specs to compiler & linker means that newlib-nano libc
+    # functions will be used.
+    #
+    # On RP2350 nano.specs also reduces code size, but using size optimised
+    # versions of memcpy, memset instead of unrolled versions has a measurable
+    # impact on performance with the more complex CPU.
+    target_compile_options(${MICROPY_TARGET} PRIVATE
+        --specs=nano.specs
+    )
+    target_link_options(${MICROPY_TARGET} PRIVATE
+        --specs=nano.specs
+    )
+endif()
 
 target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--defsym=__micropy_c_heap_size__=${MICROPY_C_HEAP_SIZE}
     -Wl,--wrap=runtime_init_clocks
     -Wl,--print-memory-usage
     -Wl,--cref
-    # see note about nano.specs, above
-    --specs=nano.specs
 )
 
 if(DEFINED PICO_FLASH_SIZE_BYTES)

--- a/ports/rp2/memmap_mp_rp2040.ld
+++ b/ports/rp2/memmap_mp_rp2040.ld
@@ -70,7 +70,7 @@ SECTIONS
          * FLASH ... we will include any thing excluded here in .data below by default */
         *(.init)
         /* Change for MicroPython... exclude gc.c, parse.c, vm.c from flash */
-        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj) .text*)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj *mem_ops_*.o) .text*)
         *(.fini)
         /* Pull all c'tors into .text */
         *crtbegin.o(.ctors)

--- a/ports/rp2/memmap_mp_rp2040.ld
+++ b/ports/rp2/memmap_mp_rp2040.ld
@@ -70,7 +70,8 @@ SECTIONS
          * FLASH ... we will include any thing excluded here in .data below by default */
         *(.init)
         /* Change for MicroPython... exclude gc.c, parse.c, vm.c from flash */
-        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj *mem_ops_*.o) .text*)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *libc_a-mem*.o *libc_a-str*.o *libm.a:
+                       *gc.c.obj *vm.c.obj *parse.c.obj *mem_ops_*.o) .text*)
         *(.fini)
         /* Pull all c'tors into .text */
         *crtbegin.o(.ctors)


### PR DESCRIPTION
### Summary

This is a follow-up to fix some performance regressions from #19299:

* Some nano libc functions weren't being picked up by the linker script to link into RAM, causing more flash cache misses. (This probably explains the +720 bytes free .bss in PR 19299!)
* RP2350 performance was significantly impacted by switching from the standard libc memcpy & memset, which unroll the loop, to the nano versions which only do byte by byte copies. Thanks @kilograham for bringing this to our attention.

In this PR:

* Only enable nano.specs for RP2040.
* On RP2040, link all libc string functions, mem functions, and the pico_mem_ops functions to RAM. The impact here is relatively small because there are the nano libc functions, and the "pico_mem_ops" are very small shim wrappers around calls to ROM memcpy and memcmp. Most of these functions were not in RAM in earlier MicroPython versions.

### Testing

Using perfbench, regarding any variation <4% as within the margin of error for cache effects caused by different binaries.

#### RP2040

Comparing pre-nano MicroPython commit to current master:

```
diff of scores (higher is better)
N=168 M=100                rp2040_pre_nano.txt -> rp2040_master.txt         diff      diff% (error%)
bm_chaos.py                    154.11 ->     152.00 :      -2.11 =  -1.369% (+/-0.09%)
bm_fannkuch.py                  56.47 ->      55.06 :      -1.41 =  -2.497% (+/-0.03%)
bm_fft.py                     1372.81 ->    1439.68 :     +66.87 =  +4.871% (+/-0.02%)
bm_float.py                   1776.33 ->    1772.48 :      -3.85 =  -0.217% (+/-0.09%)
bm_hexiom.py                    23.13 ->      23.23 :      +0.10 =  +0.432% (+/-0.06%)
bm_nqueens.py                 1965.06 ->    2051.67 :     +86.61 =  +4.407% (+/-0.14%)
bm_pidigits.py                 404.07 ->     412.89 :      +8.82 =  +2.183% (+/-0.06%)
bm_wordcount.py                 38.95 ->      34.11 :      -4.84 = -12.426% (+/-0.10%)
core_import_mpy_multi.py       232.11 ->     230.26 :      -1.85 =  -0.797% (+/-0.10%)
core_import_mpy_single.py       44.16 ->      42.96 :      -1.20 =  -2.717% (+/-0.27%)
core_locals.py                  32.57 ->      32.52 :      -0.05 =  -0.154% (+/-0.01%)
core_qstr.py                   125.85 ->     116.52 :      -9.33 =  -7.414% (+/-0.10%)
core_str.py                     17.67 ->      16.61 :      -1.06 =  -5.999% (+/-0.04%)
core_yield_from.py             225.63 ->     225.63 :      +0.00 =  +0.000% (+/-0.01%)
misc_aes.py                    239.24 ->     240.31 :      +1.07 =  +0.447% (+/-0.09%)
misc_mandel.py                1188.01 ->    1244.04 :     +56.03 =  +4.716% (+/-0.05%)
misc_pystone.py               1092.67 ->    1049.90 :     -42.77 =  -3.914% (+/-0.08%)
misc_raytrace.py               164.20 ->     161.21 :      -2.99 =  -1.821% (+/-0.05%)
viper_call0.py                 319.99 ->     319.98 :      -0.01 =  -0.003% (+/-0.00%)
viper_call1a.py                312.78 ->     312.78 :      +0.00 =  +0.000% (+/-0.01%)
viper_call1b.py                235.10 ->     235.10 :      +0.00 =  +0.000% (+/-0.00%)
viper_call1c.py                236.88 ->     236.88 :      +0.00 =  +0.000% (+/-0.00%)
viper_call2a.py                308.16 ->     308.16 :      +0.00 =  +0.000% (+/-0.01%)
viper_call2b.py                206.72 ->     206.72 :      +0.00 =  +0.000% (+/-0.00%)
```

Most of these changes are within the margin of error, but notable ones include `core_qstr.py` and `core_str.py` becoming slower.

Comparing pre-nano to this PR:

```
diff of scores (higher is better)
N=168 M=100                rp2040_pre_nano.txt -> rp2040_pr_branch.txt         diff      diff% (error%)
bm_chaos.py                    154.11 ->     152.08 :      -2.03 =  -1.317% (+/-0.08%)
bm_fannkuch.py                  56.47 ->      54.81 :      -1.66 =  -2.940% (+/-0.01%)
bm_fft.py                     1372.81 ->    1429.48 :     +56.67 =  +4.128% (+/-0.01%)
bm_float.py                   1776.33 ->    1743.59 :     -32.74 =  -1.843% (+/-0.11%)
bm_hexiom.py                    23.13 ->      22.75 :      -0.38 =  -1.643% (+/-0.05%)
bm_nqueens.py                 1965.06 ->    2125.50 :    +160.44 =  +8.165% (+/-0.05%)
bm_pidigits.py                 404.07 ->     408.43 :      +4.36 =  +1.079% (+/-0.06%)
bm_wordcount.py                 38.95 ->      38.44 :      -0.51 =  -1.309% (+/-0.03%)
core_import_mpy_multi.py       232.11 ->     228.28 :      -3.83 =  -1.650% (+/-0.09%)
core_import_mpy_single.py       44.16 ->      41.46 :      -2.70 =  -6.114% (+/-0.25%)
core_locals.py                  32.57 ->      32.55 :      -0.02 =  -0.061% (+/-0.01%)
core_qstr.py                   125.85 ->     123.39 :      -2.46 =  -1.955% (+/-0.11%)
core_str.py                     17.67 ->      17.33 :      -0.34 =  -1.924% (+/-0.03%)
core_yield_from.py             225.63 ->     225.71 :      +0.08 =  +0.035% (+/-0.01%)
misc_aes.py                    239.24 ->     230.58 :      -8.66 =  -3.620% (+/-0.09%)
misc_mandel.py                1188.01 ->    1229.93 :     +41.92 =  +3.529% (+/-0.06%)
misc_pystone.py               1092.67 ->    1065.89 :     -26.78 =  -2.451% (+/-0.06%)
misc_raytrace.py               164.20 ->     160.63 :      -3.57 =  -2.174% (+/-0.08%)
viper_call0.py                 319.99 ->     319.98 :      -0.01 =  -0.003% (+/-0.00%)
viper_call1a.py                312.78 ->     312.78 :      +0.00 =  +0.000% (+/-0.01%)
viper_call1b.py                235.10 ->     235.09 :      -0.01 =  -0.004% (+/-0.00%)
viper_call1c.py                236.88 ->     236.88 :      +0.00 =  +0.000% (+/-0.01%)
viper_call2a.py                308.16 ->     308.15 :      -0.01 =  -0.003% (+/-0.01%)
viper_call2b.py                206.72 ->     206.71 :      -0.01 =  -0.005% (+/-0.00%)
```

These results are all relatively noisy and it's hard to draw clear conclusions, but overall the second set of changes look to have less significant regression to me.  The -6% on `core_import_mpy_single.py` is odd, but this didn't appear in an earlier version of this PR so it's probably noise due to cache layout.

(EDIT: Previous version of this analysis I read something backwards!)

However at least we can say there's no obvious regression, and we still have smaller binary size & RAM usage compared to pre-nano. (339608 flash & 12692 RAM pre-nano, 338720 & 12388 with this PR.)

### RP2350

Pre-nano vs current master:

```
diff of scores (higher is better)
N=168 M=100                rp2350_pre_nano.txt -> rp2350_master.txt         diff      diff% (error%)
bm_chaos.py                    307.38 ->     274.25 :     -33.13 = -10.778% (+/-0.08%)
bm_fannkuch.py                  92.60 ->      84.65 :      -7.95 =  -8.585% (+/-0.05%)
bm_fft.py                     2989.25 ->    2776.11 :    -213.14 =  -7.130% (+/-0.03%)
bm_float.py                   4833.23 ->    4362.35 :    -470.88 =  -9.743% (+/-0.09%)
bm_hexiom.py                    43.77 ->      37.62 :      -6.15 = -14.051% (+/-0.05%)
bm_nqueens.py                 3708.24 ->    3124.45 :    -583.79 = -15.743% (+/-0.06%)
bm_pidigits.py                 773.64 ->     578.45 :    -195.19 = -25.230% (+/-0.07%)
bm_wordcount.py                 67.40 ->      67.69 :      +0.29 =  +0.430% (+/-0.03%)
core_import_mpy_multi.py       430.47 ->     445.18 :     +14.71 =  +3.417% (+/-0.08%)
core_import_mpy_single.py       89.38 ->      92.21 :      +2.83 =  +3.166% (+/-0.22%)
core_locals.py                  59.85 ->      57.90 :      -1.95 =  -3.258% (+/-0.04%)
core_qstr.py                   188.09 ->     199.66 :     +11.57 =  +6.151% (+/-0.07%)
core_str.py                     29.84 ->      29.35 :      -0.49 =  -1.642% (+/-0.05%)
core_yield_from.py             401.27 ->     362.21 :     -39.06 =  -9.734% (+/-0.03%)
misc_aes.py                    432.89 ->     393.01 :     -39.88 =  -9.213% (+/-0.07%)
misc_mandel.py                3298.48 ->    3183.31 :    -115.17 =  -3.492% (+/-0.06%)
misc_pystone.py               2012.00 ->    1884.39 :    -127.61 =  -6.342% (+/-0.09%)
misc_raytrace.py               323.51 ->     296.71 :     -26.80 =  -8.284% (+/-0.04%)
viper_call0.py                 559.93 ->     559.91 :      -0.02 =  -0.004% (+/-0.01%)
viper_call1a.py                546.13 ->     546.11 :      -0.02 =  -0.004% (+/-0.01%)
viper_call1b.py                449.52 ->     449.52 :      +0.00 =  +0.000% (+/-0.00%)
viper_call1c.py                456.37 ->     456.35 :      -0.02 =  -0.004% (+/-0.00%)
viper_call2a.py                536.34 ->     536.33 :      -0.01 =  -0.002% (+/-0.01%)
viper_call2b.py                400.32 ->     400.32 :      +0.00 =  +0.000% (+/-0.01%)
```

:grimacing: Not great, I should have checked this before merging 19929!

Pre-nano versus this PR:

```
diff of scores (higher is better)
N=168 M=100                rp2350_pre_nano.txt -> rp2350_pr_branch.txt         diff      diff% (error%)
bm_chaos.py                    307.38 ->     309.29 :      +1.91 =  +0.621% (+/-0.08%)
bm_fannkuch.py                  92.60 ->      93.53 :      +0.93 =  +1.004% (+/-0.06%)
bm_fft.py                     2989.25 ->    2818.90 :    -170.35 =  -5.699% (+/-0.03%)
bm_float.py                   4833.23 ->    4707.45 :    -125.78 =  -2.602% (+/-0.12%)
bm_hexiom.py                    43.77 ->      44.29 :      +0.52 =  +1.188% (+/-0.05%)
bm_nqueens.py                 3708.24 ->    3708.21 :      -0.03 =  -0.001% (+/-0.07%)
bm_pidigits.py                 773.64 ->     765.10 :      -8.54 =  -1.104% (+/-0.09%)
bm_wordcount.py                 67.40 ->      65.27 :      -2.13 =  -3.160% (+/-0.04%)
core_import_mpy_multi.py       430.47 ->     429.81 :      -0.66 =  -0.153% (+/-0.07%)
core_import_mpy_single.py       89.38 ->      88.22 :      -1.16 =  -1.298% (+/-0.15%)
core_locals.py                  59.85 ->      59.72 :      -0.13 =  -0.217% (+/-0.04%)
core_qstr.py                   188.09 ->     191.20 :      +3.11 =  +1.653% (+/-0.09%)
core_str.py                     29.84 ->      29.00 :      -0.84 =  -2.815% (+/-0.03%)
core_yield_from.py             401.27 ->     401.29 :      +0.02 =  +0.005% (+/-0.01%)
misc_aes.py                    432.89 ->     433.29 :      +0.40 =  +0.092% (+/-0.06%)
misc_mandel.py                3298.48 ->    3006.84 :    -291.64 =  -8.842% (+/-0.05%)
misc_pystone.py               2012.00 ->    1955.00 :     -57.00 =  -2.833% (+/-0.10%)
misc_raytrace.py               323.51 ->     319.08 :      -4.43 =  -1.369% (+/-0.04%)
viper_call0.py                 559.93 ->     564.12 :      +4.19 =  +0.748% (+/-0.01%)
viper_call1a.py                546.13 ->     550.12 :      +3.99 =  +0.731% (+/-0.01%)
viper_call1b.py                449.52 ->     452.24 :      +2.72 =  +0.605% (+/-0.00%)
viper_call1c.py                456.37 ->     459.16 :      +2.79 =  +0.611% (+/-0.00%)
viper_call2a.py                536.34 ->     540.22 :      +3.88 =  +0.723% (+/-0.01%)
viper_call2b.py                400.32 ->     402.48 :      +2.16 =  +0.540% (+/-0.01%)
```

Would expect these results to be basically the same as pre-nano, so I think the main cause of changes here is noise...

### Trade-offs and Alternatives

* We could completely revert #19299 and keep using default.specs everywhere, the differences are not that big either way so this might be the simpler approach.
* Could link our versions of libc memory & string functions from `shared/libc/string0.c` instead. This has a version of memcpy that uses full word operations, for example. Initial testing on RP2350 this showed quite small size, and performance mid-way between "nano" libc and the default newlib functions.
* We could also look at moving string functions and memcpy/memcmp to RAM on RP2350 to get more performance at the cost of less free RAM. This might be worth looking into in a follow-up PR.
* While making these changes I noted that the rp2 port linker scripts try to link `*gc.c.obj *vm.c.obj *parse.c.obj` to RAM, but these don't match anything as the pico-sdk sets `CMAKE_C_OUTPUT_EXTENSION` to `.o`. So we should either remove these, or experiment with the RAM/Performance trade-off of putting these parts of MicroPython into RAM.

### Generative AI

I did not use generative AI tools when creating this PR.
