### PR TITLE
rp2: Build with -fno-math-errno to use the hardware sqrt instruction.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -532,6 +532,11 @@ target_compile_options(${MICROPY_TARGET} PRIVATE
     -Wall
     -Werror
     -g  # always include debug information in the ELF
+
+    # Let the compiler lower sqrt()/sqrtf() to the hardware VSQRT instruction
+    # instead of a library call.  MicroPython's math module detects domain
+    # errors via isnan/isinf on the result, not errno, so this is safe.
+    -fno-math-errno
 )
 
 target_link_options(${MICROPY_TARGET} PRIVATE


### PR DESCRIPTION
Without -fno-math-errno the compiler must keep sqrt()/sqrtf() as library calls so they can set errno on a domain error, even though [the Cortex-M33 FPU has a single VSQRT.F32 instruction](https://developer.arm.com/documentation/100235/0004/the-cortex-m33-instruction-set/floating-point-instructions/vsqrt?lang=en).

MicroPython's math module detects domain errors via isnan/isinf checks on the result rather than errno, so disabling errno here is safe and lets sqrt leverage hardware.

### Summary

Make RP2 go brr. Seriously when you start to write apps and games with vector graphics and all sorts of shiny stuff you want to eke out every little iota of performance you can!

### Testing

Benchmarked on a Pico 2 (RP2350, perfbench N=150 M=100, avg of 3): misc_mandel (complex abs() in its inner loop) improves by ~12+%, with no measurable change to non-sqrt benchmarks and a slightly smaller binary.

Benchmark | Before (score) | After (score) | Change
-- | -- | -- | --
bm_chaos | 293.69 | 298.50 | +1.6%
bm_fannkuch | 82.42 | 81.32 | −1.3%
bm_fft | 3189.25 | 3223.54 | +1.1%
bm_float | 4720.96 | 4735.30 | +0.3%
bm_hexiom | 39.33 | 39.59 | +0.7%
bm_nqueens | 3154.12 | 3076.48 | −2.5%
bm_pidigits | 612.63 | 608.32 | −0.7%
bm_wordcount | 71.13 | 65.64 | −7.7%
misc_aes | 530.36 | 510.17 | −3.8%
misc_mandel | 2936.27 | 3415.50 | +16.3%
misc_pystone | 2197.17 | 2151.49 | −2.1%
misc_raytrace | 317.59 | 319.02 | +0.5%

Ran the test suite:

937 tests performed (26410 individual testcases)
937 tests passed
122 tests skipped:

### Trade-offs and Alternatives

None, as far as I'm aware. This is a win/win.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.