### PR TITLE
esp32/lockfiles: Add lockfile for ESP32-H2.

### DIFF
--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -1,0 +1,21 @@
+dependencies:
+  espressif/mdns:
+    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.1.0
+  idf:
+    source:
+      type: idf
+    version: 5.5.2
+direct_dependencies:
+- espressif/mdns
+- idf
+manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+target: esp32h2
+version: 2.0.0


### PR DESCRIPTION
### Summary

Adds lockfile.esp32h2 that was missed in #19317.

### Testing

Built locally.  Should also be tested by CI.

### Generative AI

Not used.