### PR TITLE
tools/mpy_ld.py: Fix aligned jump target in natmod trampolines.

### DIFF
--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -143,15 +143,16 @@ def fit_signed(bits, value):
 
 
 def asm_jump_x86(entry):
-    if fit_signed(7, entry):
-        return struct.pack("Bb", 0xEB, entry)
-    elif fit_signed(31, entry):
-        return struct.pack("<Bi", 0xE9, entry)
+    if fit_signed(7, entry - 2):
+        return struct.pack("Bb", 0xEB, entry - 2)
+    elif fit_signed(31, entry - 5):
+        return struct.pack("<Bi", 0xE9, entry - 5)
     else:
-        raise LinkError("large jumps on x86/x64 are not supported")
+        raise LinkError("jumps larger than 2GiB are not supported")
 
 
 def asm_jump_thumb(entry):
+    entry -= 4
     if fit_signed(11, entry):
         # Signed value fits in 12 bits.
         b0 = 0xE000 | ((entry >> 1) & 0x07FF)
@@ -161,7 +162,7 @@ def asm_jump_thumb(entry):
         #   push {r0, lr}
         #   bl <dest>
         #   pop {r0, pc}
-        entry += 2  # skip "push {r0, lr}"
+        entry -= 2  # skip "push {r0, lr}"
         b0 = 0xB400 | 0x0100 | 0x0001  # push, lr, r0
         b1 = 0xF000 | ((entry >> 12) & 0x07FF)
         b2 = 0xF800 | ((entry >> 1) & 0x07FF)
@@ -170,6 +171,7 @@ def asm_jump_thumb(entry):
 
 
 def asm_jump_thumb2(entry):
+    entry -= 4
     if fit_signed(11, entry):
         # Signed value fits in 12 bits
         b0 = 0xE000 | ((entry >> 1) & 0x07FF)
@@ -182,36 +184,37 @@ def asm_jump_thumb2(entry):
 
 
 def asm_jump_xtensa(entry):
-    if fit_signed(17, entry):
-        jump_op = (entry - 4) << 6 | 6
+    if fit_signed(17, entry - 8):
+        jump_op = ((entry - 8) << 6) | 6
         return struct.pack("<BH", jump_op & 0xFF, jump_op >> 8)
     else:
-        raise LinkError("Large jumps are not yet supported on Xtensa")
+        raise LinkError("jumps larger than 128KiB are not supported")
 
 
 def asm_jump_riscv(entry):
     if fit_signed(11, entry):
-        entry += 2
         # c.j entry
         return struct.pack(
             "<H",
             0xA001
-            | ((entry & 0x0E) << 2)
-            | ((entry & 0x300) << 1)
             | ((entry & 0x800) << 1)
             | ((entry & 0x400) >> 2)
+            | ((entry & 0x300) << 1)
             | ((entry & 0x80) >> 1)
             | ((entry & 0x40) << 1)
             | ((entry & 0x20) >> 3)
-            | ((entry & 0x10) << 7),
+            | ((entry & 0x10) << 7)
+            | ((entry & 0x0E) << 2),
         )
-    else:
+    elif fit_signed(31, entry - 8):
         # auipc t6, HI(entry)
         # jalr  zero, t6, LO(entry)
-        upper, lower = split_riscv_address(entry + 8)
+        upper, lower = split_riscv_address(entry)
         return struct.pack(
             "<II", (upper | 0x00000F97) & 0xFFFFFFFF, ((lower << 20) | 0x000F8067) & 0xFFFFFFFF
         )
+    else:
+        raise LinkError("jumps larger than 2GiB are not supported")
 
 
 class ArchData:
@@ -1199,12 +1202,33 @@ def generate_entry_point_jump(env):
     entry_point = env.find_sym("mpy_init")
     address = entry_point.section.addr + entry_point["st_value"]
     alignment = entry_point.section.alignment
-    if alignment == 1:
-        return env.arch.asm_jump(address)
-    last_jump_length = len(env.arch.asm_jump(address))
-    aligned_jump = align_to(last_jump_length, alignment)
-    jump = env.arch.asm_jump(address + aligned_jump - last_jump_length)
-    return jump.ljust(align_to(len(jump), alignment), b"\0")
+
+    if address == 0:
+        log(
+            LOG_LEVEL_2,
+            "mpy_init is the first symbol in the .text segment, do not emit trampoline",
+        )
+        return b""
+
+    # The trampoline is meant to be placed before the text segment and its
+    # size is not known at this point.  Since the trampoline size does affect
+    # the final address of `mpy_init`, try to find a trampoline that fits in
+    # the smallest block that also follows the text section's alignment
+    # constraint.
+
+    trampoline = b""
+    gap_size = alignment
+    while True:
+        jump_target = address + gap_size
+        log(
+            LOG_LEVEL_2,
+            f"Generating trampoline jumping to mpy_init at address {jump_target:08x} to fit in {gap_size} byte(s)",
+        )
+        trampoline = env.arch.asm_jump(jump_target)
+        if len(trampoline) <= gap_size:
+            return trampoline.ljust(gap_size, b"\0")
+        gap_size += alignment
+    return trampoline
 
 
 def link_objects(env, native_qstr_vals_len):
@@ -1302,6 +1326,23 @@ def link_objects(env, native_qstr_vals_len):
         raise LinkError("\n".join(undef_errors))
 
     # Generate the entry trampoline assuming the offset is already known.
+
+    text_alignment = env.find_sym("mpy_init").section.alignment
+    if env.arch.name in ("EM_386", "EM_X86_64"):
+        show_warning = text_alignment not in (1, 4)
+    elif env.arch.name in ("EM_ARM", "EM_XTENSA"):
+        show_warning = text_alignment != 4
+    elif env.arch.name == "EM_RISCV":
+        show_warning = text_alignment != 2
+    else:
+        show_warning = True
+
+    if show_warning:
+        log(
+            LOG_LEVEL_1,
+            f"A .text section with an alignment of {text_alignment} bytes for {env.arch.name} is not tested and may not work",
+        )
+
     jump = generate_entry_point_jump(env)
     env.entry_trampoline_len = len(jump)
 


### PR DESCRIPTION
### Summary

This PR fixes a regression introduced in dd476ce1f63a5a744efd2909407d7b39ba64b304, that was meant to fix native modules' entry trampolines for x86/x64 when built with Clang. Unfortunately it broke things for almost every other platform, and this was not caught by the QEMU-based CI infrastructure.

These changes aim to fix that situation by both restricting the scope of jump target alignments (this is needed only for x86 and x64 now), and by correcting a potential bug that may appear if the unaligned jump target would yield a shorter trampoline but with an out of range address if the aligned jump target requires a longer trampoline.

More information available reading comments from https://github.com/micropython/micropython/pull/19308#issuecomment-4922749331.

### Testing

The full natmod test suite was executed successfully on a RP2040 (to test armv6m), RP2350 (to test armv7m), ESP32C3 (to test rv32imc/rv64imc), ESP32S3 (to test xtensa/xtensawin), Linux/x64 using GCC (to test x86/x64 with no forced `.text` alignment), and Linux/x64 using Clang (to test x86/x64 with forced `.text` alignment).

To be even more thorough, these changes were tested on armv6m, armv7m, and rv32imc after forcing the linker to only emit the generic longer trampoline opcodes sequence.

CI is also meant to test this, although it didn't catch the regression when it happened...

### Trade-offs and Alternatives

I guess this may be made simpler but probably at the cost of touching more code somewhere else.

### Generative AI

I did not use generative AI tools when creating this PR.