### PR TITLE
WIP: Add machine.RTC.set_build_date() function for TLS cert checks.

### DIFF
--- a/ports/esp32/machine_rtc.c
+++ b/ports/esp32/machine_rtc.c
@@ -32,6 +32,7 @@
 #include <sys/time.h>
 #include "driver/gpio.h"
 
+#include "genhdr/mpversion.h"
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -106,6 +107,12 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
+static void set_rtc(const timeutils_struct_time_t *tm) {
+    struct timeval tv = { 0 };
+    tv.tv_sec = timeutils_seconds_since_epoch(tm->tm_year, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+    settimeofday(&tv, NULL);
+}
+
 static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *args, int hour_index) {
     if (n_args == 1) {
         // Get time
@@ -135,17 +142,15 @@ static mp_obj_t machine_rtc_datetime_helper(mp_uint_t n_args, const mp_obj_t *ar
         mp_obj_t *items;
         mp_obj_get_array_fixed_n(args[1], 8, &items);
 
-        struct timeval tv = {0};
-        tv.tv_sec = timeutils_seconds_since_epoch(
-            mp_obj_get_int(items[0]),
-            mp_obj_get_int(items[1]),
-            mp_obj_get_int(items[2]),
-            mp_obj_get_int(items[hour_index]),
-            mp_obj_get_int(items[hour_index + 1]),
-            mp_obj_get_int(items[hour_index + 2])
-            );
-        tv.tv_usec = mp_obj_get_int(items[7]);
-        settimeofday(&tv, NULL);
+        timeutils_struct_time_t tm = {
+            .tm_year = mp_obj_get_int(items[0]),
+            .tm_mon = mp_obj_get_int(items[1]),
+            .tm_mday = mp_obj_get_int(items[2]),
+            .tm_hour = mp_obj_get_int(items[hour_index]),
+            .tm_min = mp_obj_get_int(items[hour_index + 1]),
+            .tm_sec = mp_obj_get_int(items[hour_index + 2])
+        };
+        set_rtc(&tm);
 
         return mp_const_none;
     }
@@ -154,6 +159,17 @@ static mp_obj_t machine_rtc_datetime(size_t n_args, const mp_obj_t *args) {
     return machine_rtc_datetime_helper(n_args, args, 4);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
+
+static mp_obj_t machine_rtc_set_build_date(mp_obj_t self_ignore) {
+    const timeutils_struct_time_t BUILD_DATE = {
+        .tm_year = MICROPY_BUILD_YEAR,
+        .tm_mon = MICROPY_BUILD_MONTH,
+        .tm_mday = MICROPY_BUILD_DAY,
+    };
+    set_rtc(&BUILD_DATE);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_set_build_date_obj, machine_rtc_set_build_date);
 
 static mp_obj_t machine_rtc_init(mp_obj_t self_in, mp_obj_t date) {
     mp_obj_t args[2] = {self_in, date};
@@ -192,6 +208,7 @@ static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     #if MICROPY_HW_RTC_USER_MEM_MAX > 0
     { MP_ROM_QSTR(MP_QSTR_memory), MP_ROM_PTR(&machine_rtc_memory_obj) },
     #endif
+    { MP_ROM_QSTR(MP_QSTR_set_build_date), MP_ROM_PTR(&machine_rtc_set_build_date_obj) },
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
 

--- a/ports/rp2/machine_rtc.c
+++ b/ports/rp2/machine_rtc.c
@@ -32,6 +32,7 @@
 
 #include "pico/aon_timer.h"
 
+#include "genhdr/mpversion.h"
 #include "py/nlr.h"
 #include "py/obj.h"
 #include "py/runtime.h"
@@ -62,6 +63,13 @@ static mp_obj_t machine_rtc_make_new(const mp_obj_type_t *type, size_t n_args, s
     return (mp_obj_t)&machine_rtc_obj;
 }
 
+static void set_rtc(const timeutils_struct_time_t *tm) {
+    struct timespec ts = { 0, 0 };
+    ts.tv_sec = timeutils_seconds_since_epoch(tm->tm_year, tm->tm_mon, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec);
+    aon_timer_set_time(&ts);
+    mp_hal_time_ns_set_from_rtc();
+}
+
 static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 1) {
         struct timespec ts;
@@ -90,17 +98,26 @@ static mp_obj_t machine_rtc_datetime(mp_uint_t n_args, const mp_obj_t *args) {
             .tm_min = mp_obj_get_int(items[5]),
             .tm_sec = mp_obj_get_int(items[6]),
         };
-        struct timespec ts = { 0, 0 };
-        ts.tv_sec = timeutils_seconds_since_epoch(tm.tm_year, tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
-        aon_timer_set_time(&ts);
-        mp_hal_time_ns_set_from_rtc();
+        set_rtc(&tm);
     }
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_rtc_datetime_obj, 1, 2, machine_rtc_datetime);
 
+static mp_obj_t machine_rtc_set_build_date(mp_obj_t self_ignore) {
+    const timeutils_struct_time_t BUILD_DATE = {
+        .tm_year = MICROPY_BUILD_YEAR,
+        .tm_mon = MICROPY_BUILD_MONTH,
+        .tm_mday = MICROPY_BUILD_DAY,
+    };
+    set_rtc(&BUILD_DATE);
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_1(machine_rtc_set_build_date_obj, machine_rtc_set_build_date);
+
 static const mp_rom_map_elem_t machine_rtc_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_datetime), MP_ROM_PTR(&machine_rtc_datetime_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_build_date), MP_ROM_PTR(&machine_rtc_set_build_date_obj) },
 };
 static MP_DEFINE_CONST_DICT(machine_rtc_locals_dict, machine_rtc_locals_dict_table);
 

--- a/py/makeversionhdr.py
+++ b/py/makeversionhdr.py
@@ -123,10 +123,16 @@ def make_version_header(repo_path, filename):
 #define MICROPY_GIT_TAG "%s"
 #define MICROPY_GIT_HASH "%s"
 #define MICROPY_BUILD_DATE "%s"
+#define MICROPY_BUILD_YEAR %d
+#define MICROPY_BUILD_MONTH %d
+#define MICROPY_BUILD_DAY %d
 """ % (
         git_tag,
         git_hash or "<no hash>",
         build_date.strftime("%Y-%m-%d"),
+        int(build_date.strftime("%Y")),
+        int(build_date.strftime("%m")),
+        int(build_date.strftime("%d")),
     )
 
     # Check if the file contents changed from last time


### PR DESCRIPTION
### Summary

Verifying TLS certificate validity in an embedded context is tricky. If the device doesn't know the current time then it's not possible to check a trusted cert's validity period. A typical workaround is to disable timestamp checks, but this weakens the TLS public CA security model. Suspect the most common workaround for MicroPython developers is to disable TLS cert verification entirely, which *really* weakens the security model.

With WPA Enterprise support proposed in #17234, this problem gets even harder because a device needs to verify a certificate before it connects to the network. So setting the clock via [ntptime](https://github.com/micropython/micropython-lib/blob/master/micropython/net/ntptime/ntptime.py) or similar is not even an option.

This PR adds a function to set the current RTC time to the build date of the MicroPython firmware:

```
>>> import machine
>>> r = machine.RTC()
>>> r.datetime()
(2021, 1, 1, 4, 0, 0, 16, 0)
>>> r.set_build_date()
>>> r.datetime()
(2026, 7, 9, 3, 0, 0, 1, 0)
```

The idea is that this creates a window of time for the device to verify a long-lived certificate (i.e. root certificate).

This is one possible but flawed approach to a difficult problem.

### TODO

* [ ] Decide if this approach is reasonable.
* [ ] Implement some machine_rtc scaffolding in extmod/ to avoid copy-paste across all ports.
* [ ] Extend this function to more ports.
* [ ] Documentation, including trade-offs of using.

### Testing

TBD

### Trade-offs and Alternatives

* Ideally we'd be able to disable timestamp checks in mbedTLS at runtime, so code could do something like `tls.check_timestamps(False)`. Unfortunately [time checks are compile-time enabled in mbedTLS](https://github.com/Mbed-TLS/mbedtls/blob/0bebf8b8c7f07abe3571ded48a11aa907a1ffb20/library/x509_crt.c#L2565) (a reasonable choice for them).
* We could conceivably disable the time checks in our own mbedTLS config, for everyone all the time. This feels like a bad restriction, although it'd probably suit a lot of applications and on balance it might make MicroPython more secure (as less code will disable cert verification entirely).
* The equivalent of `r.set_build_date()` can already be done using Python code (see [Example in docs for the WPA Enterprise PR](https://github.com/micropython/micropython/pull/17234/changes#diff-2820e9345454ba3d12d62ae25db355ba9ecd1702d9259ea2effff465c18f7763R356)) but it involves parsing the build string and it's kind of hacky.
* The other existing approach would be to call `r.datetime((2026, 1, 1, 0, 0, 0, 0, 0))` or similar on each boot, to hard-code a recent date. This is pretty similar to `r.set_build_date()`, the only real difference is that it doesn't automatically roll forward when MicroPython updates.
* We could also choose to set the RTC timestamp on reset to the build date, for everyone. Currently most ports use Jan 1 2000 as the boot timestamp but some use a more recent date (i.e. Jan 1 2021 for rp2). This seems risky because all of the subtle behaviour issues mentioned here become the default rather than being chosen. So I think it's safer to make any of these clock changes be opt-in, but I could be convinced otherwise about this.

This approach also has weird failure modes:

* The device can run for a long time and the `datetime()` result may only be a little bit behind the real time. However, then it resets and goes "back in time" to the build date. If a peer certificate has renewed in the meantime then it may be valid before the reset but become invalid after the reset (i.e. cert has a "not valid before" after the build date).
* If a MicroPython program trusts an expired cert but then MicroPython is updated, the build date jumps forward in time, and the cert is no longer trusted. It's arguable if this one is a bug or a feature (on the one hand, the cert *is* expired and MicroPython now recognises this, but on the other hand the device might be unexpectedly stuck offline).

### Generative AI

I did not use generative AI tools when creating this PR.