### PR TITLE
esp32: Note CONFIG_SPI_FLASH_ROM_IMPL may cause cache error / MMU fault.

### DIFF
--- a/ports/esp32/boards/sdkconfig.free_ram
+++ b/ports/esp32/boards/sdkconfig.free_ram
@@ -20,6 +20,9 @@ CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH=y
 # Use the SPI flash functions in ROM (when available). This may limit flash chip
 # support and cause issues with some flash chips. Each SoC family has different
 # set of chip support baked into ROM.
+# IMPORTANT: On some chips such as the ESP32-S3-WROOM-1-N8R8 it may cause panics
+# (Cache error / MMU entry fault error) when writing to high PSRAM addresses, see
+# https://github.com/micropython/micropython/pull/19469 for more details.
 CONFIG_SPI_FLASH_ROM_IMPL=y
 
 # Run the Bluetooth controller from flash not IRAM


### PR DESCRIPTION
### Summary

This PR adds a comment about an issue and links it to this PR for future discoverability.

`CONFIG_SPI_FLASH_ROM_IMPL=y` seems to cause MMU errors when writing to certain high memory addresses on several ESP32-S3-WROOM-1-N8R8. Most easily triggered by allocating, because that causes a memset to zero out the new allocation.

```
>>> bytearray(7*1024*1024)

A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

MPY version : v1.29.0-preview.501.g9b8ee1d268.dirty on 2026-07-03
IDF version : v5.5.4
Machine     : <custom board> with ESP32S3

Guru Meditation Error: Core  / panic'ed (Cache error).
MMU entry fault error

Core  0 register dump:
PC      : 0x40381faa  PS      : 0x00060434  A0      : 0x82095761  A1      : 0x3fca80d0
A2      : 0x00060423  A3      : 0x00000000  A4      : 0x00060420  A5      : 0x3fca7870
A6      : 0x3fca6b98  A7      : 0x3fca6b80  A8      : 0x8037dc6e  A9      : 0x3fca80b0
A10     : 0x3fca6b98  A11     : 0x00000001  A12     : 0x00000000  A13     : 0x00000000
A14     : 0xfffffffc  A15     : 0x00000008  SAR     : 0x0000001d  EXCCAUSE: 0x00000007
EXCVADDR: 0x00000000  LBEG    : 0x00000000  LEND    : 0x00000000  LCOUNT  : 0x00000000


Backtrace: 0x40381fa7:0x3fca80d0 0x4209575e:0x3fca80f0 0x4212bd6c:0x3fca8110 0x40387060:0x3fca8130
0x40381fa7: xt_utils_wait_for_intr at /esp-idf/components/xtensa/include/xt_utils.h:82
 (inlined by) esp_cpu_wait_for_intr at /esp-idf/components/esp_hw_support/cpu.c:55
0x4209575e: esp_pm_impl_waiti at /esp-idf/components/esp_pm/pm_impl.c:1096
0x4212bd6c: esp_vApplicationIdleHook at /esp-idf/components/esp_system/freertos_hooks.c:56
0x40387060: prvIdleTask at /esp-idf/components/freertos/FreeRTOS-Kernel/tasks.c:4350 (discriminator 1)

Core  1 register dump:
PC      : 0x400570ee  PS      : 0x00060234  A0      : 0x8202a5ed  A1      : 0x3fcebb90
A2      : 0x3c1bf7d0  A3      : 0x00000000  A4      : 0x00700000  A5      : 0x3c810000
A6      : 0x0000002a  A7      : 0x00070000  A8      : 0x00060021  A9      : 0x00000000
A10     : 0x00000000  A11     : 0x00000004  A12     : 0x00000000  A13     : 0x00000000
A14     : 0x3fc9cfb8  A15     : 0xffffffff  SAR     : 0x0000001a  EXCCAUSE: 0x00000007
EXCVADDR: 0x00000000  LBEG    : 0x400570e8  LEND    : 0x400570f3  LCOUNT  : 0x0000af7c


Backtrace: 0x400570eb:0x3fcebb90 0x4202a5ea:0x3fcebba0 0x4202ab11:0x3fcebbe0 0x4202c89f:0x3fcebc00 0x42034275:0x3fcebc20 0x420360e9:0x3fcebc40 0x40378859:0x3fcebc60 0x4202e7ab:0x3fcebd00 0x420360e9:0x3fcebd50 0x420360fe:0x3fcebd70 0x420458be:0x3fcebd90 0x42045b98:0x3fcebe20 0x420276e4:0x3fcebe60
0x400570eb: ?? ??:0
0x4202a5ea: gc_alloc at /micropython/py/gc.c:993
0x4202ab11: m_malloc at /micropython/py/malloc.c:86
0x4202c89f: array_new at /micropython/py/objarray.c:110
 (inlined by) bytearray_make_new at /micropython/py/objarray.c:193
0x42034275: type_call at /micropython/py/objtype.c:1060
0x420360e9: mp_call_function_n_kw at /micropython/py/runtime.c:719
0x40378859: mp_execute_bytecode at /micropython/py/vm.c:984
0x4202e7ab: fun_bc_call at /micropython/py/objfun.c:294
0x420360e9: mp_call_function_n_kw at /micropython/py/runtime.c:719
0x420360fe: mp_call_function_0 at /micropython/py/runtime.c:693
0x420458be: parse_compile_execute at /micropython/shared/runtime/pyexec.c:137
0x42045b98: pyexec_friendly_repl at /micropython/shared/runtime/pyexec.c:725
0x420276e4: mp_task at /micropython/ports/esp32/main.c:179



ELF file SHA256: 1bbc3d584

Rebooting...
```

