### PR TITLE
lib/tinyusb: Update to version 0.21.0

### DIFF
--- a/extmod/machine_usb_device.c
+++ b/extmod/machine_usb_device.c
@@ -117,7 +117,12 @@ static mp_obj_t usb_device_submit_xfer(mp_obj_t self, mp_obj_t ep, mp_obj_t buff
         mp_raise_OSError(MP_EBUSY);
     }
 
+    #if TUSB_VERSION_NUMBER >= 2001
+    // This submit path runs from the MicroPython scheduler, never an ISR.
+    result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len, false);
+    #else
     result = usbd_edpt_xfer(RHPORT, ep_addr, buf_info.buf, buf_info.len);
+    #endif
 
     if (result) {
         // Store the buffer object until the transfer completes

--- a/ports/alif/tinyusb_port/tusb_alif_dcd.c
+++ b/ports/alif/tinyusb_port/tusb_alif_dcd.c
@@ -256,7 +256,7 @@ void dcd_set_address(uint8_t rhport, uint8_t dev_addr)
     // set and STATUS sent back to the host. Xfer call below is purely for
     // internal TinyUSB state to conclude transaction and issue next SETUP req.
 
-    dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0);
+    dcd_edpt_xfer(rhport, tu_edpt_addr(0, TUSB_DIR_IN), NULL, 0, false);
 }
 
 // Called to remote wake up host when suspended (e.g hid keyboard)
@@ -367,8 +367,9 @@ void dcd_edpt_close(uint8_t rhport, uint8_t ep_addr) TU_ATTR_WEAK;
 
 // Submit a transfer, When complete dcd_event_xfer_complete() is invoked to
 // notify the stack
-bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes)
+bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t total_bytes, bool is_isr)
 {
+    (void) is_isr;
     // DEPSTRTXFER command
     LOG("%010u >%s %u %x %u", DWT->CYCCNT, __func__, ep_addr, (uint32_t) buffer, total_bytes);
 
@@ -431,7 +432,7 @@ bool dcd_edpt_xfer(uint8_t rhport, uint8_t ep_addr, uint8_t * buffer, uint16_t t
 
 // Submit a transfer using fifo, When complete dcd_event_xfer_complete() is invoked to notify the stack
 // This API is optional, may be useful for register-based for transferring data.
-bool dcd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, uint16_t total_bytes) TU_ATTR_WEAK;
+bool dcd_edpt_xfer_fifo(uint8_t rhport, uint8_t ep_addr, tu_fifo_t * ff, uint16_t total_bytes, bool is_isr) TU_ATTR_WEAK;
 
 // Stall endpoint, any queuing transfer should be removed from endpoint
 void dcd_edpt_stall(uint8_t rhport, uint8_t ep_addr)

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -464,6 +464,7 @@ USBDEV_SRC_C += $(addprefix $(USBDEV_DIR)/,\
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c \
+	src/portable/st/stm32_fsdev/fsdev_common.c \
 	src/portable/synopsys/dwc2/dcd_dwc2.c \
 	src/portable/synopsys/dwc2/dwc2_common.c \
 	src/portable/synopsys/dwc2/hcd_dwc2.c \


### PR DESCRIPTION
### Summary

Bumps the bundled TinyUSB from `0.19.0-24` (`aa0fc2e08`) to `0.20.0-1086` (`0afee06e9`, current upstream master). The submodule pin has not moved since #18406 (Nov 2025); TinyUSB master has since changed the device endpoint-transfer API, so this also adapts the in-tree glue.

### API change adapted

TinyUSB added a trailing `bool is_isr` argument to the device transfer entry points:

- `usbd_edpt_xfer()` / `usbd_edpt_xfer_fifo()` (device stack API)
- `dcd_edpt_xfer()` / `dcd_edpt_xfer_fifo()` (driver entry points)

In-tree changes:

- `extmod/machine_usb_device.c`: the single caller is the `USBDevice.submit_xfer()` path, which runs from the MicroPython scheduler and never an ISR, so it passes `is_isr = false`.
- `ports/alif/tinyusb_port/tusb_alif_dcd.c`: this port ships a custom dcd driver; its two transfer entry points (and the internal `dcd_set_address` call) take the new argument. It is unused by the driver, matching how the in-tree reference drivers handle it.

### Testing

- rp2 (`RPI_PICO`) builds clean locally.
- Other ports rely on this PR's CI to surface per-port breakage.
- **The alif change is untested** - I have no alif hardware. The signature update is mechanical, but a maintainer should confirm the `is_isr` handling is appropriate for that controller.

### Out of scope

The `tuh_init()` -> `tusb_init(rhport, rh_init)` host-init deprecation is not touched here: there is no USB host code on master (it is only relevant to out-of-tree `machine.USBHost` work).

---

Opening as a draft to run the full CI matrix and surface any remaining per-port breakage before review.
