### PR TITLE
rp2: Fix syntax break in CMakeLists.txt.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -356,7 +356,7 @@ if (MICROPY_BLUETOOTH_BTSTACK)
 
     target_compile_definitions(${MICROPY_TARGET} PRIVATE
         MICROPY_BLUETOOTH_BTSTACK=1
-        MICROPY_BLUETOOTH_BTSTACK_CONFIG_FILE=\"btstack_inc/btstack_config.h\"
+        "MICROPY_BLUETOOTH_BTSTACK_CONFIG_FILE=\"btstack_inc/btstack_config.h\""
     )
 
     # For modbluetooth_btstack.c includes
@@ -594,7 +594,7 @@ set_source_files_properties(
 
 target_compile_definitions(${MICROPY_TARGET} PRIVATE
     ${MICROPY_DEF_BOARD}
-    FFCONF_H=\"${MICROPY_OOFATFS_DIR}/ffconf.h\"
+    "FFCONF_H=\"${MICROPY_OOFATFS_DIR}/ffconf.h\""
     LFS1_NO_MALLOC LFS1_NO_DEBUG LFS1_NO_WARN LFS1_NO_ERROR LFS1_NO_ASSERT
     LFS2_NO_MALLOC LFS2_NO_DEBUG LFS2_NO_WARN LFS2_NO_ERROR LFS2_NO_ASSERT
     PICO_FLOAT_PROPAGATE_NANS=1


### PR DESCRIPTION
Remove backslash escape from the BTStack config file setting. This broke syntax highlighting in VSCode and GitHub's web UI, even though it still worked.

Stumbled upon this while monkeying with PSRAM. It's not essential (doesn't seem to break anything) but reading CMakeLists.txt without syntax highlighting hurts.

See the break in GitHub's web UI half way through: https://github.com/micropython/micropython/blob/964803ab744297c82a9fc3cd0c71c6cf60eec6d2/ports/rp2/CMakeLists.txt#L349-L365

### Generative AI

I did not use generative AI tools when creating this PR.

