### PR TITLE
py/lexer: Don't treat a trailing backslash as line continuation.

### DIFF
--- a/py/lexer.c
+++ b/py/lexer.c
@@ -193,7 +193,7 @@ fetch_next_byte:
     }
 
     // check if we need to insert a newline at end of file
-    if (chr2 == MP_LEXER_EOF && lex->chr1 != MP_LEXER_EOF && lex->chr1 != '\n') {
+    if (chr2 == MP_LEXER_EOF && lex->chr1 != MP_LEXER_EOF && lex->chr1 != '\n' && lex->chr1 != '\\') {
         chr2 = '\n';
     }
 

--- a/tests/basics/syntaxerror.py
+++ b/tests/basics/syntaxerror.py
@@ -17,6 +17,7 @@ def test_syntax(code):
 
 # non-newline after line-continuation character (lexer error)
 test_syntax("a \\a\n")
+test_syntax("123\\")
 
 # dedent mismatch (lexer error)
 test_syntax("def f():\n  a\n a\n")


### PR DESCRIPTION
### Summary

Fixes #19061.

At EOF, the lexer inserts a synthetic newline when the last real character
isn't already a newline, so scripts not ending in `\n` still parse
correctly. If that last character is a backslash, the synthetic newline is
instead consumed by the line-continuation logic (`skip_whitespace()`
treats `\` followed by `\n` as a continuation), so the lexer silently
continues onto a "line" that never existed:

```python
eval("123\\")
```

This leaves the parser/bytecode emitter in an inconsistent state and
crashes via an `mp_emit_bc_end_pass()` size assertion, instead of raising
the `SyntaxError` a lone trailing backslash should produce (as CPython
does).

The fix skips inserting the synthetic newline when the file ends in a
backslash, so it's treated as an illegal token and raises `SyntaxError`
instead of being swallowed as a continuation. This only changes behaviour
when the very last character of the source is a backslash; a real line
continuation followed by an actual newline (`"a \\n"`, tested just above
in the same file) is unaffected.

### Testing

Built `ports/unix` (`build-standard`, Linux x86-64) and ran the full
`tests/basics`, `tests/extmod`, `tests/import` and `tests/micropython`
suites: 838/839 pass (one pre-existing, unrelated failure on this machine,
`extmod/select_poll_fd.py`, present on `master` before this change too).

Added `test_syntax("123\\")` to `tests/basics/syntaxerror.py`, next to the
existing "non-newline after line-continuation character" case. It crashes
without the fix and cleanly raises `SyntaxError` (matching CPython) with
it. This test is compared against CPython's own output by `run-tests.py`
since there's no `.exp` file, and CPython raises `SyntaxError` for the
same input.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.