### PR TITLE
rp2: Fix linker to bring vm, gc and parse into SRAM

### DIFF
--- a/ports/rp2/memmap_mp_rp2040.ld
+++ b/ports/rp2/memmap_mp_rp2040.ld
@@ -70,7 +70,7 @@ SECTIONS
          * FLASH ... we will include any thing excluded here in .data below by default */
         *(.init)
         /* Change for MicroPython... exclude gc.c, parse.c, vm.c from flash */
-        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj) .text*)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib_a-mem*.o *libm.a: *py/gc.c.o *py/vm.c.o *py/parse.c.o) .text*)
         *(.fini)
         /* Pull all c'tors into .text */
         *crtbegin.o(.ctors)

--- a/ports/rp2/memmap_mp_rp2350.ld
+++ b/ports/rp2/memmap_mp_rp2350.ld
@@ -62,7 +62,7 @@ SECTIONS
         *(.init)
         *libgcc.a:cmse_nonsecure_call.o
         /* Change for MicroPython... exclude gc.c, parse.c, vm.c from flash */
-        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *gc.c.obj *vm.c.obj *parse.c.obj) .text*)
+        *(EXCLUDE_FILE(*libgcc.a: *libc.a:*lib_a-mem*.o *libm.a: *py/gc.c.o *py/vm.c.o *py/parse.c.o) .text*)
         *(.fini)
         /* Pull all c'tors into .text */
         *crtbegin.o(.ctors)


### PR DESCRIPTION
### Summary

A small linker bugfix (`.obj` → `.o` in the rp2 `EXCLUDE_FILE` patterns) to relocate the MicroPython interpreter, GC, and parser (`py/vm.c`, `py/gc.c`, `py/parse.c`) from XIP flash into SRAM. Previously the patterns matched nothing (CMake names objects `<src>.c.o`, not `.c.obj`), so the optimisation was silently inert and these ran from flash.

I believe this reflects the *intended* behaviour, but since the ship has sailed on RP2040 (RP2350 is less affected) it's not necessarily an easy sell.

This change replaces an earlier `__not_in_flash_func` wrapper setup I was chasing to move the VM into SRAM. Though using wrappers give us mpconfigboard.cmake control over which VM + leaf functions are relocated to flash, and makes it a board-level opt-in rather than this all-or-nothing approach.

## Testing

### Pico W (RP2040, 125 MHz, average of 5)

**Mean +13.5%**

| benchmark |  | benchmark |  |
|---|--:|---|--:|
| bm_chaos | +28.9% | misc_pystone | +10.8% |
| bm_fannkuch | +26.7% | bm_float | +8.0% |
| bm_hexiom | +23.0% | bm_fft | +3.4% |
| bm_nqueens | +22.1% | misc_aes | +3.1% |
| bm_pidigits | +20.8% | bm_wordcount | −1.8% |
| misc_mandel | +18.4% | misc_raytrace | −2.0% |

Cost: ~12 KB.

### Both architectures

| board | mean | regressions |
|---|--:|---|
| RP2350 (LiPo 2, 150 MHz) | **+15.8%** | bm_fft −5.9%, bm_wordcount −4.2% |
| RP2040 (Pico W, 125 MHz) | **+13.5%** | misc_raytrace −2.0%, bm_wordcount −1.8% |

### Trade-offs and Alternatives

- VM-dispatch-bound benchmarks go brr; the alloc/GC-bound `bm_wordcount` slips
  slightly on both (it doesn't use the faster dispatch loop and loses to the
  layout shift XIP cache lottery 😭).
- `raytrace`/`fft` flip sign between architectures - probably XIP-cache placement noise on
  RP2040, not the algorithm itself.
- Net: the linker fix delivers a ~13–16% performance boost, but on the Pico W the wifi/lwIP stack already consumes RAM, so an extra ~12 KB is a noticeable chunk of heap.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

