### PR TITLE
esp32/network: Support adding/removing mDNS services.

### DIFF
--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -188,6 +188,10 @@ soft_reset_exit:
     mp_bluetooth_deinit();
     #endif
 
+    #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+    esp_mdns_deinit();
+    #endif
+
     #if MICROPY_PY_ESPNOW
     espnow_deinit(mp_const_none);
     MP_STATE_PORT(espnow_singleton) = NULL;

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -85,8 +85,10 @@ MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_ipconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_nic_ipconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_config_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj);
+MP_DECLARE_CONST_FUN_OBJ_3(esp_mdns_service_obj);
 
 mp_obj_t esp_ifname(esp_netif_t *netif);
+void esp_mdns_init(bool raise_exceptions);
 
 MP_NORETURN void esp_exceptions_helper(esp_err_t e);
 

--- a/ports/esp32/modnetwork.h
+++ b/ports/esp32/modnetwork.h
@@ -85,8 +85,14 @@ MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_ipconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_nic_ipconfig_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(esp_network_config_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj);
+MP_DECLARE_CONST_FUN_OBJ_3(esp_mdns_service_obj);
 
 mp_obj_t esp_ifname(esp_netif_t *netif);
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+void esp_mdns_init(bool raise_exceptions);
+void esp_mdns_deinit(void);
+#endif
 
 MP_NORETURN void esp_exceptions_helper(esp_err_t e);
 

--- a/ports/esp32/modnetwork_globals.h
+++ b/ports/esp32/modnetwork_globals.h
@@ -13,6 +13,10 @@
 { MP_ROM_QSTR(MP_QSTR_phy_mode), MP_ROM_PTR(&esp_network_phy_mode_obj) },
 { MP_ROM_QSTR(MP_QSTR_ipconfig), MP_ROM_PTR(&esp_network_ipconfig_obj) },
 
+#if MICROPY_HW_ENABLE_MDNS_RESPONDER
+{ MP_ROM_QSTR(MP_QSTR_mdns_service), MP_ROM_PTR(&esp_mdns_service_obj) },
+#endif
+
 // These WLAN constants are now in the WLAN class and remain here only for backwards compatibility.
 #if !MICROPY_PREVIEW_VERSION_2 && MICROPY_PY_NETWORK_WLAN
 { MP_ROM_QSTR(MP_QSTR_STA_IF), MP_ROM_INT(WIFI_IF_STA)},

--- a/ports/esp32/modsocket.c
+++ b/ports/esp32/modsocket.c
@@ -59,11 +59,14 @@
 #if MICROPY_PY_NETWORK
 
 #define SOCKET_POLL_US (100000)
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES
 #define MDNS_QUERY_TIMEOUT_MS (5000)
 #define MDNS_LOCAL_SUFFIX ".local"
 
 #ifndef NO_QSTR
 #include "mdns.h"
