### PR TITLE
rp2/rp2_psram: Switch to upstream hardware_psram.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -259,6 +259,20 @@ elseif(PICO_RISCV)
     )
 endif()
 
+# PSRAM setup is only available on RP2350.
+if(PICO_RP2350)
+    list(APPEND PICO_SDK_COMPONENTS
+        hardware_psram
+    )
+    # The port drives PSRAM bring-up explicitly (see rp2_psram.c), so disable
+    # the SDK's runtime_init auto-setup. This also avoids depending on the SDK's
+    # include-based linker scripts, which define the __psram_* symbols that
+    # runtime_init_setup_psram() references.
+    target_compile_definitions(${MICROPY_TARGET} PRIVATE
+        PICO_RUNTIME_NO_INIT_PSRAM=1
+    )
+endif()
+
 # Use our custom pico_float_micropython float implementation.  This is needed for two reasons:
 # - to fix inf handling in pico-sdk's __wrap___aeabi_fadd();
 # - so we can use our own libm functions, to fix inaccuracies in the pico-sdk versions.

--- a/ports/rp2/rp2_psram.c
+++ b/ports/rp2/rp2_psram.c
@@ -30,168 +30,43 @@
 
 #if MICROPY_HW_ENABLE_PSRAM
 
-#include "hardware/structs/ioqspi.h"
-#include "hardware/structs/qmi.h"
-#include "hardware/structs/xip_ctrl.h"
-#include "hardware/clocks.h"
+#include "hardware/gpio.h"
+#include "hardware/flash.h"
+#include "hardware/psram.h"
 #include "hardware/sync.h"
 #include "rp2_psram.h"
 
-size_t __no_inline_not_in_flash_func(psram_detect)(void) {
-    int psram_size = 0;
-
-    // Try and read the PSRAM ID via direct_csr.
-    qmi_hw->direct_csr = 30 << QMI_DIRECT_CSR_CLKDIV_LSB | QMI_DIRECT_CSR_EN_BITS;
-
-    // Need to poll for the cooldown on the last XIP transfer to expire
-    // (via direct-mode BUSY flag) before it is safe to perform the first
-    // direct-mode operation
-    while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) != 0) {
-    }
-
-    // Exit out of QMI in case we've inited already
-    qmi_hw->direct_csr |= QMI_DIRECT_CSR_ASSERT_CS1N_BITS;
-
-    // Transmit as quad.
-    qmi_hw->direct_tx = QMI_DIRECT_TX_OE_BITS | QMI_DIRECT_TX_IWIDTH_VALUE_Q << QMI_DIRECT_TX_IWIDTH_LSB | 0xf5;
-
-    while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) != 0) {
-    }
-
-    (void)qmi_hw->direct_rx;
-
-    qmi_hw->direct_csr &= ~(QMI_DIRECT_CSR_ASSERT_CS1N_BITS);
-
-    // Read the id
-    qmi_hw->direct_csr |= QMI_DIRECT_CSR_ASSERT_CS1N_BITS;
-    uint8_t kgd = 0;
-    uint8_t eid = 0;
-
-    for (size_t i = 0; i < 7; i++) {
-        if (i == 0) {
-            qmi_hw->direct_tx = 0x9f;
-        } else {
-            qmi_hw->direct_tx = 0xff;
-        }
-
-        while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_TXEMPTY_BITS) == 0) {
-        }
-
-        while ((qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) != 0) {
-        }
-
-        if (i == 5) {
-            kgd = qmi_hw->direct_rx;
-        } else if (i == 6) {
-            eid = qmi_hw->direct_rx;
-        } else {
-            (void)qmi_hw->direct_rx;
-        }
-    }
-
-    // Disable direct csr.
-    qmi_hw->direct_csr &= ~(QMI_DIRECT_CSR_ASSERT_CS1N_BITS | QMI_DIRECT_CSR_EN_BITS);
-
-    if (kgd == 0x5D) {
-        psram_size = 1024 * 1024; // 1 MiB
-        uint8_t size_id = eid >> 5;
-        if (eid == 0x26 || size_id == 2) {
-            psram_size *= 8; // 8 MiB
-        } else if (size_id == 0) {
-            psram_size *= 2; // 2 MiB
-        } else if (size_id == 1) {
-            psram_size *= 4; // 4 MiB
-        }
-    }
-
-    return psram_size;
-}
-
+// Bring up the PSRAM on the given chip-select pin using the SDK's
+// hardware_psram library, and return its size in bytes (0 if none found).
+//
+// This wraps the SDK API so the port's existing call sites are unchanged. It
+// intentionally does not rely on the SDK's runtime_init auto-setup, because
+// MicroPython also needs to re-run this after the system clock changes (see
+// machine.freq()) and after flash programming resets the QMI timings.
 size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
     gpio_set_function(cs_pin, GPIO_FUNC_XIP_CS1);
+    flash_devinfo_set_cs_gpio(1, cs_pin);
 
     uint32_t intr_stash = save_and_disable_interrupts();
 
