### PR TITLE
samd/mcu/samd21/mpconfigmcu: Drop features of the SAMD21 minimal build.

### DIFF
--- a/ports/samd/mcu/samd21/mpconfigmcu.h
+++ b/ports/samd/mcu/samd21/mpconfigmcu.h
@@ -14,10 +14,8 @@
 #define MICROPY_KBD_EXCEPTION           (1)
 #define MICROPY_HELPER_REPL             (1)
 #define MICROPY_REPL_AUTO_INDENT        (1)
-#define MICROPY_ENABLE_SOURCE_LINE      (1)
 #define MICROPY_STREAMS_NON_BLOCK       (1)
 #define MICROPY_PY_BUILTINS_HELP        (1)
-#define MICROPY_PY_BUILTINS_HELP_MODULES (1)
 #define MICROPY_ENABLE_SCHEDULER        (1)
 #define MICROPY_PY_BUILTINS_BYTES_HEX   (1)
 #define MICROPY_PY_BUILTINS_MEMORYVIEW  (1)
@@ -29,10 +27,10 @@
 #define MICROPY_PY_IO_IOBASE            (1)
 #define MICROPY_PY_OS                   (1)
 #define MICROPY_PY_JSON                 (1)
+#define MICROPY_PY_GENERATOR_PEND_THROW (0)
 #define MICROPY_PY_RE                   (1)
 #define MICROPY_PY_BINASCII             (1)
 #define MICROPY_PY_UCTYPES              (1)
-#define MICROPY_PY_HEAPQ                (1)
 #define MICROPY_PY_RANDOM               (1)
 #define MICROPY_PY_PLATFORM             (1)
 
@@ -49,6 +47,8 @@ unsigned long trng_random_u32(int delay);
 
 // selected extensions of the extra features set
 #define MICROPY_PY_OS_URANDOM           (1)
+#define MICROPY_ENABLE_SOURCE_LINE      (SAMD21_EXTRA_FEATURES)
+#define MICROPY_PY_BUILTINS_HELP_MODULES (SAMD21_EXTRA_FEATURES)
 #define MICROPY_COMP_TRIPLE_TUPLE_ASSIGN (SAMD21_EXTRA_FEATURES)
 #define MICROPY_COMP_RETURN_IF_EXPR     (SAMD21_EXTRA_FEATURES)
 #define MICROPY_OPT_MPZ_BITWISE         (SAMD21_EXTRA_FEATURES)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -503,6 +503,7 @@ function ci_samd_build {
     make ${MAKEOPTS} -C ports/samd submodules
     make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M0_EXPRESS
     make ${MAKEOPTS} -C ports/samd BOARD=ADAFRUIT_ITSYBITSY_M4_EXPRESS
+    make ${MAKEOPTS} -C ports/samd BOARD=SPARKFUN_SAMD21_DEV_BREAKOUT
 }
 
 ########################################################################################


### PR DESCRIPTION
### Summary

At some SAMD21 boards without external flash the current firmware does not fit into flash or is close to exceed the flash space. This PR drops some feature for these limited boards.
Affected feature:

- MICROPY_PY_BUILTINS_HELP_MODULES
- MICROPY_ENABLE_SOURCE_LINE

The following features are disabled for all SAMD21 boards:

- MICROPY_PY_HEAPQ
- MICROPY_PY_GENERATOR_PEND_THROW

### Testing

Build all boards to crosscheck, that it fits.

### Generative AI

I did not use generative AI tools when creating this PR.
