### PR TITLE
rp2: Revert "rp2: Build with nano.specs for newlib-nano.".

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -532,13 +532,6 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
     -Wall
     -Werror
     -g  # always include debug information in the ELF
-
-    # pico-sdk already passes --specs=nosys.specs to stub out syscall handlers,
-    # passing nano.specs as well means that newlib-nano libc functions will be used
-    # (note this is mostly a linker option, but should be passed to the compiler as
-    # well to add the newlib-nano header to the search path. Currently this happens
-    # inconsistently as pico-sdk files aren't built with this option.)
-    --specs=nano.specs
 )
 
 target_link_options(${MICROPY_TARGET} PRIVATE
@@ -546,8 +539,6 @@ target_link_options(${MICROPY_TARGET} PRIVATE
     -Wl,--wrap=runtime_init_clocks
     -Wl,--print-memory-usage
     -Wl,--cref
-    # see note about nano.specs, above
-    --specs=nano.specs
 )
 
 if(DEFINED PICO_FLASH_SIZE_BYTES)

--- a/ports/rp2/mbedtls/mbedtls_config_port.h
+++ b/ports/rp2/mbedtls/mbedtls_config_port.h
@@ -34,7 +34,6 @@
 time_t rp2_rtctime_seconds(time_t *timer);
 #define MBEDTLS_PLATFORM_TIME_MACRO rp2_rtctime_seconds
 #define MBEDTLS_PLATFORM_MS_TIME_ALT mbedtls_ms_time
-#define MBEDTLS_PLATFORM_GMTIME_R_ALT 1
 
 // Set MicroPython-specific options.
 #define MICROPY_MBEDTLS_CONFIG_BARE_METAL (1)

--- a/ports/rp2/mbedtls/mbedtls_port.c
+++ b/ports/rp2/mbedtls/mbedtls_port.c
@@ -47,13 +47,4 @@ mbedtls_ms_time_t mbedtls_ms_time(void) {
     current_ms = rp2_rtctime_seconds(tv) * 1000;
     return current_ms;
 }
-
-struct tm *mbedtls_platform_gmtime_r(const mbedtls_time_t *tt, struct tm *tm_buf) {
-    // Default mbedTLS platform implementation calls gmtime() here. This is
-    // unnecessary as this function signature already matches gmtime_r(), and
-    // additionally on newlib-nano gmtime() tries to malloc the reent buffer on
-    // demand - which will fail.
-    return gmtime_r(tt, tm_buf);
-}
-
 #endif


### PR DESCRIPTION
### Summary

This reverts commit 6552836c2c6a9833992f9d9e7229b5235386fa20 from #19299.

* RP2350 has a performance regression with this change (thanks again @kilograham for pointing this out).
* RP2040 seems like there is potential to get both good performance and good size benefits with nano.specs, but #19352 is proving more complex than expected - so suggest we revert the whole thing for now and re-add it for RP2040 at some point in the future.

### Testing

I haven't done any specific testing for this revert, but PR 19352 has some before vs after performance benchmarks.

### Trade-offs and Alternatives

* Could close this and wait for #19352 to be done instead, but it feels like it might take some time to figure out all implications of that PR.

### Generative AI

I did not use generative AI tools when creating this PR.
