### PR TITLE
rp2: Size IRQ array correctly for 48 pin variants.

### DIFF
--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -606,4 +606,4 @@ mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj) {
     return pin->id;
 }
 
-MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[30]);
+MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[NUM_BANK0_GPIOS]);


### PR DESCRIPTION
Use NUM_BANK0_GPIOS to size the pin IRQ array, avoiding a potential leak using IRQs on pins > 30.

### Testing

This is a pretty insidious one to pin down since it'll clobber some adjacent root pointer.

### Trade-offs and Alternatives

I think this one is pretty cut and dry!

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.