### PR TITLE
[RFC] unix: full-featured `machine.Pin` implementation.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -216,6 +216,7 @@ SRC_C += \
 	modsocket.c \
 	modffi.c \
 	modjni.c \
+	machine_pin.c \
 	$(wildcard $(VARIANT_DIR)/*.c)
 
 SHARED_SRC_C += $(addprefix shared/,\

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -39,6 +39,10 @@
 #error "GPIO dynamic pin allocation needs threading to work"
 #endif
 
+#if MICROPY_PY_GPIO_API_VERSION < 1 && MICROPY_PY_GPIO_API_VERSION > 2
+#error "Unsupported GPIO API version"
+#endif
+
 #include <dirent.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -74,6 +78,103 @@
 #define DEBUG_printf DEBUG_printf
 #else
 #define DEBUG_printf(...) (void)0
+#endif
+
+// v1/v2 compatibility definitions
+
+#if MICROPY_PY_GPIO_API_VERSION == 1
+typedef struct gpiohandle_config gpio_config_struct_t;
+typedef struct gpiohandle_data gpio_data_struct_t;
+typedef struct gpiohandle_request gpio_request_struct_t;
+typedef struct gpioline_info gpio_line_info_t;
+typedef struct gpioline_info_changed gpio_irq_event_t;
+#define GPIO_REQ_INPUT GPIO_HANDLE_REQUEST_INPUT
+#define GPIO_REQ_OUTPUT GPIO_HANDLE_REQUEST_INPUT
+#define GPIO_REQ_OPEN_DRAIN GPIO_HANDLE_REQUEST_OPEN_DRAIN
+#define GPIO_REQ_OPEN_SOURCE GPIO_HANDLE_REQUEST_OPEN_DRAIN
+#define GPIO_REQ_BIAS_DISABLE GPIO_HANDLE_REQUEST_BIAS_DISABLE
+#define GPIO_REQ_BIAS_PULL_UP GPIO_HANDLE_REQUEST_BIAS_PULL_UP
+#define GPIO_REQ_BIAS_PULL_DOWN GPIO_HANDLE_REQUEST_BIAS_PULL_DOWN
+#define GPIO_RES_IS_OUTPUT GPIOLINE_FLAG_IS_OUT
+#if MICROPY_PY_GPIO_IRQ
+#define GPIO_REQ_IRQ_RISING GPIOEVENT_REQUEST_RISING_EDGE
+#define GPIO_REQ_IRQ_FALLING GPIOEVENT_REQUEST_FALLING_EDGE
+#define GPIO_IRQ_GET_TIMESTAMP(event) ((event).timestamp)
+#endif
+#define GPIO_BUSY GPIOLINE_FLAG_KERNEL
+#define IOCTL_GET_LINE GPIO_GET_LINEHANDLE_IOCTL
+#define IOCTL_GET_LINEINFO GPIO_GET_LINEINFO_IOCTL
+#define IOCTL_GET_VALUE GPIOHANDLE_GET_LINE_VALUES_IOCTL
+#define IOCTL_SET_CONFIG GPIOHANDLE_SET_CONFIG_IOCTL
+#define IOCTL_SET_VALUE GPIOHANDLE_SET_LINE_VALUES_IOCTL
+#define GPIO_INIT_GET_VALUE(data) \
+    do { \
+        memset(&(data), 0x00, sizeof((data))); \
+    } while (0)
+#define GPIO_GET_VALUE(data) (!!(data).values[0])
+#define GPIO_SET_VALUE(data, value) \
+    do { \
+        (data).values[0] = !!(value); \
+    } while (0)
+#define GPIO_INIT_REQUEST(data, config, pin, consumer) \
+    do { \
+        (data).lineoffsets[0] = (pin); \
+        (data).flags = (config).flags; \
+        (data).default_values[0] = (config).default_values[0]; \
+        (data).lines = 1; \
+        strcpy((data).consumer_label, (consumer)); \
+    } while (0)
+#define GPIO_INIT_GET_INFO(data, pin) \
+    do { \
+        (data).line_offset = (pin); \
+    } while (0)
+#else
+typedef struct gpio_v2_line_config gpio_config_struct_t;
+typedef struct gpio_v2_line_values gpio_data_struct_t;
+typedef struct gpio_v2_line_request gpio_request_struct_t;
+typedef struct gpio_v2_line_info gpio_line_info_t;
+typedef struct gpio_v2_line_event gpio_irq_event_t;
+#define GPIO_REQ_INPUT GPIO_V2_LINE_FLAG_INPUT
+#define GPIO_REQ_OUTPUT GPIO_V2_LINE_FLAG_OUTPUT
+#define GPIO_REQ_OPEN_DRAIN GPIO_V2_LINE_FLAG_OPEN_DRAIN
+#define GPIO_REQ_OPEN_SOURCE GPIO_V2_LINE_FLAG_OPEN_SOURCE
+#define GPIO_REQ_BIAS_DISABLE GPIO_V2_LINE_FLAG_BIAS_DISABLED
+#define GPIO_REQ_BIAS_PULL_UP GPIO_V2_LINE_FLAG_BIAS_PULL_UP
+#define GPIO_REQ_BIAS_PULL_DOWN GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN
+#define GPIO_RES_IS_OUTPUT GPIO_V2_LINE_FLAG_OUTPUT
+#if MICROPY_PY_GPIO_IRQ
+#define GPIO_REQ_IRQ_RISING GPIO_V2_LINE_FLAG_EDGE_RISING
+#define GPIO_REQ_IRQ_FALLING GPIO_V2_LINE_FLAG_EDGE_FALLING
+#define GPIO_IRQ_GET_TIMESTAMP(event) ((event).timestamp_ns)
+#endif
+#define GPIO_BUSY GPIO_V2_LINE_FLAG_USED
+#define IOCTL_GET_LINE GPIO_V2_GET_LINE_IOCTL
+#define IOCTL_GET_LINEINFO GPIO_V2_GET_LINEINFO_IOCTL
+#define IOCTL_GET_VALUE GPIO_V2_LINE_GET_VALUES_IOCTL
+#define IOCTL_SET_CONFIG GPIO_V2_LINE_SET_CONFIG_IOCTL
+#define IOCTL_SET_VALUE GPIO_V2_LINE_SET_VALUES_IOCTL
+#define GPIO_INIT_GET_VALUE(data) \
+    do { \
+        memset(&(data), 0x00, sizeof((data))); \
+        (data).mask = (data).bits = 1U; \
+    } while (0)
+#define GPIO_GET_VALUE(data) (!!((data).bits & 1U))
+#define GPIO_SET_VALUE(data, value) \
+    do { \
+        (data).mask = 1U; \
+        (data).bits = !!(value); \
+    } while (0)
+#define GPIO_INIT_REQUEST(data, config, pin, consumer) \
+    do { \
+        (data).offsets[0] = (pin); \
+        (data).config = (config); \
+        (data).num_lines = 1; \
+        strcpy((data).consumer, (consumer)); \
+    } while (0)
+#define GPIO_INIT_GET_INFO(data, pin) \
+    do { \
+        (data).offset = (pin); \
+    } while (0)
 #endif
 
 static const char *GPIO_DEVICES_ROOT = "/sys/bus/gpio/devices/";
@@ -593,10 +694,10 @@ static uint32_t gpio_get_pin_number(mp_obj_t number_in) {
     return number;
 }
 
-static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value, mp_obj_t clock) {
+static void gpio_fill_line_config_struct(gpio_config_struct_t *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value, mp_obj_t clock) {
     assert(config && "GPIO config structrure must not be NULL");
 
-    memset(config, 0x00, sizeof(struct gpio_v2_line_config));
+    memset(config, 0x00, sizeof(gpio_config_struct_t));
 
     // Checks for mode and pull could be made simpler by just checking whether
     // the value bit is in the combined OR of all valid options, and then use
@@ -604,31 +705,26 @@ static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uin
     // why, so we have to do this instead.
 
     if (mode != mp_const_none) {
-        mp_int_t pin_mode = mp_obj_get_int(mode);
-        if ((pin_mode & ~(GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT | GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) != 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
-        }
-        if ((pin_mode & (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) == (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) {
-            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
-        }
-        if ((pin_mode & (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) == (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) {
+        mp_int_t pin_mode = mp_obj_get_int(mode) & (GPIO_REQ_INPUT | GPIO_REQ_OUTPUT | GPIO_REQ_OPEN_DRAIN | GPIO_REQ_OPEN_SOURCE);
+        if (mp_popcount(pin_mode) != 1) {
             mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
         }
         config->flags |= pin_mode;
     }
 
     if (pull != MP_OBJ_NEW_SMALL_INT(-1)) {
-        MP_STATIC_ASSERT((GPIO_V2_LINE_FLAG_BIAS_DISABLED & (GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) == 0);
-        mp_int_t pull_mode = mp_obj_get_int(pull);
-        if ((pull_mode & ~(GPIO_V2_LINE_FLAG_BIAS_DISABLED | GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) != 0) {
-            mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
-        }
+        MP_STATIC_ASSERT((GPIO_REQ_BIAS_DISABLE & (GPIO_REQ_BIAS_PULL_UP | GPIO_REQ_BIAS_PULL_DOWN)) == 0);
+        mp_int_t pull_mode = mp_obj_get_int(pull) & ~(GPIO_REQ_BIAS_DISABLE | GPIO_REQ_BIAS_PULL_UP | GPIO_REQ_BIAS_PULL_DOWN);
         if (mp_popcount(pull_mode) > 1) {
             mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
         }
         config->flags |= pull_mode;
     }
 
+    #if MICROPY_PY_GPIO_API_VERSION == 1
+    config->default_values[0] = mp_obj_is_true(value) ? 1 : 0;
+    (void)clock;
+    #else
     if (value != MP_OBJ_NULL) {
         config->num_attrs = 1;
         config->attrs[0].attr.id = GPIO_V2_LINE_ATTR_ID_OUTPUT_VALUES;
@@ -647,18 +743,17 @@ static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uin
         }
         config->flags |= clock_mode;
     }
-    #else
+    #endif
     (void)clock;
     #endif
 }
 
 static int gpio_set_state_inner(int fd, mp_int_t state) {
-    struct gpio_v2_line_values values;
+    gpio_data_struct_t values;
     memset(&values, 0x00, sizeof(values));
-    values.mask = 1U;
-    values.bits = state != 0 ? 1U : 0U;
+    GPIO_SET_VALUE(values, state);
     MP_THREAD_GIL_EXIT();
-    int result = ioctl(fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &values);
+    int result = ioctl(fd, IOCTL_SET_VALUE, &values);
     MP_THREAD_GIL_ENTER();
     return result;
 }
@@ -666,15 +761,13 @@ static int gpio_set_state_inner(int fd, mp_int_t state) {
 static int gpio_get_state_inner(int fd, mp_int_t *state) {
     assert(state && "GPIO state value pointer cannot be NULL");
 
-    struct gpio_v2_line_values values;
-    memset(&values, 0x00, sizeof(values));
-    values.mask = 1U;
-    values.bits = 1U;
+    gpio_data_struct_t values;
+    GPIO_INIT_GET_VALUE(values);
     MP_THREAD_GIL_EXIT();
-    int result = ioctl(fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values);
+    int result = ioctl(fd, IOCTL_GET_VALUE, &values);
     MP_THREAD_GIL_ENTER();
     if (result >= 0) {
-        *state = (values.bits & 1U) ? 1 : 0;
+        *state = GPIO_GET_VALUE(values);
     }
     return result;
 }
@@ -711,7 +804,7 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    struct gpio_v2_line_config config;
+    gpio_config_struct_t config;
     gpio_fill_line_config_struct(&config, pin_number, args[ARG_mode].u_obj, args[ARG_pull].u_obj, args[ARG_value].u_obj, args[ARG_clock].u_obj);
 
     mp_obj_t port_path = resolve_gpio_device_name(args[ARG_port].u_obj);
@@ -727,7 +820,7 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         // WARNING: If an IRQ callback was attached before this point, it will
         //          stay bound to the pin instance.
         if (pin->fd >= 0) {
-            gpio_ioctl(pin->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
+            gpio_ioctl(pin->fd, IOCTL_SET_CONFIG, &config);
             return existing_pin;
         }
 
@@ -755,14 +848,10 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
     }
 
-    struct gpio_v2_line_request request;
+    gpio_request_struct_t request;
     memset(&request, 0x00, sizeof(request));
-    request.offsets[0] = pin_number;
-    request.config = config;
-    request.num_lines = 1;
-    strcpy(request.consumer, consumer);
-
-    gpio_ioctl(port->fd, GPIO_V2_GET_LINE_IOCTL, &request);
+    GPIO_INIT_REQUEST(request, config, pin_number, consumer);
+    gpio_ioctl(port->fd, IOCTL_GET_LINE, &request);
 
     mp_obj_t self_out;
     nlr_buf_t nlr;
@@ -936,26 +1025,26 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
 
     if (n_args > 1 || kw_args->used != 0) {
         mp_uint_t trigger = args[ARG_trigger].u_int;
-        if ((trigger & ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING)) != 0) {
+        if ((trigger & ~(GPIO_REQ_IRQ_RISING | GPIO_REQ_IRQ_FALLING)) != 0) {
             mp_raise_ValueError(MP_ERROR_TEXT("invalid trigger"));
         }
 
-        struct gpio_v2_line_info line_info;
+        gpio_line_info_t line_info;
         memset(&line_info, 0x00, sizeof(line_info));
-        line_info.offset = self->number;
+        GPIO_INIT_GET_INFO(line_info, self->number);
         gpio_port_t *port = MP_OBJ_TO_PTR(self->port);
         assert(port && "GPIO port has gone away");
-        gpio_ioctl(port->fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+        gpio_ioctl(port->fd, IOCTL_GET_LINEINFO, &line_info);
 
-        if (line_info.flags & GPIO_V2_LINE_FLAG_OUTPUT) {
+        if (line_info.flags & GPIO_RES_IS_OUTPUT) {
             mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
         }
 
         // Pin.irq(callback) should still use the previous trigger mask.
         if (args[ARG_handler].u_obj == mp_const_none || trigger != 0) {
-            line_info.flags &= ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING);
+            line_info.flags &= ~(GPIO_REQ_IRQ_RISING | GPIO_REQ_IRQ_FALLING);
         }
-        line_info.flags &= ~GPIO_V2_LINE_FLAG_USED;
+        line_info.flags &= ~GPIO_BUSY;
 
         gpio_epoll_remove_pin(pos_args[0]);
         if (args[ARG_handler].u_obj != mp_const_none) {
@@ -977,11 +1066,11 @@ static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_
         // overhead since events will be processed and then discarded, but
         // again, the operation can be retried.
 
-        struct gpio_v2_line_config line_configuration;
-        memset(&line_configuration, 0x00, sizeof(struct gpio_v2_line_config));
+        gpio_config_struct_t line_configuration;
+        memset(&line_configuration, 0x00, sizeof(line_configuration));
         line_configuration.flags = line_info.flags;
 
-        gpio_ioctl(self->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &line_configuration);
+        gpio_ioctl(self->fd, IOCTL_SET_CONFIG, &line_configuration);
     }
 
     return mp_const_none;
@@ -1025,20 +1114,20 @@ static mp_obj_tuple_t *gpio_port_enumerate_lines(mp_obj_t port_name) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         mp_obj_tuple_t *pins = MP_OBJ_TO_PTR(mp_obj_new_tuple((size_t)lines, NULL));
-        struct gpio_v2_line_info line_info;
         // name, consumer, available
         mp_obj_t line_objects[3] = {};
         for (uint32_t index = 0; index < lines; index++) {
+            gpio_line_info_t line_info;
             memset((void *)&line_info, 0x00, sizeof(line_info));
-            line_info.offset = index;
-            gpio_ioctl(fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+            GPIO_INIT_GET_INFO(line_info, index);
+            gpio_ioctl(fd, IOCTL_GET_LINEINFO, &line_info);
             // If a pin is unnamed or is not yet claimed, then `.name` and
             // `.consumer` will be empty, and there's no real need to create
             // object copies when they can just be a reference to MP_QSTR_
             // instead - that saves some memory.
             line_objects[0] = line_info.name[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.name) : MP_OBJ_NEW_QSTR(MP_QSTR_);
             line_objects[1] = line_info.consumer[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.consumer) : MP_OBJ_NEW_QSTR(MP_QSTR_);
-            line_objects[2] = mp_obj_new_bool((line_info.flags & GPIO_V2_LINE_FLAG_USED) == 0);
+            line_objects[2] = mp_obj_new_bool((line_info.flags & GPIO_BUSY) == 0);
             pins->items[index] = mp_obj_new_tuple(3, (const void *)&line_objects);
         }
         port->items[0] = port_name;
@@ -1141,17 +1230,17 @@ static void *gpio_epoll_thread(void *arg) {
             assert(pin && (pin->callback != MP_OBJ_NULL) && "Event for a tracked pin with no callback");
 
             // Remove the event from from the source file descriptor buffer.
-            int bytes_read = read(pin->fd, &event_payload, sizeof(struct gpio_v2_line_event));
-            if (bytes_read < (ssize_t)sizeof(struct gpio_v2_line_event)) {
+            int bytes_read = read(pin->fd, &event_payload, sizeof(gpio_irq_event_t));
+            if (bytes_read < (ssize_t)sizeof(gpio_irq_event_t)) {
                 // TODO: Report an error condition here!
                 continue;
             }
 
-            if (event_payload.timestamp_ns <= pin->last_timestamp) {
+            if (GPIO_IRQ_GET_TIMESTAMP(event_payload) <= pin->last_timestamp) {
                 // Event lost :(
                 continue;
             }
-            pin->last_timestamp = event_payload.timestamp_ns;
+            pin->last_timestamp = GPIO_IRQ_GET_TIMESTAMP(event_payload);
 
             // TODO: Is this actually correct?  In theory this should work if
             //       all modifications to the pin object involve setting the
@@ -1304,41 +1393,41 @@ void mp_pin_deinit(void) {
 static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     // instance methods
 
-    { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&machine_pin_del_obj)             },
+    { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&machine_pin_del_obj)       },
 
-    { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&machine_pin_init_obj)            },
+    { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&machine_pin_init_obj)      },
 
-    { MP_ROM_QSTR(MP_QSTR_value),       MP_ROM_PTR(&machine_pin_value_obj)           },
-    { MP_ROM_QSTR(MP_QSTR_off),         MP_ROM_PTR(&machine_pin_off_obj)             },
-    { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)              },
-    { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)          },
+    { MP_ROM_QSTR(MP_QSTR_value),       MP_ROM_PTR(&machine_pin_value_obj)     },
+    { MP_ROM_QSTR(MP_QSTR_off),         MP_ROM_PTR(&machine_pin_off_obj)       },
+    { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)        },
+    { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)    },
 
     #if MICROPY_PY_GPIO_IRQ
-    { MP_ROM_QSTR(MP_QSTR_irq),         MP_ROM_PTR(&machine_pin_irq_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_irq),         MP_ROM_PTR(&machine_pin_irq_obj)       },
     #endif
 
-    { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)             },
-    { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj)       },
-    { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)                 },
-    { MP_ROM_QSTR(MP_QSTR___exit__),    MP_ROM_PTR(&machine_pin_del_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)       },
+    { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj) },
+    { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)           },
+    { MP_ROM_QSTR(MP_QSTR___exit__),    MP_ROM_PTR(&machine_pin_del_obj)       },
 
-    { MP_ROM_QSTR(MP_QSTR_enumerate),   MP_ROM_PTR(&machine_pin_enumerate_obj)       },
+    { MP_ROM_QSTR(MP_QSTR_enumerate),   MP_ROM_PTR(&machine_pin_enumerate_obj) },
 
     // class constants
 
-    { MP_ROM_QSTR(MP_QSTR_IN),          MP_ROM_INT(GPIO_V2_LINE_FLAG_INPUT)          },
-    { MP_ROM_QSTR(MP_QSTR_OUT),         MP_ROM_INT(GPIO_V2_LINE_FLAG_OUTPUT)         },
-    { MP_ROM_QSTR(MP_QSTR_OPEN_DRAIN),  MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_DRAIN)     },
-    { MP_ROM_QSTR(MP_QSTR_OPEN_SOURCE), MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_SOURCE)    },
-    { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_UP)   },
-    { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN) },
-    { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_DISABLED)  },
+    { MP_ROM_QSTR(MP_QSTR_IN),          MP_ROM_INT(GPIO_REQ_INPUT)          },
+    { MP_ROM_QSTR(MP_QSTR_OUT),         MP_ROM_INT(GPIO_REQ_OUTPUT)         },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_DRAIN),  MP_ROM_INT(GPIO_REQ_OPEN_DRAIN)     },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_SOURCE), MP_ROM_INT(GPIO_REQ_OPEN_SOURCE)    },
+    { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_REQ_BIAS_PULL_UP)   },
+    { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_REQ_BIAS_PULL_DOWN) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_REQ_BIAS_DISABLE)   },
 
     #if MICROPY_PY_GPIO_IRQ
-    { MP_ROM_QSTR(MP_QSTR_IRQ_RISING),  MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_RISING)    },
-    { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_FALLING)   },
-    #if MICROPY_PY_GPIO_IRQ_TIMESTAMP
-    { MP_ROM_QSTR(MP_QSTR_CLOCK_MONOTONIC), MP_ROM_INT(0)                            },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RISING),  MP_ROM_INT(GPIO_REQ_IRQ_RISING)     },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_REQ_IRQ_FALLING)    },
+    #if MICROPY_PY_GPIO_API_VERSION == 2 && MICROPY_PY_GPIO_IRQ_TIMESTAMP
+    { MP_ROM_QSTR(MP_QSTR_CLOCK_MONOTONIC), MP_ROM_INT(0)                   },
     { MP_ROM_QSTR(MP_QSTR_CLOCK_REALTIME), MP_ROM_INT(GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME) },
     { MP_ROM_QSTR(MP_QSTR_CLOCK_HTE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_EVENT_CLOCK_HTE) },
     #endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -32,12 +32,22 @@
 #error "Platform does not support GPIO access"
 #endif
 
+#if MICROPY_PY_GPIO_IRQ && !MICROPY_PY_THREAD
+#error "GPIO IRQ support needs threading to work"
+#endif
+
 #include <dirent.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#if MICROPY_PY_GPIO_IRQ
+#include <pthread.h>
+#include <signal.h>
+#include <sys/epoll.h>
+#endif
 
 #include <linux/gpio.h>
 
@@ -75,6 +85,16 @@ typedef struct _gpio_port_t {
     int fd;
     uint32_t lines;
 } gpio_port_t;
+
+#if MICROPY_PY_GPIO_IRQ
+
+static void *gpio_epoll_thread(void *arg);
+
+static pthread_t gpio_epoll_thread_id = 0;
+static int gpio_epoll_fd = -1;
+static volatile bool gpio_epoll_thread_stop = false;
+
+#endif
 
 static void gpio_ioctl(int fd, int call, void *payload) {
     MP_THREAD_GIL_EXIT();
@@ -184,6 +204,182 @@ static mp_obj_t resolve_gpio_device_name(mp_obj_t device) {
     return mp_obj_new_str_from_cstr(path);
 }
 
+#if MICROPY_PY_GPIO_IRQ
+
+static void gpio_epoll_init(void) {
+    mp_set_init(&MP_STATE_PORT(epoll_pins), 0);
+
+    MP_THREAD_GIL_EXIT();
+    gpio_epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (gpio_epoll_fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_create(&gpio_epoll_thread_id, NULL, &gpio_epoll_thread, (void *)&gpio_epoll_thread_stop);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static void gpio_epoll_deinit(void) {
+    gpio_epoll_thread_stop = true;
+    MP_THREAD_GIL_EXIT();
+    close(gpio_epoll_fd);
+    MP_THREAD_GIL_ENTER();
+    gpio_epoll_fd = -1;
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_cancel(gpio_epoll_thread_id);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_cancel failed to cancel the epoll thread");
+    MP_THREAD_GIL_EXIT();
+    result = pthread_join(gpio_epoll_thread_id, NULL);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_join failed to wait until the epoll thread exited");
+    (void)result;
+    gpio_epoll_thread_id = 0;
+    // The pins set can be safely cleared without being in a critical section.
+    mp_set_clear(&MP_STATE_PORT(epoll_pins));
+    m_del(struct epoll_event, MP_STATE_PORT(epoll_events), MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+}
+
+// epoll() descriptor set management functions.
+
+static void gpio_epoll_undo_addition(void *pin) {
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    mp_obj_t removed_object = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(pin), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    assert(removed_object != MP_OBJ_NULL && "Nothing to undo?");
+    (void)removed_object;
+}
+
+static void gpio_epoll_add_pin(mp_obj_t pin_in) {
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+
+    assert((pin->fd >= 0) && "Adding a pin with an invalid descriptor to the epoll list");
+
+    memset(&pin->event, 0x00, sizeof(struct epoll_event));
+    // Only report edge-trigger epoll events: we just need to know that the pin
+    // file descriptor has some incoming data, a.k.a. a line change event
+    // structure was written to the descriptor.
+    //
+    // TODO: Make EPOLLWAKEUP optional, but it requires a new keyword argument
+    //       in machine.Pin.irq.
+    pin->event.events = EPOLLIN | EPOLLET | EPOLLWAKEUP;
+    pin->event.data.ptr = pin;
+
+    mp_set_t *epoll_pins = &MP_STATE_PORT(epoll_pins);
+
+    int result = 0;
+    bool raise_exception = false;
+    nlr_buf_t nlr;
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+
+    // There's no direct way to just query a set whether an element is stored
+    // in there or not, so we traverse the items table instead.
+
+    bool element_already_added = false;
+
+    for (size_t index = 0; index < epoll_pins->alloc; index++) {
+        mp_obj_t element = epoll_pins->table[index];
+        if (element == pin_in) {
+            element_already_added = true;
+            break;
+        }
+    }
+
+    assert((!element_already_added || (element_already_added && (pin->event.events != 0 && pin->event.data.ptr != 0))) && "epoll set went out of sync");
+
+    if (!element_already_added) {
+        // Adding the file descriptor to an epoll group descriptor may fail,
+        // and if it does then we have to clean up the epoll pins set.
+        // Updating the set may also incur on a faillible memory reallocation
+        // too.  It's easier to undo a set addition rather than dealing with
+        // epoll once more.
+        //
+        // TODO: is NLR safe to use if enclosed inside a critical section?
+
+        if (nlr_push(&nlr) == 0) {
+            // mp_set_lookup may raise from mp_set_rehash on low memory.
+            mp_set_lookup(epoll_pins, pin_in, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+            MP_THREAD_GIL_EXIT();
+            result = epoll_ctl(gpio_epoll_fd, EPOLL_CTL_ADD, pin->fd, &pin->event);
+            MP_THREAD_GIL_ENTER();
+            nlr_pop();
+            if (result < 0) {
+                gpio_epoll_undo_addition(pin);
+            }
+        } else {
+            gpio_epoll_undo_addition(pin);
+            raise_exception = true;
+        }
+    }
+
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    // Move back to the previous inner if-then-else if NLRs are safe.
+    if (raise_exception) {
+        nlr_jump(nlr.ret_val);
+    }
+
+    if (result < 0) {
+        mp_raise_OSError(-result);
+    }
+}
+
+static void gpio_epoll_remove_pin(mp_obj_t pin_in) {
+    // This may be invoked during GPIO subsystem deinitialisation, so if the
+    // epoll thread should stop leave things alone (the group descriptor is
+    // probably already closed by now).
+    if (gpio_epoll_thread_stop) {
+        return;
+    }
+
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+
+    assert((pin->fd >= 0) && "Removing a pin with an invalid descriptor from the epoll group");
+    memset(&pin->event, 0x00, sizeof(struct epoll_event));
+
+    int result = 0;
+    bool element_found = false;
+    mp_set_t *epoll_pins = &MP_STATE_PORT(epoll_pins);
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+
+    for (size_t index = 0; index < epoll_pins->alloc; index++) {
+        mp_obj_t element = epoll_pins->table[index];
+        if (element == pin_in) {
+            element_found = true;
+            break;
+        }
+    }
+
+    if (element_found) {
+        // Removing an item from a set will always succeed, so the only check here
+        // is whether the removal of the pin's file descriptor from the epoll
+        // descriptors group succeeded or not.
+
+        MP_THREAD_GIL_EXIT();
+        result = epoll_ctl(gpio_epoll_fd, EPOLL_CTL_DEL, pin->fd, NULL);
+        MP_THREAD_GIL_ENTER();
+        if (result >= 0) {
+            mp_obj_t removed_object = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(pin), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+            pin->callback = mp_const_none;
+            assert(removed_object != MP_OBJ_NULL && "Pin descriptor not found in epoll group");
+            (void)removed_object;
+        }
+    }
+
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    if (result < 0) {
+        mp_raise_OSError(-result);
+    }
+}
+
+#endif
+
 // This expects to receive an already resolved port name!
 static gpio_port_t *gpio_add_port(mp_obj_t path) {
     mp_map_t *ports = &MP_STATE_PORT(ports);
@@ -251,6 +447,10 @@ static mp_obj_t gpio_find_pin(mp_obj_t port_key, uint32_t pin) {
 }
 
 static void gpio_evict_pin(mp_obj_t pin_in) {
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_remove_pin(pin_in);
+    #endif
+
     machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
     mp_map_t *ports = &MP_STATE_PORT(ports);
     mp_map_elem_t *slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP);
@@ -430,6 +630,8 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         machine_pin_obj_t *pin = MP_OBJ_TO_PTR(existing_pin);
 
         // Reconfigure the pin with the new parameters.
+        // WARNING: If an IRQ callback was attached before this point, it will
+        //          stay bound to the pin instance.
         if (pin->fd >= 0) {
             gpio_ioctl(pin->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
             return existing_pin;
@@ -475,6 +677,11 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         self->port = MP_OBJ_FROM_PTR(port);
         self->number = pin_number;
         self->fd = request.fd;
+
+        #if MICROPY_PY_GPIO_IRQ
+        self->callback = mp_const_none;
+        memset(&self->event, 0x00, sizeof(struct epoll_event));
+        #endif
 
         self_out = MP_OBJ_FROM_PTR(self);
 
@@ -587,6 +794,9 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
 
 mp_obj_t machine_pin_del(mp_obj_t self_in) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_remove_pin(self_in);
+    #endif
     MP_THREAD_GIL_EXIT();
     close(self->fd);
     MP_THREAD_GIL_ENTER();
@@ -611,6 +821,76 @@ mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
     return machine_pin_call(args[0], n_args - 1, 0, args + 1);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
+
+#if MICROPY_PY_GPIO_IRQ
+
+static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_handler, ARG_trigger, ARG_hard };
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_handler, MP_ARG_OBJ,  { .u_obj = mp_const_none                                                  } },
+        { MP_QSTR_trigger, MP_ARG_INT,  { .u_int = GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING } },
+        { MP_QSTR_hard,    MP_ARG_BOOL, { .u_bool = false                                                         } },
+    };
+
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (n_args > 1 || kw_args->used != 0) {
+        mp_uint_t trigger = args[ARG_trigger].u_int;
+        if ((trigger & ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid trigger"));
+        }
+
+        struct gpio_v2_line_info line_info;
+        memset(&line_info, 0x00, sizeof(line_info));
+        line_info.offset = self->number;
+        gpio_port_t *port = MP_OBJ_TO_PTR(self->port);
+        assert(port && "GPIO port has gone away");
+        gpio_ioctl(port->fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+
+        if (line_info.flags & GPIO_V2_LINE_FLAG_OUTPUT) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+
+        // Pin.irq(callback) should still use the previous trigger mask.
+        if (args[ARG_handler].u_obj == mp_const_none || trigger != 0) {
+            line_info.flags &= ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING);
+        }
+        line_info.flags &= ~GPIO_V2_LINE_FLAG_USED;
+
+        gpio_epoll_remove_pin(pos_args[0]);
+        if (args[ARG_handler].u_obj != mp_const_none) {
+            self->callback = args[ARG_handler].u_obj;
+            gpio_epoll_add_pin(pos_args[0]);
+            line_info.flags |= trigger;
+        }
+
+        // If this fails and the pin was meant to update the triggers mask,
+        // then it will still be part of the epoll descriptors list, but it
+        // won't receive any updates.  There's a minor overhead as the
+        // system has to still handle the edge change but not notify the
+        // descriptor.  The operation can be retried safely.
+        //
+        // If the pin was meant to lose all triggers instead and this fails,
+        // again, the situation should still be recoverable.  In this case,
+        // the pin won't be part of the epoll descriptors list, and no events
+        // will be forwarded.  Like in the other case there's still some
+        // overhead since events will be processed and then discarded, but
+        // again, the operation can be retried.
+
+        struct gpio_v2_line_config line_configuration;
+        memset(&line_configuration, 0x00, sizeof(struct gpio_v2_line_config));
+        line_configuration.flags = line_info.flags;
+
+        gpio_ioctl(self->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &line_configuration);
+    }
+
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_irq_obj, 1, machine_pin_irq);
+#endif
 
 static mp_obj_tuple_t *gpio_port_enumerate_lines(mp_obj_t port_name) {
     assert(port_name && "Port name is NULL");
@@ -737,11 +1017,76 @@ static MP_DEFINE_CONST_FUN_OBJ_0(machine_pin_enumerate_obj, machine_pin_enumerat
 
 ///////////////////////////////////////////////////////////////////////////////
 
+#if MICROPY_PY_GPIO_IRQ
+static void *gpio_epoll_thread(void *arg) {
+    // Keep a reference to the stop variable.
+    volatile bool *stop = (volatile bool *)arg;
+
+    assert(MP_STATE_PORT(epoll_events) != NULL && "GPIO epoll thread started at the wrong time?");
+
+    struct gpio_v2_line_event event_payload;
+
+    for (;;) {
+        int events = epoll_wait(gpio_epoll_fd, MP_STATE_PORT(epoll_events), MICROPY_PY_GPIO_IRQ_QUEUE_SIZE, -1);
+        if (*stop) {
+            goto done;
+        }
+
+        if (events <= 0) {
+            // This is not correct but the code isn't in its final form yet.
+            continue;
+        }
+
+        for (int event_index = 0; event_index < events; event_index++) {
+            struct epoll_event *event = ((struct epoll_event *)(&MP_STATE_PORT(epoll_events))[event_index]);
+
+            machine_pin_obj_t *pin = event->data.ptr;
+            assert(pin && (pin->callback != MP_OBJ_NULL) && "Event for a tracked pin with no callback");
+
+            // Remove the event from from the source file descriptor buffer.
+            int bytes_read = read(pin->fd, &event_payload, sizeof(struct gpio_v2_line_event));
+            if (bytes_read < (ssize_t)sizeof(struct gpio_v2_line_event)) {
+                // TODO: Report an error condition here!
+                continue;
+            }
+
+            // TODO: Is this actually correct?  In theory this should work if
+            //       all modifications to the pin object involve setting the
+            //       relevant pointers to MP_OBJ_NULL, but then what happens if
+            //       the IRQ handlers are collected?  This needs more thought.
+            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            mp_obj_t lookup_result = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(event->data.ptr), MP_MAP_LOOKUP);
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
+            if (lookup_result == MP_OBJ_NULL) {
+                continue;
+            }
+
+            // There is currently no facility to easily run a function on the
+            // main thread from another thread, so schedule the IRQ handler at
+            // whichever priority the interpreter sees fit.
+            mp_sched_schedule(pin->callback, MP_OBJ_FROM_PTR(pin));
+        }
+    }
+
+done:
+    return NULL;
+}
+#endif
+
 void mp_pin_init(void) {
     mp_map_init(&MP_STATE_PORT(ports), 0);
+
+    #if MICROPY_PY_GPIO_IRQ
+    MP_STATE_PORT(epoll_events) = m_new(struct epoll_event, MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+    gpio_epoll_init();
+    #endif
 }
 
 void mp_pin_deinit(void) {
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_deinit();
+    #endif
+
     mp_map_t *ports = &MP_STATE_PORT(ports);
     if (ports->table == NULL) {
         return;
@@ -789,6 +1134,10 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)              },
     { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)          },
 
+    #if MICROPY_PY_GPIO_IRQ
+    { MP_ROM_QSTR(MP_QSTR_irq),         MP_ROM_PTR(&machine_pin_irq_obj)             },
+    #endif
+
     { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)             },
     { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj)       },
     { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)                 },
@@ -805,6 +1154,11 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_UP)   },
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN) },
     { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_DISABLED)  },
+
+    #if MICROPY_PY_GPIO_IRQ
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RISING),  MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_RISING)    },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_FALLING)   },
+    #endif
 };
 
 static MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
@@ -826,5 +1180,11 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 // Is this safe?  What happens if the GC scans mp_map_t->table?
 MP_REGISTER_ROOT_POINTER(mp_map_t ports);
+
+#if MICROPY_PY_GPIO_IRQ
+MP_REGISTER_ROOT_POINTER(void *epoll_events);
+// Is this safe?  What happens if the GC scans mp_set_t->table?
+MP_REGISTER_ROOT_POINTER(mp_set_t epoll_pins);
+#endif
 
 #endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -1,0 +1,830 @@
+/*
+ * This file is part of the MicroPython project, https://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025-2026 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+
+#if MICROPY_PY_GPIO
+
+#ifndef __linux__
+#error "Platform does not support GPIO access"
+#endif
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <linux/gpio.h>
+
+#include "py/gc.h"
+#include "py/misc.h"
+#include "py/mperrno.h"
+#include "py/obj.h"
+#include "py/objint.h"
+#include "py/objstr.h"
+#include "py/qstr.h"
+#include "py/runtime.h"
+
+#include "pin.h"
+
+#if MICROPY_DEBUG_VERBOSE
+#define DEBUG_PRINT (1)
+#define DEBUG_printf DEBUG_printf
+#else
+#define DEBUG_printf(...) (void)0
+#endif
+
+static const char *GPIO_DEVICES_ROOT = "/sys/bus/gpio/devices/";
+
+///////////////////////////////////////////////////////////////////////////////
+
+// TODO: Turn this into a MicroPython object and then require
+//       MICROPY_ENABLE_FINALISER?
+// TODO: Use a mp_obj_list_t for the pins and keep a reference count to know
+//       when to clean the object up?
+typedef struct _gpio_port_t {
+    mp_obj_t path;
+    mp_obj_t name;
+    mp_obj_t label;
+    mp_obj_t *pins;
+    int fd;
+    uint32_t lines;
+} gpio_port_t;
+
+static void gpio_ioctl(int fd, int call, void *payload) {
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, call, payload);
+    MP_THREAD_GIL_ENTER();
+    if (result < 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+// Thanks to the existence of symbolic links, any character device on the
+// machine can be referenced by an infinite number of names.  However,
+// character devices can still be referenced by their device identifier.  Too
+// bad a device identifier *is not unique* across devices of different classes
+// so that won't save you from errors, and sending the right ioctl to the wrong
+// device may or may not be harmful.
+//
+// Still, the "/sys/bus/gpio/devices" directory will contain the names of
+// available GPIO character devices, with each entry in there being a link to
+// another directory with text files containing more information on the target
+// device.  To keep things manageable and third party dependency free (as in,
+// not making libudev a dependency), the given port name (not the full path!)
+// is checked for existence as "/sys/bus/gpio/devices/<portname>/dev", and if
+// there's a match, then it is opened as "/dev/<portname>".  This introduces a
+// potential race condition if what is reported in procfs and what is reported
+// in devtmpfs happens to change after procfs is evaluated and before devtmpfs
+// is looked into.  Security-wise, I guess said race condition could only be
+// exploitable if an attacker can manipulate entries in both "/sys" and "/dev";
+// in that case, the game may already be lost to begin with.  Probably not much
+// can be done on our end to mitigate that.
+//
+// For more mundane security mitigations, though, characters in the port name
+// are restricted to be in the ranges "a-z", "A-Z", "0-9".  The lack of
+// slashes, tildes, and other characters should be good enough for stopping
+// unwanted directory traversals.  If it does not, then patches are welcome.
+//
+// This method for resolving character devices' effective path, despite its
+// limits, makes handling dynamic GPIO ports disconnections much easier.  An
+// inotify change watch can be placed on "/sys/bus/gpio/devices" and then the
+// ports dictionary can be updated to reflect the new devices set whenever the
+// inotify callback is invoked.
+
+static mp_obj_t resolve_gpio_device_name(mp_obj_t device) {
+    mp_obj_t name = mp_const_none;
+
+    if (mp_obj_is_int(device)) {
+        mp_int_t device_node_id = mp_obj_get_int(device);
+        // Artificially limit the number of GPIO ports to 255 for now.
+        if (device_node_id < 0 || device_node_id > 255) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid device number"));
+        }
+
+        char path[sizeof("gpiochip") + 3] = {};
+        snprintf(path, sizeof(path), "gpiochip%d", (uint8_t)device_node_id);
+        name = mp_obj_new_str_from_cstr(path);
+    }
+
+    if (mp_obj_is_str(device)) {
+        name = mp_obj_is_qstr(device) ? MP_OBJ_NEW_QSTR(device) : device;
+    }
+
+    if (name == mp_const_none) {
+        mp_raise_TypeError(MP_ERROR_TEXT("invalid port type"));
+    }
+
+    size_t length = 0;
+    const char *raw_name = mp_obj_str_get_data(name, &length);
+    for (size_t index = 0; index < length; index++) {
+        char character = raw_name[index];
+        // "Be aware: These unichar_is* functions are actually ASCII-only!"
+        if (!unichar_isalpha(character) && !unichar_isdigit(character)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid port name"));
+        }
+    }
+
+    vstr_t port_path;
+    vstr_init(&port_path, sizeof(GPIO_DEVICES_ROOT) - 1 + length + sizeof("/dev") - 1);
+    vstr_add_str(&port_path, GPIO_DEVICES_ROOT);
+    vstr_add_strn(&port_path, raw_name, length);
+    vstr_add_str(&port_path, "/dev");
+    const char *path = vstr_null_terminated_str(&port_path);
+
+    MP_THREAD_GIL_EXIT();
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return mp_const_none;
+    }
+    MP_THREAD_GIL_EXIT();
+    close(fd);
+    MP_THREAD_GIL_ENTER();
+
+    vstr_init(&port_path, sizeof("/dev/") - 1 + length);
+    vstr_add_str(&port_path, "/dev/");
+    vstr_add_strn(&port_path, raw_name, length);
+    path = vstr_null_terminated_str(&port_path);
+
+    MP_THREAD_GIL_EXIT();
+    fd = open(path, O_RDWR | O_CLOEXEC);
+    close(fd);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return mp_const_none;
+    }
+
+    // Probably duplication is not needed...
+    return mp_obj_new_str_from_cstr(path);
+}
+
+// This expects to receive an already resolved port name!
+static gpio_port_t *gpio_add_port(mp_obj_t path) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    assert(ports && "Ports dictionary must not be NULL");
+    mp_map_elem_t *slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP);
+    if (slot) {
+        return (gpio_port_t *)MP_OBJ_TO_PTR(slot->value);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    mp_int_t fd = open(mp_obj_str_get_str(path), O_RDWR | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    gpio_port_t *port;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        struct gpiochip_info info;
+        memset(&info, 0x00, sizeof(info));
+        gpio_ioctl(fd, GPIO_GET_CHIPINFO_IOCTL, &info);
+
+        mp_obj_t *pins = NULL;
+        if (info.lines > 0) {
+            MP_STATIC_ASSERT(MP_OBJ_NULL == 0);
+            pins = m_new0(mp_obj_t, info.lines);
+        }
+
+        port = m_new(gpio_port_t, 1);
+        port->path = path;
+        port->name = mp_obj_new_str_from_cstr(info.name);
+        port->label = mp_obj_new_str_from_cstr(info.label);
+        port->pins = pins;
+        port->fd = fd;
+        port->lines = info.lines;
+
+        slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+        assert(slot && "No slot to fill was returned on port add");
+        slot->value = MP_OBJ_FROM_PTR(port);
+
+        nlr_pop();
+    } else {
+        close(fd);
+
+        // Re-raise the exception.
+        nlr_jump(nlr.ret_val);
+    }
+
+    return port;
+}
+
+// This expects to receive an already resolved port name!
+static mp_obj_t gpio_find_pin(mp_obj_t port_key, uint32_t pin) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    mp_map_elem_t *slot = mp_map_lookup(ports, port_key, MP_MAP_LOOKUP);
+    if (!slot || slot->value == MP_OBJ_NULL) {
+        return MP_OBJ_NULL;
+    }
+    gpio_port_t *port = (gpio_port_t *)MP_OBJ_TO_PTR(slot->value);
+    if (pin >= port->lines) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+    return port->pins[pin];
+}
+
+static void gpio_evict_pin(mp_obj_t pin_in) {
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    mp_map_elem_t *slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP);
+    if (!slot) {
+        // The port this pin belongs to may have already been evicted during
+        // GPIO support deinitialisation or by a pin object finaliser.
+        return;
+    }
+
+    gpio_port_t *port = MP_OBJ_TO_PTR(slot->value);
+    assert((port == (gpio_port_t *)MP_OBJ_TO_PTR(pin->port)) && "Pin and port went out of sync");
+    assert((pin->number < port->lines) && "Pin and port went out of sync");
+    assert(port->pins[pin->number] == pin_in && "Pin objects mismatch");
+    port->pins[pin->number] = MP_OBJ_NULL;
+
+    bool empty_port = true;
+    for (size_t index = 0; index < port->lines; index++) {
+        if (port->pins[index] != MP_OBJ_NULL) {
+            empty_port = false;
+            break;
+        }
+    }
+
+    if (!empty_port) {
+        return;
+    }
+
+    slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+    assert(slot && "Port disappeared from map");
+    MP_THREAD_GIL_EXIT();
+    close(port->fd);
+    MP_THREAD_GIL_ENTER();
+    port->fd = -1;
+    m_del(mp_obj_t, port->pins, port->lines);
+    slot->value = MP_OBJ_NULL;
+    m_del(gpio_port_t, port, 1);
+}
+
+static uint32_t gpio_get_pin_number(mp_obj_t number_in) {
+    assert(mp_obj_is_int(number_in) && "Invalid pin number type");
+
+    uint32_t number = 0;
+
+    // If mp_obj_int_to_bytes would signal whether the number was truncated or
+    // not, this NLR shouldn't be needed.  For this case a more appropriate
+    // error message is required rather than "integer out of range".
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_obj_int_to_bytes(number_in, sizeof(uint32_t), (byte *)&number,
+            #if MP_ENDIANNESS_BIG
+            true,
+            #else
+            false,
+            #endif
+            false, true);
+        nlr_pop();
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+
+    return number;
+}
+
+static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value) {
+    assert(config && "GPIO config structrure must not be NULL");
+
+    memset(config, 0x00, sizeof(struct gpio_v2_line_config));
+
+    // Checks for mode and pull could be made simpler by just checking whether
+    // the value bit is in the combined OR of all valid options, and then use
+    // the value directly.  Initialisation will fail anyway but you won't know
+    // why, so we have to do this instead.
+
+    if (mode != mp_const_none) {
+        mp_int_t pin_mode = mp_obj_get_int(mode);
+        if ((pin_mode & ~(GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT | GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        if ((pin_mode & (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) == (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        if ((pin_mode & (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) == (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        config->flags |= pin_mode;
+    }
+
+    if (pull != MP_OBJ_NEW_SMALL_INT(-1)) {
+        MP_STATIC_ASSERT((GPIO_V2_LINE_FLAG_BIAS_DISABLED & (GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) == 0);
+        mp_int_t pull_mode = mp_obj_get_int(pull);
+        if ((pull_mode & ~(GPIO_V2_LINE_FLAG_BIAS_DISABLED | GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
+        }
+        if (mp_popcount(pull_mode) > 1) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
+        }
+        config->flags |= pull_mode;
+    }
+
+    if (value != MP_OBJ_NULL) {
+        config->num_attrs = 1;
+        config->attrs[0].attr.id = GPIO_V2_LINE_ATTR_ID_OUTPUT_VALUES;
+        config->attrs[0].attr.values = (mp_obj_is_true(value) ? 1U : 0U);
+        config->attrs[0].mask = 1U;
+    }
+}
+
+static int gpio_set_state_inner(int fd, mp_int_t state) {
+    struct gpio_v2_line_values values;
+    memset(&values, 0x00, sizeof(values));
+    values.mask = 1U;
+    values.bits = state != 0 ? 1U : 0U;
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &values);
+    MP_THREAD_GIL_ENTER();
+    return result;
+}
+
+static int gpio_get_state_inner(int fd, mp_int_t *state) {
+    assert(state && "GPIO state value pointer cannot be NULL");
+
+    struct gpio_v2_line_values values;
+    memset(&values, 0x00, sizeof(values));
+    values.mask = 1U;
+    values.bits = 1U;
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values);
+    MP_THREAD_GIL_ENTER();
+    if (result >= 0) {
+        *state = (values.bits & 1U) ? 1 : 0;
+    }
+    return result;
+}
+
+static void gpio_set_state(mp_obj_t self_in, mp_int_t state) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (gpio_set_state_inner(self->fd, state) < 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static bool gpio_get_state(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t state;
+    if (gpio_get_state_inner(self->fd, &state) < 0) {
+        mp_raise_OSError(errno);
+    }
+    return !!state;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_mode, ARG_pull, ARG_value, ARG_port, ARG_consumer };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode,                      MP_ARG_OBJ, { .u_obj = mp_const_none                        }},
+        { MP_QSTR_pull,                      MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(-1)             }},
+        { MP_QSTR_value,    MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NULL                          }},
+        { MP_QSTR_port,     MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(0)              }},
+        { MP_QSTR_consumer, MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_MicroPython) }},
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    struct gpio_v2_line_config config;
+    gpio_fill_line_config_struct(&config, pin_number, args[ARG_mode].u_obj, args[ARG_pull].u_obj, args[ARG_value].u_obj);
+
+    mp_obj_t port_path = resolve_gpio_device_name(args[ARG_port].u_obj);
+    if (port_path == mp_const_none) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid port name"));
+    }
+
+    mp_obj_t existing_pin = gpio_find_pin(port_path, pin_number);
+    if (existing_pin != MP_OBJ_NULL) {
+        machine_pin_obj_t *pin = MP_OBJ_TO_PTR(existing_pin);
+
+        // Reconfigure the pin with the new parameters.
+        if (pin->fd >= 0) {
+            gpio_ioctl(pin->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
+            return existing_pin;
+        }
+
+        gpio_evict_pin(existing_pin);
+    }
+
+    if (!mp_obj_is_str(args[ARG_consumer].u_obj)) {
+        mp_raise_TypeError(MP_ERROR_TEXT("invalid consumer"));
+    }
+    const char *consumer;
+    size_t consumer_length;
+    if (mp_obj_is_qstr(args[ARG_consumer].u_obj)) {
+        consumer = (const char *)qstr_data(MP_OBJ_QSTR_VALUE(args[ARG_consumer].u_obj), &consumer_length);
+    } else {
+        consumer = mp_obj_str_get_data(args[ARG_consumer].u_obj, &consumer_length);
+    }
+    if (consumer_length >= GPIO_MAX_NAME_SIZE) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid consumer"));
+    }
+
+    // If the port is already known then it will just return the old instance.
+    gpio_port_t *port = gpio_add_port(port_path);
+
+    if (pin_number >= port->lines) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+
+    struct gpio_v2_line_request request;
+    memset(&request, 0x00, sizeof(request));
+    request.offsets[0] = pin_number;
+    request.config = config;
+    request.num_lines = 1;
+    strcpy(request.consumer, consumer);
+
+    gpio_ioctl(port->fd, GPIO_V2_GET_LINE_IOCTL, &request);
+
+    mp_obj_t self_out;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        machine_pin_obj_t *self = mp_obj_malloc_with_finaliser(machine_pin_obj_t, &machine_pin_type);
+        self->port = MP_OBJ_FROM_PTR(port);
+        self->number = pin_number;
+        self->fd = request.fd;
+
+        self_out = MP_OBJ_FROM_PTR(self);
+
+        if (port->pins[pin_number] != MP_OBJ_NULL) {
+            machine_pin_obj_t *old_self = MP_OBJ_TO_PTR(port->pins[pin_number]);
+            gpio_evict_pin(port->pins[pin_number]);
+            port->pins[pin_number] = MP_OBJ_NULL;
+            MP_THREAD_GIL_EXIT();
+            close(old_self->fd);
+            MP_THREAD_GIL_ENTER();
+        }
+        port->pins[pin_number] = self_out;
+
+        nlr_pop();
+    } else {
+        MP_THREAD_GIL_EXIT();
+        close(request.fd);
+        MP_THREAD_GIL_ENTER();
+
+        nlr_jump(nlr.ret_val);
+    }
+
+    return self_out;
+}
+
+mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    if (mp_obj_is_type(args[0], &machine_pin_type)) {
+        return args[0];
+    }
+
+    if (mp_obj_is_int(args[0])) {
+        uint32_t number = gpio_get_pin_number(args[0]);
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        return init_helper(number, n_args - 1, args + 1, &kw_args);
+    }
+
+    mp_raise_TypeError(MP_ERROR_TEXT("invalid pin type"));
+}
+
+static void machine_pin_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    (void)kind;
+    const machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    const gpio_port_t *port = MP_OBJ_TO_PTR(self->port);
+    mp_printf(print, "Pin(%s, %d)", mp_obj_str_get_str(port->name), self->number);
+}
+
+static mp_obj_t machine_pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (n_args == 0) {
+        return MP_OBJ_NEW_SMALL_INT(gpio_get_state(self));
+    }
+    gpio_set_state(self, mp_obj_is_true(args[0]));
+    return mp_const_none;
+}
+
+static mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->fd < 0) {
+        if (errcode != NULL) {
+            *errcode = MP_EPIPE;
+        }
+        return -1;
+    }
+
+    switch (request) {
+        case MP_PIN_READ: {
+            mp_int_t state = 0;
+            int result = gpio_get_state_inner(self->fd, &state);
+            if (errcode != NULL) {
+                *errcode = result < 0 ? result : 0;
+            }
+            return result < 0 ? -1 : state;
+        }
+
+        case MP_PIN_WRITE: {
+            int result = gpio_set_state_inner(self->fd, arg != 0 ? 1 : 0);
+            if (errcode != NULL) {
+                *errcode = result;
+            }
+            return result < 0 ? -1 : 0;
+        }
+
+        default:
+            return -1;
+    }
+}
+
+static mp_obj_t machine_pin_off(mp_obj_t self_in) {
+    gpio_set_state(self_in, 0);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_off_obj, machine_pin_off);
+
+static mp_obj_t machine_pin_on(mp_obj_t self_in) {
+    gpio_set_state(self_in, 1);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
+
+static mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
+    gpio_set_state(self_in, gpio_get_state(self_in) ? 0 : 1);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
+
+mp_obj_t machine_pin_del(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    MP_THREAD_GIL_EXIT();
+    close(self->fd);
+    MP_THREAD_GIL_ENTER();
+    self->fd = -1;
+    gpio_evict_pin(self_in);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_del_obj, machine_pin_del);
+
+static mp_obj_t machine_pin_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    return init_helper(gpio_get_pin_number(args[0]), n_args - 1, args + 1, kw_args);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_init_obj, 1, machine_pin_init);
+
+static mp_obj_t machine_pin_available(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(self->fd != -1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_available_obj, machine_pin_available);
+
+mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
+    return machine_pin_call(args[0], n_args - 1, 0, args + 1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
+
+static mp_obj_tuple_t *gpio_port_enumerate_lines(mp_obj_t port_name) {
+    assert(port_name && "Port name is NULL");
+
+    mp_obj_t device_name = resolve_gpio_device_name(port_name);
+    if (device_name == mp_const_none) {
+        return MP_OBJ_NULL;
+    }
+
+    int fd;
+    MP_THREAD_GIL_EXIT();
+    fd = open(mp_obj_str_get_str(device_name), O_RDWR | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return MP_OBJ_NULL;
+    }
+
+    mp_obj_tuple_t *port = mp_obj_new_tuple(2, NULL);
+    bool success = true;
+    uint32_t lines = 0;
+
+    {
+        struct gpiochip_info chip_info;
+        memset(&chip_info, 0x00, sizeof(chip_info));
+        MP_THREAD_GIL_EXIT();
+        int result = ioctl(fd, GPIO_GET_CHIPINFO_IOCTL, &chip_info);
+        MP_THREAD_GIL_ENTER();
+        if (result < 0) {
+            success = false;
+            goto done;
+        }
+        lines = chip_info.lines;
+    }
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_obj_tuple_t *pins = MP_OBJ_TO_PTR(mp_obj_new_tuple((size_t)lines, NULL));
+        struct gpio_v2_line_info line_info;
+        // name, consumer, available
+        mp_obj_t line_objects[3] = {};
+        for (uint32_t index = 0; index < lines; index++) {
+            memset((void *)&line_info, 0x00, sizeof(line_info));
+            line_info.offset = index;
+            gpio_ioctl(fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+            // If a pin is unnamed or is not yet claimed, then `.name` and
+            // `.consumer` will be empty, and there's no real need to create
+            // object copies when they can just be a reference to MP_QSTR_
+            // instead - that saves some memory.
+            line_objects[0] = line_info.name[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.name) : MP_OBJ_NEW_QSTR(MP_QSTR_);
+            line_objects[1] = line_info.consumer[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.consumer) : MP_OBJ_NEW_QSTR(MP_QSTR_);
+            line_objects[2] = mp_obj_new_bool((line_info.flags & GPIO_V2_LINE_FLAG_USED) == 0);
+            pins->items[index] = mp_obj_new_tuple(3, (const void *)&line_objects);
+        }
+        port->items[0] = port_name;
+        port->items[1] = MP_OBJ_FROM_PTR(pins);
+
+        nlr_pop();
+    } else {
+        success = false;
+    }
+
+done:
+    close(fd);
+
+    return success ? port : MP_OBJ_NULL;
+}
+
+// TODO: Implement this in Python and let it call gpio_port_enumerate_lines
+//       through a wrapper?
+static mp_obj_t machine_pin_enumerate(void) {
+    DIR *devices_directory = NULL;
+
+    MP_THREAD_GIL_EXIT();
+    devices_directory = opendir(GPIO_DEVICES_ROOT);
+    MP_THREAD_GIL_ENTER();
+    if (!devices_directory) {
+        if (errno == ENOENT) {
+            // GPIO support is not enabled in the running kernel?
+            return mp_obj_new_tuple(0, NULL);
+        } else {
+            mp_raise_OSError(errno);
+        }
+    }
+
+    bool failed = false;
+    mp_obj_t ports = mp_obj_new_list(0, NULL);
+    struct dirent *device_entry = NULL;
+    do {
+        errno = 0;
+        MP_THREAD_GIL_EXIT();
+        device_entry = readdir(devices_directory);
+        MP_THREAD_GIL_ENTER();
+        if (device_entry == NULL) {
+            failed = errno != 0;
+            break;
+        }
+        const char *name = device_entry->d_name;
+        char *end = NULL;
+        if (memcmp(name, "gpiochip", sizeof("gpiochip") - 1) == 0) {
+            name += sizeof("gpiochip") - 1;
+            long index = strtol(name, &end, 10);
+            if ((index == LONG_MIN || index == LONG_MAX) && errno == ERANGE) {
+                continue;
+            }
+            if (*end != '\0') {
+                continue;
+            }
+            mp_obj_t port = gpio_port_enumerate_lines(mp_obj_new_str_from_cstr(device_entry->d_name));
+            if (port != MP_OBJ_NULL) {
+                mp_obj_list_append(ports, MP_OBJ_FROM_PTR(port));
+            }
+        }
+    } while (device_entry != NULL);
+
+    closedir(devices_directory);
+    if (failed) {
+        mp_raise_OSError(errno);
+    }
+
+    // TODO: Is there a better way to achieve this?
+    return mp_obj_new_tuple(((mp_obj_list_t *)MP_OBJ_TO_PTR(ports))->len, ((mp_obj_list_t *)MP_OBJ_TO_PTR(ports))->items);
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(machine_pin_enumerate_obj, machine_pin_enumerate);
+
+///////////////////////////////////////////////////////////////////////////////
+
+void mp_pin_init(void) {
+    mp_map_init(&MP_STATE_PORT(ports), 0);
+}
+
+void mp_pin_deinit(void) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    if (ports->table == NULL) {
+        return;
+    }
+
+    for (size_t port_index = 0; port_index < ports->alloc; port_index++) {
+        if (!mp_map_slot_is_filled(ports, port_index)) {
+            continue;
+        }
+
+        mp_map_elem_t slot = ports->table[port_index];
+        gpio_port_t *port = MP_OBJ_TO_PTR(slot.value);
+        close(port->fd);
+        if (port->lines > 0) {
+            for (size_t pin = 0; pin < port->lines; pin++) {
+                if (port->pins[pin] != MP_OBJ_NULL) {
+                    machine_pin_del(port->pins[pin]);
+                    port->pins[pin] = MP_OBJ_NULL;
+                }
+            }
+            m_del(mp_obj_t, port->pins, port->lines);
+            port->pins = NULL;
+        }
+        assert(port->pins == NULL && "GPIO port count went out of sync");
+        m_del_obj(gpio_port_t, port);
+        slot.value = MP_OBJ_NULL;
+    }
+    mp_map_clear(ports);
+
+    // Root pointers will be freed by the OS after this point.  For the Unix
+    // port, once the main interpreter loop exits there's no recovery unlike
+    // on QEMU or other microcontroller-based ports where the board would just
+    // reboot and restart things up.
+}
+
+static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
+    // instance methods
+
+    { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&machine_pin_del_obj)             },
+
+    { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&machine_pin_init_obj)            },
+
+    { MP_ROM_QSTR(MP_QSTR_value),       MP_ROM_PTR(&machine_pin_value_obj)           },
+    { MP_ROM_QSTR(MP_QSTR_off),         MP_ROM_PTR(&machine_pin_off_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)              },
+    { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)          },
+
+    { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj)       },
+    { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)                 },
+    { MP_ROM_QSTR(MP_QSTR___exit__),    MP_ROM_PTR(&machine_pin_del_obj)             },
+
+    { MP_ROM_QSTR(MP_QSTR_enumerate),   MP_ROM_PTR(&machine_pin_enumerate_obj)       },
+
+    // class constants
+
+    { MP_ROM_QSTR(MP_QSTR_IN),          MP_ROM_INT(GPIO_V2_LINE_FLAG_INPUT)          },
+    { MP_ROM_QSTR(MP_QSTR_OUT),         MP_ROM_INT(GPIO_V2_LINE_FLAG_OUTPUT)         },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_DRAIN),  MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_DRAIN)     },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_SOURCE), MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_SOURCE)    },
+    { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_UP)   },
+    { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_DISABLED)  },
+};
+
+static MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
+
+static const mp_pin_p_t machine_pin_obj_protocol = {
+    .ioctl = pin_ioctl,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_pin_type,
+    MP_QSTR_Pin,
+    MP_TYPE_FLAG_NONE,
+    make_new, mp_pin_make_new,
+    print, machine_pin_obj_print,
+    call, machine_pin_call,
+    protocol, &machine_pin_obj_protocol,
+    locals_dict, &machine_pin_locals_dict
+    );
+
+// Is this safe?  What happens if the GC scans mp_map_t->table?
+MP_REGISTER_ROOT_POINTER(mp_map_t ports);
+
+#endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -35,6 +35,9 @@
 #if MICROPY_PY_GPIO_IRQ && !MICROPY_PY_THREAD
 #error "GPIO IRQ support needs threading to work"
 #endif
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION && !MICROPY_PY_THREAD
+#error "GPIO dynamic pin allocation needs threading to work"
+#endif
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -47,6 +50,10 @@
 #include <pthread.h>
 #include <signal.h>
 #include <sys/epoll.h>
+#endif
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+#include <unistd.h>
+#include <sys/inotify.h>
 #endif
 
 #include <linux/gpio.h>
@@ -84,6 +91,9 @@ typedef struct _gpio_port_t {
     mp_obj_t *pins;
     int fd;
     uint32_t lines;
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    int watch_descriptor;
+    #endif
 } gpio_port_t;
 
 #if MICROPY_PY_GPIO_IRQ
@@ -93,6 +103,16 @@ static void *gpio_epoll_thread(void *arg);
 static pthread_t gpio_epoll_thread_id = 0;
 static int gpio_epoll_fd = -1;
 static volatile bool gpio_epoll_thread_stop = false;
+
+#endif
+
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+
+static void *gpio_inotify_thread(void *arg);
+
+static pthread_t gpio_inotify_thread_id = 0;
+static int gpio_inotify_fd = -1;
+static volatile bool gpio_inotify_thread_stop = false;
 
 #endif
 
@@ -380,6 +400,45 @@ static void gpio_epoll_remove_pin(mp_obj_t pin_in) {
 
 #endif
 
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+
+static void gpio_inotify_init(void) {
+    MP_THREAD_GIL_EXIT();
+    gpio_inotify_fd = inotify_init1(IN_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (gpio_inotify_fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_create(&gpio_inotify_thread_id, NULL, &gpio_inotify_thread, (void *)&gpio_inotify_thread_stop);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static void gpio_inotify_deinit(void) {
+    gpio_inotify_thread_stop = true;
+    MP_THREAD_GIL_EXIT();
+    close(gpio_inotify_fd);
+    MP_THREAD_GIL_ENTER();
+    gpio_inotify_fd = -1;
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_cancel(gpio_inotify_thread_id);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_cancel failed to cancel the inotify thread");
+    MP_THREAD_GIL_EXIT();
+    result = pthread_join(gpio_inotify_thread_id, NULL);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_join failed to wait until the inotify exited");
+    (void)result;
+    gpio_inotify_thread_id = 0;
+    m_del(struct inotify_event, MP_STATE_PORT(inotify_events), MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE);
+}
+
+#endif
+
 // This expects to receive an already resolved port name!
 static gpio_port_t *gpio_add_port(mp_obj_t path) {
     mp_map_t *ports = &MP_STATE_PORT(ports);
@@ -395,6 +454,10 @@ static gpio_port_t *gpio_add_port(mp_obj_t path) {
     if (fd < 0) {
         mp_raise_OSError(errno);
     }
+
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    int watch_descriptor = -1;
+    #endif
 
     gpio_port_t *port;
     nlr_buf_t nlr;
@@ -417,12 +480,27 @@ static gpio_port_t *gpio_add_port(mp_obj_t path) {
         port->fd = fd;
         port->lines = info.lines;
 
+        #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+        // TODO: See if an inotify watch on the /dev entry is sufficient, otherwise
+        //       rebuild a sysfs path out of this.
+        watch_descriptor = inotify_add_watch(gpio_inotify_fd, mp_obj_str_get_str(path), IN_DELETE | IN_DELETE_SELF);
+        if (watch_descriptor < 0) {
+            mp_raise_OSError(errno);
+        }
+        port->watch_descriptor = watch_descriptor;
+        #endif
+
         slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
         assert(slot && "No slot to fill was returned on port add");
         slot->value = MP_OBJ_FROM_PTR(port);
 
         nlr_pop();
     } else {
+        #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+        if (watch_descriptor != -1) {
+            inotify_rm_watch(gpio_inotify_fd, watch_descriptor);
+        }
+        #endif
         close(fd);
 
         // Re-raise the exception.
@@ -1098,16 +1176,92 @@ done:
 }
 #endif
 
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+static void *gpio_inotify_thread(void *arg) {
+    // Keep a reference to the stop variable.
+    volatile bool *stop = (volatile bool *)arg;
+
+    for (;;) {
+        ssize_t read_count = read(gpio_inotify_fd, MP_STATE_PORT(inotify_events), MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE * sizeof(struct inotify_event));
+        if (*stop) {
+            goto done;
+        }
+
+        if (read_count < 0) {
+            // This is not correct but the code isn't in its final form yet.
+            continue;
+        }
+
+        const char *current_pointer = MP_STATE_PORT(inotify_events);
+        for (;;) {
+            const struct inotify_event *event = (const struct inotify_event *)current_pointer;
+            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            // Find which port is involved with the removal event.
+            mp_map_t *ports = &MP_STATE_PORT(ports);
+            if (ports->table != NULL) {
+                for (size_t port_index = 0; port_index < ports->alloc; port_index++) {
+                    if (!mp_map_slot_is_filled(ports, port_index)) {
+                        continue;
+                    }
+                    mp_map_elem_t slot = ports->table[port_index];
+                    gpio_port_t *port = MP_OBJ_TO_PTR(slot.value);
+                    if (port->watch_descriptor != event->wd) {
+                        continue;
+                    }
+                    // This port was removed.  Evict all pins so the last one
+                    // will deallocate the port as well.
+                    for (size_t pin = 0; pin < port->lines; pin++) {
+                        if (port->pins[pin] != MP_OBJ_NULL) {
+                            gpio_evict_pin(port->pins[pin]);
+                        }
+                    }
+                    // Remove the watch.
+                    inotify_rm_watch(gpio_inotify_fd, event->wd);
+                    break;
+                }
+            }
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
+            current_pointer += sizeof(struct inotify_event) + event->len;
+            if (((ptrdiff_t)current_pointer - (ptrdiff_t)MP_STATE_PORT(inotify_events)) >= read_count) {
+                break;
+            }
+        }
+    }
+
+done:
+    return NULL;
+}
+#endif
+
 void mp_pin_init(void) {
     mp_map_init(&MP_STATE_PORT(ports), 0);
 
     #if MICROPY_PY_GPIO_IRQ
     MP_STATE_PORT(epoll_events) = m_new(struct epoll_event, MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+    #endif
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    // The documentation suggests to align the buffer using the structure size
+    // as the alignment boundary, to improve performance.  In this case we can
+    // make the trade-off to wait a millisecond or so later to know that a
+    // GPIO port went away.  Even if something happens between the port
+    // disappearance and the inotify report, any ioctl on the port's pin file
+    // descriptors (or on the port's descriptor itself) would fail, and this
+    // should be accounted for anyway.
+    MP_STATE_PORT(inotify_events) = m_new(struct inotify_event, MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE);
+    #endif
+
+    #if MICROPY_PY_GPIO_IRQ
     gpio_epoll_init();
+    #endif
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    gpio_inotify_init();
     #endif
 }
 
 void mp_pin_deinit(void) {
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    gpio_inotify_deinit();
+    #endif
     #if MICROPY_PY_GPIO_IRQ
     gpio_epoll_deinit();
     #endif
@@ -1215,6 +1369,10 @@ MP_REGISTER_ROOT_POINTER(mp_map_t ports);
 MP_REGISTER_ROOT_POINTER(void *epoll_events);
 // Is this safe?  What happens if the GC scans mp_set_t->table?
 MP_REGISTER_ROOT_POINTER(mp_set_t epoll_pins);
+#endif
+
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+MP_REGISTER_ROOT_POINTER(void *inotify_events);
 #endif
 
 #endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -35,6 +35,9 @@
 #if MICROPY_PY_GPIO_IRQ && !MICROPY_PY_THREAD
 #error "GPIO IRQ support needs threading to work"
 #endif
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION && !MICROPY_PY_THREAD
+#error "GPIO dynamic pin allocation needs threading to work"
+#endif
 
 #include <dirent.h>
 #include <fcntl.h>
@@ -47,6 +50,10 @@
 #include <pthread.h>
 #include <signal.h>
 #include <sys/epoll.h>
+#endif
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+#include <unistd.h>
+#include <sys/inotify.h>
 #endif
 
 #include <linux/gpio.h>
@@ -84,6 +91,9 @@ typedef struct _gpio_port_t {
     mp_obj_t *pins;
     int fd;
     uint32_t lines;
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    int watch_descriptor;
+    #endif
 } gpio_port_t;
 
 #if MICROPY_PY_GPIO_IRQ
@@ -93,6 +103,16 @@ static void *gpio_epoll_thread(void *arg);
 static pthread_t gpio_epoll_thread_id = 0;
 static int gpio_epoll_fd = -1;
 static volatile bool gpio_epoll_thread_stop = false;
+
+#endif
+
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+
+static void *gpio_inotify_thread(void *arg);
+
+static pthread_t gpio_inotify_thread_id = 0;
+static int gpio_inotify_fd = -1;
+static volatile bool gpio_inotify_thread_stop = false;
 
 #endif
 
@@ -380,6 +400,45 @@ static void gpio_epoll_remove_pin(mp_obj_t pin_in) {
 
 #endif
 
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+
+static void gpio_inotify_init(void) {
+    MP_THREAD_GIL_EXIT();
+    gpio_inotify_fd = inotify_init1(IN_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (gpio_inotify_fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_create(&gpio_inotify_thread_id, NULL, &gpio_inotify_thread, (void *)&gpio_inotify_thread_stop);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static void gpio_inotify_deinit(void) {
+    gpio_inotify_thread_stop = true;
+    MP_THREAD_GIL_EXIT();
+    close(gpio_inotify_fd);
+    MP_THREAD_GIL_ENTER();
+    gpio_inotify_fd = -1;
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_cancel(gpio_inotify_thread_id);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_cancel failed to cancel the inotify thread");
+    MP_THREAD_GIL_EXIT();
+    result = pthread_join(gpio_inotify_thread_id, NULL);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_join failed to wait until the inotify exited");
+    (void)result;
+    gpio_inotify_thread_id = 0;
+    m_del(struct inotify_event, MP_STATE_PORT(inotify_events), MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE);
+}
+
+#endif
+
 // This expects to receive an already resolved port name!
 static gpio_port_t *gpio_add_port(mp_obj_t path) {
     mp_map_t *ports = &MP_STATE_PORT(ports);
@@ -395,6 +454,10 @@ static gpio_port_t *gpio_add_port(mp_obj_t path) {
     if (fd < 0) {
         mp_raise_OSError(errno);
     }
+
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    int watch_descriptor = -1;
+    #endif
 
     gpio_port_t *port;
     nlr_buf_t nlr;
@@ -417,12 +480,27 @@ static gpio_port_t *gpio_add_port(mp_obj_t path) {
         port->fd = fd;
         port->lines = info.lines;
 
+        #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+        // TODO: See if an inotify watch on the /dev entry is sufficient, otherwise
+        //       rebuild a sysfs path out of this.
+        watch_descriptor = inotify_add_watch(gpio_inotify_fd, mp_obj_str_get_str(path), IN_DELETE | IN_DELETE_SELF);
+        if (watch_descriptor < 0) {
+            mp_raise_OSError(errno);
+        }
+        port->watch_descriptor = watch_descriptor;
+        #endif
+
         slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
         assert(slot && "No slot to fill was returned on port add");
         slot->value = MP_OBJ_FROM_PTR(port);
 
         nlr_pop();
     } else {
+        #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+        if (watch_descriptor != -1) {
+            inotify_rm_watch(gpio_inotify_fd, watch_descriptor);
+        }
+        #endif
         close(fd);
 
         // Re-raise the exception.
@@ -1073,16 +1151,92 @@ done:
 }
 #endif
 
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+static void *gpio_inotify_thread(void *arg) {
+    // Keep a reference to the stop variable.
+    volatile bool *stop = (volatile bool *)arg;
+
+    for (;;) {
+        ssize_t read_count = read(gpio_inotify_fd, MP_STATE_PORT(inotify_events), MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE * sizeof(struct inotify_event));
+        if (*stop) {
+            goto done;
+        }
+
+        if (read_count < 0) {
+            // This is not correct but the code isn't in its final form yet.
+            continue;
+        }
+
+        const char *current_pointer = MP_STATE_PORT(inotify_events);
+        for (;;) {
+            const struct inotify_event *event = (const struct inotify_event *)current_pointer;
+            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            // Find which port is involved with the removal event.
+            mp_map_t *ports = &MP_STATE_PORT(ports);
+            if (ports->table != NULL) {
+                for (size_t port_index = 0; port_index < ports->alloc; port_index++) {
+                    if (!mp_map_slot_is_filled(ports, port_index)) {
+                        continue;
+                    }
+                    mp_map_elem_t slot = ports->table[port_index];
+                    gpio_port_t *port = MP_OBJ_TO_PTR(slot.value);
+                    if (port->watch_descriptor != event->wd) {
+                        continue;
+                    }
+                    // This port was removed.  Evict all pins so the last one
+                    // will deallocate the port as well.
+                    for (size_t pin = 0; pin < port->lines; pin++) {
+                        if (port->pins[pin] != MP_OBJ_NULL) {
+                            gpio_evict_pin(port->pins[pin]);
+                        }
+                    }
+                    // Remove the watch.
+                    inotify_rm_watch(gpio_inotify_fd, event->wd);
+                    break;
+                }
+            }
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
+            current_pointer += sizeof(struct inotify_event) + event->len;
+            if (((ptrdiff_t)current_pointer - (ptrdiff_t)MP_STATE_PORT(inotify_events)) >= read_count) {
+                break;
+            }
+        }
+    }
+
+done:
+    return NULL;
+}
+#endif
+
 void mp_pin_init(void) {
     mp_map_init(&MP_STATE_PORT(ports), 0);
 
     #if MICROPY_PY_GPIO_IRQ
     MP_STATE_PORT(epoll_events) = m_new(struct epoll_event, MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+    #endif
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    // The documentation suggests to align the buffer using the structure size
+    // as the alignment boundary, to improve performance.  In this case we can
+    // make the trade-off to wait a millisecond or so later to know that a
+    // GPIO port went away.  Even if something happens between the port
+    // disappearance and the inotify report, any ioctl on the port's pin file
+    // descriptors (or on the port's descriptor itself) would fail, and this
+    // should be accounted for anyway.
+    MP_STATE_PORT(inotify_events) = m_new(struct inotify_event, MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE);
+    #endif
+
+    #if MICROPY_PY_GPIO_IRQ
     gpio_epoll_init();
+    #endif
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    gpio_inotify_init();
     #endif
 }
 
 void mp_pin_deinit(void) {
+    #if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+    gpio_inotify_deinit();
+    #endif
     #if MICROPY_PY_GPIO_IRQ
     gpio_epoll_deinit();
     #endif
@@ -1185,6 +1339,10 @@ MP_REGISTER_ROOT_POINTER(mp_map_t ports);
 MP_REGISTER_ROOT_POINTER(void *epoll_events);
 // Is this safe?  What happens if the GC scans mp_set_t->table?
 MP_REGISTER_ROOT_POINTER(mp_set_t epoll_pins);
+#endif
+
+#if MICROPY_PY_GPIO_DYNAMIC_ALLOCATION
+MP_REGISTER_ROOT_POINTER(void *inotify_events);
 #endif
 
 #endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -1,0 +1,830 @@
+/*
+ * This file is part of the MicroPython project, https://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2025-2026 Alessandro Gatti
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/mphal.h"
+
+#if MICROPY_PY_GPIO
+
+#ifndef __linux__
+#error "Platform does not support GPIO access"
+#endif
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <linux/gpio.h>
+
+#include "py/gc.h"
+#include "py/misc.h"
+#include "py/mperrno.h"
+#include "py/obj.h"
+#include "py/objint.h"
+#include "py/objstr.h"
+#include "py/qstr.h"
+#include "py/runtime.h"
+
+#include "pin.h"
+
+#if MICROPY_DEBUG_VERBOSE
+#define DEBUG_PRINT (1)
+#define DEBUG_printf DEBUG_printf
+#else
+#define DEBUG_printf(...) (void)0
+#endif
+
+static const char *GPIO_DEVICES_ROOT = "/sys/bus/gpio/devices/";
+
+///////////////////////////////////////////////////////////////////////////////
+
+// TODO: Turn this into a MicroPython object and then require
+//       MICROPY_ENABLE_FINALISER?
+// TODO: Use a mp_obj_list_t for the pins and keep a reference count to know
+//       when to clean the object up?
+typedef struct _gpio_port_t {
+    mp_obj_t path;
+    mp_obj_t name;
+    mp_obj_t label;
+    mp_obj_t *pins;
+    int fd;
+    uint32_t lines;
+} gpio_port_t;
+
+static void gpio_ioctl(int fd, int call, void *payload) {
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, call, payload);
+    MP_THREAD_GIL_ENTER();
+    if (result < 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+// Thanks to the existence of symbolic links, any character device on the
+// machine can be referenced by an infinite number of names.  However,
+// character devices can still be referenced by their device identifier.  Too
+// bad a device identifier *is not unique* across devices of different classes
+// so that won't save you from errors, and sending the right ioctl to the wrong
+// device may or may not be harmful.
+//
+// Still, the "/sys/bus/gpio/devices" directory will contain the names of
+// available GPIO character devices, with each entry in there being a link to
+// another directory with text files containing more information on the target
+// device.  To keep things manageable and third party dependency free (as in,
+// not making libudev a dependency), the given port name (not the full path!)
+// is checked for existence as "/sys/bus/gpio/devices/<portname>/dev", and if
+// there's a match, then it is opened as "/dev/<portname>".  This introduces a
+// potential race condition if what is reported in procfs and what is reported
+// in devtmpfs happens to change after procfs is evaluated and before devtmpfs
+// is looked into.  Security-wise, I guess said race condition could only be
+// exploitable if an attacker can manipulate entries in both "/sys" and "/dev";
+// in that case, the game may already be lost to begin with.  Probably not much
+// can be done on our end to mitigate that.
+//
+// For more mundane security mitigations, though, characters in the port name
+// are restricted to be in the ranges "a-z", "A-Z", "0-9".  The lack of
+// slashes, tildes, and other characters should be good enough for stopping
+// unwanted directory traversals.  If it does not, then patches are welcome.
+//
+// This method for resolving character devices' effective path, despite its
+// limits, makes handling dynamic GPIO ports disconnections much easier.  An
+// inotify change watch can be placed on "/sys/bus/gpio/devices" and then the
+// ports dictionary can be updated to reflect the new devices set whenever the
+// inotify callback is invoked.
+
+static mp_obj_t resolve_gpio_device_name(mp_obj_t device) {
+    mp_obj_t name = mp_const_none;
+
+    if (mp_obj_is_int(device)) {
+        mp_int_t device_node_id = mp_obj_get_int(device);
+        // Artificially limit the number of GPIO ports to 255 for now.
+        if (device_node_id < 0 || device_node_id > 255) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid device number"));
+        }
+
+        char path[sizeof("gpiochip") + 3] = {};
+        snprintf(path, sizeof(path), "gpiochip%d", (uint8_t)device_node_id);
+        name = mp_obj_new_str_from_cstr(path);
+    }
+
+    if (mp_obj_is_str(device)) {
+        name = mp_obj_is_qstr(device) ? mp_obj_str_intern_checked(device) : device;
+    }
+
+    if (name == mp_const_none) {
+        mp_raise_TypeError(MP_ERROR_TEXT("invalid port type"));
+    }
+
+    size_t length = 0;
+    const char *raw_name = mp_obj_str_get_data(name, &length);
+    for (size_t index = 0; index < length; index++) {
+        char character = raw_name[index];
+        // "Be aware: These unichar_is* functions are actually ASCII-only!"
+        if (!unichar_isalpha(character) && !unichar_isdigit(character)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid port name"));
+        }
+    }
+
+    vstr_t port_path;
+    vstr_init(&port_path, sizeof(GPIO_DEVICES_ROOT) - 1 + length + sizeof("/dev") - 1);
+    vstr_add_str(&port_path, GPIO_DEVICES_ROOT);
+    vstr_add_strn(&port_path, raw_name, length);
+    vstr_add_str(&port_path, "/dev");
+    const char *path = vstr_null_terminated_str(&port_path);
+
+    MP_THREAD_GIL_EXIT();
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return mp_const_none;
+    }
+    MP_THREAD_GIL_EXIT();
+    close(fd);
+    MP_THREAD_GIL_ENTER();
+
+    vstr_init(&port_path, sizeof("/dev/") - 1 + length);
+    vstr_add_str(&port_path, "/dev/");
+    vstr_add_strn(&port_path, raw_name, length);
+    path = vstr_null_terminated_str(&port_path);
+
+    MP_THREAD_GIL_EXIT();
+    fd = open(path, O_RDWR | O_CLOEXEC);
+    close(fd);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return mp_const_none;
+    }
+
+    // Probably duplication is not needed...
+    return mp_obj_new_str_from_cstr(path);
+}
+
+// This expects to receive an already resolved port name!
+static gpio_port_t *gpio_add_port(mp_obj_t path) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    assert(ports && "Ports dictionary must not be NULL");
+    mp_map_elem_t *slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP);
+    if (slot) {
+        return (gpio_port_t *)MP_OBJ_TO_PTR(slot->value);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    mp_int_t fd = open(mp_obj_str_get_str(path), O_RDWR | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    gpio_port_t *port;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        struct gpiochip_info info;
+        memset(&info, 0x00, sizeof(info));
+        gpio_ioctl(fd, GPIO_GET_CHIPINFO_IOCTL, &info);
+
+        mp_obj_t *pins = NULL;
+        if (info.lines > 0) {
+            MP_STATIC_ASSERT(MP_OBJ_NULL == 0);
+            pins = m_new0(mp_obj_t, info.lines);
+        }
+
+        port = m_new(gpio_port_t, 1);
+        port->path = path;
+        port->name = mp_obj_new_str_from_cstr(info.name);
+        port->label = mp_obj_new_str_from_cstr(info.label);
+        port->pins = pins;
+        port->fd = fd;
+        port->lines = info.lines;
+
+        slot = mp_map_lookup(ports, path, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+        assert(slot && "No slot to fill was returned on port add");
+        slot->value = MP_OBJ_FROM_PTR(port);
+
+        nlr_pop();
+    } else {
+        close(fd);
+
+        // Re-raise the exception.
+        nlr_jump(nlr.ret_val);
+    }
+
+    return port;
+}
+
+// This expects to receive an already resolved port name!
+static mp_obj_t gpio_find_pin(mp_obj_t port_key, uint32_t pin) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    mp_map_elem_t *slot = mp_map_lookup(ports, port_key, MP_MAP_LOOKUP);
+    if (!slot || slot->value == MP_OBJ_NULL) {
+        return MP_OBJ_NULL;
+    }
+    gpio_port_t *port = (gpio_port_t *)MP_OBJ_TO_PTR(slot->value);
+    if (pin >= port->lines) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+    return port->pins[pin];
+}
+
+static void gpio_evict_pin(mp_obj_t pin_in) {
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    mp_map_elem_t *slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP);
+    if (!slot) {
+        // The port this pin belongs to may have already been evicted during
+        // GPIO support deinitialisation or by a pin object finaliser.
+        return;
+    }
+
+    gpio_port_t *port = MP_OBJ_TO_PTR(slot->value);
+    assert((port == (gpio_port_t *)MP_OBJ_TO_PTR(pin->port)) && "Pin and port went out of sync");
+    assert((pin->number < port->lines) && "Pin and port went out of sync");
+    assert(port->pins[pin->number] == pin_in && "Pin objects mismatch");
+    port->pins[pin->number] = MP_OBJ_NULL;
+
+    bool empty_port = true;
+    for (size_t index = 0; index < port->lines; index++) {
+        if (port->pins[index] != MP_OBJ_NULL) {
+            empty_port = false;
+            break;
+        }
+    }
+
+    if (!empty_port) {
+        return;
+    }
+
+    slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+    assert(slot && "Port disappeared from map");
+    MP_THREAD_GIL_EXIT();
+    close(port->fd);
+    MP_THREAD_GIL_ENTER();
+    port->fd = -1;
+    m_del(mp_obj_t, port->pins, port->lines);
+    slot->value = MP_OBJ_NULL;
+    m_del(gpio_port_t, port, 1);
+}
+
+static uint32_t gpio_get_pin_number(mp_obj_t number_in) {
+    assert(mp_obj_is_int(number_in) && "Invalid pin number type");
+
+    uint32_t number = 0;
+
+    // If mp_obj_int_to_bytes would signal whether the number was truncated or
+    // not, this NLR shouldn't be needed.  For this case a more appropriate
+    // error message is required rather than "integer out of range".
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_obj_int_to_bytes(number_in, sizeof(uint32_t), (byte *)&number,
+            #if MP_ENDIANNESS_BIG
+            true,
+            #else
+            false,
+            #endif
+            false, true);
+        nlr_pop();
+    } else {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+
+    return number;
+}
+
+static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value) {
+    assert(config && "GPIO config structrure must not be NULL");
+
+    memset(config, 0x00, sizeof(struct gpio_v2_line_config));
+
+    // Checks for mode and pull could be made simpler by just checking whether
+    // the value bit is in the combined OR of all valid options, and then use
+    // the value directly.  Initialisation will fail anyway but you won't know
+    // why, so we have to do this instead.
+
+    if (mode != mp_const_none) {
+        mp_int_t pin_mode = mp_obj_get_int(mode);
+        if ((pin_mode & ~(GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT | GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        if ((pin_mode & (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) == (GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_OUTPUT)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        if ((pin_mode & (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) == (GPIO_V2_LINE_FLAG_OPEN_DRAIN | GPIO_V2_LINE_FLAG_OPEN_SOURCE)) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+        config->flags |= pin_mode;
+    }
+
+    if (pull != MP_OBJ_NEW_SMALL_INT(-1)) {
+        MP_STATIC_ASSERT((GPIO_V2_LINE_FLAG_BIAS_DISABLED & (GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) == 0);
+        mp_int_t pull_mode = mp_obj_get_int(pull);
+        if ((pull_mode & ~(GPIO_V2_LINE_FLAG_BIAS_DISABLED | GPIO_V2_LINE_FLAG_BIAS_PULL_UP | GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
+        }
+        if (mp_popcount(pull_mode) > 1) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pull mode"));
+        }
+        config->flags |= pull_mode;
+    }
+
+    if (value != MP_OBJ_NULL) {
+        config->num_attrs = 1;
+        config->attrs[0].attr.id = GPIO_V2_LINE_ATTR_ID_OUTPUT_VALUES;
+        config->attrs[0].attr.values = (mp_obj_is_true(value) ? 1U : 0U);
+        config->attrs[0].mask = 1U;
+    }
+}
+
+static int gpio_set_state_inner(int fd, mp_int_t state) {
+    struct gpio_v2_line_values values;
+    memset(&values, 0x00, sizeof(values));
+    values.mask = 1U;
+    values.bits = state != 0 ? 1U : 0U;
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &values);
+    MP_THREAD_GIL_ENTER();
+    return result;
+}
+
+static int gpio_get_state_inner(int fd, mp_int_t *state) {
+    assert(state && "GPIO state value pointer cannot be NULL");
+
+    struct gpio_v2_line_values values;
+    memset(&values, 0x00, sizeof(values));
+    values.mask = 1U;
+    values.bits = 1U;
+    MP_THREAD_GIL_EXIT();
+    int result = ioctl(fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values);
+    MP_THREAD_GIL_ENTER();
+    if (result >= 0) {
+        *state = (values.bits & 1U) ? 1 : 0;
+    }
+    return result;
+}
+
+static void gpio_set_state(mp_obj_t self_in, mp_int_t state) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (gpio_set_state_inner(self->fd, state) < 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static bool gpio_get_state(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    mp_int_t state;
+    if (gpio_get_state_inner(self->fd, &state) < 0) {
+        mp_raise_OSError(errno);
+    }
+    return !!state;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_mode, ARG_pull, ARG_value, ARG_port, ARG_consumer };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_mode,                      MP_ARG_OBJ, { .u_obj = mp_const_none                        }},
+        { MP_QSTR_pull,                      MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(-1)             }},
+        { MP_QSTR_value,    MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NULL                          }},
+        { MP_QSTR_port,     MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(0)              }},
+        { MP_QSTR_consumer, MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_MicroPython) }},
+    };
+
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    struct gpio_v2_line_config config;
+    gpio_fill_line_config_struct(&config, pin_number, args[ARG_mode].u_obj, args[ARG_pull].u_obj, args[ARG_value].u_obj);
+
+    mp_obj_t port_path = resolve_gpio_device_name(args[ARG_port].u_obj);
+    if (port_path == mp_const_none) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid port name"));
+    }
+
+    mp_obj_t existing_pin = gpio_find_pin(port_path, pin_number);
+    if (existing_pin != MP_OBJ_NULL) {
+        machine_pin_obj_t *pin = MP_OBJ_TO_PTR(existing_pin);
+
+        // Reconfigure the pin with the new parameters.
+        if (pin->fd >= 0) {
+            gpio_ioctl(pin->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
+            return existing_pin;
+        }
+
+        gpio_evict_pin(existing_pin);
+    }
+
+    if (!mp_obj_is_str(args[ARG_consumer].u_obj)) {
+        mp_raise_TypeError(MP_ERROR_TEXT("invalid consumer"));
+    }
+    const char *consumer;
+    size_t consumer_length;
+    if (mp_obj_is_qstr(args[ARG_consumer].u_obj)) {
+        consumer = (const char *)qstr_data(MP_OBJ_QSTR_VALUE(args[ARG_consumer].u_obj), &consumer_length);
+    } else {
+        consumer = mp_obj_str_get_data(args[ARG_consumer].u_obj, &consumer_length);
+    }
+    if (consumer_length >= GPIO_MAX_NAME_SIZE) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid consumer"));
+    }
+
+    // If the port is already known then it will just return the old instance.
+    gpio_port_t *port = gpio_add_port(port_path);
+
+    if (pin_number >= port->lines) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid pin number"));
+    }
+
+    struct gpio_v2_line_request request;
+    memset(&request, 0x00, sizeof(request));
+    request.offsets[0] = pin_number;
+    request.config = config;
+    request.num_lines = 1;
+    strcpy(request.consumer, consumer);
+
+    gpio_ioctl(port->fd, GPIO_V2_GET_LINE_IOCTL, &request);
+
+    mp_obj_t self_out;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        machine_pin_obj_t *self = mp_obj_malloc_with_finaliser(machine_pin_obj_t, &machine_pin_type);
+        self->port = MP_OBJ_FROM_PTR(port);
+        self->number = pin_number;
+        self->fd = request.fd;
+
+        self_out = MP_OBJ_FROM_PTR(self);
+
+        if (port->pins[pin_number] != MP_OBJ_NULL) {
+            machine_pin_obj_t *old_self = MP_OBJ_TO_PTR(port->pins[pin_number]);
+            gpio_evict_pin(port->pins[pin_number]);
+            port->pins[pin_number] = MP_OBJ_NULL;
+            MP_THREAD_GIL_EXIT();
+            close(old_self->fd);
+            MP_THREAD_GIL_ENTER();
+        }
+        port->pins[pin_number] = self_out;
+
+        nlr_pop();
+    } else {
+        MP_THREAD_GIL_EXIT();
+        close(request.fd);
+        MP_THREAD_GIL_ENTER();
+
+        nlr_jump(nlr.ret_val);
+    }
+
+    return self_out;
+}
+
+mp_obj_t mp_pin_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 1, MP_OBJ_FUN_ARGS_MAX, true);
+
+    if (mp_obj_is_type(args[0], &machine_pin_type)) {
+        return args[0];
+    }
+
+    if (mp_obj_is_int(args[0])) {
+        uint32_t number = gpio_get_pin_number(args[0]);
+        mp_map_t kw_args;
+        mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
+        return init_helper(number, n_args - 1, args + 1, &kw_args);
+    }
+
+    mp_raise_TypeError(MP_ERROR_TEXT("invalid pin type"));
+}
+
+static void machine_pin_obj_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+    (void)kind;
+    const machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    const gpio_port_t *port = MP_OBJ_TO_PTR(self->port);
+    mp_printf(print, "Pin(%s, %d)", mp_obj_str_get_str(port->name), self->number);
+}
+
+static mp_obj_t machine_pin_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+    mp_arg_check_num(n_args, n_kw, 0, 1, false);
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    if (n_args == 0) {
+        return MP_OBJ_NEW_SMALL_INT(gpio_get_state(self));
+    }
+    gpio_set_state(self, mp_obj_is_true(args[0]));
+    return mp_const_none;
+}
+
+static mp_uint_t pin_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+
+    if (self->fd < 0) {
+        if (errcode != NULL) {
+            *errcode = MP_EPIPE;
+        }
+        return -1;
+    }
+
+    switch (request) {
+        case MP_PIN_READ: {
+            mp_int_t state = 0;
+            int result = gpio_get_state_inner(self->fd, &state);
+            if (errcode != NULL) {
+                *errcode = result < 0 ? result : 0;
+            }
+            return result < 0 ? -1 : state;
+        }
+
+        case MP_PIN_WRITE: {
+            int result = gpio_set_state_inner(self->fd, arg != 0 ? 1 : 0);
+            if (errcode != NULL) {
+                *errcode = result;
+            }
+            return result < 0 ? -1 : 0;
+        }
+
+        default:
+            return -1;
+    }
+}
+
+static mp_obj_t machine_pin_off(mp_obj_t self_in) {
+    gpio_set_state(self_in, 0);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_off_obj, machine_pin_off);
+
+static mp_obj_t machine_pin_on(mp_obj_t self_in) {
+    gpio_set_state(self_in, 1);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_on_obj, machine_pin_on);
+
+static mp_obj_t machine_pin_toggle(mp_obj_t self_in) {
+    gpio_set_state(self_in, gpio_get_state(self_in) ? 0 : 1);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
+
+mp_obj_t machine_pin_del(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    MP_THREAD_GIL_EXIT();
+    close(self->fd);
+    MP_THREAD_GIL_ENTER();
+    self->fd = -1;
+    gpio_evict_pin(self_in);
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_del_obj, machine_pin_del);
+
+static mp_obj_t machine_pin_init(size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
+    return init_helper(gpio_get_pin_number(args[0]), n_args - 1, args + 1, kw_args);
+}
+MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_init_obj, 1, machine_pin_init);
+
+static mp_obj_t machine_pin_available(mp_obj_t self_in) {
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    return mp_obj_new_bool(self->fd != -1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_available_obj, machine_pin_available);
+
+mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
+    return machine_pin_call(args[0], n_args - 1, 0, args + 1);
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
+
+static mp_obj_tuple_t *gpio_port_enumerate_lines(mp_obj_t port_name) {
+    assert(port_name && "Port name is NULL");
+
+    mp_obj_t device_name = resolve_gpio_device_name(port_name);
+    if (device_name == mp_const_none) {
+        return MP_OBJ_NULL;
+    }
+
+    int fd;
+    MP_THREAD_GIL_EXIT();
+    fd = open(mp_obj_str_get_str(device_name), O_RDWR | O_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (fd < 0) {
+        return MP_OBJ_NULL;
+    }
+
+    mp_obj_tuple_t *port = mp_obj_new_tuple(2, NULL);
+    bool success = true;
+    uint32_t lines = 0;
+
+    {
+        struct gpiochip_info chip_info;
+        memset(&chip_info, 0x00, sizeof(chip_info));
+        MP_THREAD_GIL_EXIT();
+        int result = ioctl(fd, GPIO_GET_CHIPINFO_IOCTL, &chip_info);
+        MP_THREAD_GIL_ENTER();
+        if (result < 0) {
+            success = false;
+            goto done;
+        }
+        lines = chip_info.lines;
+    }
+
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        mp_obj_tuple_t *pins = MP_OBJ_TO_PTR(mp_obj_new_tuple((size_t)lines, NULL));
+        struct gpio_v2_line_info line_info;
+        // name, consumer, available
+        mp_obj_t line_objects[3] = {};
+        for (uint32_t index = 0; index < lines; index++) {
+            memset((void *)&line_info, 0x00, sizeof(line_info));
+            line_info.offset = index;
+            gpio_ioctl(fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+            // If a pin is unnamed or is not yet claimed, then `.name` and
+            // `.consumer` will be empty, and there's no real need to create
+            // object copies when they can just be a reference to MP_QSTR_
+            // instead - that saves some memory.
+            line_objects[0] = line_info.name[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.name) : MP_OBJ_NEW_QSTR(MP_QSTR_);
+            line_objects[1] = line_info.consumer[0] != '\0' ? mp_obj_new_str_from_cstr(line_info.consumer) : MP_OBJ_NEW_QSTR(MP_QSTR_);
+            line_objects[2] = mp_obj_new_bool((line_info.flags & GPIO_V2_LINE_FLAG_USED) == 0);
+            pins->items[index] = mp_obj_new_tuple(3, (const void *)&line_objects);
+        }
+        port->items[0] = port_name;
+        port->items[1] = MP_OBJ_FROM_PTR(pins);
+
+        nlr_pop();
+    } else {
+        success = false;
+    }
+
+done:
+    close(fd);
+
+    return success ? port : MP_OBJ_NULL;
+}
+
+// TODO: Implement this in Python and let it call gpio_port_enumerate_lines
+//       through a wrapper?
+static mp_obj_t machine_pin_enumerate(void) {
+    DIR *devices_directory = NULL;
+
+    MP_THREAD_GIL_EXIT();
+    devices_directory = opendir(GPIO_DEVICES_ROOT);
+    MP_THREAD_GIL_ENTER();
+    if (!devices_directory) {
+        if (errno == ENOENT) {
+            // GPIO support is not enabled in the running kernel?
+            return mp_obj_new_tuple(0, NULL);
+        } else {
+            mp_raise_OSError(errno);
+        }
+    }
+
+    bool failed = false;
+    mp_obj_t ports = mp_obj_new_list(0, NULL);
+    struct dirent *device_entry = NULL;
+    do {
+        errno = 0;
+        MP_THREAD_GIL_EXIT();
+        device_entry = readdir(devices_directory);
+        MP_THREAD_GIL_ENTER();
+        if (device_entry == NULL) {
+            failed = errno != 0;
+            break;
+        }
+        const char *name = device_entry->d_name;
+        char *end = NULL;
+        if (memcmp(name, "gpiochip", sizeof("gpiochip") - 1) == 0) {
+            name += sizeof("gpiochip") - 1;
+            long index = strtol(name, &end, 10);
+            if ((index == LONG_MIN || index == LONG_MAX) && errno == ERANGE) {
+                continue;
+            }
+            if (*end != '\0') {
+                continue;
+            }
+            mp_obj_t port = gpio_port_enumerate_lines(mp_obj_new_str_from_cstr(device_entry->d_name));
+            if (port != MP_OBJ_NULL) {
+                mp_obj_list_append(ports, MP_OBJ_FROM_PTR(port));
+            }
+        }
+    } while (device_entry != NULL);
+
+    closedir(devices_directory);
+    if (failed) {
+        mp_raise_OSError(errno);
+    }
+
+    // TODO: Is there a better way to achieve this?
+    return mp_obj_new_tuple(((mp_obj_list_t *)MP_OBJ_TO_PTR(ports))->len, ((mp_obj_list_t *)MP_OBJ_TO_PTR(ports))->items);
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(machine_pin_enumerate_obj, machine_pin_enumerate);
+
+///////////////////////////////////////////////////////////////////////////////
+
+void mp_pin_init(void) {
+    mp_map_init(&MP_STATE_PORT(ports), 0);
+}
+
+void mp_pin_deinit(void) {
+    mp_map_t *ports = &MP_STATE_PORT(ports);
+    if (ports->table == NULL) {
+        return;
+    }
+
+    for (size_t port_index = 0; port_index < ports->alloc; port_index++) {
+        if (!mp_map_slot_is_filled(ports, port_index)) {
+            continue;
+        }
+
+        mp_map_elem_t slot = ports->table[port_index];
+        gpio_port_t *port = MP_OBJ_TO_PTR(slot.value);
+        close(port->fd);
+        if (port->lines > 0) {
+            for (size_t pin = 0; pin < port->lines; pin++) {
+                if (port->pins[pin] != MP_OBJ_NULL) {
+                    machine_pin_del(port->pins[pin]);
+                    port->pins[pin] = MP_OBJ_NULL;
+                }
+            }
+            m_del(mp_obj_t, port->pins, port->lines);
+            port->pins = NULL;
+        }
+        assert(port->pins == NULL && "GPIO port count went out of sync");
+        m_del_obj(gpio_port_t, port);
+        slot.value = MP_OBJ_NULL;
+    }
+    mp_map_clear(ports);
+
+    // Root pointers will be freed by the OS after this point.  For the Unix
+    // port, once the main interpreter loop exits there's no recovery unlike
+    // on QEMU or other microcontroller-based ports where the board would just
+    // reboot and restart things up.
+}
+
+static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
+    // instance methods
+
+    { MP_ROM_QSTR(MP_QSTR___del__),     MP_ROM_PTR(&machine_pin_del_obj)             },
+
+    { MP_ROM_QSTR(MP_QSTR_init),        MP_ROM_PTR(&machine_pin_init_obj)            },
+
+    { MP_ROM_QSTR(MP_QSTR_value),       MP_ROM_PTR(&machine_pin_value_obj)           },
+    { MP_ROM_QSTR(MP_QSTR_off),         MP_ROM_PTR(&machine_pin_off_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)              },
+    { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)          },
+
+    { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)             },
+    { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj)       },
+    { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)                 },
+    { MP_ROM_QSTR(MP_QSTR___exit__),    MP_ROM_PTR(&machine_pin_del_obj)             },
+
+    { MP_ROM_QSTR(MP_QSTR_enumerate),   MP_ROM_PTR(&machine_pin_enumerate_obj)       },
+
+    // class constants
+
+    { MP_ROM_QSTR(MP_QSTR_IN),          MP_ROM_INT(GPIO_V2_LINE_FLAG_INPUT)          },
+    { MP_ROM_QSTR(MP_QSTR_OUT),         MP_ROM_INT(GPIO_V2_LINE_FLAG_OUTPUT)         },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_DRAIN),  MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_DRAIN)     },
+    { MP_ROM_QSTR(MP_QSTR_OPEN_SOURCE), MP_ROM_INT(GPIO_V2_LINE_FLAG_OPEN_SOURCE)    },
+    { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_UP)   },
+    { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN) },
+    { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_DISABLED)  },
+};
+
+static MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
+
+static const mp_pin_p_t machine_pin_obj_protocol = {
+    .ioctl = pin_ioctl,
+};
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    machine_pin_type,
+    MP_QSTR_Pin,
+    MP_TYPE_FLAG_NONE,
+    make_new, mp_pin_make_new,
+    print, machine_pin_obj_print,
+    call, machine_pin_call,
+    protocol, &machine_pin_obj_protocol,
+    locals_dict, &machine_pin_locals_dict
+    );
+
+// Is this safe?  What happens if the GC scans mp_map_t->table?
+MP_REGISTER_ROOT_POINTER(mp_map_t ports);
+
+#endif

--- a/ports/unix/machine_pin.c
+++ b/ports/unix/machine_pin.c
@@ -32,12 +32,22 @@
 #error "Platform does not support GPIO access"
 #endif
 
+#if MICROPY_PY_GPIO_IRQ && !MICROPY_PY_THREAD
+#error "GPIO IRQ support needs threading to work"
+#endif
+
 #include <dirent.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#if MICROPY_PY_GPIO_IRQ
+#include <pthread.h>
+#include <signal.h>
+#include <sys/epoll.h>
+#endif
 
 #include <linux/gpio.h>
 
@@ -75,6 +85,16 @@ typedef struct _gpio_port_t {
     int fd;
     uint32_t lines;
 } gpio_port_t;
+
+#if MICROPY_PY_GPIO_IRQ
+
+static void *gpio_epoll_thread(void *arg);
+
+static pthread_t gpio_epoll_thread_id = 0;
+static int gpio_epoll_fd = -1;
+static volatile bool gpio_epoll_thread_stop = false;
+
+#endif
 
 static void gpio_ioctl(int fd, int call, void *payload) {
     MP_THREAD_GIL_EXIT();
@@ -184,6 +204,182 @@ static mp_obj_t resolve_gpio_device_name(mp_obj_t device) {
     return mp_obj_new_str_from_cstr(path);
 }
 
+#if MICROPY_PY_GPIO_IRQ
+
+static void gpio_epoll_init(void) {
+    mp_set_init(&MP_STATE_PORT(epoll_pins), 0);
+
+    MP_THREAD_GIL_EXIT();
+    gpio_epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    MP_THREAD_GIL_ENTER();
+    if (gpio_epoll_fd < 0) {
+        mp_raise_OSError(errno);
+    }
+
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_create(&gpio_epoll_thread_id, NULL, &gpio_epoll_thread, (void *)&gpio_epoll_thread_stop);
+    MP_THREAD_GIL_ENTER();
+    if (result != 0) {
+        mp_raise_OSError(errno);
+    }
+}
+
+static void gpio_epoll_deinit(void) {
+    gpio_epoll_thread_stop = true;
+    MP_THREAD_GIL_EXIT();
+    close(gpio_epoll_fd);
+    MP_THREAD_GIL_ENTER();
+    gpio_epoll_fd = -1;
+    MP_THREAD_GIL_EXIT();
+    int result = pthread_cancel(gpio_epoll_thread_id);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_cancel failed to cancel the epoll thread");
+    MP_THREAD_GIL_EXIT();
+    result = pthread_join(gpio_epoll_thread_id, NULL);
+    MP_THREAD_GIL_ENTER();
+    assert(result >= 0 && "pthread_join failed to wait until the epoll thread exited");
+    (void)result;
+    gpio_epoll_thread_id = 0;
+    // The pins set can be safely cleared without being in a critical section.
+    mp_set_clear(&MP_STATE_PORT(epoll_pins));
+    m_del(struct epoll_event, MP_STATE_PORT(epoll_events), MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+}
+
+// epoll() descriptor set management functions.
+
+static void gpio_epoll_undo_addition(void *pin) {
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+    mp_obj_t removed_object = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(pin), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+    assert(removed_object != MP_OBJ_NULL && "Nothing to undo?");
+    (void)removed_object;
+}
+
+static void gpio_epoll_add_pin(mp_obj_t pin_in) {
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+
+    assert((pin->fd >= 0) && "Adding a pin with an invalid descriptor to the epoll list");
+
+    memset(&pin->event, 0x00, sizeof(struct epoll_event));
+    // Only report edge-trigger epoll events: we just need to know that the pin
+    // file descriptor has some incoming data, a.k.a. a line change event
+    // structure was written to the descriptor.
+    //
+    // TODO: Make EPOLLWAKEUP optional, but it requires a new keyword argument
+    //       in machine.Pin.irq.
+    pin->event.events = EPOLLIN | EPOLLET | EPOLLWAKEUP;
+    pin->event.data.ptr = pin;
+
+    mp_set_t *epoll_pins = &MP_STATE_PORT(epoll_pins);
+
+    int result = 0;
+    bool raise_exception = false;
+    nlr_buf_t nlr;
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+
+    // There's no direct way to just query a set whether an element is stored
+    // in there or not, so we traverse the items table instead.
+
+    bool element_already_added = false;
+
+    for (size_t index = 0; index < epoll_pins->alloc; index++) {
+        mp_obj_t element = epoll_pins->table[index];
+        if (element == pin_in) {
+            element_already_added = true;
+            break;
+        }
+    }
+
+    assert((!element_already_added || (element_already_added && (pin->event.events != 0 && pin->event.data.ptr != 0))) && "epoll set went out of sync");
+
+    if (!element_already_added) {
+        // Adding the file descriptor to an epoll group descriptor may fail,
+        // and if it does then we have to clean up the epoll pins set.
+        // Updating the set may also incur on a faillible memory reallocation
+        // too.  It's easier to undo a set addition rather than dealing with
+        // epoll once more.
+        //
+        // TODO: is NLR safe to use if enclosed inside a critical section?
+
+        if (nlr_push(&nlr) == 0) {
+            // mp_set_lookup may raise from mp_set_rehash on low memory.
+            mp_set_lookup(epoll_pins, pin_in, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+            MP_THREAD_GIL_EXIT();
+            result = epoll_ctl(gpio_epoll_fd, EPOLL_CTL_ADD, pin->fd, &pin->event);
+            MP_THREAD_GIL_ENTER();
+            nlr_pop();
+            if (result < 0) {
+                gpio_epoll_undo_addition(pin);
+            }
+        } else {
+            gpio_epoll_undo_addition(pin);
+            raise_exception = true;
+        }
+    }
+
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    // Move back to the previous inner if-then-else if NLRs are safe.
+    if (raise_exception) {
+        nlr_jump(nlr.ret_val);
+    }
+
+    if (result < 0) {
+        mp_raise_OSError(-result);
+    }
+}
+
+static void gpio_epoll_remove_pin(mp_obj_t pin_in) {
+    // This may be invoked during GPIO subsystem deinitialisation, so if the
+    // epoll thread should stop leave things alone (the group descriptor is
+    // probably already closed by now).
+    if (gpio_epoll_thread_stop) {
+        return;
+    }
+
+    machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
+
+    assert((pin->fd >= 0) && "Removing a pin with an invalid descriptor from the epoll group");
+    memset(&pin->event, 0x00, sizeof(struct epoll_event));
+
+    int result = 0;
+    bool element_found = false;
+    mp_set_t *epoll_pins = &MP_STATE_PORT(epoll_pins);
+    mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+
+    for (size_t index = 0; index < epoll_pins->alloc; index++) {
+        mp_obj_t element = epoll_pins->table[index];
+        if (element == pin_in) {
+            element_found = true;
+            break;
+        }
+    }
+
+    if (element_found) {
+        // Removing an item from a set will always succeed, so the only check here
+        // is whether the removal of the pin's file descriptor from the epoll
+        // descriptors group succeeded or not.
+
+        MP_THREAD_GIL_EXIT();
+        result = epoll_ctl(gpio_epoll_fd, EPOLL_CTL_DEL, pin->fd, NULL);
+        MP_THREAD_GIL_ENTER();
+        if (result >= 0) {
+            mp_obj_t removed_object = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(pin), MP_MAP_LOOKUP_REMOVE_IF_FOUND);
+            pin->callback = mp_const_none;
+            assert(removed_object != MP_OBJ_NULL && "Pin descriptor not found in epoll group");
+            (void)removed_object;
+        }
+    }
+
+    MICROPY_END_ATOMIC_SECTION(atomic_state);
+
+    if (result < 0) {
+        mp_raise_OSError(-result);
+    }
+}
+
+#endif
+
 // This expects to receive an already resolved port name!
 static gpio_port_t *gpio_add_port(mp_obj_t path) {
     mp_map_t *ports = &MP_STATE_PORT(ports);
@@ -251,6 +447,10 @@ static mp_obj_t gpio_find_pin(mp_obj_t port_key, uint32_t pin) {
 }
 
 static void gpio_evict_pin(mp_obj_t pin_in) {
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_remove_pin(pin_in);
+    #endif
+
     machine_pin_obj_t *pin = MP_OBJ_TO_PTR(pin_in);
     mp_map_t *ports = &MP_STATE_PORT(ports);
     mp_map_elem_t *slot = mp_map_lookup(ports, pin->port, MP_MAP_LOOKUP);
@@ -315,7 +515,7 @@ static uint32_t gpio_get_pin_number(mp_obj_t number_in) {
     return number;
 }
 
-static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value) {
+static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uint32_t pin, mp_obj_t mode, mp_obj_t pull, mp_obj_t value, mp_obj_t clock) {
     assert(config && "GPIO config structrure must not be NULL");
 
     memset(config, 0x00, sizeof(struct gpio_v2_line_config));
@@ -357,6 +557,21 @@ static void gpio_fill_line_config_struct(struct gpio_v2_line_config *config, uin
         config->attrs[0].attr.values = (mp_obj_is_true(value) ? 1U : 0U);
         config->attrs[0].mask = 1U;
     }
+
+    #if MICROPY_PY_GPIO_IRQ_TIMESTAMP
+    if (clock != MP_OBJ_NEW_SMALL_INT(0)) {
+        mp_int_t clock_mode = mp_obj_get_int(clock);
+        if ((clock_mode & ~(GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME | GPIO_V2_LINE_FLAG_EVENT_CLOCK_HTE)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid clock mode"));
+        }
+        if (mp_popcount(clock_mode) > 1) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid clock mode"));
+        }
+        config->flags |= clock_mode;
+    }
+    #else
+    (void)clock;
+    #endif
 }
 
 static int gpio_set_state_inner(int fd, mp_int_t state) {
@@ -405,20 +620,21 @@ static bool gpio_get_state(mp_obj_t self_in) {
 ///////////////////////////////////////////////////////////////////////////////
 
 static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
-    enum { ARG_mode, ARG_pull, ARG_value, ARG_port, ARG_consumer };
+    enum { ARG_mode, ARG_pull, ARG_value, ARG_port, ARG_consumer, ARG_clock };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mode,                      MP_ARG_OBJ, { .u_obj = mp_const_none                        }},
         { MP_QSTR_pull,                      MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(-1)             }},
         { MP_QSTR_value,    MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NULL                          }},
         { MP_QSTR_port,     MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(0)              }},
         { MP_QSTR_consumer, MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_QSTR(MP_QSTR_MicroPython) }},
+        { MP_QSTR_clock,    MP_ARG_KW_ONLY | MP_ARG_OBJ, { .u_obj = MP_OBJ_NEW_SMALL_INT(0)              }},
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     struct gpio_v2_line_config config;
-    gpio_fill_line_config_struct(&config, pin_number, args[ARG_mode].u_obj, args[ARG_pull].u_obj, args[ARG_value].u_obj);
+    gpio_fill_line_config_struct(&config, pin_number, args[ARG_mode].u_obj, args[ARG_pull].u_obj, args[ARG_value].u_obj, args[ARG_clock].u_obj);
 
     mp_obj_t port_path = resolve_gpio_device_name(args[ARG_port].u_obj);
     if (port_path == mp_const_none) {
@@ -430,6 +646,8 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         machine_pin_obj_t *pin = MP_OBJ_TO_PTR(existing_pin);
 
         // Reconfigure the pin with the new parameters.
+        // WARNING: If an IRQ callback was attached before this point, it will
+        //          stay bound to the pin instance.
         if (pin->fd >= 0) {
             gpio_ioctl(pin->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &config);
             return existing_pin;
@@ -475,6 +693,14 @@ static mp_obj_t init_helper(uint32_t pin_number, size_t n_args, const mp_obj_t *
         self->port = MP_OBJ_FROM_PTR(port);
         self->number = pin_number;
         self->fd = request.fd;
+
+        #if MICROPY_PY_GPIO_IRQ
+        self->callback = mp_const_none;
+        memset(&self->event, 0x00, sizeof(struct epoll_event));
+        #if MICROPY_PY_GPIO_IRQ_TIMESTAMP
+        self->last_timestamp = 0;
+        #endif
+        #endif
 
         self_out = MP_OBJ_FROM_PTR(self);
 
@@ -587,6 +813,9 @@ static MP_DEFINE_CONST_FUN_OBJ_1(machine_pin_toggle_obj, machine_pin_toggle);
 
 mp_obj_t machine_pin_del(mp_obj_t self_in) {
     machine_pin_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_remove_pin(self_in);
+    #endif
     MP_THREAD_GIL_EXIT();
     close(self->fd);
     MP_THREAD_GIL_ENTER();
@@ -611,6 +840,76 @@ mp_obj_t machine_pin_value(size_t n_args, const mp_obj_t *args) {
     return machine_pin_call(args[0], n_args - 1, 0, args + 1);
 }
 static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(machine_pin_value_obj, 1, 2, machine_pin_value);
+
+#if MICROPY_PY_GPIO_IRQ
+
+static mp_obj_t machine_pin_irq(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_handler, ARG_trigger, ARG_hard };
+
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_handler, MP_ARG_OBJ,  { .u_obj = mp_const_none                                                  } },
+        { MP_QSTR_trigger, MP_ARG_INT,  { .u_int = GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING } },
+        { MP_QSTR_hard,    MP_ARG_BOOL, { .u_bool = false                                                         } },
+    };
+
+    machine_pin_obj_t *self = MP_OBJ_TO_PTR(pos_args[0]);
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 1, pos_args + 1, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+
+    if (n_args > 1 || kw_args->used != 0) {
+        mp_uint_t trigger = args[ARG_trigger].u_int;
+        if ((trigger & ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING)) != 0) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid trigger"));
+        }
+
+        struct gpio_v2_line_info line_info;
+        memset(&line_info, 0x00, sizeof(line_info));
+        line_info.offset = self->number;
+        gpio_port_t *port = MP_OBJ_TO_PTR(self->port);
+        assert(port && "GPIO port has gone away");
+        gpio_ioctl(port->fd, GPIO_V2_GET_LINEINFO_IOCTL, &line_info);
+
+        if (line_info.flags & GPIO_V2_LINE_FLAG_OUTPUT) {
+            mp_raise_ValueError(MP_ERROR_TEXT("invalid pin mode"));
+        }
+
+        // Pin.irq(callback) should still use the previous trigger mask.
+        if (args[ARG_handler].u_obj == mp_const_none || trigger != 0) {
+            line_info.flags &= ~(GPIO_V2_LINE_FLAG_EDGE_RISING | GPIO_V2_LINE_FLAG_EDGE_FALLING);
+        }
+        line_info.flags &= ~GPIO_V2_LINE_FLAG_USED;
+
+        gpio_epoll_remove_pin(pos_args[0]);
+        if (args[ARG_handler].u_obj != mp_const_none) {
+            self->callback = args[ARG_handler].u_obj;
+            gpio_epoll_add_pin(pos_args[0]);
+            line_info.flags |= trigger;
+        }
+
+        // If this fails and the pin was meant to update the triggers mask,
+        // then it will still be part of the epoll descriptors list, but it
+        // won't receive any updates.  There's a minor overhead as the
+        // system has to still handle the edge change but not notify the
+        // descriptor.  The operation can be retried safely.
+        //
+        // If the pin was meant to lose all triggers instead and this fails,
+        // again, the situation should still be recoverable.  In this case,
+        // the pin won't be part of the epoll descriptors list, and no events
+        // will be forwarded.  Like in the other case there's still some
+        // overhead since events will be processed and then discarded, but
+        // again, the operation can be retried.
+
+        struct gpio_v2_line_config line_configuration;
+        memset(&line_configuration, 0x00, sizeof(struct gpio_v2_line_config));
+        line_configuration.flags = line_info.flags;
+
+        gpio_ioctl(self->fd, GPIO_V2_LINE_SET_CONFIG_IOCTL, &line_configuration);
+    }
+
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_KW(machine_pin_irq_obj, 1, machine_pin_irq);
+#endif
 
 static mp_obj_tuple_t *gpio_port_enumerate_lines(mp_obj_t port_name) {
     assert(port_name && "Port name is NULL");
@@ -737,11 +1036,82 @@ static MP_DEFINE_CONST_FUN_OBJ_0(machine_pin_enumerate_obj, machine_pin_enumerat
 
 ///////////////////////////////////////////////////////////////////////////////
 
+#if MICROPY_PY_GPIO_IRQ
+static void *gpio_epoll_thread(void *arg) {
+    // Keep a reference to the stop variable.
+    volatile bool *stop = (volatile bool *)arg;
+
+    assert(MP_STATE_PORT(epoll_events) != NULL && "GPIO epoll thread started at the wrong time?");
+
+    struct gpio_v2_line_event event_payload;
+
+    for (;;) {
+        int events = epoll_wait(gpio_epoll_fd, MP_STATE_PORT(epoll_events), MICROPY_PY_GPIO_IRQ_QUEUE_SIZE, -1);
+        if (*stop) {
+            goto done;
+        }
+
+        if (events <= 0) {
+            // This is not correct but the code isn't in its final form yet.
+            continue;
+        }
+
+        for (int event_index = 0; event_index < events; event_index++) {
+            struct epoll_event *event = ((struct epoll_event *)(&MP_STATE_PORT(epoll_events))[event_index]);
+
+            machine_pin_obj_t *pin = event->data.ptr;
+            assert(pin && (pin->callback != MP_OBJ_NULL) && "Event for a tracked pin with no callback");
+
+            // Remove the event from from the source file descriptor buffer.
+            int bytes_read = read(pin->fd, &event_payload, sizeof(struct gpio_v2_line_event));
+            if (bytes_read < (ssize_t)sizeof(struct gpio_v2_line_event)) {
+                // TODO: Report an error condition here!
+                continue;
+            }
+
+            if (event_payload.timestamp_ns <= pin->last_timestamp) {
+                // Event lost :(
+                continue;
+            }
+            pin->last_timestamp = event_payload.timestamp_ns;
+
+            // TODO: Is this actually correct?  In theory this should work if
+            //       all modifications to the pin object involve setting the
+            //       relevant pointers to MP_OBJ_NULL, but then what happens if
+            //       the IRQ handlers are collected?  This needs more thought.
+            mp_uint_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
+            mp_obj_t lookup_result = mp_set_lookup(&MP_STATE_PORT(epoll_pins), MP_OBJ_FROM_PTR(event->data.ptr), MP_MAP_LOOKUP);
+            MICROPY_END_ATOMIC_SECTION(atomic_state);
+            if (lookup_result == MP_OBJ_NULL) {
+                continue;
+            }
+
+            // There is currently no facility to easily run a function on the
+            // main thread from another thread, so schedule the IRQ handler at
+            // whichever priority the interpreter sees fit.
+            mp_sched_schedule(pin->callback, MP_OBJ_FROM_PTR(pin));
+        }
+    }
+
+done:
+    return NULL;
+}
+#endif
+
 void mp_pin_init(void) {
     mp_map_init(&MP_STATE_PORT(ports), 0);
+
+    #if MICROPY_PY_GPIO_IRQ
+    MP_STATE_PORT(epoll_events) = m_new(struct epoll_event, MICROPY_PY_GPIO_IRQ_QUEUE_SIZE);
+    gpio_epoll_init();
+    #endif
 }
 
 void mp_pin_deinit(void) {
+    #if MICROPY_PY_GPIO_IRQ
+    gpio_epoll_deinit();
+    #endif
+
     mp_map_t *ports = &MP_STATE_PORT(ports);
     if (ports->table == NULL) {
         return;
@@ -789,6 +1159,10 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_on),          MP_ROM_PTR(&machine_pin_on_obj)              },
     { MP_ROM_QSTR(MP_QSTR_toggle),      MP_ROM_PTR(&machine_pin_toggle_obj)          },
 
+    #if MICROPY_PY_GPIO_IRQ
+    { MP_ROM_QSTR(MP_QSTR_irq),         MP_ROM_PTR(&machine_pin_irq_obj)             },
+    #endif
+
     { MP_ROM_QSTR(MP_QSTR_close),       MP_ROM_PTR(&machine_pin_del_obj)             },
     { MP_ROM_QSTR(MP_QSTR_available),   MP_ROM_PTR(&machine_pin_available_obj)       },
     { MP_ROM_QSTR(MP_QSTR___enter__),   MP_ROM_PTR(&mp_identity_obj)                 },
@@ -805,6 +1179,16 @@ static const mp_rom_map_elem_t machine_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_PULL_UP),     MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_UP)   },
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN) },
     { MP_ROM_QSTR(MP_QSTR_PULL_NONE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_BIAS_DISABLED)  },
+
+    #if MICROPY_PY_GPIO_IRQ
+    { MP_ROM_QSTR(MP_QSTR_IRQ_RISING),  MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_RISING)    },
+    { MP_ROM_QSTR(MP_QSTR_IRQ_FALLING), MP_ROM_INT(GPIO_V2_LINE_FLAG_EDGE_FALLING)   },
+    #if MICROPY_PY_GPIO_IRQ_TIMESTAMP
+    { MP_ROM_QSTR(MP_QSTR_CLOCK_MONOTONIC), MP_ROM_INT(0)                            },
+    { MP_ROM_QSTR(MP_QSTR_CLOCK_REALTIME), MP_ROM_INT(GPIO_V2_LINE_FLAG_EVENT_CLOCK_REALTIME) },
+    { MP_ROM_QSTR(MP_QSTR_CLOCK_HTE),   MP_ROM_INT(GPIO_V2_LINE_FLAG_EVENT_CLOCK_HTE) },
+    #endif
+    #endif
 };
 
 static MP_DEFINE_CONST_DICT(machine_pin_locals_dict, machine_pin_locals_dict_table);
@@ -826,5 +1210,11 @@ MP_DEFINE_CONST_OBJ_TYPE(
 
 // Is this safe?  What happens if the GC scans mp_map_t->table?
 MP_REGISTER_ROOT_POINTER(mp_map_t ports);
+
+#if MICROPY_PY_GPIO_IRQ
+MP_REGISTER_ROOT_POINTER(void *epoll_events);
+// Is this safe?  What happens if the GC scans mp_set_t->table?
+MP_REGISTER_ROOT_POINTER(mp_set_t epoll_pins);
+#endif
 
 #endif

--- a/ports/unix/main.c
+++ b/ports/unix/main.c
@@ -502,6 +502,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
     (void)emit_opt;
     #endif
 
+    #if MICROPY_PY_GPIO
+    extern void mp_pin_init(void);
+    mp_pin_init();
+    #endif
+
     #if MICROPY_VFS_POSIX
     {
         // Mount the host FS at the root of our internal VFS
@@ -728,6 +733,11 @@ MP_NOINLINE int main_(int argc, char **argv) {
     #if MICROPY_PY_BLUETOOTH
     int mp_bluetooth_deinit(void);
     mp_bluetooth_deinit();
+    #endif
+
+    #if MICROPY_PY_GPIO
+    extern void mp_pin_deinit(void);
+    mp_pin_deinit();
     #endif
 
     #if MICROPY_PY_THREAD

--- a/ports/unix/modmachine.c
+++ b/ports/unix/modmachine.c
@@ -36,6 +36,13 @@
 #define MICROPY_PAGE_MASK (MICROPY_PAGE_SIZE - 1)
 #endif
 
+#if MICROPY_PY_GPIO
+
+#define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
+    { MP_ROM_QSTR(MP_QSTR_Pin), MP_ROM_PTR(&machine_pin_type) },
+
+#endif
+
 uintptr_t mod_machine_mem_get_addr(mp_obj_t addr_o, uint align) {
     uintptr_t addr = mp_obj_get_int_truncated(addr_o);
     if ((addr & (align - 1)) != 0) {

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -178,6 +178,8 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_DEBUG_PRINTER (&mp_stderr_print)
 #define MICROPY_ERROR_PRINTER (&mp_stderr_print)
 
+#define MICROPY_DEBUG_VERBOSE (0)
+
 // For the native emitter configure how to mark a region as executable.
 void mp_unix_alloc_exec(size_t min_size, void **ptr, size_t *size);
 void mp_unix_free_exec(void *ptr, size_t size);
@@ -198,6 +200,28 @@ static inline unsigned long mp_random_seed_init(void) {
 #ifdef __linux__
 // Can access physical memory using /dev/mem
 #define MICROPY_PLAT_DEV_MEM  (1)
+
+#ifndef MICROPY_PY_GPIO
+#define MICROPY_PY_GPIO                   (0)
+#endif
+
+#if MICROPY_PY_GPIO
+// If you do not need IRQs or you are polling the GPIO pins anyway, you can
+// disable this (with a smaller footprint and slightly faster execution).
+//
+// This requires threading support to be enabled, as it is essentially a
+// background thread doing blocking epoll()s on a file descriptor.
+#define MICROPY_PY_GPIO_IRQ               (MICROPY_PY_THREAD)
+
+// Since GPIO line change events may be batched, this indicates how many
+// events can be reported at the same time per epoll operation.  Each entry
+// takes up sizeof(struct epoll_event) bytes of heap.
+//
+// TODO: Make this configurable at runtime instead?
+#define MICROPY_PY_GPIO_IRQ_QUEUE_SIZE    (16)
+
+#define MICROPY_PY_MACHINE_PIN_MAKE_NEW   mp_pin_make_new
+#endif
 #endif
 
 #ifdef __ANDROID__
@@ -206,6 +230,11 @@ static inline unsigned long mp_random_seed_init(void) {
 // Bionic libc in Android 1.5 misses these 2 functions
 #define MP_NEED_LOG2 (1)
 #define nan(x) NAN
+#endif
+
+// Android is "Linux", but its GPIO support cannot be tested at the moment.
+#if MICROPY_PY_GPIO
+#error "GPIO support is not available on Android."
 #endif
 #endif
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -223,6 +223,24 @@ static inline unsigned long mp_random_seed_init(void) {
 // TODO: Make this configurable at runtime instead?
 #define MICROPY_PY_GPIO_IRQ_QUEUE_SIZE    (16)
 
+#if MICROPY_PY_GPIO_IRQ
+// Depending on the hardware, it may happen that pin events may be delivered in
+// an out-of-order fashion to the polling thread.  In this case, a timestamp is
+// kept on each pin object to keep track of the last event that was successfully
+// processed, and events that have occurred before that instant are discarded.
+//
+// To better tailor behaviour of timestamp management, this also enables three
+// new flags to `machine.Pin(…, clock=)`:
+//
+// - `Pin.CLOCK_MONOTONIC` - the default, this sources the timestamp from the
+//                           monotonic system clock
+// - `Pin.CLOCK_REALTIME`  - this sources the timestamp from the realtime system
+//                           clock
+// - `Pin.CLOCK_HTE`       - this sources the timestamp from the GPIO hardware's
+//                           time provider, if one is present.
+#define MICROPY_PY_GPIO_IRQ_TIMESTAMP     (1)
+#endif
+
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW   mp_pin_make_new
 #endif
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -181,6 +181,8 @@ extern const struct _mp_print_t mp_stderr_print;
 #define MICROPY_DEBUG_PRINTER (&mp_stderr_print)
 #define MICROPY_ERROR_PRINTER (&mp_stderr_print)
 
+#define MICROPY_DEBUG_VERBOSE (0)
+
 // For the native emitter configure how to mark a region as executable.
 void mp_unix_alloc_exec(size_t min_size, void **ptr, size_t *size);
 void mp_unix_free_exec(void *ptr, size_t size);
@@ -201,6 +203,28 @@ static inline unsigned long mp_random_seed_init(void) {
 #ifdef __linux__
 // Can access physical memory using /dev/mem
 #define MICROPY_PLAT_DEV_MEM  (1)
+
+#ifndef MICROPY_PY_GPIO
+#define MICROPY_PY_GPIO                   (0)
+#endif
+
+#if MICROPY_PY_GPIO
+// If you do not need IRQs or you are polling the GPIO pins anyway, you can
+// disable this (with a smaller footprint and slightly faster execution).
+//
+// This requires threading support to be enabled, as it is essentially a
+// background thread doing blocking epoll()s on a file descriptor.
+#define MICROPY_PY_GPIO_IRQ               (MICROPY_PY_THREAD)
+
+// Since GPIO line change events may be batched, this indicates how many
+// events can be reported at the same time per epoll operation.  Each entry
+// takes up sizeof(struct epoll_event) bytes of heap.
+//
+// TODO: Make this configurable at runtime instead?
+#define MICROPY_PY_GPIO_IRQ_QUEUE_SIZE    (16)
+
+#define MICROPY_PY_MACHINE_PIN_MAKE_NEW   mp_pin_make_new
+#endif
 #endif
 
 #ifdef __ANDROID__
@@ -209,6 +233,11 @@ static inline unsigned long mp_random_seed_init(void) {
 // Bionic libc in Android 1.5 misses these 2 functions
 #define MP_NEED_LOG2 (1)
 #define nan(x) NAN
+#endif
+
+// Android is "Linux", but its GPIO support cannot be tested at the moment.
+#if MICROPY_PY_GPIO
+#error "GPIO support is not available on Android."
 #endif
 #endif
 

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -209,6 +209,15 @@ static inline unsigned long mp_random_seed_init(void) {
 #endif
 
 #if MICROPY_PY_GPIO
+
+// Use the GPIO v2 ioctl()s to control GPIO lines.  GPIO v2 is available from
+// kernel 5.10 and onwards; if usage of GPIO v1 ioctl()s is a requirement, then
+// set MICROPY_PY_GPIO_API_VERSION to 1.  Any other values besides 1 and 2 will
+// trigger a compilation error.
+#ifndef MICROPY_PY_GPIO_API_VERSION
+#define MICROPY_PY_GPIO_API_VERSION       (2)
+#endif
+
 // If the GPIO pins are provided by a device that may or may not be always
 // attached to the system (ie. USB GPIO extender, PCI device that can be
 // disabled via `rmmod`, etc.), then enable this at the expense of a larger
@@ -242,7 +251,7 @@ static inline unsigned long mp_random_seed_init(void) {
 // TODO: Make this configurable at runtime instead?
 #define MICROPY_PY_GPIO_IRQ_QUEUE_SIZE    (16)
 
-#if MICROPY_PY_GPIO_IRQ
+#if MICROPY_PY_GPIO_IRQ && MICROPY_PY_GPIO_API_VERSION == 2
 // Depending on the hardware, it may happen that pin events may be delivered in
 // an out-of-order fashion to the polling thread.  In this case, a timestamp is
 // kept on each pin object to keep track of the last event that was successfully
@@ -258,6 +267,8 @@ static inline unsigned long mp_random_seed_init(void) {
 // - `Pin.CLOCK_HTE`       - this sources the timestamp from the GPIO hardware's
 //                           time provider, if one is present.
 #define MICROPY_PY_GPIO_IRQ_TIMESTAMP     (1)
+#else
+#define MICROPY_PY_GPIO_IRQ_TIMESTAMP     (0)
 #endif
 
 #define MICROPY_PY_MACHINE_PIN_MAKE_NEW   mp_pin_make_new

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -206,6 +206,25 @@ static inline unsigned long mp_random_seed_init(void) {
 #endif
 
 #if MICROPY_PY_GPIO
+// If the GPIO pins are provided by a device that may or may not be always
+// attached to the system (ie. USB GPIO extender, PCI device that can be
+// disabled via `rmmod`, etc.), then enable this at the expense of a larger
+// binary.  Otherwise, if the pins are provided by a SoC (f.e. via a device
+// tree file) or if you can guarantee the device providing the pins will never
+// be removed from a running system, feel free to disable this (with a smaller
+// footprint and slightly faster execution).
+//
+// This requires threading support to be enabled, as it is essentially a
+// background thread doing blocking reads on a file descriptor.
+#define MICROPY_PY_GPIO_DYNAMIC_ALLOCATION (MICROPY_PY_THREAD)
+
+// Device removal events may be batched, this indicates how many events can be
+// reported at the same time per inotify operation.  Each entry takes up
+// sizeof(struct inotify_event) bytes of heap.
+//
+// TODO: Make this configurable at runtime instead?
+#define MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE (16)
+
 // If you do not need IRQs or you are polling the GPIO pins anyway, you can
 // disable this (with a smaller footprint and slightly faster execution).
 //

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -209,6 +209,25 @@ static inline unsigned long mp_random_seed_init(void) {
 #endif
 
 #if MICROPY_PY_GPIO
+// If the GPIO pins are provided by a device that may or may not be always
+// attached to the system (ie. USB GPIO extender, PCI device that can be
+// disabled via `rmmod`, etc.), then enable this at the expense of a larger
+// binary.  Otherwise, if the pins are provided by a SoC (f.e. via a device
+// tree file) or if you can guarantee the device providing the pins will never
+// be removed from a running system, feel free to disable this (with a smaller
+// footprint and slightly faster execution).
+//
+// This requires threading support to be enabled, as it is essentially a
+// background thread doing blocking reads on a file descriptor.
+#define MICROPY_PY_GPIO_DYNAMIC_ALLOCATION (MICROPY_PY_THREAD)
+
+// Device removal events may be batched, this indicates how many events can be
+// reported at the same time per inotify operation.  Each entry takes up
+// sizeof(struct inotify_event) bytes of heap.
+//
+// TODO: Make this configurable at runtime instead?
+#define MICROPY_PY_GPIO_ALLOCATION_QUEUE_SIZE (16)
+
 // If you do not need IRQs or you are polling the GPIO pins anyway, you can
 // disable this (with a smaller footprint and slightly faster execution).
 //

--- a/ports/unix/pin.h
+++ b/ports/unix/pin.h
@@ -1,9 +1,9 @@
 /*
- * This file is part of the MicroPython project, http://micropython.org/
+ * This file is part of the MicroPython project, https://micropython.org/
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2025 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,34 @@
  * THE SOFTWARE.
  */
 
-// Set base feature level.
-#define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
+#ifndef MICROPY_INCLUDED_UNIX_PIN_H
+#define MICROPY_INCLUDED_UNIX_PIN_H
 
-#if defined(__linux__)
-#define MICROPY_PY_GPIO (1)
+#include "py/mphal.h"
+
+#if MICROPY_PY_GPIO
+
+#ifndef __linux__
+#error "Platform does not support GPIO access"
 #endif
 
-// Enable extra Unix features.
-#include "../mpconfigvariant_common.h"
+#include <stdint.h>
+
+#include "py/obj.h"
+#include "py/runtime.h"
+
+extern const mp_obj_type_t machine_pin_type;
+
+typedef struct {
+    mp_obj_base_t base;
+    mp_obj_t port;
+    int fd;
+    uint32_t number;
+} machine_pin_obj_t;
+
+void mp_pin_init(void);
+void mp_pin_deinit(void);
+
+#endif
+
+#endif

--- a/ports/unix/pin.h
+++ b/ports/unix/pin.h
@@ -37,6 +37,10 @@
 
 #include <stdint.h>
 
+#if MICROPY_PY_GPIO_IRQ
+#include <sys/epoll.h>
+#endif
+
 #include "py/obj.h"
 #include "py/runtime.h"
 
@@ -47,6 +51,13 @@ typedef struct {
     mp_obj_t port;
     int fd;
     uint32_t number;
+    #if MICROPY_PY_GPIO_IRQ
+    #if MICROPY_PY_GPIO_IRQ_TIMESTAMP
+    uint64_t last_timestamp;
+    #endif
+    struct epoll_event event;
+    mp_obj_t callback;
+    #endif
 } machine_pin_obj_t;
 
 void mp_pin_init(void);

--- a/ports/unix/pin.h
+++ b/ports/unix/pin.h
@@ -37,6 +37,10 @@
 
 #include <stdint.h>
 
+#if MICROPY_PY_GPIO_IRQ
+#include <sys/epoll.h>
+#endif
+
 #include "py/obj.h"
 #include "py/runtime.h"
 
@@ -47,6 +51,10 @@ typedef struct {
     mp_obj_t port;
     int fd;
     uint32_t number;
+    #if MICROPY_PY_GPIO_IRQ
+    struct epoll_event event;
+    mp_obj_t callback;
+    #endif
 } machine_pin_obj_t;
 
 void mp_pin_init(void);


### PR DESCRIPTION
### Summary

This PR is meant to act as a RFC for a Linux-native `machine.Pin` implementation, using the Linux kernel APIs to operate on exposed GPIOs.  It is also marked as draft as it is still not merge-quality right now.

(Note: To keep the jargon equal across ports, Linux's GPIO devices will be called "ports" and GPIO lines will be called "pins" from here on.)

The code in this PR implements almost everything that could be needed by a `machine.Pin` implementation, however its API has to obey a slightly different set of rules:

Generic MCUs running MicroPython aren't really meant to run more than a single application and said application usually has exclusive and total control of any available I/O peripherals.  This is not the case for Linux.

- GPIO pins' ownership by MicroPython could, in theory, not last for the complete lifetime of the running code; pins can be claimed and released at any time
- GPIO pin access could be, if desired, non-exclusive; this means that if a pin is claimed in non-exclusive mode its value must not be cached for output pins because another process may have altered its state (or even its mode!)
- Claiming a GPIO pin may actually not succeed; if the pin was already claimed in exclusive mode by another process then the claim will fail
- GPIO ports may appear and disappear at any time; on embedded systems this is usually not a concern as ports and pins are often allocated at kernel boot time via device tree files; however there are USB devices that may act as GPIO ports, and therefore no assumptions on ports and pins availability must be made
- Each pin can be tagged with a 32 bytes ASCII string (31 + terminator) indicating the owner of the GPIO line; this is optional but not providing it doesn't save any memory as each line structure has a fixed-size buffer associated with it for this purpose - note that this value cannot be changed unless the pin is released and claimed again
- Linux GPIO support has no concept of alternate functions, as each I/O operation targets a specialised device that will handle pin mapping behind the scenes
- If a GPIO port is removed from the system even though it is being used by MicroPython (eg. removable device that gets yanked out of the machine), things will *probably* go out of sync.  There's some support for listening to device files going away, but it's not really tested that much.

This means the MicroPython GPIO Pin API needs to be tweaked to make sure these facts do not come in the way of regular usage:

- The `Pin` class constructor gains two different keyword-only arguments:
	- `port`, which is meant to receive either a number indicating which `/dev/gpiochipX` character device to use for I/O requests, or a full fledged filesystem path; if not provided it will default to `/dev/gpiochip0`
	- `consumer`, which is meant to receive a string that's up to 31 ASCII bytes long containing the owner of the claimed GPIO pin; if not provided it will default to "MicroPython"
- A new instance method called `Pin.close` is introduced to manually give control of the pin back to the operating system; this is the same as manually calling `del` on the instance, but this allows for more fine-grained control of the pin's ownership lifetime (this is safe to be called multiple times, just like `del` is)
- A new instance method called `Pin.available` is introduced to check whether a pin instance can be used or if the underlying GPIO pin's ownership has been already given back to the operating system
- A new class method called `Pin.enumerate` is introduced to get a list of available GPIO ports and the pins associated with each port, returning a tuple of (port_name, (pin_name, consumer, available)) values
- The `Pin` class is now context-aware, so `__enter__` and `__exit__` instance methods have been added to make lifetime control easier to manage
- Since GPIO ports are dynamic *no* `Pin` operation is guaranteed to succeed, however on most if not all embedded systems GPIO pins are provided by a device tree file and already set up and ready to go by the time `initrd` has finished; however if the `Pin` instances are backed by an external device that may get removed without notice, get ready for `OSError` exceptions being raised on seemingly innocuous method calls
- GPIO direction validity is strictly enforced: if a pin is defined as input, setting its value will fail with an `OSError`; if you've got code that pre-sets a GPIO value and toggles its direction later, it will work on a microcontroller but will fail on Linux
- IRQs, even if marked as `hard`, are still scheduled for execution by the MicroPython scheduler (the `hard` parameter to `Pin.irq` is parsed but ignored, for compatibility reasons)
- For the time being, thread safety is *not guaranteed*, so use this together with threads or asynchronous code at your own risk.

If anything, this peripheral access pattern can be replicated for other hardware subsystem exposed as character devices like I²C, I²S, SPI, low level UART, etc.

There are a few `TODO`s in the code, for which suggestions are welcome!

I am aware there is already a basic implementation for `machine.Pin` in `micropython-lib`, however this implements a lot of other functionality that I'm not sure it can be easily implemented in a pure-Python way.  If all of this can be replicated in pure Python, that's even better :)

Technically this could also be implemented with some extra work as a FFI library over libgpiod.  This implementation overhead is still less than the space taken by libgpiod on current Arm 64-bits systems.  If there are other applications using that library then it may make more sense to use that instead, otherwise if all it's needed to run is a single static binary, this implementation is still competitive size-wise.

### Testing

Albeit this is considered as experimental, this bit of code has been in daily usage for almost 18 months now - on a MilkV-Duo RV64 and a RPi3B+, among others.  Compliance with the MicroPython's test suite for the `machine.Pin` class has not been yet looked into since this PR is not guaranteed to be considered for inclusion (same applies to documentation).

### Trade-offs and Alternatives

This obviously comes with a larger footprint and associated extra code complexity, although it can be made disabled by default if so chosen.

### Generative AI

I did not use generative AI tools when creating this PR.
