### PR TITLE
esp32/machine_sdcard: Make default SPI pins board-configurable.

### DIFF
--- a/ports/esp32/boards/LILYGO_T3_S3/mpconfigboard.h
+++ b/ports/esp32/boards/LILYGO_T3_S3/mpconfigboard.h
@@ -12,3 +12,9 @@
 #define MICROPY_HW_SPI1_MOSI                (6)
 #define MICROPY_HW_SPI1_MISO                (3)
 #define MICROPY_HW_SPI1_SCK                 (5)
+
+// microSD card in SPI mode: machine.SDCard(slot=2).
+#define MICROPY_HW_SDCARD_SPI_MOSI          (11)
+#define MICROPY_HW_SDCARD_SPI_MISO          (2)
+#define MICROPY_HW_SDCARD_SPI_SCK           (14)
+#define MICROPY_HW_SDCARD_SPI_CS            (13)

--- a/ports/esp32/boards/LILYGO_TTGO_LORA32/mpconfigboard.h
+++ b/ports/esp32/boards/LILYGO_TTGO_LORA32/mpconfigboard.h
@@ -1,3 +1,9 @@
 #define MICROPY_HW_BOARD_NAME "LILYGO TTGO LoRa32"
 #define MICROPY_HW_MCU_NAME "ESP32"
 #define MICROPY_PY_NETWORK_HOSTNAME_DEFAULT "mpy-ttgo-lora32"
+
+// microSD card in SPI mode: machine.SDCard(slot=2).
+#define MICROPY_HW_SDCARD_SPI_MOSI (15)
+#define MICROPY_HW_SDCARD_SPI_MISO (2)
+#define MICROPY_HW_SDCARD_SPI_SCK  (14)
+#define MICROPY_HW_SDCARD_SPI_CS   (13)

--- a/ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.h
+++ b/ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.h
@@ -10,3 +10,9 @@
 #define MICROPY_HW_SPI1_MOSI (9)
 #define MICROPY_HW_SPI1_MISO (8)
 #define MICROPY_HW_SPI1_SCK  (7)
+
+// microSD (Sense expansion board) in SPI mode: machine.SDCard(slot=2).
+#define MICROPY_HW_SDCARD_SPI_MOSI (9)
+#define MICROPY_HW_SDCARD_SPI_MISO (8)
+#define MICROPY_HW_SDCARD_SPI_SCK  (7)
+#define MICROPY_HW_SDCARD_SPI_CS   (21)

--- a/ports/esp32/boards/SPARKFUN_THINGPLUS_ESP32C5/mpconfigboard.h
+++ b/ports/esp32/boards/SPARKFUN_THINGPLUS_ESP32C5/mpconfigboard.h
@@ -9,3 +9,9 @@
 #define MICROPY_HW_SPI1_SCK  (10)
 #define MICROPY_HW_SPI1_MOSI (8)
 #define MICROPY_HW_SPI1_MISO (9)
+
+// microSD card in SPI mode (shares the SPI1 bus): machine.SDCard(slot=2).
+#define MICROPY_HW_SDCARD_SPI_MOSI (8)
+#define MICROPY_HW_SDCARD_SPI_MISO (9)
+#define MICROPY_HW_SDCARD_SPI_SCK  (10)
+#define MICROPY_HW_SDCARD_SPI_CS   (25)

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -44,6 +44,8 @@
 #include "sdmmc_cmd.h"
 #include "esp_log.h"
 
+#include "machine_sdcard.h"
+
 #define DEBUG 0
 #if DEBUG
 #define DEBUG_printf(...) ESP_LOGI("modsdcard", __VA_ARGS__)
