### PR TITLE
docs: machine.CAN availability

### DIFF
--- a/docs/library/machine.CAN.rst
+++ b/docs/library/machine.CAN.rst
@@ -24,6 +24,8 @@ errors.
 .. note:: The planned ``can`` and ``aiocan`` micropython-lib modules will be the
           recommended way to use CAN with MicroPython.
 
+Availability: **STM32, MIMXRT**
+
 Constructor
 -----------
 


### PR DESCRIPTION
### Summary

Just adds "Availability: STM32, MIMXRT" to indicate that `machine.CAN` is only available on those ports. Modeled on the `machine.Counter` equivalent.

### Testing

Built the docs locally; looked correct.

### Trade-offs and Alternatives

We could have a document that showed a table of features vs ports so you could see at-a-glance which features were implemented for each port. Even if we added that table, displaying the port availability in the documentation is still valuable.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.