### PR TITLE
docs/machine: Add port availability notes.

### DIFF
--- a/docs/library/machine.I2CTarget.rst
+++ b/docs/library/machine.I2CTarget.rst
@@ -74,6 +74,8 @@ example, to see the raw events as they are triggered::
     )
     i2c.irq(irq_handler, trigger=all_triggers, hard=True)
 
+Availability: **Alif, ESP32, MIMXRT, RP2, SAMD, STM32, Zephyr**
+
 Constructors
 ------------
 

--- a/docs/library/machine.I2S.rst
+++ b/docs/library/machine.I2S.rst
@@ -79,6 +79,8 @@ other things.  For these drivers see:
 
 - :ref:`wm8960`
 
+Availability: **ESP32, MIMXRT, RP2, STM32**
+
 Constructor
 -----------
 

--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -13,6 +13,7 @@ Example usage::
     rtc.datetime((2020, 1, 21, 2, 10, 32, 36, 0))
     print(rtc.datetime())
 
+Availability: **Alif, ESP32, ESP8266, MIMXRT, Renesas-RA, RP2, SAMD, STM32**
 
 Constructors
 ------------

--- a/docs/library/machine.USBDevice.rst
+++ b/docs/library/machine.USBDevice.rst
@@ -4,9 +4,9 @@
 class USBDevice -- USB Device driver
 ====================================
 
-.. note:: ``machine.USBDevice`` is currently only supported for esp32, rp2 and
-          samd ports. Native USB support is also required, and not every board
-          supports native USB.
+Availability: **ESP32, RP2, SAMD**
+
+.. note:: Native USB support is required, and not every board supports native USB.
 
 USBDevice provides a low-level Python API for implementing USB device functions using
 Python code.

--- a/docs/library/machine.WDT.rst
+++ b/docs/library/machine.WDT.rst
@@ -15,7 +15,7 @@ Example usage::
     wdt = WDT(timeout=2000)  # enable it with a timeout of 2s
     wdt.feed()
 
-Availability of this class: pyboard, WiPy, esp8266, esp32, rp2040, mimxrt.
+Availability: **ESP32, ESP8266, MIMXRT, RP2, SAMD, STM32, Zephyr**
 
 Constructors
 ------------


### PR DESCRIPTION
### Summary

Expanding on #19375, I've added "Availability: [ports]" to other features, specifically: 

- **I2S**: ESP32, MIMXRT, RP2, STM32
- **I2CTarget**: Alif, ESP32, MIMXRT, RP2, SAMD, STM32, Zephyr
- **USBDevice**: ESP32, RP2, SAMD
- **RTC**: Alif, ESP32, ESP8266, MIMXRT, Renesas-RA, RP2, SAMD, STM32
- **WDT**: ESP32, ESP8266, MIMXRT, RP2, SAMD, STM32, Zephyr 

### Testing

I generated the docs locally; they appeared to render correctly.

### Trade-offs and Alternatives

Perhaps some features should have "Availability: All ports"?

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.