### PR TITLE
py/dynruntime.mk: Build x64 native modules on non-x64 hosts.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -370,6 +370,25 @@ jobs:
       if: failure()
       run: tests/run-tests.py --print-failures
 
+  qemu_x64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v7
+    - uses: actions/setup-python@v6
+      # Python 3.12 is the default for ubuntu-24.04, but that has compatibility issues with settrace tests.
+      # Can remove this step when ubuntu-latest uses a more recent Python 3.x as the default.
+      with:
+        python-version: '3.11'
+    - name: Install packages
+      run: tools/ci.sh unix_qemu_x64_setup
+    - name: Build
+      run: tools/ci.sh unix_qemu_x64_build
+    - name: Run main test suite
+      run: tools/ci.sh unix_qemu_x64_run_tests
+    - name: Print failures
+      if: failure()
+      run: tests/run-tests.py --print-failures
+
   sanitize_address:
     runs-on: ubuntu-latest
     steps:

--- a/py/dynruntime.mk
+++ b/py/dynruntime.mk
@@ -55,7 +55,7 @@ MICROPY_FLOAT_IMPL ?= double
 else ifeq ($(ARCH),x64)
 
 # x64
-CROSS =
+CROSS = x86_64-linux-gnu-
 CFLAGS_ARCH += -fno-stack-protector
 MICROPY_FLOAT_IMPL ?= double
 

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -614,6 +614,12 @@ CI_UNIX_OPTS_QEMU_LOONG64=(
     MICROPY_STANDALONE=1
 )
 
+CI_UNIX_OPTS_QEMU_X64=(
+    CROSS_COMPILE=x86_64-linux-gnu-
+    VARIANT=coverage
+    MICROPY_STANDALONE=1
+)
+
 CI_UNIX_OPTS_SANITIZE_ADDRESS=(
     # Macro MP_ASAN allows detecting ASan on gcc<=13
     CFLAGS_EXTRA="-fsanitize=address --param asan-use-after-return=0 -DMP_ASAN=1"
@@ -1028,6 +1034,34 @@ qemu-loongarch64-static "$MPY_PATH"/micropython $@
 EOF
     chmod +x ./ports/unix/build-coverage/micropython-runner
     (cd tests && MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython-runner MICROPY_TEST_TIMEOUT=180 ./run-tests.py)
+}
+
+function ci_unix_qemu_x64_setup {
+    sudo apt-get update
+    sudo apt-get install gcc-x86-64-linux-gnu g++-x86-64-linux-gnu libc6-amd64-cross libltdl-dev
+    sudo apt-get install qemu-user-static
+    python3 -m pip install pyelftools
+    python3 -m pip install ar
+    qemu-x86_64-static --version
+    sudo mkdir -p /usr/gnemul
+    sudo ln -s /usr/x86_64-linux-gnu /usr/gnemul/qemu-x86_64
+}
+
+function ci_unix_qemu_x64_build {
+    ci_unix_build_helper "${CI_UNIX_OPTS_QEMU_X64[@]}"
+    ci_unix_build_ffi_lib_helper x86_64-linux-gnu-gcc
+    ci_native_mpy_modules_build x64
+}
+
+function ci_unix_qemu_x64_run_tests {
+    # Issues with x64 tests on non-x64 hosts:
+    # - thread/stress_aes.py takes around 90 seconds
+    # - ports/unix/ffi_callback.py crashes QEMU (x86_64-binfmt-P: QEMU internal SIGSEGV {code=MAPERR, addr=0x20})
+    file ./ports/unix/build-coverage/micropython
+    pushd tests
+    MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-tests.py --exclude '(thread/stress_aes.py|ports/unix/ffi_callback.py)'
+    MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-natmodtests.py extmod/btree*.py extmod/deflate*.py extmod/framebuf*.py extmod/heapq*.py extmod/random_basic*.py extmod/re*.py
+    popd
 }
 
 function ci_unix_repr_b_build {


### PR DESCRIPTION
### Summary

This PR continues the work on making building and testing MicroPython architecture-neutral.  After removing the limitation on x86 natmods having to be built on a x86/x64 system, now it's the turn of x64 to receive a similar treatment.

These changes force a `CROSS` toolchain prefix for x64 natmods, which has been available for a few years now on all Linux systems whose GCC distribution isn't particularly broken.

Since a long time, GCC distributions built to target the same architecture as the host system are available both as regular binaries without any architecture prefix, and as explicit cross-compiler binaries as well.  
  
So, on an x64 Linux host the user can build code using either `gcc` or  `x86_64-linux-gnu-gcc`, obtaining the same result.  This fact is leveraged to always pick the more specific form of the compiler prefix so on AArch64 x64 natmods can be built the same way as long as an x86-64 cross compiler toolchain is available.

To further validate these changes, a QEMU-based Linux/x64 CI job is added.  This is not running on the regular `ubuntu-latest` CI image but on the latest available non-preview Arm64-based Ubuntu image instead.  So not only natmods are built on a foreign architecture but they are also tested under a foreign architecture too (see https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
### Testing

Building x64 natmods was done successfully under AMD64 with Ubuntu 24.04, Ubuntu 26.04, and current Arch Linux, then under AArch64 on a RPi3B+ running the latest Raspbian, and finally under RV64 on a MilkV-Duo board running a custom Yocto-based system.

QEMU/x64 tests were executed successfully on RPi3B+ and by CI.
### Trade-offs and Alternatives

The runners pool for AArch64 is smaller than the one for Amd64 so it might happen that the `qemu_x64` job has to wait a bit longer to be executed.
### Generative AI

I did not use generative AI tools when creating this PR.

---

Whilst I believe this PR can be submitted as-is, the work in making the infrastructure arch-neutral is not done.  I was thinking about adding selected Arm64-hosted jobs to the Unix workflow but I'd like some feedback first.

My idea is to add `standard_arm64`, `coverage_arm64`, `float_arm64`, and possibly `standard_v2_arm64`.  By themselves they don't add much time to a full CI run, however the same remark about a smaller runners pool still applies here.