### PR TITLE
alif: implement machine.WDT

### DIFF
--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -15,7 +15,7 @@ Example usage::
     wdt = WDT(timeout=2000)  # enable it with a timeout of 2s
     wdt.feed()
 
-Availability: **ESP32, ESP8266, MIMXRT, RP2, SAMD, STM32, Zephyr**
+Availability: **Alif, ESP32, ESP8266, MIMXRT, RP2, SAMD, STM32, Zephyr**
 
 Constructors
 ------------
@@ -26,6 +26,10 @@ Constructors
    Once it is running the timeout cannot be changed and the WDT cannot be stopped either.
 
    Notes:
+
+   - On the alif port the HP and HE cores have independent watchdogs, both accessed
+     by the default ``id=0``.  The maximum timeout on the HP core is 10737ms.  The
+     watchdog does not run during deepsleep.
 
    - On the esp8266 port a timeout cannot be specified, it is determined by the underlying
      system.

--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -111,6 +111,7 @@ SRC_O += \
 
 SRC_C = \
 	alif_flash.c \
+	cgu_ext.c \
 	cyw43_port_spi.c \
 	fatfs_port.c \
 	lptimer_ext.c \

--- a/ports/alif/cgu_ext.c
+++ b/ports/alif/cgu_ext.c
@@ -1,0 +1,72 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 OpenMV LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "cgu_ext.h"
+#include "peripheral_types.h"
+
+#if CORE_M55_HP
+#define CLK_BIT_OFFSET (0)
+#elif CORE_M55_HE
+#define CLK_BIT_OFFSET (4)
+#endif
+
+// Get RTSS_Hx_CLK in kHz.
+uint32_t cgu_get_rtss_hx_clk_khz(void) {
+    uint32_t es = (CGU->PLL_CLK_SEL >> (16 + CLK_BIT_OFFSET)) & 1;
+    if (es == 0) {
+        // Clock routed via ESx_OSC.
+        uint32_t es_osc = (CGU->ESCLK_SEL >> (8 + CLK_BIT_OFFSET)) & 3;
+        if (es_osc == 0 || es_osc == 2) {
+            // 76.8MHz ring-oscillator, or 76.8MHz crystal oscillator.
+            return 76800;
+        } else {
+            // 38.4MHz ring-oscillator, or 38.4MHz crystal oscillator.
+            return 38400;
+        }
+    } else {
+        // Clock routed via ESx_PLL.
+        uint32_t es_pll = (CGU->ESCLK_SEL >> (0 + CLK_BIT_OFFSET)) & 3;
+        #if CORE_M55_HP
+        if (es_pll == 0) {
+            return 100000;
+        } else if (es_pll == 1) {
+            return 200000;
+        } else {
+            return 400000;
+        }
+        #elif CORE_M55_HE
+        if (es_pll == 0) {
+            return 60000;
+        } else if (es_pll == 1) {
+            return 80000;
+        } else if (es_pll == 2) {
+            return 120000;
+        } else {
+            return 160000;
+        }
+        #endif
+    }
+}

--- a/ports/alif/cgu_ext.h
+++ b/ports/alif/cgu_ext.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 OpenMV LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ALIF_CGU_EXT_H
+#define MICROPY_INCLUDED_ALIF_CGU_EXT_H
+
+#include <stdint.h>
+
+uint32_t cgu_get_rtss_hx_clk_khz(void);
+
+#endif // MICROPY_INCLUDED_ALIF_CGU_EXT_H