-    size_t psram_size = psram_detect();
-
+    // Detect the chip (reads KGD/EID via the bootrom); psram_detect_size()
+    // handles the APS6404 and ISSI EID-to-size mappings.
+    size_t psram_size = psram_detect_size();
     if (!psram_size) {
+        flash_devinfo_set_cs_size(1, FLASH_DEVINFO_SIZE_NONE);
         restore_interrupts(intr_stash);
         return 0;
     }
+    flash_devinfo_set_cs_size(1, flash_devinfo_bytes_to_size(psram_size));
 
-    // Read clock speed before entering direct mode (flash access is
-    // unavailable while QMI direct mode is enabled)
-    const int max_psram_freq = 133000000;
-    const int clock_hz = clock_get_hz(clk_sys);
-
-    // Enable direct mode, PSRAM CS, clkdiv of 10.
-    qmi_hw->direct_csr = 10 << QMI_DIRECT_CSR_CLKDIV_LSB | \
-        QMI_DIRECT_CSR_EN_BITS | \
-        QMI_DIRECT_CSR_AUTO_CS1N_BITS;
-    while (qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) {
+    // Compute timing for the current system clock and apply it (enables QPI
+    // mode, sets read/write formats, and makes PSRAM writable).
+    if (psram_configure_params(PICO_DEFAULT_PSRAM_MAX_FREQ,
+        PICO_DEFAULT_PSRAM_MAX_SELECT, PICO_DEFAULT_PSRAM_MIN_DESELECT) != PICO_OK ||
+        psram_reinitialize() != PICO_OK) {
+        restore_interrupts(intr_stash);
+        return 0;
     }
-
-    // Enable QPI mode on the PSRAM
-    const uint CMD_QPI_EN = 0x35;
-    qmi_hw->direct_tx = QMI_DIRECT_TX_NOPUSH_BITS | CMD_QPI_EN;
-
-    while (qmi_hw->direct_csr & QMI_DIRECT_CSR_BUSY_BITS) {
-    }
-
-    // Set PSRAM timing for APS6404
-    //
-    // Using an rxdelay equal to the divisor isn't enough when running the APS6404 close to 133MHz.
-    // So: don't allow running at divisor 1 above 100MHz (because delay of 2 would be too late),
-    // and add an extra 1 to the rxdelay if the divided clock is > 100MHz (i.e. sys clock > 200MHz).
-    int divisor = (clock_hz + max_psram_freq - 1) / max_psram_freq;
-    if (divisor == 1 && clock_hz > 100000000) {
-        divisor = 2;
-    }
-    int rxdelay = divisor;
-    if (clock_hz / divisor > 100000000) {
-        rxdelay += 1;
-    }
-
-    // - Max select must be <= 8us.  The value is given in multiples of 64 system clocks.
-    // - Min deselect must be >= 18ns.  The value is given in system clock cycles - ceil(divisor / 2).
-    const int clock_period_fs = 1000000000000000ll / clock_hz;
-    const int max_select = (125 * 1000000) / clock_period_fs;  // 125 = 8000ns / 64
-    const int min_deselect = (18 * 1000000 + (clock_period_fs - 1)) / clock_period_fs - (divisor + 1) / 2;
-
-    qmi_hw->m[1].timing = 1 << QMI_M1_TIMING_COOLDOWN_LSB |
-        QMI_M1_TIMING_PAGEBREAK_VALUE_1024 << QMI_M1_TIMING_PAGEBREAK_LSB |
-        max_select << QMI_M1_TIMING_MAX_SELECT_LSB |
-        min_deselect << QMI_M1_TIMING_MIN_DESELECT_LSB |
-        rxdelay << QMI_M1_TIMING_RXDELAY_LSB |
-        divisor << QMI_M1_TIMING_CLKDIV_LSB;
-
-    // Set PSRAM commands and formats
-    qmi_hw->m[1].rfmt =
-        QMI_M0_RFMT_PREFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_PREFIX_WIDTH_LSB | \
-            QMI_M0_RFMT_ADDR_WIDTH_VALUE_Q << QMI_M0_RFMT_ADDR_WIDTH_LSB | \
-            QMI_M0_RFMT_SUFFIX_WIDTH_VALUE_Q << QMI_M0_RFMT_SUFFIX_WIDTH_LSB | \
-            QMI_M0_RFMT_DUMMY_WIDTH_VALUE_Q << QMI_M0_RFMT_DUMMY_WIDTH_LSB | \
-            QMI_M0_RFMT_DATA_WIDTH_VALUE_Q << QMI_M0_RFMT_DATA_WIDTH_LSB | \
-            QMI_M0_RFMT_PREFIX_LEN_VALUE_8 << QMI_M0_RFMT_PREFIX_LEN_LSB | \
-            6 << QMI_M0_RFMT_DUMMY_LEN_LSB;
-
-    qmi_hw->m[1].rcmd = 0xEB;
-
-    qmi_hw->m[1].wfmt =
-        QMI_M0_WFMT_PREFIX_WIDTH_VALUE_Q << QMI_M0_WFMT_PREFIX_WIDTH_LSB | \
-            QMI_M0_WFMT_ADDR_WIDTH_VALUE_Q << QMI_M0_WFMT_ADDR_WIDTH_LSB | \
-            QMI_M0_WFMT_SUFFIX_WIDTH_VALUE_Q << QMI_M0_WFMT_SUFFIX_WIDTH_LSB | \
-            QMI_M0_WFMT_DUMMY_WIDTH_VALUE_Q << QMI_M0_WFMT_DUMMY_WIDTH_LSB | \
-            QMI_M0_WFMT_DATA_WIDTH_VALUE_Q << QMI_M0_WFMT_DATA_WIDTH_LSB | \
-            QMI_M0_WFMT_PREFIX_LEN_VALUE_8 << QMI_M0_WFMT_PREFIX_LEN_LSB;
-
-    qmi_hw->m[1].wcmd = 0x38;
-
-    // Disable direct mode
-    qmi_hw->direct_csr = 0;
-
-    // Enable writes to PSRAM
-    hw_set_bits(&xip_ctrl_hw->ctrl, XIP_CTRL_WRITABLE_M1_BITS);
 
     restore_interrupts(intr_stash);
 


### PR DESCRIPTION
Edit: Sorry this has become something of a stream of consciousness as I feel out how this change should take shape.

⚠️  PSA ⚠️  I feel we ought to go for a full upstream conversion, as presented in: https://github.com/micropython/micropython/pull/19418

This PR remains for comment/comparison.

### Summary

I petitioned for upstream support for PSRAM in Pico SDK back when we first started the RP2350 bringup, it didn't arrive quickly enough for us to skip a downstream alternative but now it's here and we should switch to it.

Originally asked for https://github.com/raspberrypi/pico-sdk/issues/2372

Fixes https://github.com/micropython/micropython/issues/19209

### Testing

Tested on a Pico LiPo 2 with 8MB PSRAM. This will probably need verification from other vendors with PSRAM-enabled boards, since we (Pimoroni) use the same boring part on everything we ship so my tests are extremely narrow. 

So, uh, gentle nudge to:

* @gatesphere: ADAFRUIT_FEATHER_RP2350
* @sfe-SparkFro: SPARKFUN_IOTNODE_LORAWAN_RP2350, SPARKFUN_PROMICRO_RP2350, SPARKFUN_THINGPLUS_RP2350, SPARKFUN_XRP_CONTROLLER
* @SFE-Brudnerd: SPARKFUN_IOTREDBOARD_RP2350
* @bikeNomad: WAVESHARE_RP2350B_CORE

#### Things To Do

Set your PSRAM config upstream:

```
// --- PSRAM ---
#ifndef PICO_PSRAM_CS_PIN
#define PICO_PSRAM_CS_PIN 19
#endif

pico_board_cmake_set_default(PICO_PSRAM_SIZE_BYTES, (8 * 1024 * 1024))
#ifndef PICO_PSRAM_SIZE_BYTES
#define PICO_PSRAM_SIZE_BYTES (8 * 1024 * 1024)
#endif
```

A few boards already have an assumed 8MB, I'm not sure of its provenance but downstream (MicroPython) should endeavour to respect this - https://github.com/search?q=repo%3Araspberrypi%2Fpico-sdk+PICO_PSRAM_SIZE_BYTES+path%3A%2F%5Esrc%5C%2Fboards%5C%2Finclude%5C%2Fboards%5C%2F%2F&type=code

#### Things To Test

* Board starts up and runs, a good start 😆 
* `gc.mem_free()` reports the correct gc_heap region (may include SRAM, will exclude a large chunk for GC tracking)
* `machine.freq()` changes (within reason) do not push PSRAM timings out of whack or baulk the board
* flash writes (merely saving a file, or otherwise, since these disable IRQs and more) restore the PSRAM settings upon completion

### Trade-offs and Alternatives

As with linker includes we'd be silly not to defer to upstream for this, but as with any deferral it does remove some downstream flexibility. Either way we probably don't want to own grotty code like this if we don't have to.

Right now this change is an attempt at a minimal impact switch over to Pico SDK's `hardware_psram`, but linking this library includes auto-bringup which we could leverage to more or less remove rp2_psram.c altogether.

We'd need to set `PICO_PSRAM_CS_PIN`, and either `PICO_PSRAM_SIZE_BYTES` or `PICO_AUTO_DETECT_PSRAM_SIZE`. We can also potentially use `PICO_AUTO_DETECT_PSRAM` but since we already have a CS configured I suggest the best approach would be `PICO_PSRAM_CS_PIN` + `PICO_AUTO_DETECT_PSRAM_SIZE` to replicate the current behaviour. Then we could use the SDK's `psram_get_size()` instead of our `psram_init()`

For clock changes we'd need:

```c
psram_configure_params(PICO_DEFAULT_PSRAM_MAX_FREQ, PICO_DEFAULT_PSRAM_MAX_SELECT, PICO_DEFAULT_PSRAM_MIN_DESELECT);
psram_reinitialize();
```

And if `psram_reinitialize()` fails we'll need to panic, since rugging the PSRAM portion of gc_heap from under the running system is never going to be recoverable.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

(P.S. if anyone wants to throw their boards my way - or gently remind me I can pilfer one from stock - for verifying stuff like this, it would be helpful!)