### PR TITLE
tests/run-multitests.py: Fix location of extmod for MICROPYPATH.

### DIFF
--- a/tests/run-multitests.py
+++ b/tests/run-multitests.py
@@ -598,7 +598,7 @@ def main():
     cmd_args = cmd_parser.parse_args()
 
     # clear search path to make sure tests use only builtin modules and those in extmod
-    os.environ["MICROPYPATH"] = os.pathsep.join((".frozen", "../extmod"))
+    os.environ["MICROPYPATH"] = os.pathsep.join((".frozen", base_path("../extmod")))
 
     test_files = prepare_test_file_list(cmd_args.files)
     max_instances = max(t[1] for t in test_files)


### PR DESCRIPTION
### Summary

Tests are run from within their directory, so extmod is actually two levels up, not one.  Use `base_path()` to get the correct value, following how it's done in `run-tests.py`.

### Testing

Tested running:
```
$ MICROPY_MICROPYTHON=../ports/unix/build-coverage/micropython ./run-multitests.py multi_net/asyncio_tcp_*.py
```
That now works.  Prior to this fix it would just skip all those asyncio tests because asyncio could not be imported.

### Generative AI

Not used.