### PR TITLE
github/workflows: Deploy docs previews for pull requests.

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,57 @@
+name: Cleanup docs preview
+
+# Removes a PR's published preview from the separate previews repository when
+# the PR is closed or merged. This uses pull_request_target so the deploy key
+# is available, but it never checks out or runs PR code: it only deletes the
+# preview directory, so it is not exposed to untrusted input.
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    paths:
+      - docs/**
+      - tests/cpydiff/**
+
+# Share the deploy workflow's lane so a close cannot race a final deploy.
+concurrency:
+  group: docs-preview-publish
+
+permissions: {}  # no access to this repository is required
+
+env:
+  preview_repo: ${{ github.repository_owner }}/micropython-docs-previews
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Remove preview directory from previews repository
+      env:
+        DEPLOY_KEY: ${{ secrets.PREVIEW_DEPLOY_KEY }}
+        PR: ${{ github.event.number }}
+      run: |
+        if [ -z "$DEPLOY_KEY" ]; then
+          echo "PREVIEW_DEPLOY_KEY is not set; nothing to clean up."
+          exit 0
+        fi
+        # github.event.number is a trusted integer from the event payload, but
+        # validate defensively before using it in a path.
+        if ! [[ "$PR" =~ ^[1-9][0-9]*$ ]]; then
+          echo "Refusing to clean up: invalid PR number '$PR'." >&2
+          exit 1
+        fi
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        echo "$DEPLOY_KEY" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+        git clone --branch gh-pages --depth 1 \
+          "git@github.com:${preview_repo}.git" previews
+        cd previews
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        rm -rf "pr-${PR}"
+        git add -A
+        git diff --cached --quiet || \
+          git commit -m "Remove docs preview for PR #${PR}"
+        git push

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -1,0 +1,107 @@
+name: Deploy docs preview
+
+# Runs after "Build docs" completes. Using workflow_run means this job runs in
+# the context of the base repository (not the PR fork), so it can access the
+# deploy key, while the build that ran untrusted PR code had only a read-only
+# token.
+#
+# Previews are published to a SEPARATE repository (<owner>/micropython-docs-
+# previews) so that this repository's history and clone size are never affected.
+# Pushing there uses a repo-scoped SSH deploy key held in the PREVIEW_DEPLOY_KEY
+# secret; this repository's GITHUB_TOKEN is never granted write access.
+#
+# If PREVIEW_DEPLOY_KEY is not set (e.g. on a fork, or before a maintainer has
+# configured the previews repository), the deployment steps are skipped and the
+# job succeeds without doing anything.
+
+on:
+  workflow_run:
+    workflows: ["Build docs"]
+    types:
+      - completed
+
+# Serialise with the cleanup workflow so concurrent pushes to the previews
+# repository from different PRs cannot reject each other.
+concurrency:
+  group: docs-preview-publish
+
+permissions:
+  pull-requests: write  # comment the preview link on the PR
+  actions: read         # download the artifact from the triggering run
+
+env:
+  preview_repo: ${{ github.repository_owner }}/micropython-docs-previews
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+    - name: Check previews are configured
+      id: config
+      env:
+        DEPLOY_KEY: ${{ secrets.PREVIEW_DEPLOY_KEY }}
+      run: |
+        if [ -n "$DEPLOY_KEY" ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "PREVIEW_DEPLOY_KEY is not set; skipping preview deployment."
+        fi
+    - name: Download docs artifact
+      if: steps.config.outputs.enabled == 'true'
+      uses: actions/download-artifact@v4
+      with:
+        name: docs-html
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: artifact
+    - name: Read and validate PR number
+      if: steps.config.outputs.enabled == 'true'
+      id: pr
+      run: |
+        # pr-number.txt comes from the build artifact, which is produced by
+        # untrusted PR code, so the value must be validated before it is used in
+        # a path. Accept a plain positive integer only.
+        n="$(cat artifact/pr-number.txt)"
+        if ! [[ "$n" =~ ^[1-9][0-9]*$ ]]; then
+          echo "Refusing to deploy: invalid PR number '$n'." >&2
+          exit 1
+        fi
+        echo "number=$n" >> "$GITHUB_OUTPUT"
+    - name: Publish preview to previews repository
+      if: steps.config.outputs.enabled == 'true'
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        deploy_key: ${{ secrets.PREVIEW_DEPLOY_KEY }}
+        external_repository: ${{ env.preview_repo }}
+        publish_dir: artifact/docs/build/html
+        destination_dir: pr-${{ steps.pr.outputs.number }}
+        keep_files: true  # preserve previews belonging to other PRs
+    - name: Comment preview link
+      if: steps.config.outputs.enabled == 'true'
+      uses: actions/github-script@v9
+      env:
+        preview_repo: ${{ env.preview_repo }}
+        pr_number: ${{ steps.pr.outputs.number }}
+      with:
+        script: |
+          const n = Number(process.env.pr_number);
+          const [owner, repo] = process.env.preview_repo.split('/');
+          const url = `https://${owner}.github.io/${repo}/pr-${n}/`;
+          const marker = '<!-- docs-preview -->';
+          const body = `${marker}\n📖 Documentation preview for this PR: ${url}`;
+          const { data: comments } = await github.rest.issues.listComments({
+            ...context.repo, issue_number: n,
+          });
+          const existing = comments.find(c => c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              ...context.repo, comment_id: existing.id, body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              ...context.repo, issue_number: n, body,
+            });
+          }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     paths:
       - docs/**
-      - py/**
       - tests/cpydiff/**
 
 concurrency:
@@ -25,3 +24,17 @@ jobs:
       run: tools/ci.sh unix_build_helper
     - name: Build docs
       run: make -C docs/ html
+    # The following steps capture the built docs so the "Deploy docs preview"
+    # workflow can publish them. They run on pull requests only, where the
+    # GITHUB_TOKEN is read-only, so untrusted fork code never gains write access.
+    - name: Save PR number
+      if: github.event_name == 'pull_request'
+      run: echo "${{ github.event.number }}" > pr-number.txt
+    - name: Upload docs artifact
+      if: github.event_name == 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs-html
+        path: |
+          docs/build/html
+          pr-number.txt


### PR DESCRIPTION
### Summary

Build the documentation for pull requests that touch `docs/` or `tests/cpydiff/` (_not_ `py/`) and publish it to a _separate_ repository (<owner>/micropython-docs-previews) served via GitHub Pages, under a per-PR directory (`pr-<N>/`). The preview link is posted as a comment on the PR, and the directory is removed when the PR is closed.

Previews live in a separate repository so this repository's history and clone size are never affected. The build runs under pull_request with a read-only token so untrusted fork code never gains write access; a separate workflow_run job performs the privileged publish using a repo-scoped SSH deploy key held in the PREVIEW_DEPLOY_KEY secret. If this is merged, I'll need some help setting this up in the micropython organization.

The PR number passed from the build is validated before use, and the deploy and cleanup jobs skip cleanly when PREVIEW_DEPLOY_KEY is not set, so the workflows are inert on forks and until a maintainer configures the previews repository.

### Testing

I tested by merging this in my fork and then configuring a repo/token. Raising a dummy PR that modified docs published the docs to the repo. Removing the PR removed the published docs.

### Trade-offs and Alternatives

I initially started by publishing to the micropython repository but this cost commits for each PR as it requires modifications to the `gh_pages` folder. Not ideal.

I also investigated using external services including [Read the Docs](https://about.readthedocs.com/) and [Cloudflare Pages](https://pages.cloudflare.com/). Both were possible but had tradeoffs; RtD had limits on the number of active branches supported and both meant using an external service with an account to manage.

We'll need to keep an eye on the size of the pages deployed, GitHub has a limit of ~1GB of gh_pages content. Each deployment of the docs consumes ~20MB so we'd need ~50 active PRs that modify docs to exceed the limit. Very unlikely. But worth keeping in mind if GitHub reduce the limit or if we have a spate of PRs.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.
