### PR TITLE
stm32/boards/PYBD_SF2: Free up more space in internal flash.

### DIFF
--- a/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
+++ b/ports/stm32/boards/PYBD_SF2/f722_qspi.ld
@@ -50,7 +50,9 @@ SECTIONS
     .text_ext :
     {
         . = ALIGN(4);
-        *py/emit*(.text.emit_inline_thumb_* .rodata.emit_inline_thumb_*)
+        *py/asmthumb.o(.text* .rodata*)
+        *py/emitinlinethumb.o(.text* .rodata*)
+        *py/emitnthumb.o(.text* .rodata*)
         *lib/btstack/*(.text* .rodata*)
         *lib/mbedtls/*(.text* .rodata*)
         *lib/mynewt-nimble/*(.text* .rodata*)


### PR DESCRIPTION
### Summary

Some recent additions -- such as `pulse_width_us`, `pulse_width_ns`, WWDG support and improved Unicode -- have increased stm32 firmware by about 1.5k.  All up, that made that the internal flash of PYBD_SF3 overflow by about 80 bytes.

Following on from 702f15ab9800769c76539d760fe7b365d8654595, this commit moves all machine-code-based emitter functions from internal to external QSPI flash.  That frees up about 13k internal flash, and shouldn't affect performance.

### Testing

Built PYBD_SF3 firmware to ensure it fits.

Built PYBD_SF2 firmware and ran all tests.  There were no regressions.

### Trade-offs and Alternatives

Makes the native emitter and inline assembler a bit slower.  But we need the space!

### Generative AI

Not used.