### PR TITLE
py/objint: Add signed param to int.from_bytes().

### DIFF
--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -103,15 +103,9 @@ Functions and types
 
 .. class:: int()
 
-   .. classmethod:: from_bytes(bytes, byteorder)
-
-      In MicroPython, `byteorder` parameter must be positional (this is
-      compatible with CPython).
+   .. classmethod:: from_bytes(bytes, byteorder='big', *, signed=False)
 
    .. method:: to_bytes(size, byteorder, /, *, signed=False)
-
-      In MicroPython, `byteorder` parameter must be positional (this is
-      compatible with CPython).
 
 .. function:: isinstance()
 

--- a/py/mpz.c
+++ b/py/mpz.c
@@ -850,22 +850,33 @@ size_t mpz_set_from_str(mpz_t *z, const char *str, size_t len, bool neg, unsigne
     return cur - str;
 }
 
-void mpz_set_from_bytes(mpz_t *z, bool big_endian, size_t len, const byte *buf) {
+void mpz_set_from_bytes(mpz_t *z, bool big_endian, bool is_signed, size_t len, const byte *buf) {
+    if (len == 0) {
+        return;
+    }
+    mpz_dig_t carry = 0;
+    if (is_signed && (buf[big_endian ? 0 : len - 1] & 0x80)) {
+        z->neg = 1;
+        carry = 1;
+    }
     int delta = 1;
     if (big_endian) {
         buf += len - 1;
         delta = -1;
     }
-
     mpz_need_dig(z, (len * 8 + DIG_SIZE - 1) / DIG_SIZE);
-
-    mpz_dig_t d = 0;
+    mpz_dbl_dig_t d = 0;
     int num_bits = 0;
-    z->neg = 0;
-    z->len = 0;
+    mpz_dig_t byte_val;
     while (len) {
         while (len && num_bits < DIG_SIZE) {
-            d |= *buf << num_bits;
+            byte_val = *buf;
+            if (z->neg) {
+                byte_val = ((~byte_val) & 0xff) + carry;
+                carry = byte_val >> 8;
+                byte_val &= 0xff;
+            }
+            d |= (byte_val & DIG_MASK) << num_bits;
             num_bits += 8;
             buf += delta;
             len--;
@@ -879,7 +890,6 @@ void mpz_set_from_bytes(mpz_t *z, bool big_endian, size_t len, const byte *buf) 
         #endif
         num_bits -= DIG_SIZE;
     }
-
     z->len = mpn_remove_trailing_zeros(z->dig, z->dig + z->len);
 }
 

--- a/py/mpz.h
+++ b/py/mpz.h
@@ -114,7 +114,7 @@ void mpz_set_from_ll(mpz_t *z, long long i, bool is_signed);
 void mpz_set_from_float(mpz_t *z, mp_float_t src);
 #endif
 size_t mpz_set_from_str(mpz_t *z, const char *str, size_t len, bool neg, unsigned int base);
-void mpz_set_from_bytes(mpz_t *z, bool big_endian, size_t len, const byte *buf);
+void mpz_set_from_bytes(mpz_t *z, bool big_endian, bool is_signed, size_t len, const byte *buf);
 
 static inline bool mpz_is_zero(const mpz_t *z) {
     return z->len == 0;

--- a/py/objint.c
+++ b/py/objint.c
@@ -398,37 +398,48 @@ mp_obj_t mp_obj_int_binary_op_extra_cases(mp_binary_op_t op, mp_obj_t lhs_in, mp
     return MP_OBJ_NULL; // op not supported
 }
 
-// this is a classmethod
-static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *args) {
-    // TODO: Support signed param (assumes signed=False at the moment)
-
+// classmethod int.from_bytes(bytes, byteorder='big', *, signed=False)
+static mp_obj_t int_from_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    enum { ARG_byteorder, ARG_signed };
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_byteorder, MP_ARG_OBJ, { .u_rom_obj = MP_ROM_QSTR(MP_QSTR_big) } },
+        { MP_QSTR_signed,    MP_ARG_BOOL, {.u_bool = false} },
+    };
+    mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args - 2, pos_args + 2, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     // get the buffer info
     mp_buffer_info_t bufinfo;
-    mp_get_buffer_raise(args[1], &bufinfo, MP_BUFFER_READ);
+    mp_get_buffer_raise(pos_args[1], &bufinfo, MP_BUFFER_READ);
+    bool big_endian = args[ARG_byteorder].u_obj != MP_OBJ_NEW_QSTR(MP_QSTR_little);
+    bool is_signed = args[ARG_signed].u_bool;
 
     const byte *buf = (const byte *)bufinfo.buf;
     int delta = 1;
-    bool big_endian = n_args < 3 || args[2] != MP_OBJ_NEW_QSTR(MP_QSTR_little);
     if (!big_endian) {
         buf += bufinfo.len - 1;
         delta = -1;
     }
-
-    mp_uint_t value = 0;
+    mp_int_t value = 0;
     size_t len = bufinfo.len;
-    for (; len--; buf += delta) {
-        #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
-        if (value > (MP_SMALL_INT_MAX >> 8)) {
-            // Result will overflow a small-int so construct a big-int
-            return mp_obj_int_from_bytes_impl(big_endian, bufinfo.len, bufinfo.buf);
+    if (len) {
+        if (is_signed && (*buf & 0x80) != 0) {
+            value = (int8_t)(*buf); // propagate the sign bit
+            buf += delta;
+            len--;
         }
-        #endif
-        value = (value << 8) | *buf;
+        for (; len--; buf += delta) {
+            #if MICROPY_LONGINT_IMPL != MICROPY_LONGINT_IMPL_NONE
+            if ((value > (MP_SMALL_INT_MAX >> 8)) || (value < (MP_SMALL_INT_MIN >> 8))) {
+                // Result will overflow a small-int so construct a big-int
+                return mp_obj_int_from_bytes_impl(big_endian, is_signed, bufinfo.len, bufinfo.buf);
+            }
+            #endif
+            value = ((mp_uint_t)value << 8) | *buf;
+        }
     }
-    return mp_obj_new_int_from_uint(value);
+    return mp_obj_new_int(value);
 }
-
-static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(int_from_bytes_fun_obj, 2, 4, int_from_bytes);
+static MP_DEFINE_CONST_FUN_OBJ_KW(int_from_bytes_fun_obj, 1, int_from_bytes);
 static MP_DEFINE_CONST_CLASSMETHOD_OBJ(int_from_bytes_obj, MP_ROM_PTR(&int_from_bytes_fun_obj));
 
 static mp_obj_t int_to_bytes(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {

--- a/py/objint.h
+++ b/py/objint.h
@@ -55,7 +55,7 @@ char *mp_obj_int_formatted_impl(char **buf, size_t *buf_size, size_t *fmt_size, 
     int base, const char *prefix, char base_char, char comma);
 
 mp_int_t mp_obj_int_hash(mp_obj_t self_in);
-mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf);
+mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, bool is_signed, size_t len, const byte *buf);
 // Write an integer to a byte sequence.
 // If overflow_check is true, raises OverflowError if 'self_in' doesn't fit. If false, truncate to fit.
 void mp_obj_int_to_bytes(mp_obj_t self_in, size_t buf_len, byte *buf, bool big_endian, bool is_signed, bool overflow_check);

--- a/py/objint_longlong.c
+++ b/py/objint_longlong.c
@@ -48,7 +48,7 @@ static void raise_long_long_overflow(void) {
     mp_raise_msg(&mp_type_OverflowError, MP_ERROR_TEXT("result overflows long long storage"));
 }
 
-mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf) {
+mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, bool is_signed, size_t len, const byte *buf) {
     int delta = 1;
     if (!big_endian) {
         buf += len - 1;
@@ -56,8 +56,18 @@ mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf
     }
 
     mp_longint_impl_t value = 0;
-    for (; len--; buf += delta) {
-        value = (value << 8) | *buf;
+    if (len) {
+        if (is_signed && (*buf & 0x80) != 0) {
+            value = (int8_t)(*buf); // propagate the sign bit
+            buf += delta;
+            len--;
+        }
+        for (; len--; buf += delta) {
+            if ((value > (LLONG_MAX >> 8)) || (value < (LLONG_MIN >> 8))) {
+                raise_long_long_overflow();
+            }
+            value = ((unsigned long long)value << 8) | *buf;
+        }
     }
     return mp_obj_new_int_from_ll(value);
 }

--- a/py/objint_mpz.c
+++ b/py/objint_mpz.c
@@ -106,9 +106,9 @@ char *mp_obj_int_formatted_impl(char **buf, size_t *buf_size, size_t *fmt_size, 
     return str;
 }
 
-mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, size_t len, const byte *buf) {
+mp_obj_t mp_obj_int_from_bytes_impl(bool big_endian, bool is_signed, size_t len, const byte *buf) {
     mp_obj_int_t *o = mp_obj_int_new_mpz();
-    mpz_set_from_bytes(&o->mpz, big_endian, len, buf);
+    mpz_set_from_bytes(&o->mpz, big_endian, is_signed, len, buf);
     return MP_OBJ_FROM_PTR(o);
 }
 

--- a/tests/basics/int_from_bytes.py
+++ b/tests/basics/int_from_bytes.py
@@ -1,0 +1,67 @@
+try:
+    # for 64 bit archs
+    x = 4611686018427387903 # small 2**62-1
+    x = -4611686018427387903 # small
+    # x = 4611686018427387904 # big
+    # x = -4611686018427387904 # big
+except OverflowError:
+    print("SKIP")  # Port can't represent this size of integer
+    raise SystemExit
+
+
+def test_int(x, byteorder, signed):
+    if signed:
+        x = -x
+
+    size = 12
+    if x <= 1073741823 and x >= -1073741823:  # 2**30 - 1
+        size = 4
+    elif x <= 4611686018427387903 and x >= -4611686018427387903:  # 2**62 - 1
+        size = 8
+    
+    print("x:{}, x:0x{}, size:{}".format(x, x, size), end="")
+    b = x.to_bytes(size, byteorder=byteorder, signed=signed)
+    print(", to_bytes:{}".format(b), end="")
+    y = int.from_bytes(b, byteorder=byteorder, signed=signed)
+    print(", y = x.from_bytes:{}, {}".format(y, x == y))
+    print()
+    assert x == y
+
+
+def do_test_int(byteorder, signed):
+    print("========== byteorder:{}, signed:{} ==========".format(byteorder, signed))
+    test_int(0, byteorder, signed)
+    test_int(2, byteorder, signed)
+    test_int(2**7 - 2, byteorder, signed)
+    test_int(2**7, byteorder, signed)
+    test_int(2**7 + 2, byteorder, signed)
+    test_int(2**15 - 2, byteorder, signed)
+    test_int(2**15, byteorder, signed)
+    test_int(2**15 + 2, byteorder, signed)
+    test_int(2**23 - 2, byteorder, signed)
+    test_int(2**23, byteorder, signed)
+    test_int(2**23 + 2, byteorder, signed)
+    test_int(2**30 - 2, byteorder, signed)
+    test_int(2**30, byteorder, signed)
+    test_int(2**30 + 2, byteorder, signed)
+    test_int(2**31 - 2, byteorder, signed)
+    test_int(2**31, byteorder, signed)
+    test_int(2**31 + 2, byteorder, signed)
+    test_int(2**39 - 2, byteorder, signed)
+    test_int(2**39, byteorder, signed)
+    test_int(2**39 + 2, byteorder, signed)
+    test_int(2**47 - 2, byteorder, signed)
+    test_int(2**47, byteorder, signed)
+    test_int(2**47 + 2, byteorder, signed)
+    test_int(2**55 - 2, byteorder, signed)
+    test_int(2**55, byteorder, signed)
+    test_int(2**55 + 2, byteorder, signed)
+    test_int(4611686018427387903 - 1, byteorder, signed)  # 2**62 - 2
+
+
+do_test_int(byteorder="big", signed=False)
+do_test_int(byteorder="little", signed=False)
+do_test_int(byteorder="big", signed=True)
+do_test_int(byteorder="little", signed=True)
+
+print("Ok.")

--- a/tests/basics/int_from_bytes_intbig.py
+++ b/tests/basics/int_from_bytes_intbig.py
@@ -1,0 +1,39 @@
+def test_int(x, byteorder, signed):
+    if signed:
+        x = -x
+
+    size = 12
+    if x <= 1073741823 and x >= -1073741823:  # 2**30 - 1
+        size = 4
+    elif x <= 4611686018427387903 and x >= -4611686018427387903:  # 2**62 - 1
+        size = 8
+    
+    print("x:{}, x:0x{}, size:{}".format(x, x, size), end="")
+    b = x.to_bytes(size, byteorder=byteorder, signed=signed)
+    print(", to_bytes:{}".format(b), end="")
+    y = int.from_bytes(b, byteorder=byteorder, signed=signed)
+    print(", y = x.from_bytes:{}, {}".format(y, x == y))
+    print()
+    assert x == y
+
+
+def do_test_int(byteorder, signed):
+    print("========== byteorder:{}, signed:{} ==========".format(byteorder, signed))
+    test_int(0, byteorder, signed)
+    test_int(2**55 - 2, byteorder, signed)
+    test_int(2**55, byteorder, signed)
+    test_int(2**55 + 2, byteorder, signed)
+    test_int(2**62 - 2, byteorder, signed)
+    test_int(2**62, byteorder, signed)
+    test_int(2**62 + 2, byteorder, signed)
+    test_int(2**70 - 2, byteorder, signed)
+    test_int(2**70, byteorder, signed)
+    test_int(2**70 + 2, byteorder, signed)
+
+
+do_test_int(byteorder="big", signed=False)
+do_test_int(byteorder="little", signed=False)
+do_test_int(byteorder="big", signed=True)
+do_test_int(byteorder="little", signed=True)
+
+print("Ok.")


### PR DESCRIPTION
### Summary
Support `signed=True` param:
result = int.from_bytes(bytearray(), byteorder='big'|'little', signed=False|True)
```
>>> int.from_bytes(b'\xff', byteorder='little', signed=False)
255
>>> int.from_bytes(b'\xff', byteorder='little', signed=True)
-1
>>> 
```

### Testing
micropython/tests/basics/int_from_bytes.py
micropython/tests/basics/int_from_bytes_intbig.py

Tested on ESP32 board.

### Generative AI

I did not use generative AI tools when creating this PR.