--- a/ports/alif/machine_wdt.c
+++ b/ports/alif/machine_wdt.c
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 OpenMV LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// This file is never compiled standalone, it's included directly from
+// extmod/machine_wdt.c via MICROPY_PY_MACHINE_WDT_INCLUDEFILE.
+
+#include "cgu_ext.h"
+#include "wdt.h"
+#include "se_services.h"
+
+#if CORE_M55_HP
+#define WDT_CTRL (WDT_CTRL_Type *)(WDT_HP_CTRL_BASE)
+#elif CORE_M55_HE
+#define WDT_CTRL (WDT_CTRL_Type *)(WDT_HE_CTRL_BASE)
+#endif
+
+#define WDT_COUNTER_MAX (0xffffffffU)
+
+typedef struct _machine_wdt_obj_t {
+    mp_obj_base_t base;
+    uint32_t timeout_ticks;
+} machine_wdt_obj_t;
+
+static machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}, 0};
+
+// When the WDT fires it triggers the NMI interrupt.
+void NMI_Handler(void) {
+    wdt_unlock(WDT_CTRL);
+    wdt_stop(WDT_CTRL);
+    se_services_reset_soc();
+}
+
+static machine_wdt_obj_t *mp_machine_wdt_make_new_instance(mp_obj_t id_obj, mp_int_t timeout_ms) {
+    // Verify the WDT id.
+    mp_int_t id = mp_obj_get_int(id_obj);
+    if (id != 0) {
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT(%d) doesn't exist"), id);
+    }
+
+    // Convert milliseconds to ticks.
+    uint64_t timeout_ticks = (uint64_t)timeout_ms * (uint64_t)cgu_get_rtss_hx_clk_khz();
+
+    // Check that the timeout is within range of the peripheral limits.
+    if (timeout_ticks <= 0) {
+        mp_raise_ValueError(MP_ERROR_TEXT("WDT timeout too short"));
+    } else if (timeout_ticks > WDT_COUNTER_MAX) {
+        unsigned int max_timeout_ms = WDT_COUNTER_MAX / cgu_get_rtss_hx_clk_khz();
+        mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("WDT timeout too long, max %ums"), max_timeout_ms);
+    }
+
+    // Start the watchdog.
+    machine_wdt.timeout_ticks = timeout_ticks;
+    wdt_unlock(WDT_CTRL);
+    wdt_start(WDT_CTRL, timeout_ticks);
+    wdt_lock(WDT_CTRL);
+
+    return &machine_wdt;
+}
+
+static void mp_machine_wdt_feed(machine_wdt_obj_t *self) {
+    wdt_unlock(WDT_CTRL);
+    wdt_feed(WDT_CTRL, self->timeout_ticks);
+    wdt_lock(WDT_CTRL);
+}

--- a/ports/alif/mpconfigport.h
+++ b/ports/alif/mpconfigport.h
@@ -156,6 +156,8 @@
 #define MICROPY_PY_MACHINE_MEM_BACKUP           (1)
 #endif
 #define MICROPY_PY_MACHINE_MEM_BACKUP_INCLUDEFILE "ports/alif/machine_mem_backup.c"
+#define MICROPY_PY_MACHINE_WDT                  (1)
+#define MICROPY_PY_MACHINE_WDT_INCLUDEFILE      "ports/alif/machine_wdt.c"
 #define MICROPY_PY_NETWORK                      (CORE_M55_HP)
 #ifndef MICROPY_PY_NETWORK_HOSTNAME_DEFAULT
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT     "mpy-alif"


### PR DESCRIPTION
### Summary

This PR implements the standard `machine.WDT` class on the alif port.  The WDT peripheral on the alif is essentially a simple down counter, and triggers the NMI IRQ when it gets to 0.  So the SoC reset has to be done manually in `NMI_Handler()` (as done in this PR).

It supports both the HP and HE cores, which have independent watchdogs.

The maximum timeout is about 10s.  Testing shows that the watchdog runs during lightsleep but not during deepsleep.

### Testing

Tested on ALIF_ENSEMBLE and OPENMV_AE3 on the HP core, using various timeouts between 100ms and 10s.  Measured the time to make sure it's correct.  Also tested with `lightsleep()` and `deepsleep()`.  The watchdog seems to turn off when the SoC is in deepsleep.

### Trade-offs and Alternatives

This is a relatively minimal implementation, the peripheral is simple enough.  Although I did need to add a helper function to compute the WDT source clock frequency.

### Generative AI

Not used.