+#endif
 #endif
 
 enum {

--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -36,14 +36,20 @@
 #include "py/runtime.h"
 #include "py/parsenum.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "shared/netutils/netutils.h"
 #include "modnetwork.h"
+#include "extmod/modnetwork.h"
 
 #include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_wifi.h"
 #include "lwip/sockets.h"
 #include "lwip/dns.h"
+
+#ifndef NO_QSTR
+#include "mdns.h"
+#endif
 
 MP_NORETURN void esp_exceptions_helper(esp_err_t e) {
     switch (e) {
@@ -339,3 +345,55 @@ static mp_obj_t esp_phy_mode(size_t n_args, const mp_obj_t *args) {
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj, 0, 1, esp_phy_mode);
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+static bool mdns_initialised = false;
+void esp_mdns_init(bool raise_exceptions) {
+    esp_err_t res;
+    mp_rom_error_text_t msg;
+    if (!mdns_initialised) {
+        res = mdns_init();
+        if (res != ESP_OK) {
+            msg = MP_ERROR_TEXT("Failed to initialize mDNS (%d)");
+            goto fail;
+        }
+        #if MICROPY_HW_ENABLE_MDNS_RESPONDER
+        res = mdns_hostname_set(mod_network_hostname_data);
+        if (res != ESP_OK) {
+            mdns_free();
+            msg = MP_ERROR_TEXT("Failed to set mDNS hostname (%d)");
+            goto fail;
+        }
+        res = mdns_instance_name_set(mod_network_hostname_data);
+        if (res != ESP_OK) {
+            mdns_free();
+            msg = MP_ERROR_TEXT("Failed to set mDNS instance name (%d)");
+            goto fail;
+        }
+        #endif
+        mdns_initialised = true;
+    }
+    return;
+
+fail:
+    mp_obj_t exc = mp_obj_new_exception_msg_varg(&mp_type_OSError, msg, res);
+    if (raise_exceptions) {
+        nlr_raise(exc);
+    } else {
+        mp_obj_print_exception(&mp_plat_print, exc);
+    }
+}
+
+#if MICROPY_HW_ENABLE_MDNS_RESPONDER
+mp_obj_t esp_mdns_service(mp_obj_t service_type, mp_obj_t proto, mp_obj_t port) {
+    esp_mdns_init(true);
+    if (port == mp_const_none) {
+        check_esp_err(mdns_service_remove(mp_obj_str_get_str(service_type), mp_obj_str_get_str(proto)));
+    } else {
+        check_esp_err(mdns_service_add(NULL, mp_obj_str_get_str(service_type), mp_obj_str_get_str(proto), mp_obj_get_int(port), NULL, 0));
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_3(esp_mdns_service_obj, esp_mdns_service);
+#endif
+#endif

--- a/ports/esp32/network_common.c
+++ b/ports/esp32/network_common.c
@@ -36,14 +36,22 @@
 #include "py/runtime.h"
 #include "py/parsenum.h"
 #include "py/mperrno.h"
+#include "py/mphal.h"
 #include "shared/netutils/netutils.h"
 #include "modnetwork.h"
+#include "extmod/modnetwork.h"
 
 #include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_wifi.h"
 #include "lwip/sockets.h"
 #include "lwip/dns.h"
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+#ifndef NO_QSTR
+#include "mdns.h"
+#endif
+#endif
 
 MP_NORETURN void esp_exceptions_helper(esp_err_t e) {
     switch (e) {
@@ -339,3 +347,68 @@ static mp_obj_t esp_phy_mode(size_t n_args, const mp_obj_t *args) {
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_network_phy_mode_obj, 0, 1, esp_phy_mode);
+
+#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
+static bool mdns_initialised = false;
+void esp_mdns_init(bool raise_exceptions) {
+    esp_err_t res;
+    mp_rom_error_text_t msg;
+    if (!mdns_initialised) {
+        res = mdns_init();
+        if (res != ESP_OK) {
+            msg = MP_ERROR_TEXT("Failed to initialize mDNS (%d)");
+            goto fail;
+        }
+        #if MICROPY_HW_ENABLE_MDNS_RESPONDER
+        res = mdns_hostname_set(mod_network_hostname_data);
+        if (res != ESP_OK) {
+            mdns_free();
+            msg = MP_ERROR_TEXT("Failed to set mDNS hostname (%d)");
+            goto fail;
+        }
+        res = mdns_instance_name_set(mod_network_hostname_data);
+        if (res != ESP_OK) {
+            mdns_free();
+            msg = MP_ERROR_TEXT("Failed to set mDNS instance name (%d)");
+            goto fail;
+        }
+        #endif
+        mdns_initialised = true;
+    }
+    return;
+
+fail:
+    if (raise_exceptions) {
+        mp_raise_msg_varg(&mp_type_OSError, msg, res);
+    } else {
+        #if MICROPY_ROM_TEXT_COMPRESSION
+        byte decompressed[MP_MAX_UNCOMPRESSED_TEXT_LEN + 1] = { 0 };
+        if (MP_IS_COMPRESSED_ROM_STRING(msg)) {
+            mp_decompress_rom_string(decompressed, (const mp_rom_error_text_t)msg);
+            msg = (mp_rom_error_text_t)decompressed;
+        }
+        #endif
+        printf((const char *)msg, res);
+        printf("\n");
+    }
+}
+void esp_mdns_deinit() {
+    if (mdns_initialised) {
+        mdns_free();
+        mdns_initialised = false;
+    }
+}
+
+#if MICROPY_HW_ENABLE_MDNS_RESPONDER
+mp_obj_t esp_mdns_service(mp_obj_t service_type, mp_obj_t proto, mp_obj_t port) {
+    esp_mdns_init(true);
+    if (port == mp_const_none) {
+        check_esp_err(mdns_service_remove(mp_obj_str_get_str(service_type), mp_obj_str_get_str(proto)));
+    } else {
+        check_esp_err(mdns_service_add(NULL, mp_obj_str_get_str(service_type), mp_obj_str_get_str(proto), mp_obj_get_int(port), NULL, 0));
+    }
+    return mp_const_none;
+}
+MP_DEFINE_CONST_FUN_OBJ_3(esp_mdns_service_obj, esp_mdns_service);
+#endif
+#endif

--- a/ports/esp32/network_lan.c
+++ b/ports/esp32/network_lan.c
@@ -45,18 +45,6 @@
 #include "modnetwork.h"
 #include "extmod/modnetwork.h"
 
-#ifndef NO_QSTR
-#include "mdns.h"
-#endif
-
-#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-#if MICROPY_PY_NETWORK_WLAN
-extern bool mdns_initialised; // Defined in network_wlan.c
-#else
-static bool mdns_initialised = false;
-#endif
-#endif
-
 #if PHY_LAN867X_ENABLED
 #include "esp_eth_phy_lan867x.h"
 #endif
@@ -119,14 +107,7 @@ static void eth_event_handler(void *arg, esp_event_base_t event_base,
                 eth_status = ETH_GOT_IP;
                 ESP_LOGI("ethernet", "Ethernet Got IP");
                 #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-                if (!mdns_initialised) {
-                    mdns_init();
-                    #if MICROPY_HW_ENABLE_MDNS_RESPONDER
-                    mdns_hostname_set(mod_network_hostname_data);
-                    mdns_instance_name_set(mod_network_hostname_data);
-                    #endif
-                    mdns_initialised = true;
-                }
+                esp_mdns_init(false);
                 #endif
                 break;
             default:

--- a/ports/esp32/network_wlan.c
+++ b/ports/esp32/network_wlan.c
@@ -51,10 +51,6 @@
 #include "esp_wifi_ap_get_sta_list.h"
 #endif
 
-#ifndef NO_QSTR
-#include "mdns.h"
-#endif
-
 #if MICROPY_PY_NETWORK_WLAN
 
 #if (WIFI_MODE_STA & WIFI_MODE_AP != WIFI_MODE_NULL || WIFI_MODE_STA | WIFI_MODE_AP != WIFI_MODE_APSTA)
@@ -78,11 +74,6 @@ static bool wifi_sta_connected = false;
 
 // Store the current status. 0 means None here, safe to do so as first enum value is WIFI_REASON_UNSPECIFIED=1.
 static uint8_t wifi_sta_disconn_reason = 0;
-
-#if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-// Whether mDNS has been initialised or not (shared with network_lan.c)
-bool mdns_initialised = false;
-#endif
 
 static uint8_t conf_wifi_sta_reconnects = 0;
 static uint8_t wifi_sta_reconnects;
@@ -196,14 +187,7 @@ static void network_wlan_ip_event_handler(void *event_handler_arg, esp_event_bas
             wifi_sta_connected = true;
             wifi_sta_disconn_reason = 0; // Success so clear error. (in case of new error will be replaced anyway)
             #if MICROPY_HW_ENABLE_MDNS_QUERIES || MICROPY_HW_ENABLE_MDNS_RESPONDER
-            if (!mdns_initialised) {
-                mdns_init();
-                #if MICROPY_HW_ENABLE_MDNS_RESPONDER
-                mdns_hostname_set(mod_network_hostname_data);
-                mdns_instance_name_set(mod_network_hostname_data);
-                #endif
-                mdns_initialised = true;
-            }
+            esp_mdns_init(false);
             #endif
             break;
 


### PR DESCRIPTION
### Summary

Adds a new function `network.mdns_service(service_type, proto, port)` which can be used to let the existing mDNS responder advertise custom mDNS services. Interface is fairly generic on purpose so that it might be extended / ported.

Additionally, it moves the currently duplicated initialisation of the mDNS from both LAN and WLAN to a central function, which now also performs error checking (previously, it would fail silently, which if you're explicitly advertising services is extra bad).

Exceptions in the interface initialisation callbacks are only printed (because those do not happen in a MicroPython context so raising them just crashes the board), but are raised when the failure occurs through `network.mdns_service()`.

Note: Marked as draft because it currently lacks documentation and unit tests.

### Testing

Tested on a few custom boards with the original ESP32 with Ethernet. mDNS responses work and custom services can be found on the network with for example `avahi-browse -r _my_custom_service._udp`.

### Trade-offs and Alternatives

The underlying library also supports adding TXT records to the service; I toyed a bit with supporting that too by letting the user pass a dict however the code got a bit more complicated so I've kept it out of scope for now; the ability to advertise services at all is already quite useful for various purposes and integrations.

### Generative AI

I did not use generative AI tools when creating this PR.
