### PR TITLE
esp32: Update mdns component, re-enable on ESP32-H2

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_H2/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_H2/mpconfigboard.h
@@ -7,9 +7,5 @@
 #define MICROPY_PY_NETWORK_WLAN             (0)
 #define MICROPY_PY_ESPNOW                   (0)
 
-// Disable mDNS (doesn't build due to WiFi dependencies)
-#define MICROPY_HW_ENABLE_MDNS_QUERIES      (0)
-#define MICROPY_HW_ENABLE_MDNS_RESPONDER    (0)
-
 // Enable UART REPL for modules that have an external USB-UART and don't use native USB.
 #define MICROPY_HW_ENABLE_UART_REPL         (1)

--- a/ports/esp32/boards/sdkconfig.h2
+++ b/ports/esp32/boards/sdkconfig.h2
@@ -5,3 +5,8 @@ CONFIG_IEEE802154_ENABLED=n
 # Using the SPI flash implementation in ROM saves about 10KB of binary size
 # (and some static RAM)
 CONFIG_SPI_FLASH_ROM_IMPL=y
+
+# mDNS component is enabled (for SPI based Ethernet), but disable
+# mDNS netifs for Wi-Fi STA, AP to save a small amount of resources
+CONFIG_MDNS_PREDEF_NETIF_STA=n
+CONFIG_MDNS_PREDEF_NETIF_AP=n

--- a/ports/esp32/lockfiles/README.md
+++ b/ports/esp32/lockfiles/README.md
@@ -10,3 +10,16 @@ ESP-IDF version to the last time the file was updated.
 
 *Please do not commit changes to these files and submit PRs unless the PR needs
 to change versions of components or ESP-IDF.*
+
+## How to update a component
+
+To update a component to the newest version and submit the change back to
+MicroPython:
+
+1. Edit `main/idf_component.yml` with the new version.
+2. Build and test the change on your preferred board.
+3. Build one board for each supported chip
+   (i.e. `make BOARD=ESP32_GENERIC; make BOARD=ESP32_GENERIC_S2; make BOARD=ESP32_GENERIC_S3`)
+4. Commit the idf_component.yml change and all of the changed lockfiles in this
+   directory.
+

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -13,7 +13,7 @@ dependencies:
     - esp32p4
     version: 1.0.3
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -21,7 +21,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -30,6 +30,6 @@ direct_dependencies:
 - espressif/lan867x
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32c2
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32c3
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32c5
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32c6
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   idf:
     source:
       type: idf
@@ -16,6 +16,6 @@ dependencies:
 direct_dependencies:
 - espressif/mdns
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32h2
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -1,6 +1,6 @@
 dependencies:
   espressif/eppp_link:
-    component_hash: 41f6519edda527ec6a0553c872ebaf8fc6d3812523c9d4c8d1660ad21c720abe
+    component_hash: 04f7f31868b8ae6014c96132740a192d09611a6e46aaa7038c865ffc7e26b38f
     dependencies:
     - name: espressif/esp_serial_slave_link
       registry_url: https://components.espressif.com
@@ -12,7 +12,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.1.3
+    version: 1.1.5
   espressif/esp_hosted:
     component_hash: 53544436deb5fcbfdbf4a8e2c643cdbe31126556781784278c016d674df99cd2
     dependencies:
@@ -54,7 +54,7 @@ dependencies:
       type: service
     version: 0.15.2
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -62,7 +62,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   espressif/tinyusb:
     component_hash: ee1c962cff61eb975d508258d509974d58031cc27ff0d6c4117a67a613a49594
     dependencies:
@@ -88,6 +88,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32p4
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   espressif/tinyusb:
     component_hash: ee1c962cff61eb975d508258d509974d58031cc27ff0d6c4117a67a613a49594
     dependencies:
@@ -32,6 +32,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32s2
 version: 2.0.0

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -1,6 +1,6 @@
 dependencies:
   espressif/mdns:
-    component_hash: 46ee81d32fbf850462d8af1e83303389602f6a6a9eddd2a55104cb4c063858ed
+    component_hash: 31117d76cae83a6d83ffd7f035f6fdae5bd05b914fc30b641afeb208b84de19a
     dependencies:
     - name: idf
       require: private
@@ -8,7 +8,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.1.0
+    version: 1.3.2
   espressif/tinyusb:
     component_hash: ee1c962cff61eb975d508258d509974d58031cc27ff0d6c4117a67a613a49594
     dependencies:
@@ -32,6 +32,6 @@ direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb
 - idf
-manifest_hash: 40b684ab14058130e675aab422296e4ad9d87ee39c5aa46d7b3df55c245e14f5
+manifest_hash: 135591912bdd610e3288fb8e418f83f05825b2ad683bbd749a57be0ca3752ab2
 target: esp32s3
 version: 2.0.0

--- a/ports/esp32/main/idf_component.yml
+++ b/ports/esp32/main/idf_component.yml
@@ -1,5 +1,7 @@
 dependencies:
-  espressif/mdns: "~1.1.0"
+  # holding off on updating mdns as newer versions have higher
+  # resource usage
+  espressif/mdns: "~1.3.0"
   espressif/tinyusb:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"


### PR DESCRIPTION
### Summary

* Update mdns component from 1.1.0 to 1.3.x (current 1.3.2).
* This version of mdns component builds on ESP32-H2 again, so revert 67f7fdd37 (https://github.com/micropython/micropython/pull/18784)) to re-enable mDNS on this chip (used with SPI Ethernet interface only).

*This work was funded through GitHub Sponsors.*

### Testing

* Verified the `ESP32_GENERIC_H2` board builds.
* Flashed `ESP32_GENERIC_S3` board and verified board's mDNS hostname (set via `network.hostname()`) was resolvable via mDNS, and that the board could resolve other hosts via mDNS using the `.local` name suffix.

### Trade-offs and Alternatives

* Some risk of regression, but 1.1.0 is pretty old so we'd have needed to update at some point.
* First version of this PR used the latest mdns component 1.11.3, but this adds 7452 bytes of flash size and over 2KB of static RAM usage. 1.3.2 seems to fix the H2 build without as much bloat (adds 5104 bytes of flash size but no extra static RAM). Have reported to Espressif as https://github.com/espressif/esp-protocols/issues/1100 .

### Generative AI

I did not use generative AI tools when creating this PR.