### PR TITLE
tools/mpremote: Normalise ":" target prefix in mip install.

### DIFF
--- a/tools/mpremote/mpremote/mip.py
+++ b/tools/mpremote/mpremote/mip.py
@@ -92,6 +92,14 @@ def _download_file(transport, url, dest):
     transport.fs_writefile(dest, data, progress_callback=show_progress_bar)
 
 
+def _normalise_target(target):
+    if target == ":":
+        return "."
+    if target.startswith(":"):
+        return target[1:]
+    return target
+
+
 def _install_json(transport, package_json_url, index, target, version, mpy):
     base_url = ""
     if package_json_url.startswith(_ALLOWED_MIP_URL_PREFIXES):
@@ -194,6 +202,8 @@ def do_mip(state, args):
 
             if args.mpy is None:
                 args.mpy = True
+
+            args.target = _normalise_target(args.target)
 
             try:
                 _install_package(

--- a/tools/mpremote/tests/test_mip.py
+++ b/tools/mpremote/tests/test_mip.py
@@ -1,0 +1,8 @@
+from mpremote.mip import _normalise_target
+
+
+def test_normalise_target_accepts_remote_prefix():
+    assert _normalise_target(":") == "."
+    assert _normalise_target(":.") == "."
+    assert _normalise_target(":/lib") == "/lib"
+    assert _normalise_target("/lib") == "/lib"


### PR DESCRIPTION
### Summary

Fixes #18705.

`mpremote mip install --target :<path>` is documented shorthand for a path
relative to the connected device's current directory, with a bare `:`
meaning the current directory itself. `do_mip()` passes `args.target`
straight through to the installer, which treats it as an ordinary
directory name and joins it onto the package path with
`target + "/" + path`, so:

- `--target :` creates a literal directory called `:` on the device
  instead of installing into the current directory.
- `--target :.` creates a literal directory called `:.`.
- `--target :/lib` creates a directory literally named `:` containing
  `lib`, instead of resolving to `/lib`.

Added `_normalise_target()`, applied to `args.target` right before it
reaches the installer, so `:` and `:.` become `.`, and a leading `:` is
stripped from anything else (`:/lib` -> `/lib`). This only affects an
explicit `--target` value passed on the command line; the default target
inferred from `sys.path` when `--target` isn't given is untouched.

### Testing

Added a unit test (`tools/mpremote/tests/test_mip.py`) covering the four
cases above, verified with `pytest tools/mpremote/tests/test_mip.py`
(passes). This is pure string-normalisation logic with no device I/O, so
it doesn't need a connected board to verify — I don't currently have a
way to run the `.sh`-based device test suite
(`tools/mpremote/tests/run-mpremote-tests.sh`) against real hardware, so
please let me know if you'd like this converted to that format instead.
Note that `tools/mpremote` doesn't currently have pytest wired into CI
(`.github/workflows/mpremote.yml` only builds/packages the wheel), so this
test isn't automatically exercised yet.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.