### PR TITLE
py/modmicropython: Support scheduling a KeyboardInterrupt from Python.

### DIFF
--- a/docs/library/micropython.rst
+++ b/docs/library/micropython.rst
@@ -186,6 +186,10 @@ Functions
    There is a finite queue to hold the scheduled functions and `schedule()`
    will raise a `RuntimeError` if the queue is full.
 
+   As a special case, it's possible to pass `micropython.kbd_intr` to this function
+   as the first argument (and ``None`` as the second argument), and that will
+   schedule a `KeyboardInterrupt` to be raised "very soon" in the main thread.
+
 Classes
 -------
 

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -157,13 +157,35 @@ static MP_DEFINE_CONST_FUN_OBJ_1(mp_micropython_kbd_intr_obj, mp_micropython_kbd
 #endif
 
 #if MICROPY_ENABLE_SCHEDULER
+
+#if MICROPY_KBD_EXCEPTION && MICROPY_SCHEDULER_STATIC_NODES
+static mp_sched_node_t mp_keyboard_interrupt_sched_node;
+static void mp_sched_keyboard_interrupt_wrapper(mp_sched_node_t *node) {
+    mp_sched_keyboard_interrupt();
+}
+#endif
+
 static mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
+    #if MICROPY_KBD_EXCEPTION
+    if (function == MP_OBJ_FROM_PTR(&mp_micropython_kbd_intr_obj)) {
+        #if MICROPY_SCHEDULER_STATIC_NODES
+        // Allow calling `micropython.schedule(micropython.kbd_intr, None)` as a
+        // special case to schedule a keyboard interrupt.
+        mp_sched_schedule_node(&mp_keyboard_interrupt_sched_node, mp_sched_keyboard_interrupt_wrapper);
+        return mp_const_none;
+        #else
+        // Signal that passing `micropython.kbd_intr` is not supported.
+        mp_raise_ValueError(NULL);
+        #endif
+    }
+    #endif
     if (!mp_sched_schedule(function, arg)) {
         mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("schedule queue full"));
     }
     return mp_const_none;
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_schedule);
+
 #endif
 
 static const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {

--- a/tests/micropython/schedule_kbd_intr.py
+++ b/tests/micropython/schedule_kbd_intr.py
@@ -1,0 +1,72 @@
+# Test using micropython.schedule() to schedule a KeyboardInterrupt.
+# Note: this test cannot use unittest because the unittest overhead
+# may trigger the scheduler when we don't want it to.
+
+try:
+    from time import sleep
+    from micropython import schedule, kbd_intr
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+########################################################################
+# Test basic scheduling.
+
+try:
+    schedule(kbd_intr, None)
+except ValueError:
+    # Scheduling `kbd_intr` is not supported on this target.
+    print("SKIP")
+    raise SystemExit
+
+try:
+    sleep(0)
+    sleep(0)
+    print("fail")
+except KeyboardInterrupt:
+    print("KeyboardInterrupt")
+
+########################################################################
+# Should be able to schedule it many times without error, and that
+# should only trigger one KeyboardInterrupt.
+
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+schedule(kbd_intr, None)
+try:
+    sleep(0)
+    sleep(0)
+    print("fail")
+except KeyboardInterrupt:
+    print("KeyboardInterrupt")
+
+# This should not raise.
+for _ in range(100):
+    sleep(0)
+
+########################################################################
+# Test nested scheduling.
+
+
+def callback(_):
+    schedule(kbd_intr, None)
+    # This should not raise because we are in schedule context.
+    for _ in range(100):
+        sleep(0)
+
+
+schedule(callback, None)
+sleep(0)
+try:
+    sleep(0)
+    sleep(0)
+    print("fail")
+except KeyboardInterrupt:
+    print("KeyboardInterrupt")

--- a/tests/micropython/schedule_kbd_intr.py.exp
+++ b/tests/micropython/schedule_kbd_intr.py.exp
@@ -1,0 +1,3 @@
+KeyboardInterrupt
+KeyboardInterrupt
+KeyboardInterrupt


### PR DESCRIPTION
### Summary

This PR allows scheduling a KeyboardInterrupt to be raised "very soon" in the main thread.

Calling the C function `mp_sched_keyboard_interrupt()` directly won't work as expected, because that will raise the exception almost immediately, *even if running within a scheduled context*.  So that call is pretty much equivalent to `raise KeyboardInterrupt` from the Python side.

Instead, this PR adds a way to schedule a call to `mp_sched_keyboard_interrupt()`, so that the exception is never raised within a schedule context, but rather always in the main thread context.

To reduce code size I reused existing functions, so you use it this way:
```py
micropython.schedule(micropython.kbd_intr, None)
```

Addresses #19424.  Supersedes #16809.

### Testing

Added a test that runs under CI.

### Trade-offs and Alternatives

Could add a new function `micropython.sched_kbd_intr()`, but this is a pretty niche feature and I really wanted to keep code size down.  So it reuses existing functions in a relatively intuitive way (IMO).

I used the static node scheduler so that it's always guaranteed to succeed (scheduling the KeyboardInterrupt).  That uses a little bit of RAM.

### Generative AI

Not used.