### PR TITLE
py/makeqstrdefs.py: now creates mp_sys_version.json.

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -3,6 +3,38 @@ This script processes the output from the C preprocessor and extracts all
 qstr. Each qstr is transformed into a qstr definition of the form 'Q(...)'.
 
 This script works with Python 3.3+.
+
+Example call for command 'split':
+
+    makeqstrdefs.py \
+        split \
+        qstr \
+        micropython/ports/rp2/build-RPI_PICO_W/genhdr/qstr.i.last \
+        micropython/ports/rp2/build-RPI_PICO_W/genhdr/qstr \
+        _
+
+
+Example call for command 'pp':
+
+    makeqstrdefs.py \
+        pp       /usr/bin/arm-none-eabi-gcc -E \
+        output   micropython/ports/rp2/build-RPI_PICO_W/genhdr/qstr.i.last \
+        cflags   -Imicropython/ports/rp2/lwip_inc -DMICROPY_PY_LWIP=1 -mcpu=cortex-m0plus \
+        cxxflags -Imicropython/ports/rp2/lwip_inc -mcpu=cortex-m0plus -mthumb -DNO_QSTR \
+        sources  micropython/py/argcheck.c micropython/py/builtinhelp.c
+
+    In the folder specified by the 'output' parameter, a file 'mp_sys_version.json' is
+    written with this example content:
+        {
+            "sys_implementation_build": "RPI_PICO_W",
+            "sys_implementation_machine": "Raspberry Pi Pico W with RP2040",
+            "sys_version": "3.4.0; MicroPython v1.23.0-preview.3247.g964803ab74.dirty on 2026-07-03"
+        }
+    
+    This allows to verify if the running MicroPython version corresponds to this build:
+        MicroPython:
+        >>> sys.version                   # Must correspond to mp_sys_version.json: sys_version
+        >>> sys.implementation._machine   # Must correspond to mp_sys_version.json: sys_implementation_machine
 """
 
 import io
@@ -10,6 +42,7 @@ import os
 import re
 import subprocess
 import sys
+import json
 import multiprocessing, multiprocessing.dummy
 
 
@@ -38,6 +71,54 @@ def is_cxx_source(fname):
     return os.path.splitext(fname)[1] in [".cc", ".cp", ".cxx", ".cpp", ".CPP", ".c++", ".C"]
 
 
+def write_version_json(filename_output: str, output_bytes: bytes) -> None:
+    """
+    Write 'mp_sys_version.json' as specified in the file doc string.
+    """
+
+    def get_regex(pattern: "re.Pattern[bytes]") -> str:  # re.Pattern is python 3.7+
+        match = pattern.search(output_bytes)
+        if match is None:
+            raise ValueError(f"Could not find '{pattern.pattern!r}' in: {filename_output}")
+        text = match.group(1)
+        # Example 'mcu_name': "LOLIN_C3_MINI" " with " "ESP32-C3FH4"
+        text = eval(text)  # pylint: disable=eval-used
+        # Example 'mcu_name': LOLIN_C3_MINI with ESP32-C3FH4
+        assert isinstance(text, str)
+        return text
+
+    directory_full = os.path.dirname(os.path.realpath(filename_output))
+    if "/ports/" not in directory_full:
+        # This if will skip for build in the mpy-cross folder!
+        return
+
+    for not_supported_port in ("bare-arm", "minimal", "powerpc", "zephyr"):
+        if f"/ports/{not_supported_port}/" in directory_full:
+            # This port does not support 'mp_sys_version.json'
+            return
+
+    # static const mp_obj_str_t mp_sys_version_obj = {{&mp_type_str}, 0, sizeof("3.4.0; " "MicroPython " "v1.24.1" " on " "2024-12-12") - 1, (const byte *)"3.4.0; " "MicroPython " "v1.24.1" " on " "2024-12-12"};
+    # static const mp_obj_str_t mp_sys_version_obj = {{&mp_type_str}, 0, sizeof("3.4.0; " "MicroPython " "v1.25.0-preview.147.g136058496" " on " "2024-12-22") - 1, (const byte *)"3.4.0; " "MicroPython " "v1.25.0-preview.147.g136058496" " on " "2024-12-22"};
+    _regex_version = re.compile(rb"mp_sys_version_obj.*?sizeof\((\".+?\")\)")
+
+    # static const mp_obj_str_t mp_sys_implementation_machine_obj = {{&mp_type_str}, 0, sizeof("Raspberry Pi Pico2" " with " "RP2350-RISCV") - 1, (const byte *)"Raspberry Pi Pico2" " with " "RP2350-RISCV"};
+    # static const mp_obj_str_t mp_sys_implementation_machine_obj = {{&mp_type_str}, 0, sizeof("ESP module (512K)" " with " "ESP8266") - 1, (const byte *)"ESP module (512K)" " with " "ESP8266"};
+    _regex_machine = re.compile(rb"mp_sys_implementation_machine_obj.*?sizeof\((\".+?\")\)")
+
+    # static const mp_obj_str_t mp_sys_implementation__build_obj = {{&mp_type_str}, 0, sizeof("PYBV11") - 1, (const byte *)"PYBV11"};
+    _regex_build = re.compile(rb"mp_sys_implementation__build_obj.*?sizeof\((\".+?\")\)")
+
+    version_dict = {
+        "sys_implementation_build": get_regex(_regex_build),
+        "sys_implementation_machine": get_regex(_regex_machine),
+        "sys_version": get_regex(_regex_version),
+    }
+
+    json_filename = os.path.join(directory_full, "mp_sys_version.json")
+    with open(json_filename, "w") as fp:
+        json.dump(obj=version_dict, fp=fp, indent=4, sort_keys=True)
+
+
 def preprocess():
     if any(src in args.dependencies for src in args.changed_sources):
         sources = args.sources
@@ -62,7 +143,7 @@ def preprocess():
     # short so they are as efficient as possible. (The stm32 port needs symbols of the
     # form `micropy_hw_xxx` so they are also kept.)
     re_line_file = re.compile(rb"^#(?:line)?\s+\d+\s\"")
-    re_mp_info = re.compile(rb"MP_COMP|MP_QSTR|MP_REGI|micropy_hw")
+    re_mp_info = re.compile(rb"MP_COMP|MP_QSTR|MP_REGI|micropy_hw|mp_sys_")
 
     def pp(flags):
         def run(files):
@@ -91,15 +172,21 @@ def preprocess():
     except NotImplementedError:
         cpus = 1
     p = multiprocessing.dummy.Pool(cpus)
-    with open(args.output[0], "wb") as out_file:
-        for flags, sources in (
-            (args.cflags, csources),
-            (args.cxxflags, cxxsources),
-        ):
-            batch_size = (len(sources) + cpus - 1) // cpus
-            chunks = [sources[i : i + batch_size] for i in range(0, len(sources), batch_size or 1)]
-            for output in p.imap(pp(flags), chunks):
-                out_file.write(output)
+    output_buffer = io.BytesIO()
+    for flags, sources in (
+        (args.cflags, csources),
+        (args.cxxflags, cxxsources),
+    ):
+        batch_size = (len(sources) + cpus - 1) // cpus
+        chunks = [sources[i : i + batch_size] for i in range(0, len(sources), batch_size or 1)]
+        for output in p.imap(pp(flags), chunks):
+            output_buffer.write(output)
+
+    output_bytes = output_buffer.getvalue()
+    with open(args.output[0], "wb") as f:
+        f.write(output_bytes)
+
+    write_version_json(filename_output=args.output[0], output_bytes=output_bytes)
 
 
 def write_out(fname, output):


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->
This PR resolves https://github.com/micropython/micropython/issues/19414.

### Summary

After flashing a MicroPython board, I would like to make sure that the correct version was flashed.

With this PR a `mp_sys_version.json` is created for every build:
```json
{
    // >>> sys.implementation._build
    "sys_implementation_build": "RPI_PICO_W",
    // >>> sys.implementation._machine
    "sys_implementation_machine": "Raspberry Pi Pico W with RP2040",
    // >>> sys.version
    "sys_version": "3.4.0; MicroPython v1.23.0-preview.3247.g964803ab74.dirty on 2026-07-03"
}
```

These are the matching constants on the running MicroPython board:
```python
>>> sys.version                # Must correspond to mp_sys_version.json: sys_version
>>> sys.implementation.build   # Must correspond to mp_sys_version.json: sys_implementation_build
```

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Running Octoprobe on all available tentacles. This proves that the json file was created for all connected boards/variantes and the values are correct as Octoprobe will compare the build against the flashed image.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

The implementation depends on the C preprocessor to read mp_sys_version_obj and mp_sys_implementation_machine_obj.

Alternative: The moment where the version string is injected into the C code would be a better place to create mp_sys_version.json.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
