### PR TITLE
py: Check for size_t overflow before allocating repeated sequences.

### DIFF
--- a/py/objlist.c
+++ b/py/objlist.c
@@ -132,6 +132,9 @@ static mp_obj_t list_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (n < 0) {
                 n = 0;
             }
+            if (o->len != 0 && (size_t)n > SIZE_MAX / o->len / sizeof(*o->items)) {
+                mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("repeated sequence is too long"));
+            }
             mp_obj_list_t *s = list_new(o->len * n);
             mp_seq_multiply(o->items, sizeof(*o->items), o->len, n, s->items);
             return MP_OBJ_FROM_PTR(s);

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -473,6 +473,9 @@ mp_obj_t mp_obj_str_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_i
         if (n <= 0) {
             return make_empty_str_of_type(lhs_type);
         }
+        if (lhs_len != 0 && (size_t)n > SIZE_MAX / lhs_len) {
+            mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("repeated sequence is too long"));
+        }
         vstr_t vstr;
         vstr_init_len(&vstr, lhs_len * n);
         mp_seq_multiply(lhs_data, sizeof(*lhs_data), lhs_len, n, vstr.buf);

--- a/py/objtuple.c
+++ b/py/objtuple.c
@@ -169,6 +169,9 @@ mp_obj_t mp_obj_tuple_binary_op(mp_binary_op_t op, mp_obj_t lhs, mp_obj_t rhs) {
             if (n <= 0) {
                 return mp_const_empty_tuple;
             }
+            if (o->len != 0 && (size_t)n > SIZE_MAX / o->len / sizeof(*o->items)) {
+                mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("repeated sequence is too long"));
+            }
             mp_obj_tuple_t *s = MP_OBJ_TO_PTR(mp_obj_new_tuple(o->len * n, NULL));
             mp_seq_multiply(o->items, sizeof(*o->items), o->len, n, s->items);
             return MP_OBJ_FROM_PTR(s);

--- a/tests/basics/memoryerror.py
+++ b/tests/basics/memoryerror.py
@@ -2,7 +2,11 @@
 l = list(range(1000))
 try:
     1000000000 * l
-except MemoryError:
+except (MemoryError, OverflowError):
+    # On targets where size_t is 32 bits, 1000 * 1000000000 elements
+    # overflows the allocation size check and raises OverflowError
+    # before an allocation is even attempted, instead of the allocation
+    # itself failing with MemoryError.
     print('MemoryError')
 print(len(l), l[0], l[-1])
 

--- a/tests/basics/seq_repeat_overflow.py
+++ b/tests/basics/seq_repeat_overflow.py
@@ -1,0 +1,47 @@
+# Test that repeating a sequence with a count large enough to overflow the
+# internal byte-size computation raises a clean exception instead of
+# wrapping around and corrupting memory. This is checked against a fixed
+# .exp file (rather than comparing against CPython) because the size at
+# which this overflows is a size_t vs machine-int implementation detail
+# that differs between CPython (limited by Py_ssize_t, ie sys.maxsize) and
+# MicroPython (limited by the C size_t used for the allocation, which is
+# larger), so the two don't necessarily raise the same exception type here.
+import sys
+
+if not hasattr(sys, "maxsize"):
+    print("SKIP")
+    raise SystemExit
+
+
+def test_repeat_overflow(seq):
+    n = sys.maxsize // len(seq) + 2
+    try:
+        seq * n
+    except (OverflowError, MemoryError):
+        print(type(seq).__name__, "raises")
+    else:
+        print(type(seq).__name__, "no exception (unexpected)")
+
+
+test_repeat_overflow(b"ab")
+test_repeat_overflow("ab")
+test_repeat_overflow([1, 2])
+test_repeat_overflow((1, 2))
+
+
+# The case above only reaches the overflow check for list/tuple: with
+# 1-byte elements, len(seq) * n itself doesn't exceed size_t for an
+# in-range n when len(seq) is small, so bytes/str instead just fail a
+# (very) large allocation with MemoryError, never actually exercising
+# their own OverflowError check. Use a longer sequence so an in-range n
+# can push len(seq) * n itself past SIZE_MAX, hitting that check directly.
+def test_repeat_overflow_direct(seq):
+    n = sys.maxsize
+    try:
+        seq * n
+    except OverflowError:
+        print(type(seq).__name__, "raises directly")
+
+
+test_repeat_overflow_direct(b"abc")
+test_repeat_overflow_direct("abc")

