### PR TITLE
py/parse: Add MICROPY_EVENT_POLL_HOOK in cycles of parsing and compiling.

### DIFF
--- a/py/compile.c
+++ b/py/compile.c
@@ -3509,6 +3509,8 @@ void mp_compile_to_raw_code(mp_parse_tree_t *parse_tree, qstr source_file, bool 
     #endif
     uint max_num_labels = 0;
     for (scope_t *s = comp->scope_head; s != NULL && comp->compile_error == MP_OBJ_NULL; s = s->next) {
+        mp_event_handle_nowait();
+
         #if MICROPY_EMIT_INLINE_ASM
         if (s->emit_options == MP_EMIT_OPT_ASM) {
             compile_scope_inline_asm(comp, s, MP_PASS_SCOPE);
@@ -3534,6 +3536,7 @@ void mp_compile_to_raw_code(mp_parse_tree_t *parse_tree, qstr source_file, bool 
 
     // compute some things related to scope and identifiers
     for (scope_t *s = comp->scope_head; s != NULL && comp->compile_error == MP_OBJ_NULL; s = s->next) {
+        mp_event_handle_nowait();
         scope_compute_things(s);
     }
 
@@ -3545,6 +3548,8 @@ void mp_compile_to_raw_code(mp_parse_tree_t *parse_tree, qstr source_file, bool 
     emit_t *emit_native = NULL;
     #endif
     for (scope_t *s = comp->scope_head; s != NULL && comp->compile_error == MP_OBJ_NULL; s = s->next) {
+        mp_event_handle_nowait();
+
         #if MICROPY_EMIT_INLINE_ASM
         if (s->emit_options == MP_EMIT_OPT_ASM) {
             // inline assembly

--- a/py/parse.c
+++ b/py/parse.c
@@ -1090,6 +1090,8 @@ mp_parse_tree_t mp_parse(mp_lexer_t *lex, mp_parse_input_kind_t input_kind) {
 
     for (;;) {
     next_rule:
+        mp_event_handle_nowait();
+
         if (parser.rule_stack_top == 0) {
             break;
         }


### PR DESCRIPTION
### Summary

Big files and scripts take a lot of time for parsing and compilation. There is no way to reset the watchdog timer at this point.

### Testing

Tested on unix port and in our board.

```cpp
#define MICROPY_EVENT_POLL_HOOK                \
    do {                                       \
        extern void mp_hal_event_poll_hook();  \
        mp_hal_event_poll_hook();              \
    } while (0);
```
```cpp
extern "C" void mp_hal_event_poll_hook(void)
{
    GetBoard().WatchdogReset();
}
```

### Trade-offs and Alternatives

I don't know can i use `MICROPY_EVENT_POLL_HOOK` in parsing and compiling. I think it can break another ports. May be i should create new hook?


### Generative AI

I did not use generative AI tools when creating this PR.