### PR TITLE
webassembly/library: Fix ccall ABI for mp_hal_get_interrupt_char.

### DIFF
--- a/ports/webassembly/README.md
+++ b/ports/webassembly/README.md
@@ -123,6 +123,10 @@ MicroPython code execution will suspend the browser so be sure to atomize usage
 within this environment. Unfortunately interrupts have not been implemented for the
 browser.
 
+In Node.js, pressing Ctrl+C during Python execution sends a keyboard interrupt
+(``KeyboardInterrupt``) to the running MicroPython instance via ``mp_js_hook``,
+which periodically polls stdin for the interrupt character.
+
 Testing
 -------
 

--- a/ports/webassembly/library.js
+++ b/ports/webassembly/library.js
@@ -35,8 +35,8 @@ mergeInto(LibraryManager.library, {
             const mp_interrupt_char = Module.ccall(
                 "mp_hal_get_interrupt_char",
                 "number",
-                ["number"],
-                ["null"],
+                [],
+                [],
             );
             const fs = require("fs");
 


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

Adjust the `ccall` ABI for `mp_hal_get_interrupt_char()` on the WebAssembly port.
`mp_hal_get_interrupt_char` takes no arguments (`void`), but `library.js` was passing an argument.
calling it via Emscripten's `ccall` with a spurious `["number"]`` argument type`
and `["null"]` argument value:
```js
// before (wrong)
Module.ccall("mp_hal_get_interrupt_char", "number", ["number"], ["null"]);

// after (correct)
Module.ccall("mp_hal_get_interrupt_char", "number", [], []);
```
Attempting to pass arguments to a no-arguments WebAssembly function, even with `ccall`, is against the type signature of the function and may result in misbehaviour, or even an exception being thrown, depending on the Emscripten build configuration.
See https://github.com/micropython/micropython/issues/19380 (the `mp_hal_get_interrupt_char` ABI part, as maintainer confirmed).

### Testing

Tested on `webassembly` port (standard variant) under Node.js:
- Existing test suite (`make test`) passes.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
