### PR TITLE
rp2: Fix RP2350 watchdog time to ~16s.

### DIFF
--- a/ports/rp2/machine_wdt.c
+++ b/ports/rp2/machine_wdt.c
@@ -29,8 +29,14 @@
 
 #include "hardware/watchdog.h"
 
-// The maximum timeout in milliseconds is: 0xffffff / 2 / 1000
+// The maximum timeout is set by the 24-bit watchdog counter and the number of
+// ticks it decrements per microsecond (WATCHDOG_XFACTOR): 2 on RP2040, 1 on
+// RP2350.  So the max in milliseconds is 0xffffff / WATCHDOG_XFACTOR / 1000.
+#if PICO_RP2350
+#define WDT_TIMEOUT_MAX 16777
+#else
 #define WDT_TIMEOUT_MAX 8388
+#endif
 
 typedef struct _machine_wdt_obj_t {
     mp_obj_base_t base;


### PR DESCRIPTION
The RP2350 watchdog supports a 16777ms period vs the RP2040s 8388ms.

### Testing

Tested with various timeouts on the Pico 2W.

### Trade-offs and Alternatives

None, this is a bugfix!

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.