Or, the slightly more useful error output of a IDFv5.4.3, and this time using a loop and large `MICROPY_GC_INITIAL_HEAP_SIZE` so we actually reach these high memory addresses instead of the GC removing old allocation before we do:

```
paste mode; Ctrl-C to cancel, Ctrl-D to finish
=== while True:
===     allocate = bytearray(1024)
===

A fatal error occurred. The crash dump printed below may be used to help
determine what caused it. If you are not already running the most recent
version of MicroPython, consider upgrading. New versions often fix bugs.

To learn more about how to debug and/or report this crash visit the wiki
page at: https://github.com/micropython/micropython/wiki/ESP32-debugging

MPY version : v1.29.0-preview.501.g9b8ee1d268.dirty on 2026-07-03
IDF version : v5.4.3
Machine     : <custom board> with ESP32S3

Guru Meditation Error: Core  / panic'ed (Cache disabled but cached memory region accessed).
MMU entry fault error occurred while accessing the address 0x3c810000 (invalid mmu entry)


Core  0 register dump:
PC      : 0x40383732  PS      : 0x00060434  A0      : 0x82092ca1  A1      : 0x3fca9420
A2      : 0x00060423  A3      : 0x00000000  A4      : 0x00060420  A5      : 0x3fca8bb0
A6      : 0x3fca7ef4  A7      : 0x3fca7edc  A8      : 0x8037e982  A9      : 0x3fca9400
A10     : 0x3fca7ef4  A11     : 0x00000001  A12     : 0x00000000  A13     : 0x00000000
A14     : 0x00060023  A15     : 0x00000008  SAR     : 0x0000001d  EXCCAUSE: 0x00000007
EXCVADDR: 0x00000000  LBEG    : 0x00000000  LEND    : 0x00000000  LCOUNT  : 0x00000000


Backtrace: 0x4038372f:0x3fca9420 0x42092c9e:0x3fca9440 0x42008b30:0x3fca9460 0x40388a18:0x3fca9480
0x4038372f: xt_utils_wait_for_intr at /esp-idf/components/xtensa/include/xt_utils.h:82
 (inlined by) esp_cpu_wait_for_intr at /esp-idf/components/esp_hw_support/cpu.c:55
0x42092c9e: esp_pm_impl_waiti at /esp-idf/components/esp_pm/pm_impl.c:1049
0x42008b30: esp_vApplicationIdleHook at /esp-idf/components/esp_system/freertos_hooks.c:56
0x40388a18: prvIdleTask at /esp-idf/components/freertos/FreeRTOS-Kernel/tasks.c:4341 (discriminator 1)

Core  1 register dump:
PC      : 0x400570ee  PS      : 0x00060434  A0      : 0x8202a59d  A1      : 0x3fcb49f0
A2      : 0x3c80fef0  A3      : 0x00000000  A4      : 0x00000400  A5      : 0x3c810000
A6      : 0x0000002a  A7      : 0x00000040  A8      : 0x82029915  A9      : 0x3fcb49c0
A10     : 0x3fca38d0  A11     : 0x3fcb4e58  A12     : 0x00000000  A13     : 0x00000000
A14     : 0x0000000a  A15     : 0x3fcb4e54  SAR     : 0x0000001a  EXCCAUSE: 0x00000007
EXCVADDR: 0x00000000  LBEG    : 0x400570e8  LEND    : 0x400570f3  LCOUNT  : 0x0000002e


Backtrace: 0x400570eb:0x3fcb49f0 0x4202a59a:0x3fcb4a00 0x4202aac1:0x3fcb4a40 0x4202c84f:0x3fcb4a60 0x42034225:0x3fcb4a80 0x42036099:0x3fcb4aa0 0x40379515:0x3fcb4ac0 0x4202e75b:0x3fcb4b60 0x42036099:0x3fcb4bb0 0x420360ae:0x3fcb4bd0 0x42045826:0x3fcb4bf0 0x42045b00:0x3fcb4c80 0x420276f4:0x3fcb4cc0
0x400570eb: ?? ??:0
0x4202a59a: gc_alloc at /micropython/py/gc.c:993
0x4202aac1: m_malloc at /micropython/py/malloc.c:86
0x4202c84f: array_new at /micropython/py/objarray.c:110
 (inlined by) bytearray_make_new at /micropython/py/objarray.c:193
0x42034225: type_call at /micropython/py/objtype.c:1060
0x42036099: mp_call_function_n_kw at /micropython/py/runtime.c:719
0x40379515: mp_execute_bytecode at /micropython/py/vm.c:984
0x4202e75b: fun_bc_call at /micropython/py/objfun.c:294
0x42036099: mp_call_function_n_kw at /micropython/py/runtime.c:719
0x420360ae: mp_call_function_0 at /micropython/py/runtime.c:693
0x42045826: parse_compile_execute at /micropython/shared/runtime/pyexec.c:137
0x42045b00: pyexec_friendly_repl at /micropython/shared/runtime/pyexec.c:725
0x420276f4: mp_task at /micropython/ports/esp32/main.c:179



ELF file SHA256: f86822dea

Rebooting...
```

When setting `CONFIG_SPI_FLASH_ROM_IMPL=n` I can no longer reproduce the issue. [The documentation for `CONFIG_SPI_FLASH_ROM_IMPL`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/spi_flash/spi_flash_idf_vs_rom.html) mentions only potential SPI flash issues; perhaps one of those are the true underlying cause for this PSRAM issue, although I cannot see why (it doesn't seem `memset` would require reading from flash while the cache is disabled, or something like that).

Either way, disabling this option seems to reliably avoid the crash. So this PR adds a comment for awareness.

### Testing

No code changes, just a comment. But tested it on the ESP32-S3-WROOM-1-N8R8.

### Generative AI

I did not use generative AI tools when creating this PR.
