### PR TITLE
tests/unicode: Split out unicode f-string test to separate file.

### DIFF
--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -987,7 +987,7 @@ def run_tests(pyb, tests, args, result_dir, num_threads=1):
         is_slice = test_name.find("slice") != -1
         is_async = test_name.startswith(("async_", "asyncio_")) or test_name.endswith("_async")
         is_const = test_name.startswith("const")
-        is_fstring = test_name.startswith("string_fstring")
+        is_fstring = test_name.startswith("string_fstring") or test_name.endswith("_fstring")
         is_tstring = test_name.startswith("string_tstring") or test_name.endswith("_tstring")
         is_inlineasm = test_name.startswith("asm")
 

--- a/tests/unicode/unicode_char_format.py
+++ b/tests/unicode/unicode_char_format.py
@@ -22,12 +22,6 @@ print("{:c}".format(169))
 print("{:c}".format(0x4E00))
 print("{:c}{:c}".format(0x3BC, 0x1F40D))
 
-# test with f-strings
-c = 169
-print(f"{c:c}")
-c = 0x1F600
-print(f"{c:c}")
-
 # Test boundary values - valid maximum unicode codepoint
 print("%c" % 0x10FFFF)  # Last valid unicode codepoint
 

--- a/tests/unicode/unicode_char_format_fstring.py
+++ b/tests/unicode/unicode_char_format_fstring.py
@@ -1,0 +1,6 @@
+# test %c formatting with unicode characters in f-strings
+
+c = 169
+print(f"{c:c}")
+c = 0x1F600
+print(f"{c:c}")


### PR DESCRIPTION
### Summary

Split it out the f-string test, so it can be skipped if the target has unicode enabled but doesn't support f-strings.  For example ADAFRUIT_ITSYBITSY_M0_EXPRESS.

This came about due to the combination of #18854 and #19168.

### Testing

Tested locally on ADAFRUIT_ITSYBITSY_M0_EXPRESS, the unicode tests now all pass on this board.

### Generative AI

Not used.