### PR TITLE
py/emitglue: Refactor cache flushing for AArch32.

### DIFF
--- a/ports/qemu/mphalport.h
+++ b/ports/qemu/mphalport.h
@@ -28,3 +28,12 @@
 #include "shared/runtime/interrupt_char.h"
 
 void mp_hal_get_random(size_t n, uint8_t *buf);
+
+#if defined(__ARM_32BIT_STATE)
+#if __has_builtin(__builtin___clear_cache)
+#define MP_HAL_CLEAN_DCACHE(fun_data, fun_len) \
+    do { \
+        __builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len); \
+    } while (0)
+#endif
+#endif

--- a/ports/unix/mphalport.h
+++ b/ports/unix/mphalport.h
@@ -122,5 +122,14 @@ enum {
 void mp_hal_get_mac(int idx, uint8_t buf[6]);
 #endif
 
+#if defined(__linux__) && (defined(__ARM_32BIT_STATE) || defined(__riscv))
+#if __has_builtin(__builtin___clear_cache)
+#define MP_HAL_CLEAN_DCACHE(fun_data, fun_len) \
+    do { \
+        __builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len); \
+    } while (0)
+#endif
+#endif
+
 // Global variable to control compile-only mode.
 extern bool mp_compile_only;

--- a/py/emitglue.c
+++ b/py/emitglue.c
@@ -107,17 +107,20 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, cons
     // Some architectures require flushing/invalidation of the I/D caches,
     // so that the generated native code which was created in data RAM will
     // be available for execution from instruction RAM.
-    #if defined(__thumb__) || defined(__thumb2__)
+    #if defined(__linux__) && defined(MP_HAL_CLEAN_DCACHE)
+    // On Linux always flush caches if there's a chance, just in case.
+    MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
+    #elif defined(__thumb__) || defined(__thumb2__)
     #if __ICACHE_PRESENT == 1
     // Flush D-cache, so the code emitted is stored in RAM.
     MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
     // Invalidate I-cache, so the newly-created code is reloaded from RAM.
     SCB_InvalidateICache();
     #endif
+    #elif defined(__ARM_32BIT_STATE) && defined(MP_HAL_CLEAN_DCACHE)
+    // Flush the D-cache.
+    MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
     #elif defined(__arm__)
-    #if (defined(__linux__) && defined(__GNUC__)) || __ARM_ARCH == 7
-    __builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len);
-    #else
     // Flush I-cache and D-cache.
     asm volatile (
         "0:"
@@ -126,7 +129,6 @@ void mp_emit_glue_assign_native(mp_raw_code_t *rc, mp_raw_code_kind_t kind, cons
         "mov r0, #0\n"
         "mcr p15, 0, r0, c7, c7, 0\n" // invalidate I-cache and D-cache
         : : : "r0", "cc");
-    #endif
     #elif defined(__riscv) && defined(MP_HAL_CLEAN_DCACHE)
     // Flush the D-cache.
     MP_HAL_CLEAN_DCACHE(fun_data, fun_len);


### PR DESCRIPTION
### Summary

This PR updates the cache flushing logic when running on AArch32.

Before these changes, when running on Linux the instruction and data caches would be cleared only for AArch32 targets.  However, said checks did not trigger properly when running an AArch32 binary on certain AArch64 machines.

For example, the Unix port - when built using a 32-bits hard-float toolchain - would work just fine on a Raspberry Pi 3B+ running a 64-bits OS, but the very same binary all of a sudden becomes flaky when handling generated code on a Raspberry Pi 4.

These changes aim to generalise cache flushing on Linux, enabling that unconditionally whenever the target binary is built for either AArch32, or for RISC-V.  Doing this for RISC-V acts both as a preventative measure for the wide variety of RISC-V chips out there, and may also help explaining some rare crashes seen when testing native modules on certain MilkV-Duo RV64 boards.

If a binary targeting Linux is built with a compiler that is either not compatible with GCC's builtins, or it does not provide `__builtin___clear_cache` (too old or just broken), you'll have to provide your own `MP_HAL_CLEAN_DCACHE` implementation.  See the cacheflush(2) man page for why a generic fallback solution is not provided.

This refactoring also made it required to provide a cache flush callback for QEMU/SABRELITE, which has been generalised to cover all AArch32 targets.

This came out of the discussion at https://github.com/orgs/micropython/discussions/19341, where a cross-compiled AArch32 build would crash on generated code when run on a Raspberry Pi 4, but not on a similarly configured Raspberry Pi 3B+.  @Josverl kindly gave me access to his RPi4, otherwise I'd still be trying things out blindly.

### Testing

Viper tests pass on a Raspberry Pi 3B+ with a cross-compiled AArch32 binary executed on a 64-bits OS.  An earlier iteration (which should be equivalent to this version) of the PR was also tested on a Raspberry Pi 4.

### Trade-offs and Alternatives

There may be a small performance hit if this is executed on a AArch32 or RISC-V Linux system whose cache flush isn't needed before running generated code.  Binaries will be a handful of bytes larger when built for RISC-V and for certain AArch32 configurations.

This has not been refactored further because I'm not sure whether it is safe in all cases to use a single `__builtin___clear_cache` as a fall-back in case a specific function is not available.  It may be possible to remove all of that and turn it into:

```c
#if defined(MP_HAL_CLEAN_DCACHE)
MP_HAL_CLEAN_DCACHE(fun_data, fun_len);
#elif __has_builtin(__builtin___clear_cache) && !MICROPY_PY_SKIP_CACHE_FLUSH
__builtin___clear_cache((void *)fun_data, (char *)fun_data + fun_len);
#endif
```

but that may require some thought.

### Generative AI

I did not use generative AI tools when creating this PR.