--- a/tests/basics/seq_repeat_overflow.py.exp
+++ b/tests/basics/seq_repeat_overflow.py.exp
@@ -1,0 +1,6 @@
+bytes raises
+str raises
+list raises
+tuple raises
+bytes raises directly
+str raises directly


### PR DESCRIPTION
### Summary

Fixes #19314.

`seq * n` for `str`/`bytes`/`list`/`tuple` sizes the result as
`len(seq) * n` in unchecked `size_t` arithmetic, allocates a buffer of that
(possibly wrapped) size, then unconditionally writes the real
`len(seq) * n` elements into it via `mp_seq_multiply()`. When
`len(seq) * n` overflows `size_t` the allocation ends up undersized while
the write does not, producing a heap buffer overflow — reachable with an
ordinary in-range Python int on 32-bit targets, where `size_t` is only 32
bits, as the issue's report demonstrates in detail (AddressSanitizer trace
included).

This rejects the multiply up front when it would overflow, matching
CPython's `OverflowError`, instead of silently wrapping and corrupting the
heap.

One refinement on the issue's own suggested patch: for `list`/`tuple`,
guarding only the element *count* (`n > SIZE_MAX / o->len`) turns out not
to be enough, because `list_new()`/`mp_obj_new_tuple()` actually allocate
`count * sizeof(mp_obj_t)` bytes. A count that comfortably fits under
`SIZE_MAX` can still overflow once multiplied by `sizeof(mp_obj_t)` (8 or
16 bytes) &mdash; e.g. `[1, 2] * (sys.maxsize // 2 + 2)` still segfaults with
only the count-level check, since the count itself (~4.6e18) is well under
`SIZE_MAX` (~1.8e19) but the *byte size* wraps to 16. I hit this while
testing the count-only version of the check against a wider range of `n`
than the issue's own PoCs use. The fix divides by `sizeof(*o->items)` as
well, so the check bounds the actual allocation size rather than just the
element count. `str`/`bytes` don't need this extra factor since their
elements are already 1 byte, so `py/objstr.c` is unchanged from the
issue's suggested patch.

### Testing

Built `ports/unix` (`build-standard`, Linux x86-64) and ran the full
`tests/basics`, `tests/extmod`, `tests/import` and `tests/micropython`
suites: 838/839 pass (one pre-existing, unrelated failure on this machine,
`extmod/select_poll_fd.py`, present on `master` before this change too).

Reproduced the crash before the fix:
- `[1, 2] * (sys.maxsize // 2 + 2)` &rarr; segfault with only the
  count-level check (confirms the refinement above is necessary, not just
  defensive).
- The issue's own `list`/`tuple` PoCs (`[0] * 65536 * (2**48)`, etc.)
  segfault on current `master`.

Added `tests/basics/seq_repeat_overflow.py`, exercising `bytes`, `str`,
`list` and `tuple` with `n = sys.maxsize // len(seq) + 2` (chosen to
overflow the `list`/`tuple` byte-size check while staying an in-range
machine int). It's checked against a `.exp` file rather than compared to
CPython, because the two implementations bound this differently in a way
that's a genuine, benign difference: CPython is limited by `Py_ssize_t`
(`sys.maxsize`, i.e. 2**63-1 on 64-bit) and raises `OverflowError`
uniformly, while MicroPython's checks are against the *unsigned* `size_t`
range (2**64-1), so for 1-byte elements (`bytes`/`str`) the same `n` value
here doesn't reach MicroPython's overflow threshold and instead fails via
a plain, safe allocation-too-large `MemoryError` &mdash; not a crash, just a
different (also correct) exception type than `list`/`tuple` get for the
same `n`. The test accepts either `OverflowError` or `MemoryError` as a
passing, non-crashing outcome for exactly this reason.

All four of the issue's PoC snippets (A-D) were also tried manually against
the patched build and now raise `OverflowError: repeated <type> is too
long` instead of crashing.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.