### PR TITLE
esp32/machine_uart: Make default UART pins board-configurable.

### DIFF
--- a/ports/esp32/machine_uart.c
+++ b/ports/esp32/machine_uart.c
@@ -39,6 +39,7 @@
 #include "py/mperrno.h"
 #include "py/mphal.h"
 #include "uart.h"
+#include "machine_uart.h"
 #include "machine_timer.h"
 
 #if SOC_UART_SUPPORT_XTAL_CLK
@@ -60,6 +61,30 @@
 #define MP_UART_ALLOWED_FLAGS (UART_IRQ_RX | UART_IRQ_RXIDLE | UART_IRQ_BREAK)
 #define RXIDLE_TIMER_MIN (machine_timer_freq_hz() * 5 / 10000) // 500us minimum rxidle time
 #define UART_QUEUE_SIZE (3)
+
+typedef struct _machine_uart_default_pins_t {
+    gpio_num_t tx;
+    gpio_num_t rx;
+} machine_uart_default_pins_t;
+
+// Indexed by uart_port_t. The LP UART (if present) follows the HP UARTs in
+// the enum, so a single table indexed by UART_NUM_MAX covers all of them.
+static const machine_uart_default_pins_t machine_uart_default_pins[UART_NUM_MAX] = {
+    [UART_NUM_0] = { MICROPY_HW_UART0_TX, MICROPY_HW_UART0_RX },
+    [UART_NUM_1] = { MICROPY_HW_UART1_TX, MICROPY_HW_UART1_RX },
+    #if SOC_UART_HP_NUM > 2
+    [UART_NUM_2] = { MICROPY_HW_UART2_TX, MICROPY_HW_UART2_RX },
+    #endif
+    #if SOC_UART_HP_NUM > 3
+    [UART_NUM_3] = { MICROPY_HW_UART3_TX, MICROPY_HW_UART3_RX },
+    #endif
+    #if SOC_UART_HP_NUM > 4
+    [UART_NUM_4] = { MICROPY_HW_UART4_TX, MICROPY_HW_UART4_RX },
+    #endif
+    #if SOC_UART_LP_NUM >= 1
+    [LP_UART_NUM_0] = { MICROPY_HW_LP_UART0_TX, MICROPY_HW_LP_UART0_RX },
+    #endif
+};
 
 enum {
     RXIDLE_INACTIVE,
@@ -270,46 +295,12 @@ static void mp_machine_uart_init_helper(machine_uart_obj_t *self, size_t n_args,
         self->uart_queue = NULL;
         self->rxidle_state = RXIDLE_INACTIVE;
 
-        // Set the MicroPython default UART pins. These may be overwritten with
-        // caller-provided pins, below
-        switch (self->uart_num) {
-            case UART_NUM_0:
-                self->rx = UART_PIN_NO_CHANGE; // GPIO 3
-                self->tx = UART_PIN_NO_CHANGE; // GPIO 1
-                break;
-            case UART_NUM_1:
-                #if CONFIG_IDF_TARGET_ESP32 && CONFIG_SPIRAM
-                // ESP32 usually uses pins 9 and 10 for SPIRAM bus, so avoid those pins as defaults.
-                self->rx = 4;
-                self->tx = 5;
-                #else
-                self->rx = 9;
-                self->tx = 10;
-                #endif
-                break;
-            #if SOC_UART_HP_NUM > 2
-            case UART_NUM_2:
-                self->rx = 16;
-                self->tx = 17;
-                break;
-            #endif
-            #if SOC_UART_LP_NUM >= 1
-            case LP_UART_NUM_0:
-                self->rx = 4;
-                self->tx = 5;
-                break;
-            #endif
-            #if SOC_UART_HP_NUM > 3
-            case UART_NUM_3:
-                break;
-            #endif
-            #if SOC_UART_HP_NUM > 4
-            case UART_NUM_4:
-                break;
-            #endif
-            case UART_NUM_MAX:
-                assert(0); // Range is checked in mp_machine_uart_make_new, value should be unreachable
-        }
+        // Set the MicroPython default UART pins, overridable per board via
+        // MICROPY_HW_UARTn_TX/RX. These may be overwritten with caller-provided
+        // pins, below. The valid range of uart_num is checked in
+        // mp_machine_uart_make_new.
+        self->tx = machine_uart_default_pins[self->uart_num].tx;
+        self->rx = machine_uart_default_pins[self->uart_num].rx;
     } else {
         // wait for all data to be transmitted before changing settings
         uart_wait_tx_done(self->uart_num, pdMS_TO_TICKS(1000));

--- a/ports/esp32/machine_uart.h
+++ b/ports/esp32/machine_uart.h
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2025 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef MICROPY_INCLUDED_ESP32_MACHINE_UART_H
+#define MICROPY_INCLUDED_ESP32_MACHINE_UART_H
+
+#include "driver/uart.h"
+#include "soc/uart_pins.h"
+
+// Default UART pins. A board may override any of these in its mpconfigboard.h
+// to match the pins it actually breaks out, consistent with the existing
+// MICROPY_HW_SPIn_* and MICROPY_HW_I2Cn_* board defaults. Pins left at
+// UART_PIN_NO_CHANGE keep the IDF/hardware default routing.
+
+// UART0 is normally the REPL/console. Keep the hardware default pins, which is
+// what the IDF assigns per chip (U0TXD_GPIO_NUM / U0RXD_GPIO_NUM).
+#ifndef MICROPY_HW_UART0_TX
+#define MICROPY_HW_UART0_TX (UART_PIN_NO_CHANGE)
+#define MICROPY_HW_UART0_RX (UART_PIN_NO_CHANGE)
+#endif
+
+// UART1 historical MicroPython default pins.
+#ifndef MICROPY_HW_UART1_TX
+#if CONFIG_IDF_TARGET_ESP32 && CONFIG_SPIRAM
+// On ESP32 pins 9 and 10 are normally used by the SPIRAM bus, so when SPIRAM is
+// enabled fall back to pins that do not collide with it.
+#define MICROPY_HW_UART1_TX (5)
+#define MICROPY_HW_UART1_RX (4)
+#else
+#define MICROPY_HW_UART1_TX (10)
+#define MICROPY_HW_UART1_RX (9)
+#endif
+#endif
+
+#if SOC_UART_HP_NUM > 2
+// UART2 historical MicroPython default pins.
+#ifndef MICROPY_HW_UART2_TX
+#define MICROPY_HW_UART2_TX (17)
+#define MICROPY_HW_UART2_RX (16)
+#endif
+#endif
+
+#if SOC_UART_HP_NUM > 3
+// UART3 (e.g. ESP32-P4) has no historical or IOMUX default pins; leave it at
+// UART_PIN_NO_CHANGE so a board can assign it via MICROPY_HW_UART3_TX/RX.
+#ifndef MICROPY_HW_UART3_TX
+#define MICROPY_HW_UART3_TX (UART_PIN_NO_CHANGE)
+#define MICROPY_HW_UART3_RX (UART_PIN_NO_CHANGE)
+#endif
+#endif
+
+#if SOC_UART_HP_NUM > 4
+#ifndef MICROPY_HW_UART4_TX
+#define MICROPY_HW_UART4_TX (UART_PIN_NO_CHANGE)
+#define MICROPY_HW_UART4_RX (UART_PIN_NO_CHANGE)
+#endif
+#endif
+
+#if SOC_UART_LP_NUM >= 1
+// LP UART: use the IDF per-chip IOMUX pins, which are correct on all chips
+// (e.g. 5/4 on C5/C6 but 14/15 on P4).
+#ifndef MICROPY_HW_LP_UART0_TX
+#define MICROPY_HW_LP_UART0_TX (LP_U0TXD_GPIO_NUM)
+#define MICROPY_HW_LP_UART0_RX (LP_U0RXD_GPIO_NUM)
+#endif
+#endif
+
+#endif // MICROPY_INCLUDED_ESP32_MACHINE_UART_H


### PR DESCRIPTION
On the esp32 port the default TX/RX pins for each UART were hard-coded in a
`switch` statement in `machine_uart.c`, so a board could not change them. This
is inconsistent with `machine.SPI` and `machine.I2C`, which already take
board-level defaults from `MICROPY_HW_SPIn_*` and `MICROPY_HW_I2Cn_*`, and with
the rp2 and stm32 ports, which already use `MICROPY_HW_UARTn_TX/RX`.

This PR moves the default pins into a new `machine_uart.h` header as
`#ifndef`-overridable defines (`MICROPY_HW_UART0..4_TX/RX` and
`MICROPY_HW_LP_UART0_TX/RX`), and replaces the `switch` with a table indexed by
the UART number. A board can now set its real UART pins in `mpconfigboard.h`,
e.g.:

```c
#define MICROPY_HW_UART1_TX (43)
#define MICROPY_HW_UART1_RX (44)
```

The existing default pin values are kept unchanged, so behaviour is identical
for all current boards. Passing `tx=`/`rx=` at runtime works exactly as before;
only the default changes.

Additional improvements that fall out of this:

- UART3 and UART4 (e.g. on the ESP32-P4) now get proper default pins instead of
  being left uninitialised in the old empty `switch` cases, and can be assigned
  from a board. Related to #19153.
- The LP UART default pins are now taken from the IDF
  (`LP_U0TXD_GPIO_NUM` / `LP_U0RXD_GPIO_NUM`) instead of being hard-coded, which
  is correct on all chips (e.g. 14/15 on the ESP32-P4 rather than 5/4).

### Testing

Built and tested on real hardware:

- ESP32-C6 (2 HP UARTs + 1 LP UART): `UART(1)` keeps the previous default pins
  (tx=10, rx=9); `UART(2)` (the LP UART) correctly picks up the IDF pins
  (tx=5, rx=4). Setting `MICROPY_HW_UART1_TX/RX` in the board config overrides
  the default as expected.
- ESP32-S3 (3 HP UARTs): `UART(0)` and `UART(1)` keep their previous default
  pins; a board-level `MICROPY_HW_UART*_TX/RX` override is applied correctly.

Default pin values are unchanged for every chip, so existing boards are not
affected.

### Trade-offs and Alternatives

The default pins still need per-chip `#if` guards (chips have a different number
of UARTs, and the ESP32 SPIRAM case), but they are now collected in one header
and overridable, rather than hard-coded in the init logic.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.
