### PR TITLE
tools/uf2conv: Fix TypeError when reporting bad blocks.

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -76,14 +76,14 @@ def convert_from_uf2(buf):
         block = buf[ptr : ptr + 512]
         hd = struct.unpack(b"<IIIIIIII", block[0:32])
         if hd[0] != UF2_MAGIC_START0 or hd[1] != UF2_MAGIC_START1:
-            print("Skipping block at " + ptr + "; bad magic")
+            print("Skipping block at " + str(ptr) + "; bad magic")
             continue
         if hd[2] & 1:
             # NO-flash flag set; skip block
             continue
         datalen = hd[4]
         if datalen > 476:
-            assert False, "Invalid UF2 data size at " + ptr
+            assert False, "Invalid UF2 data size at " + str(ptr)
         newaddr = hd[3]
         if (hd[2] & 0x2000) and (currfamilyid is None):
             currfamilyid = hd[7]
@@ -94,11 +94,11 @@ def convert_from_uf2(buf):
                 appstartaddr = newaddr
         padding = newaddr - curraddr
         if padding < 0:
-            assert False, "Block out of order at " + ptr
+            assert False, "Block out of order at " + str(ptr)
         if padding > 10 * 1024 * 1024:
-            assert False, "More than 10M of padding needed at " + ptr
+            assert False, "More than 10M of padding needed at " + str(ptr)
         if padding % 4 != 0:
-            assert False, "Non-word padding size at " + ptr
+            assert False, "Non-word padding size at " + str(ptr)
         while padding > 0:
             padding -= 4
             outp += b"\x00\x00\x00\x00"


### PR DESCRIPTION
### Summary

In `convert_from_uf2()`, five diagnostic messages concatenate the integer block offset `ptr` directly to a string, e.g. `"Skipping block at " + ptr`. In Python this raises `TypeError: can only concatenate str (not "int") to str`, so when a malformed UF2 block is encountered the tool crashes with an unrelated `TypeError` instead of printing the intended message (or assertion text). This wraps `ptr` in `str()` in the affected `print` and `assert` messages.

### Testing

Tested on host (Linux, CPython 3.12) by calling `convert_from_uf2()` with a 512-byte block that has bad magic:

- Before: raises `TypeError: can only concatenate str (not "int") to str`.
- After: correctly prints `Skipping block at 0; bad magic` and continues.

`ruff format --check tools/uf2conv.py` passes and `tools/verifygitlog.py` passes for the commit.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.