### PR TITLE
WIP: Python/PyPI packaging for Unix port

### DIFF
--- a/.github/workflows/ports_python.yml
+++ b/.github/workflows/ports_python.yml
@@ -48,8 +48,24 @@ jobs:
           name: wheels-${{ matrix.cibw_platform }}
           path: wheelhouse/*.whl
 
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false # good security practice
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+
   publish:
-    needs: build_wheels
+    needs: [build_wheels, make_sdist]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: pypi
@@ -61,7 +77,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      # avoid trying to upload pyodide wheels - not supported by PyPi
+      # avoid trying to upload old pyodide tagged wheels - not supported by PyPi
       - run: rm -f dist/*pyodide*.whl
 
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ports_python.yml
+++ b/.github/workflows/ports_python.yml
@@ -1,0 +1,67 @@
+name: Python package for MicroPython
+
+on:
+  push:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheels for ${{ matrix.cibw_platform }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_platform: linux
+          - os: macos-latest
+            cibw_platform: macos
+          - os: ubuntu-latest
+            cibw_platform: pyodide
+          - os: windows-latest
+            cibw_platform: windows
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup MSBuild
+        if: matrix.os == 'windows-latest'
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.0.0
+        env:
+          CIBW_BEFORE_ALL: "make -C ports/unix submodules && make -C mpy-cross"
+          CIBW_PLATFORM: ${{ matrix.cibw_platform }}
+          CIBW_SKIP: "cp38-* cp39-* *_i686"
+          CIBW_ENABLE: pyodide-prerelease
+          CIBW_TEST_COMMAND: "python {package}/test_micropython_module.py"
+        with:
+          package-dir: ports/python
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-${{ matrix.cibw_platform }}
+          path: wheelhouse/*.whl
+
+  publish:
+    needs: build_wheels
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+
+      # avoid trying to upload pyodide wheels - not supported by PyPi
+      - run: rm -f dist/*pyodide*.whl
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+prune *
+global-exclude __pycache__
+global-exclude build*
+global-exclude venv
+graft py
+graft ports/python
+graft ports/unix
+graft ports/windows
+graft shared
+include pyproject.toml

--- a/ports/python/micropython.py
+++ b/ports/python/micropython.py
@@ -1,0 +1,10 @@
+
+# expose all functions from C module on this Python module
+from micropython_module import *
+import sys
+
+def main():
+    return run_main(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/ports/python/micropython_module.cpp
+++ b/ports/python/micropython_module.cpp
@@ -1,0 +1,48 @@
+// CPython module for MicroPython
+// Allows to run MicroPython code from CPython
+// and to package this easily for pip/PyPi
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+// From libmicropython.a
+extern "C" {
+    int micropython_unix_main(int argc, char **argv);
+}
+
+namespace py = pybind11;
+
+void convert_to_argv(const std::vector<std::string>& args, int& argc, char*** argv) {
+    argc = args.size();
+    *argv = new char*[argc + 1];
+
+    int i = 0;
+    for (const auto& s : args) {
+        (*argv)[i++] = strdup(s.c_str());
+    }
+    (*argv)[argc] = nullptr;
+}
+
+void free_argv(int argc, char** argv) {
+    for (int i = 0; i < argc; ++i) {
+        free(argv[i]);
+    }
+    delete[] argv;
+}
+
+int run_main(std::vector<std::string> args) {
+
+    int argc;
+    char** argv;
+    convert_to_argv(args, argc, &argv);
+
+    const int ret = micropython_unix_main(argc, argv);
+
+    free_argv(argc, argv);
+    return ret;
+}
+
+PYBIND11_MODULE(micropython_module, m) {
+    m.doc() = "CPython module for MicroPython";
+    m.def("run_main", &run_main, "Run main()");
+}

--- a/ports/python/pyproject.toml
+++ b/ports/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jonnor-micropython"
-version = "1.28.0.2"
+version = "1.28.0.3"
 description = "CPython wrapper for MicroPython"
 authors = [{name = "MicroPython community"}]
 dependencies = ["pybind11"]

--- a/ports/python/pyproject.toml
+++ b/ports/python/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools", "pybind11"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jonnor-micropython"
+version = "1.28.0.2"
+description = "CPython wrapper for MicroPython"
+authors = [{name = "MicroPython community"}]
+dependencies = ["pybind11"]
+
+[project.scripts]
+micropython = "micropython:main"
+
+[tool.setuptools]
+py-modules = ["micropython"]
+zip-safe = false

--- a/ports/python/setup.py
+++ b/ports/python/setup.py
@@ -1,0 +1,94 @@
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as build_ext_original
+import sys
+import os
+import setuptools
+import subprocess
+
+import sysconfig
+
+target_is_windows = sys.platform == "win32"
+
+if target_is_windows:
+    extra_objects = ["../windows/build-standard/micropython.lib"]
+    extra_link_args = ["Bcrypt.lib"]
+else:
+    extra_objects = ["../unix/build-standard/libmicropython.a"]
+    extra_link_args = []
+
+
+def get_msvc_platform():
+    arch = sysconfig.get_platform()  # e.g. 'win32', 'win-amd64', 'win-arm64'
+    return {
+        "win32": "Win32",
+        "win-amd64": "x64",
+        "win-arm64": "ARM64",
+    }[arch]
+
+class get_pybind_include:
+    """Helper class to determine the pybind11 include path"""
+
+    def __str__(self):
+        import pybind11
+        return pybind11.get_include()
+
+class build_ext(build_ext_original):
+    """
+    Run neccesary make steps before Python module build
+
+    This enables to use pip install for the entire build flow,
+    such as when doing building from a git repo. Example:
+    pip install "git+https://github.com/micropython/micropython.git@main#subdirectory=ports/unix"
+    """
+    def run(self):
+
+        if target_is_windows:
+            # For Windows, build with MSVC
+            msbuild_platform = get_msvc_platform()
+            subprocess.run(
+                [
+                    "msbuild",
+                    "libmicropython.vcxproj",
+                    "/p:Configuration=Release",
+                    f"/p:Platform={msbuild_platform}",
+                ],
+                cwd="../windows",
+                check=True,
+            )
+
+        else:
+            extra_args = [
+                # btree uses headers not available in emscripten
+                # btree #include <sys/cdefs.h> fails gives warning/erro on musl
+                "MICROPY_PY_BTREE=0",
+            ]
+            # Unix port, build with make
+            subprocess.check_call(["make", "submodules"], cwd="../unix")
+            subprocess.check_call(["make", "clean", "libmicropython",
+                "V=1",
+                "CFLAGS_EXTRA=-fPIC -fno-omit-frame-pointer -DMICROPY_UNIX_NO_MAIN=1",
+                "MICROPY_PY_FFI=0", # libffi causes linking error
+                "VARIANT=standard",
+            ] + extra_args, cwd="../unix")
+
+        super().run()
+
+ext_modules = [
+    Extension(
+        "micropython_module",
+        ["micropython_module.cpp"],
+        include_dirs=[
+            get_pybind_include(),
+        ],
+        extra_objects=extra_objects,
+        extra_link_args=extra_link_args,
+        language="c++"
+    ),
+]
+
+# NOTE: static metadata is in pyproject.toml
+setup(
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+)

--- a/ports/python/test_micropython_module.py
+++ b/ports/python/test_micropython_module.py
@@ -1,0 +1,89 @@
+"""
+Test the "micropython" CPython module
+"""
+
+from pathlib import Path
+import json
+import os
+import subprocess
+
+import micropython
+
+# NOTE: pyodide (browser/emscripten) environment does not support subprocess
+# use_subprocess=True allows to capture stdout/stderr, useful for debugging exceptions
+def run_file(path : Path, use_subprocess=False):
+
+    args = [ 'micropython', path ]
+    if use_subprocess:
+        subprocess.check_output(args)
+    else:
+        return micropython.run_main(args)
+
+def run_code(code : str, use_subprocess=False):
+
+    args = [ 'micropython', '-c', code ]
+    if use_subprocess:
+        subprocess.check_output(args)
+    else:
+        return micropython.run_main(args)
+
+
+# Simple MicroPython program. Checks module imports, writing to disk
+micropython_program_dump_implementation = """\
+import json
+import sys
+out_file = 'out.txt'
+with open(out_file, 'w') as f:
+    o = sys.implementation
+    s = json.dumps(dict(name=o.name, version=o.version, _mpy=o._mpy))
+    f.write(s)
+    f.flush()
+"""
+
+def test_run_file_simple():
+
+    # clean existing outputs
+    out_file = 'out.txt'
+    if os.path.exists(out_file):
+        os.unlink(out_file)
+
+    # recreate script on-disk
+    script_path = 'script.py'
+    if os.path.exists(script_path):
+        os.unlink(script_path)
+    with open(script_path, 'w') as f:
+        f.write(micropython_program_dump_implementation)
+
+    # run as script
+    run_file(script_path)
+
+    # check output
+    assert os.path.exists(out_file)
+    with open(out_file) as f:
+        data = json.load(f)
+
+    assert data['name'] == 'micropython'
+
+def test_run_code_simple():
+
+    # clean existing outputs
+    out_file = 'out.txt'
+    if os.path.exists(out_file):
+        os.unlink(out_file)
+
+    code = micropython_program_dump_implementation
+    run_code(code)
+
+    assert os.path.exists(out_file)
+
+    with open(out_file) as f:
+        data = json.load(f)
+
+    assert data['name'] == 'micropython'
+
+def main():
+    test_run_code_simple()
+    test_run_file_simple()
+
+if __name__ == '__main__':
+    main()

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -319,3 +319,10 @@ install: $(BUILD)/$(PROG)
 
 uninstall:
 	-rm $(BINDIR)/$(PROG)
+
+# Build static library
+$(BUILD)/libmicropython.a: $(OBJ)
+	$(AR) rcs $@ $^
+
+.PHONY: libmicropython
+libmicropython: $(BUILD)/libmicropython.a

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -435,7 +435,7 @@ static void sys_set_excecutable(char *argv0) {
 
 MP_NOINLINE int main_(int argc, char **argv);
 
-int main(int argc, char **argv) {
+int micropython_unix_main(int argc, char **argv) {
     #if MICROPY_PY_THREAD
     mp_thread_init();
     #endif
@@ -446,11 +446,18 @@ int main(int argc, char **argv) {
     // We should capture stack top ASAP after start, and it should be
     // captured guaranteedly before any other stack variables are allocated.
     // For this, actual main (renamed main_) should not be inlined into
-    // this function. main_() itself may have other functions inlined (with
-    // their own stack variables), that's why we need this main/main_ split.
+    // this function.
+    // main_() itself may have other functions inlined (with
+    // their own stack variables), that's why we need this split.
     mp_cstack_init_with_sp_here(stack_size);
     return main_(argc, argv);
 }
+
+#if !MICROPY_UNIX_NO_MAIN
+int main(int argc, char **argv) {
+    return micropython_unix_main(argc, argv);
+}
+#endif
 
 MP_NOINLINE int main_(int argc, char **argv) {
     #ifdef SIGPIPE

--- a/ports/windows/libmicropython.vcxproj
+++ b/ports/windows/libmicropython.vcxproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0" DefaultTargets="Build">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{740F3C30-EB6C-4B59-9C50-AE4D5A4A9D12}</ProjectGuid>
+    <RootNamespace>micropython</RootNamespace>
+    <ReadOnlyProject>true</ReadOnlyProject>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/release.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/debug.props" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="msvc/common.props" />
+    <Import Project="msvc/release.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros">
+    <CustomPropsFile Condition="'$(CustomPropsFile)'==''">msvc/user.props</CustomPropsFile>
+    <TargetName>$(PyProg)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile />
+    <Link />
+  </ItemDefinitionGroup>
+  <Import Project="msvc/sources.props" />
+  <ItemGroup>
+    <ClCompile Include="@(PyCoreSource)" />
+    <ClCompile Include="@(PyExtModSource)" />
+    <ClCompile Include="$(PyBaseDir)shared\libc\printf.c" />
+    <ClCompile Include="$(PyBaseDir)shared\readline\*.c" />
+    <ClCompile Include="$(PyBaseDir)shared\runtime\gchelper_generic.c" />
+    <ClCompile Include="$(PyBaseDir)shared\runtime\pyexec.c" />
+    <ClCompile Include="$(PyBaseDir)ports\windows\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\windows\msvc\*.c" />
+    <ClCompile Include="$(PyBaseDir)ports\unix\gccollect.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\input.c"/>
+    <ClCompile Include="$(PyBaseDir)ports\unix\main.c">
+      <PreprocessorDefinitions>MICROPY_UNIX_NO_MAIN=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <ClCompile Include="$(PyVariantDir)*.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="@(PyCoreInclude)" />
+    <ClInclude Include="@(PyExtModInclude)" />
+    <ClInclude Include="$(PyBaseDir)ports\windows\*.h" />
+    <ClInclude Include="$(PyBaseDir)ports\windows\msvc\*.h" />
+  </ItemGroup>
+  <Import Project="msvc/genhdr.targets" />
+  <Import Project="$(CustomPropsFile)" Condition="exists('$(CustomPropsFile)')" />
+  <Target Name="GenerateMicroPythonSources" BeforeTargets="BuildGenerateSources" DependsOnTargets="GenerateHeaders;FreezeModules">
+  </Target>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,18 @@ exclude = [
   "tests/micropython/test_normalize_newlines.py",
   "tests/micropython/viper_args.py",
 ]
+
+[build-system]
+requires = ["setuptools>=64", "wheel", "pybind11"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = []
+package-dir = {"" = "ports/python"}
+
+[project]
+name = "jonnor-micropython"
+version = "1.28.0.2"
+description = "CPython wrapper for MicroPython"
+authors = [{name = "MicroPython community"}]
+dependencies = ["pybind11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ package-dir = {"" = "ports/python"}
 
 [project]
 name = "jonnor-micropython"
-version = "1.28.0.2"
+version = "1.28.0.3"
 description = "CPython wrapper for MicroPython"
 authors = [{name = "MicroPython community"}]
 dependencies = ["pybind11"]


### PR DESCRIPTION
### Summary

Builds a Python package for Unix port, and sets up MicroPython.

This is an early version. High-level feedback and review comments are very welcomed. Once the overall approach is agreed on, I will clean it up accordingly.

Suggested next steps:

- Unify naming of the various files - I propose to use micropython_unix. 
- Make the check.py file into a basic testcase, and run this for each and every wheel (cibuildwheel has support for this)

Prebuilt packages are available via `pip install jonnor-micropython-unix`. For Mac OS (ARM) and Linux (x86_64). It should work on Windows Subsystem for Linux using the Linux packages. I chose to support CPython 3.10+ (2021). I believe this is a practical starting point in terms of coverage, that should cover the majority of users.

It is possible to build and install the package from source by doing `pip install "git+https://github.com/jonnor/micropython.git@unix-python-package-1#subdirectory=ports/unix"`. This requires build tools such as `make` and a compiler.

### Testing

Tested installing the built package a couple of different Linux distributions.

- Ubuntu 22.04, 24.04
- CentOS 9 (with Python 3.12)
- Arch Linux (current as of July 2026)
- Fedora 44
- Alpine with MUSL libc (current as of July 2026)
- Pyodide (browser) using Jupyter Lite 

And by others also on WSL and Mac OS:

- Mac OS Tahoe. By @Gadgetoid 
- Windows Subsystem for Linux by @Josverl 

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

Details: I did not use any code as-is from gen AI. It was primarily used for searching for information online, and for trying to understand some compile error messages.
