### PR TITLE
py/runtime: Don't propagate AttributeError from __all__ lookup.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1603,7 +1603,7 @@ void mp_import_all(mp_obj_t module) {
 
     #if MICROPY_MODULE___ALL__
 
-    mp_load_method_maybe(module, MP_QSTR___all__, dest);
+    mp_load_method_protected(module, MP_QSTR___all__, dest, false);
     if (dest[0] != MP_OBJ_NULL) {
         // When __all__ is defined, we must explicitly load all specified
         // symbols, possibly invoking the module __getattr__ function

--- a/tests/import/import_star.py
+++ b/tests/import/import_star.py
@@ -18,6 +18,7 @@ print("VisibleClass" in globals())
 print("_hiddenFun" in globals())
 print("_HiddenClass" in globals())
 print(visibleFun())
+print("__getattr__" in globals())
 
 # 2. test explicit visibility as defined by __all__ (as an array)
 from pkgstar_all_array import *
@@ -57,3 +58,14 @@ try:
     print("missed detection of incorrect __all__ definition")
 except TypeError as er:
     print("TypeError triggered for bad __all__ definition")
+
+# 6. test that a genuine bug in __getattr__ (as opposed to it correctly
+# raising AttributeError for "no __all__ here") is not swallowed
+try:
+    from pkgstar_getattr_error import *
+
+    print("missed propagation of __getattr__ bug")
+except ValueError as er:
+    print("ValueError triggered by buggy __getattr__")
+except AttributeError as er:
+    print("wrongly swallowed as AttributeError")

--- a/tests/import/pkgstar_default/__init__.py
+++ b/tests/import/pkgstar_default/__init__.py
@@ -18,3 +18,7 @@ def _hiddenFun():
 class _HiddenClass:
     def __init__(self):
         self._val = -1
+
+
+def __getattr__(attr):
+    raise AttributeError(attr)

--- a/tests/import/pkgstar_getattr_error/__init__.py
+++ b/tests/import/pkgstar_getattr_error/__init__.py
@@ -1,0 +1,5 @@
+def __getattr__(attr):
+    # A real bug in __getattr__ (not "attribute not found") must propagate
+    # out of `from pkg import *`, not be swallowed as if __all__ were
+    # simply absent.
+    raise ValueError("bug, not attribute-not-found")


### PR DESCRIPTION
### Summary

Fixes #19265.

`mp_import_all()` probes a module's `__all__` attribute with
`mp_load_method_maybe()` to decide which names `from module import *`
should bind. For a module that implements PEP 562 module-level
`__getattr__` (`MICROPY_MODULE_GETATTR`, enabled by default) and has no
`__all__`, `module_attr()` falls back to calling that `__getattr__`, which
is conventionally expected to raise `AttributeError` for unknown
attributes (this is how CPython's own module `__getattr__` protocol
works). `mp_load_method_maybe()` doesn't catch that exception, so it
propagates straight out of `mp_import_all()` and `import *` fails
completely instead of falling back to binding all public names, as
CPython does:

```python
# pkg/__init__.py
def __getattr__(attr):
    raise AttributeError(attr)
```
```python
>>> from pkg import *   # raises AttributeError('__all__') on MicroPython,
                         # works fine on CPython
```

This is the reduced repro @dpgeorge posted on the issue; it also matches a
real-world break reported against
[micropython-msgpack](https://github.com/peterhinch/micropython-msgpack).

The fix uses `mp_load_method_protected()`, which is the exact same helper
the `getattr()` and `hasattr()` builtins already use for this pattern, so
`AttributeError` from `__getattr__` is swallowed while any other exception
it raises still propagates normally.

### Testing

Built `ports/unix` (`build-standard`, Linux x86-64) and ran the full
`tests/basics`, `tests/extmod`, `tests/import` and `tests/micropython`
suites: 838/839 pass (one pre-existing, unrelated failure on this machine,
`extmod/select_poll_fd.py`, present on `master` before this change too).

Added a `__getattr__` that raises `AttributeError` to
`tests/import/pkgstar_default/__init__.py` (the package already used to
test the "default visibility" `import *` case) and asserted `import *`
from it still completes and does not leak `__getattr__` itself into the
importing module's globals. Fails with the reported `AttributeError`
before this change, passes with it.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.