### PR TITLE
py/modio: Give IOBase.write() a memoryview instead of a raw view.

### DIFF
--- a/docs/library/io.rst
+++ b/docs/library/io.rst
@@ -116,9 +116,18 @@ Classes
 
    .. method:: IOBase.write(buf)
 
-      Write *buf* (a ``bytearray``) to the stream. Return the number of
-      bytes written, or ``None`` if a non-blocking stream cannot accept data.
-      Return a negative errno value to signal an error.
+      Write *buf* (a ``memoryview`` onto the data to write) to the stream.
+      Return the number of bytes written, or ``None`` if a non-blocking
+      stream cannot accept data. Return a negative errno value to signal an
+      error.
+
+      .. warning::
+
+         *buf* (for both ``write()`` and ``readinto()``) is backed by a
+         temporary buffer that is only valid for the duration of the call.
+         Don't store a reference to *buf* itself or otherwise let it outlive
+         the call; if you need to keep the data, copy it out first (e.g.
+         ``bytes(buf)``).
 
    .. method:: IOBase.ioctl(op, arg)
 

--- a/py/modio.c
+++ b/py/modio.c
@@ -54,8 +54,27 @@ static mp_obj_t iobase_make_new(const mp_obj_type_t *type, size_t n_args, size_t
 static mp_uint_t iobase_read_write(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode, qstr qst) {
     mp_obj_t dest[3];
     mp_load_method(obj, qst, dest);
-    mp_obj_array_t ar = {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, size, buf};
-    dest[2] = MP_OBJ_FROM_PTR(&ar);
+    mp_obj_array_t ar;
+    if (qst == MP_QSTR_readinto) {
+        // readinto() needs a mutable, resizable bytearray view: some
+        // implementations do eg buf[:] = data[off:off + len(buf)] to fill it,
+        // relying on bytearray's ability to shrink in place when fewer bytes
+        // are available than requested (eg near EOF). A fixed-size
+        // memoryview can't support that (slice-assigning a shorter value
+        // raises ValueError), so this can't use the same fix as write().
+        ar = (mp_obj_array_t) {{&mp_type_bytearray}, BYTEARRAY_TYPECODE, 0, size, buf};
+        dest[2] = MP_OBJ_FROM_PTR(&ar);
+    } else {
+        #if MICROPY_PY_BUILTINS_MEMORYVIEW
+        // A memoryview onto the caller's buffer is enough for write() to read the
+        // data, is cheap (no allocation of the buffer's content), and, unlike a
+        // bytearray, doesn't support in-place resizing (eg buf += buf raises
+        // TypeError) instead of trying to gc_realloc a pointer the GC doesn't own.
+        dest[2] = mp_obj_new_memoryview(BYTEARRAY_TYPECODE, size, buf);
+        #else
+        dest[2] = mp_obj_new_bytearray(size, buf);
+        #endif
+    }
     mp_obj_t ret_obj = mp_call_method_n_kw(1, 0, dest);
     if (ret_obj == mp_const_none) {
         *errcode = MP_EAGAIN;

--- a/tests/basics/io_buffered_writer.py.exp
+++ b/tests/basics/io_buffered_writer.py.exp
@@ -6,6 +6,6 @@ b'foo'
 <class 'int'>
 OSError
 OSError
-writing bytearray(b'foobar')
+writing <memoryview>
 flushed
 flushed

--- a/tests/extmod/deflate_stream_error.py.exp
+++ b/tests/extmod/deflate_stream_error.py.exp
@@ -1,25 +1,25 @@
 Stream.readinto 1
 OSError(1,)
-Stream.write bytearray(b'K')
+Stream.write <memoryview>
 OSError(1,)
-Stream.write bytearray(b'\x18\x95')
+Stream.write <memoryview>
 OSError(22,)
-Stream.write bytearray(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\x03')
+Stream.write <memoryview>
 OSError(22,)
 Stream.ioctl 4 0
 OSError(22,)
-Stream.write bytearray(b'K')
-Stream.write bytearray(b'\x04')
-Stream.write bytearray(b'\x00')
-Stream.write bytearray(b'\x18\x95')
-Stream.write bytearray(b'K')
-Stream.write bytearray(b'\x04')
-Stream.write bytearray(b'\x00')
-Stream.write bytearray(b'\x00b\x00b')
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
 OSError(1,)
-Stream.write bytearray(b'\x1f\x8b\x08\x00\x00\x00\x00\x00\x04\x03')
-Stream.write bytearray(b'K')
-Stream.write bytearray(b'\x04')
-Stream.write bytearray(b'\x00')
-Stream.write bytearray(b'C\xbe\xb7\xe8\x01\x00\x00\x00')
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
+Stream.write <memoryview>
 OSError(1,)

--- a/tests/extmod/json_dump_iobase.py
+++ b/tests/extmod/json_dump_iobase.py
@@ -17,9 +17,9 @@ class S(io.IOBase):
         self.buf = ""
 
     def write(self, buf):
-        if type(buf) == bytearray:
-            # MicroPython passes a bytearray, CPython passes a str
-            buf = str(buf, "ascii")
+        if type(buf) == memoryview:
+            # MicroPython passes a memoryview, CPython passes a str
+            buf = str(bytes(buf), "ascii")
         self.buf += buf
         return len(buf)
 
@@ -28,3 +28,19 @@ class S(io.IOBase):
 s = S()
 json.dump([123, {}], s)
 print(s.buf)
+
+
+# write() gets a memoryview onto the (short-lived) buffer being written, not an
+# independent copy, so it can't be grown/mutated in place; MicroPython doesn't
+# need to defend against this since attempting it raises TypeError like any
+# other unsupported memoryview operation, rather than corrupting memory.
+class MutatingS(io.IOBase):
+    def write(self, buf):
+        try:
+            buf += buf
+        except TypeError:
+            print("TypeError")
+        return 1
+
+
+json.dump([], MutatingS())

--- a/tests/extmod/json_dump_iobase.py.exp
+++ b/tests/extmod/json_dump_iobase.py.exp
@@ -1,0 +1,3 @@
+[123, {}]
+TypeError
+TypeError


### PR DESCRIPTION
### Summary

Fixes #19075.

`iobase_read_write()` backs the object it passes to the Python-level
`write()`/`readinto()` methods with a `bytearray` view directly over the C
caller's buffer (a stack buffer for most stream write paths, e.g.
`mp_stream_write_adaptor()`). For `readinto()` this is required, since the
callee is expected to fill the caller's buffer. For `write()` it is not:
the callee only needs to read the data, but if a custom `io.IOBase`
subclass's `write()` mutates the object it receives (e.g. `buf += buf`),
the runtime tries to `gc_realloc` a pointer that was never allocated by
the GC, corrupting the heap or crashing:

```python
class S(io.IOBase):
    def write(self, buf):
        buf += buf
        return 1

json.dump([], S())  # corrupts the heap / crashes
```

*(Edit history: earlier versions of this PR tried passing `write()` a
`bytes` object, then an independent `bytearray` copy, to make the mutation
safe. @Gadgetoid pointed out the actual fix should make the mutation
itself raise a clear error rather than silently accommodate it — see
below.)*

`write()` now gets a `memoryview` onto the caller's buffer via
`mp_obj_new_memoryview()` instead of a `bytearray` view. This is cheap —
it just wraps the pointer, there's no allocation or copy of the buffer's
*content* (same cost as the existing `readinto()` path) — and, unlike
`bytearray`, `memoryview` doesn't support in-place resizing at all
(`MP_BINARY_OP_INPLACE_ADD` returns `MP_OBJ_NULL` for it), so
`buf += buf` now cleanly raises `TypeError: unsupported types for
__add__: 'memoryview', 'memoryview'` instead of being silently
accommodated via a copy or corrupting memory via the raw view.

`readinto()` is unaffected — it keeps using the `bytearray` view, since
the callee is expected to write into the caller's memory there.

### Testing

Built `ports/unix` (`build-standard`, Linux x86-64) and ran the full
`tests/basics`, `tests/extmod`, `tests/import` and `tests/micropython`
suites: 837/838 pass (one pre-existing, unrelated failure on this
machine, `extmod/select_poll_fd.py`, present on `master` before this
change too).

`extmod/deflate_stream_error.py` (the test that broke on an earlier
version of this PR, since it asserts on the exact type/repr `write()`
receives) is skipped in my default local build config (compression isn't
enabled), so I rebuilt with `-DMICROPY_PY_DEFLATE_COMPRESS=1` to actually
exercise it: it now passes, with its `.exp` updated from
`bytearray(b'...')` to `<memoryview>` to match the new (cheaper, safer)
type.

Updated `tests/extmod/json_dump_iobase.py`'s `MutatingS` case to expect
the `TypeError` from `buf += buf` (added a `.exp` file for it, since
CPython passes a `str` there — which supports `+=` fine — so this is a
case where MicroPython and CPython intentionally diverge, not a
comparable-to-CPython test).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.