@@ -88,19 +90,10 @@ typedef struct _sdcard_obj_t {
 
 static const spi_bus_config_t spi_bus_defaults[NUM_SD_SPI_BUS] = {
     {
-        #if CONFIG_IDF_TARGET_ESP32
-        .miso_io_num = GPIO_NUM_19,
-        .mosi_io_num = GPIO_NUM_23,
-        .sclk_io_num = GPIO_NUM_18,
-        #elif CONFIG_IDF_TARGET_ESP32S3
-        .miso_io_num = GPIO_NUM_36,
-        .mosi_io_num = GPIO_NUM_35,
-        .sclk_io_num = GPIO_NUM_37,
-        #else
-        .miso_io_num = GPIO_NUM_NC,
-        .mosi_io_num = GPIO_NUM_NC,
-        .sclk_io_num = GPIO_NUM_NC,
-        #endif
+        // Primary SPI SD bus (slot 2): board-configurable via machine_sdcard.h.
+        .miso_io_num = MICROPY_HW_SDCARD_SPI_MISO,
+        .mosi_io_num = MICROPY_HW_SDCARD_SPI_MOSI,
+        .sclk_io_num = MICROPY_HW_SDCARD_SPI_SCK,
         .data2_io_num = GPIO_NUM_NC,
         .data3_io_num = GPIO_NUM_NC,
         .data4_io_num = GPIO_NUM_NC,
@@ -139,16 +132,14 @@ static const uint8_t spi_dma_channel_defaults[NUM_SD_SPI_BUS] = {
 static const sdspi_device_config_t spi_dev_defaults[NUM_SD_SPI_BUS] = {
     #if NUM_SD_SPI_BUS > 1
     {
+        // Primary SPI SD bus (slot 2): CS is board-configurable via
+        // machine_sdcard.h; host_id stays chip-specific.
         #if CONFIG_IDF_TARGET_ESP32
         .host_id = VSPI_HOST,
-        .gpio_cs = GPIO_NUM_5,
-        #elif CONFIG_IDF_TARGET_ESP32S3
-        .host_id = SPI3_HOST,
-        .gpio_cs = GPIO_NUM_34,
         #else
         .host_id = SPI3_HOST,
-        .gpio_cs = GPIO_NUM_NC,
         #endif
+        .gpio_cs = MICROPY_HW_SDCARD_SPI_CS,
         .gpio_cd = SDSPI_SLOT_NO_CD,
         .gpio_wp = SDSPI_SLOT_NO_WP,
         .gpio_int = SDSPI_SLOT_NO_INT,
@@ -351,6 +342,16 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         spi_dma_chan_t dma_channel = SPI_DMA_CH_AUTO;
         #endif
         sdspi_device_config_t dev_config = spi_dev_defaults[slot_num];
+
+        #if NUM_SD_SPI_BUS == 1
+        // Single-bus chips use SDSPI_DEVICE_CONFIG_DEFAULT() for the only SPI SD
+        // bus (slot 2), which hard-codes its CS pin. If a board provides a
+        // default CS, apply it instead (keeping the IDF default otherwise). An
+        // explicit cs= argument still takes precedence below.
+        if (MICROPY_HW_SDCARD_SPI_CS != GPIO_NUM_NC) {
+            dev_config.gpio_cs = MICROPY_HW_SDCARD_SPI_CS;
+        }
+        #endif
 
         SET_CONFIG_PIN(bus_config, miso_io_num, ARG_miso);
         SET_CONFIG_PIN(bus_config, mosi_io_num, ARG_mosi);

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Pavel Revak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
+#define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
+
+// Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
+// available on every ESP32 variant, so a board may override these in its
+// mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.
+// SDMMC-mode pins (slots 0/1) are not affected.
+#ifndef MICROPY_HW_SDCARD_SPI_SCK
+#if CONFIG_IDF_TARGET_ESP32
+#define MICROPY_HW_SDCARD_SPI_SCK (GPIO_NUM_18)
+#define MICROPY_HW_SDCARD_SPI_MOSI (GPIO_NUM_23)
+#define MICROPY_HW_SDCARD_SPI_MISO (GPIO_NUM_19)
+#define MICROPY_HW_SDCARD_SPI_CS (GPIO_NUM_5)
+#elif CONFIG_IDF_TARGET_ESP32S3
+#define MICROPY_HW_SDCARD_SPI_SCK (GPIO_NUM_37)
+#define MICROPY_HW_SDCARD_SPI_MOSI (GPIO_NUM_35)
+#define MICROPY_HW_SDCARD_SPI_MISO (GPIO_NUM_36)
+#define MICROPY_HW_SDCARD_SPI_CS (GPIO_NUM_34)
+#else
+// Other chips have no historical default; a board or the runtime must assign.
+#define MICROPY_HW_SDCARD_SPI_SCK (GPIO_NUM_NC)
+#define MICROPY_HW_SDCARD_SPI_MOSI (GPIO_NUM_NC)
+#define MICROPY_HW_SDCARD_SPI_MISO (GPIO_NUM_NC)
+#define MICROPY_HW_SDCARD_SPI_CS (GPIO_NUM_NC)
+#endif
+#endif
+
+#endif // MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H


### PR DESCRIPTION
### Summary

The default pins for the SPI-mode SD card bus (`machine.SDCard(slot=2)`) on the esp32 port are hard-coded per chip in `machine_sdcard.c`. This makes `machine.SDCard(slot=2)` unusable out of the box on many boards — most notably the ESP32-S3 defaults (GPIO 35/36/37) clash with the octal SPIRAM bus, so on an S3 board with octal PSRAM the call reconfigures the PSRAM pins and crashes.

This PR makes those pins board-configurable, consistent with how I2C (`machine_i2c.h`) and SPI (`machine_hw_spi.c`) already expose their default pins.

### Changes

- New `ports/esp32/machine_sdcard.h` defining `MICROPY_HW_SDCARD_SPI_SCK` / `_MOSI` / `_MISO` / `_CS` for the primary SPI SD bus (slot 2), guarded with `#ifndef` so a board can override them in `mpconfigboard.h`.
- `machine_sdcard.c` uses these macros for the primary bus/device defaults.
- Wires up the mechanism on four boards with an onboard SPI-mode microSD slot whose pins differ from the chip default: `SEEED_XIAO_ESP32S3`, `LILYGO_T3_S3`, `LILYGO_TTGO_LORA32`, `SPARKFUN_THINGPLUS_ESP32C5`. Pins are taken from each board's definition or official documentation.

### Behaviour / compatibility

- **Default behaviour is unchanged.** The macro defaults equal the previous hard-coded per-chip values (ESP32 18/23/19 + CS 5, S3 37/35/36 + CS 34, others `GPIO_NUM_NC`).
- On chips with a single SPI SD bus (C3/C6/C5/H2/S2), the built-in IDF default CS is kept unless a board provides one.
- Runtime `sck=`/`miso=`/`mosi=`/`cs=` arguments still take precedence.
- **Only SPI mode (slot 2) is affected. SDMMC mode (slots 0/1) is untouched.**

### Testing

Verified on a Seeed XIAO ESP32S3 (Sense) with a microSD card: `machine.SDCard(slot=2)` works with no arguments and `sd.info()` returns `(1977614336, 512)`. The `SPARKFUN_THINGPLUS_ESP32C5` board (single SPI bus) exercises the `NUM_SD_SPI_BUS == 1` code path at build time in CI. The other boards' pins were confirmed against their schematics.

### Affected ports

ESP32 only (all variants).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.