### PR TITLE
py/asmrv32: Improve registers allocation.

### DIFF
--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -780,9 +780,9 @@ static inline uint8_t asm_rv32_allowed_extensions(void) {
 #define REG_ARG_2 ASM_RV32_REG_A1
 #define REG_ARG_3 ASM_RV32_REG_A2
 #define REG_ARG_4 ASM_RV32_REG_A3
-#define REG_TEMP0 ASM_RV32_REG_T1
-#define REG_TEMP1 ASM_RV32_REG_T2
-#define REG_TEMP2 ASM_RV32_REG_T3
+#define REG_TEMP0 ASM_RV32_REG_A4
+#define REG_TEMP1 ASM_RV32_REG_A5
+#define REG_TEMP2 ASM_RV32_REG_A6
 #define REG_FUN_TABLE ASM_RV32_REG_S1
 #define REG_LOCAL_1 ASM_RV32_REG_S3
 #define REG_LOCAL_2 ASM_RV32_REG_S2


### PR DESCRIPTION
### Summary

This PR modifies the mapping between predefined value holders and their associated static CPU registers.

Temporary values marked as `REG_TEMP0`, `REG_TEMP1`, and `REG_TEMP2` were associated with three caller-save registers (T1, T2, and T3 respectively).  Whilst this works, these registers cannot be mapped to the restricted registers set used by most compressed opcodes, leaving potential size optimisations on the table.

If those values are mapped to A4, A5, and A6, it means that both `REG_TEMP0` and `REG_TEMP1` have more chances to trigger a compressed opcode (the involved registers window only covers S0, S1, and A0 to A5). This requires no external changes as those registers are caller-saved as well.

Size savings are not huge but they do add up (the whole of `/tests` - ignoring skipped files - is 3.5% smaller):

```bash
# Before
$ cd /micropython/tests ; for i in **/*.py; do /micropython/mpy-cross/build/mpy-cross -X emit=native -march=rv32imc $i; done; du -bcs **/*.mpy | tail -n 1
3438764 total

# After
$ cd /micropython/tests ; for i in **/*.py; do /micropython/mpy-cross/build/mpy-cross -X emit=native -march=rv32imc $i; done; du -bcs **/*.mpy | tail -n 1
3316471 total
```

It's quite embarassing I didn't catch this back then and it took all that time to sort this out, better late than never.

### Testing

The `tests/micropython` tests were executed successfully on an ESP32C3.  This is also to be tested by CI for the QEMU/VIRT_RV32 board when using `--via-mpy --emit=native`.

### Generative AI

I did not use generative AI tools when creating this PR.