### PR TITLE
mimxrt/eth: Sleep while waiting for ETH link to come up.

### DIFF
--- a/ports/mimxrt/eth.c
+++ b/ports/mimxrt/eth.c
@@ -341,13 +341,17 @@ static void eth_phy_init(phy_handle_t *phyHandle, phy_config_t *phy_config,
     if (status == kStatus_Success) {
         uint64_t t = ticks_us64() + PHY_AUTONEGO_TIMEOUT_US;
         // Wait for auto-negotiation success and link up
-        do {
+        for (;;) {
             PHY_GetAutoNegotiationStatus(phyHandle, &autonego);
             PHY_GetLinkStatus(phyHandle, &link);
             if (autonego && link) {
                 break;
             }
-        } while (ticks_us64() < t);
+            if (ticks_us64() > t) {
+                break;
+            }
+            mp_hal_delay_ms(2);
+        }
         if (!autonego) {
             mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("PHY Auto-negotiation failed."));
         }


### PR DESCRIPTION
### Summary

Waiting for the link has a 5 second timeout, and the system should sleep efficiently and poll/process other events while waiting.

Fixes issue #19410.

### Testing

Built TEENS41 to verify that it builds.

I did not test on hardware.  I need to see if I can find a mimxrt board with ETH...

### Trade-offs and Alternatives

The 2ms delay between subsequent polling of the PHY was copied from how the stm32 port works.  That should be fast enough for minimal latency, but not too fast.

### Generative AI

Not used.