### PR TITLE
py/asmrv32: Add support for Zcmt opcodes.

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -150,7 +150,7 @@ static int usage(char **argv) {
         "                x86, x64, armv6, armv6m, armv7m, armv7em, armv7emsp,\n"
         "                armv7emdp, xtensa, xtensawin, rv32imc, rv64imc, host, debug\n"
         "-march-flags=<flags> : set architecture-specific flags (can be either a dec/hex/bin value or a comma-separated flags string)\n"
-        "                       supported flags for rv32imc: zba, zcmp\n"
+        "                       supported flags for rv32imc: zba, zcmp, zcmt\n"
         "\n"
         "Implementation specific options:\n", argv[0]
         );
@@ -285,6 +285,8 @@ static bool parse_rv32_flags_string(const char *source, unsigned long *flags) {
             collected_flags |= RV32_EXT_ZBA;
         } else if (length == (sizeof("zcmp") - 1) && memcmp(current, "zcmp", length) == 0) {
             collected_flags |= RV32_EXT_ZCMP;
+        } else if (length == (sizeof("zcmt") - 1) && memcmp(current, "zcmt", length) == 0) {
+            collected_flags |= RV32_EXT_ZCMT;
         } else {
             return false;
         }

--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -105,14 +105,14 @@ GCC_VERSION = $(word 1, $(subst ., , $(shell $(CC) -dumpversion)))
 
 RV32_ABI = ilp32
 
-QEMU_ARGS += -bios none -cpu rv32,zcd=off,zcmp=on
+QEMU_ARGS += -bios none -cpu rv32,zcd=off,zcmp=on,zcmt=on
 
 # GCC 10 and lower do not recognise the Zicsr extension in the architecture name.
 ifeq ($(shell test $(GCC_VERSION) -le 10; echo $$?),0)
 RV32_ARCH ?= rv32imac
 else
 # Recent GCC versions explicitly require to declare extensions.
-RV32_ARCH ?= rv32imac_zicsr
+RV32_ARCH ?= rv32imac_zicsr_zifencei
 endif
 
 AFLAGS += -mabi=$(RV32_ABI) -march=$(RV32_ARCH)

--- a/ports/qemu/mcu/rv32/startup.c
+++ b/ports/qemu/mcu/rv32/startup.c
@@ -29,13 +29,28 @@
 #include <stdlib.h>
 
 #include "uart.h"
+#include "mpconfigport.h"
 
 extern void set_interrupt_table(void);
 extern int main(int argc, char **argv);
+extern const uintptr_t mp_fun_table;
 
 void _entry_point(void) {
     // Set interrupt table
     set_interrupt_table();
+    #if MICROPY_EMIT_RV32_ZCMT
+    // Relocate the table address to always perform a jump and link (index has
+    // to be between 32 and 255), so that calling function index #32 will perform
+    // a jump-and-link to the real function at index #0 (see §28.14.5).
+    __asm volatile (
+        // Use the JVT CSR index directly for compatibility.
+        "csrw    0x017, %0 \n"
+        "fence.i           \n"
+        :
+        : "r" ((ptrdiff_t)&mp_fun_table - (ptrdiff_t)(32 * sizeof(uintptr_t)))
+        : "memory"
+        );
+    #endif
     // Enable UART
     uart_init();
     // Now that we have a basic system up and running we can call main

--- a/ports/qemu/mpconfigport.h
+++ b/ports/qemu/mpconfigport.h
@@ -44,6 +44,10 @@
 #define MICROPY_EMIT_RV32           (1)
 #define MICROPY_EMIT_RV32_ZBA       (1)
 #define MICROPY_EMIT_RV32_ZCMP      (1)
+#define MICROPY_EMIT_RV32_ZCMT      (0)
+#if MICROPY_EMIT_RV32_ZCMT
+#define MICROPY_NATIVE_FUN_TABLE_ALIGNMENT (64)
+#endif
 #define MICROPY_EMIT_INLINE_RV32    (1)
 #elif (__riscv_xlen == 64)
 #define MICROPY_PERSISTENT_CODE_LOAD_NATIVE (1)

--- a/py/asmrv32.c
+++ b/py/asmrv32.c
@@ -61,6 +61,10 @@ static bool asm_rv32_allow_zcmp_opcodes(void) {
     return asm_rv32_allowed_extensions() & RV32_EXT_ZCMP;
 }
 
+static bool asm_rv32_allow_zcmt_opcodes(void) {
+    return asm_rv32_allowed_extensions() & RV32_EXT_ZCMT;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void asm_rv32_emit_word_opcode(asm_rv32_t *state, mp_uint_t word) {
@@ -336,9 +340,24 @@ void asm_rv32_end_pass(asm_rv32_t *state) {
 }
 
 void asm_rv32_emit_call_ind(asm_rv32_t *state, mp_uint_t index) {
-    mp_uint_t offset = index * ASM_WORD_SIZE;
     state->saved_registers_mask |= (1U << ASM_RV32_REG_RA);
 
+    // To always trigger a jump-with-link opcode, cm.jalt table indices are
+    // always offset by 32.
+
+    #if !MICROPY_DYNAMIC_COMPILER && ((MICROPY_RV32_EXTENSIONS & RV32_EXT_ZCMT) != 0)
+    MP_STATIC_ASSERT(MP_ARRAY_SIZE(mp_fun_table) <= (255 - 32));
+
+    // cm.jalt offset + 32
+    asm_rv32_opcode_cmjalt(state, index + 32);
+    #else
+    if (asm_rv32_allow_zcmt_opcodes() && (index <= (255 - 32))) {
+        // cm.jalt offset + 32
+        asm_rv32_opcode_cmjalt(state, index + 32);
+        return;
+    }
+
+    mp_uint_t offset = index * ASM_WORD_SIZE;
     if (RV32_IS_IN_C_REGISTER_WINDOW(REG_FUN_TABLE) && RV32_IS_IN_C_REGISTER_WINDOW(INTERNAL_TEMPORARY) && FIT_UNSIGNED(offset, 6)) {
         state->saved_registers_mask |= (1U << INTERNAL_TEMPORARY);
         // c.lw   temporary, offset(fun_table)
@@ -368,6 +387,7 @@ void asm_rv32_emit_call_ind(asm_rv32_t *state, mp_uint_t index) {
     asm_rv32_opcode_cadd(state, REG_TEMP2, REG_FUN_TABLE);
     asm_rv32_opcode_lw(state, REG_TEMP2, REG_TEMP2, lower);
     asm_rv32_opcode_cjalr(state, REG_TEMP2);
+    #endif
 }
 
 void asm_rv32_emit_jump_if_reg_eq(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t label) {

--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -126,8 +126,9 @@ enum {
     RV32_EXT_NONE = 0,
     RV32_EXT_ZBA = 1 << 0,
     RV32_EXT_ZCMP = 1 << 1,
+    RV32_EXT_ZCMT = 1 << 2,
 
-    RV32_EXT_ALL = RV32_EXT_ZBA | RV32_EXT_ZCMP
+    RV32_EXT_ALL = RV32_EXT_ZBA | RV32_EXT_ZCMP | RV32_EXT_ZCMT
 };
 
 typedef struct _asm_rv32_backend_options_t {
@@ -760,7 +761,8 @@ static inline void asm_rv32_opcode_xori(asm_rv32_t *state, mp_uint_t rd, mp_uint
 
 #define MICROPY_RV32_EXTENSIONS \
     ((MICROPY_EMIT_RV32_ZBA ? RV32_EXT_ZBA : 0) | \
-    (MICROPY_EMIT_RV32_ZCMP ? RV32_EXT_ZCMP : 0))
+    (MICROPY_EMIT_RV32_ZCMP ? RV32_EXT_ZCMP : 0) | \
+    (MICROPY_EMIT_RV32_ZCMT ? RV32_EXT_ZCMT : 0))
 
 static inline uint8_t asm_rv32_allowed_extensions(void) {
     uint8_t extensions = MICROPY_RV32_EXTENSIONS;

--- a/py/asmrv32.h
+++ b/py/asmrv32.h
@@ -209,6 +209,8 @@ void asm_rv32_end_pass(asm_rv32_t *state);
     ((((r2s >= ASM_RV32_REG_S0 && r2s <= ASM_RV32_REG_S1) ? \
     (r2s - ASM_RV32_REG_S0) : (r2s - ASM_RV32_REG_S2 + 2)) & 0x07) << 2))
 
+#define RV32_ENCODE_TYPE_CMJT(op, ft6, index) \
+    ((op & 0x03) | ((ft6 & 0x3F) << 10) | ((index & 0xFF) << 2))
 
 #define RV32_ENCODE_TYPE_CR(op, ft4, rs1, rs2) \
     ((op & 0x03) | ((rs2 & 0x1F) << 2) | ((rs1 & 0x1F) << 7) | ((ft4 & 0x0F) << 12))
@@ -452,6 +454,16 @@ static inline void asm_rv32_opcode_cxor(asm_rv32_t *state, mp_uint_t rd, mp_uint
     // CA: 100011 ... 01 ... 01
     asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CA(0x01, 0x23, 0x01, rd, rs));
 }
+
+// CM.JALT INDEX
+static inline void asm_rv32_opcode_cmjalt(asm_rv32_t *state, mp_uint_t index) {
+    // CMJT: 101000 ........ 10
+    asm_rv32_emit_halfword_opcode(state, RV32_ENCODE_TYPE_CMJT(0x02, 0x28, index));
+}
+
+// Indices < 32 trigger a plain jump, otherwise a jump with link.
+// CM.JT INDEX
+#define asm_rv32_opcode_cmjt asm_rv32_opcode_cmjalt
 
 // CM.MVA01S R1S', R2S'
 static inline void asm_rv32_opcode_cmmva01s(asm_rv32_t *state, mp_uint_t r1s, mp_uint_t r2s) {

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -558,6 +558,14 @@ typedef uint64_t mp_uint_t;
 // generated or loaded from a file).  This does not cover inline asm code.
 #define MICROPY_ENABLE_NATIVE_CODE (MICROPY_EMIT_NATIVE || MICROPY_PERSISTENT_CODE_LOAD_NATIVE)
 
+// Whether to align the native function table to an arbitrary boundary.  This
+// is needed if MICROPY_EMIT_RV32_ZCMT is enabled and the function table isn't
+// copied in RAM, in which case this should be set to 64.  0 means leaving the
+// compiler in charge of figuring out the alignment.
+#ifndef MICROPY_NATIVE_FUN_TABLE_ALIGNMENT
+#define MICROPY_NATIVE_FUN_TABLE_ALIGNMENT (0)
+#endif
+
 /*****************************************************************************/
 /* Compiler configuration                                                    */
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -525,6 +525,11 @@ typedef uint64_t mp_uint_t;
 #define MICROPY_EMIT_RV32_ZCMP (0)
 #endif
 
+// Whether to emit RISC-V RV32 Zcmt opcodes in native code
+#ifndef MICROPY_EMIT_RV32_ZCMT
+#define MICROPY_EMIT_RV32_ZCMT (0)
+#endif
+
 // Whether to enable the RISC-V RV32 inline assembler
 #ifndef MICROPY_EMIT_INLINE_RV32
 #define MICROPY_EMIT_INLINE_RV32 (0)

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -254,8 +254,15 @@ static double mp_obj_get_float_to_d(mp_obj_t o) {
 
 #endif
 
+#if MICROPY_NATIVE_FUN_TABLE_ALIGNMENT > 0
+#define ALIGN(x) __attribute__((aligned(x)))
+#define FUN_TABLE_ALIGNMENT ALIGN(MICROPY_NATIVE_FUN_TABLE_ALIGNMENT)
+#else
+#define FUN_TABLE_ALIGNMENT
+#endif
+
 // these must correspond to the respective enum in nativeglue.h
-const mp_fun_table_t mp_fun_table = {
+const mp_fun_table_t mp_fun_table FUN_TABLE_ALIGNMENT = {
     mp_const_none,
     mp_const_false,
     mp_const_true,

--- a/tests/run-tests.py
+++ b/tests/run-tests.py
@@ -36,6 +36,7 @@ from test_utils import (
 RV32_ARCH_FLAGS = {
     "zba": 1 << 0,
     "zcmp": 1 << 1,
+    "zcmt": 1 << 2,
 }
 
 # Tests require at least CPython 3.3. If your default python3 executable

--- a/tools/mpy_ld.py
+++ b/tools/mpy_ld.py
@@ -1674,6 +1674,7 @@ def parse_linkerscript(source):
 RV32_EXTENSIONS = {
     "zba": 1 << 0,
     "zcmp": 1 << 1,
+    "zcmt": 1 << 2,
 }
 
 


### PR DESCRIPTION
### Summary

This PR adds support for the `Zcmt` extension to RISC-V 32 targets.

RISC-V has *a few* ways to encode indirect jumps, each with different code sequences depending on the register used to jump through and on how many bits are used by the offset.  Sequences emitted by MicroPython range between 2 to 14 bytes in length.  Enter `Zcmt` [1], implementing table-indexed jumps with a single 2-bytes opcode, which is supported by QEMU (more in the "Testing" section), and by the ESP32P4/ESP32S31 as far as known targets go.  With these changes, the emitter will use a single opcode for each emitted indirect call, instead of having to sort through the best combination of register and offset.

Rebuilding the whole of `/tests` just using `Zcmt` did yield a 15.45% size reduction, and together with `Zcmp` code ended up being 18.04% smaller :

```
# Before
$ cd /micropython/tests ; for i in **/*.py; do /micropython/mpy-cross/build/mpy-cross -X emit=native -march=rv32imc $i; done; du -bcs **/*.mpy | tail -n 1
3440738 total

# After with just Zcmt
$ cd /micropython/tests ; for i in **/*.py; do /micropython/mpy-cross/build/mpy-cross -X emit=native -march=rv32imc -march-flags=zcmt $i; done; du -bcs **/*.mpy | tail -n 1
2908947 total

# After with Zcmp + Zcmt
$ cd /micropython/tests ; for i in **/*.py; do /micropython/mpy-cross/build/mpy-cross -X emit=native -march=rv32imc -march-flags=zcmp,zcmt $i; done; du -bcs **/*.mpy | tail -n 1
2819863 total
```

There's a minor size increase due to `mp_fun_table` having to be re-aligned, leaving some space unused.  On my machine the QEMU firmware is 46 bytes larger.

Integration is not a matter of toggling a compilation definition though.  To make this work, ports need to perform two extra steps besides turning on `MICROPY_EMIT_RV32_ZCMT`.

First, ports have to make sure the function table **must** be aligned to a 64 bytes (or larger) boundary.  This is required since the table address will be stored in a place that requires the bottom 6 bits to be used for something else.  To achieve this, a new configuration option was added: `MICROPY_NATIVE_FUN_TABLE_ALIGNMENT`.  Leaving this to its default value won't do anything, however if it is set to a value greater than 0 it will tell the compiler to forcefully align the native function call table to the requested boundary (64, if you want to get `Zcmt` opcodes to work).

Then it's time to let the CPU know *where* the table is.  This is the most interesting part, since there are two opcodes to perform the function calls: `cm.jalt` and `cm.jt`.  The first one performs a jump-with-link (aka call), the other just jumps and won't return by itself.  The best part is that their opcode values are the *same*, so indices between 0 and 31 will not return from the jump, whilst indices from 31 to 255 will.  To work around that the table offset that needs to be stored has to be offset by -128 (32 * `sizeof(uintptr_t)`).  This value needs to be stored in the `JVT` CSR, and after that it is more or less mandatory a full instruction cache flush.  A TL;DR of this paragraph can be summed up as this snippet:

```c
#if MICROPY_EMIT_RV32_ZCMT
extern const uintptr_t mp_fun_table;

__asm volatile (
    // Use the JVT CSR index directly for compatibility with all toolchains.
    "csrw    0x017, %0 \n"
    "fence.i           \n" // or your SDK equivalent
    :
    : "r" ((ptrdiff_t)&mp_fun_table - (ptrdiff_t)(32 * sizeof(uintptr_t)))
    : "memory"
);  
#endif
```

See the changes in `ports/qemu` for how that works in practice.

Inline assembler support for this is ~10 lines of code, but until there's a physical target running with this enabled I'll wait to add that.

### Testing

The QEMU `VIRT_RV32` board passes the full test suite (regular, `--via-mpy`, and `--via-mpy --emit=native`)  when running on QEMU 11.0.2.  The CI image's version of QEMU seems to have issues with Zcmt opcodes, and therefore the QEMU port doesn't have this functionality switched on by default to let CI pass.

Whilst this is supposed to be working on ESP32P4/ESP32S31 as well, this was not tested as my P4 board is lost somewhere at customs.  However, the code needed for this to work should be this:

```diff
diff --git i/ports/esp32/esp32_common.cmake w/ports/esp32/esp32_common.cmake
index fee776fa6..0706e650e 100644
--- i/ports/esp32/esp32_common.cmake
+++ w/ports/esp32/esp32_common.cmake
@@ -252,7 +252,7 @@ if(CONFIG_IDF_TARGET_ARCH_XTENSA)
     set(MICROPY_CROSS_FLAGS -march=xtensawin)
 elseif(CONFIG_IDF_TARGET_ARCH_RISCV)
     if (CONFIG_IDF_TARGET_ESP32P4)
-        set(MICROPY_CROSS_FLAGS "-march=rv32imc -march-flags=zcmp")
+        set(MICROPY_CROSS_FLAGS "-march=rv32imc -march-flags=zcmp,zcmt")
     else()
         set(MICROPY_CROSS_FLAGS -march=rv32imc)
     endif()
diff --git i/ports/esp32/main.c w/ports/esp32/main.c
index 697f4efde..047f1ac84 100644
--- i/ports/esp32/main.c
+++ w/ports/esp32/main.c
@@ -276,11 +276,28 @@ void boardctrl_startup(void) {
     }
 }
 
+extern const void **mp_fun_table;
+
 void MICROPY_ESP_IDF_ENTRY(void) {
     // Hook for a board to run code at start up.
     // This defaults to initialising NVS and detecting the flash size.
     MICROPY_BOARD_STARTUP();
 
+    #if CONFIG_IDF_TARGET_ESP32P4 && MICROPY_EMIT_RV32_ZCMT
+    uintptr_t relocated_table = (ptrdiff_t)&mp_fun_table - (ptrdiff_t)(32 * sizeof(uintptr_t));
+    // Relocate the table address to always perform a jump and link (index has
+    // to be between 32 and 255), so that calling function index #32 will perform
+    // a jump-and-link to the real function at index #0 (see §28.14.5).
+    __asm volatile (
+        // Use the JVT CSR index directly for compatibility.
+        "csrw 0x017, %0 \n"
+        :
+        : "r" (relocated_table)
+        : "memory"
+        );
+    MP_HAL_CLEAN_DCACHE(relocated_table, 128 * sizeof(uintptr_t));
+    #endif
+
     // Create and transfer control to the MicroPython task.
     xTaskCreatePinnedToCore(mp_task, "mp_task", MICROPY_TASK_STACK_SIZE / sizeof(StackType_t), NULL, MP_TASK_PRIORITY, &mp_main_task_handle, MP_TASK_COREID);
 }
diff --git i/ports/esp32/mpconfigport.h w/ports/esp32/mpconfigport.h
index 632c2f317..ba0bbfb94 100644
--- i/ports/esp32/mpconfigport.h
+++ w/ports/esp32/mpconfigport.h
@@ -46,6 +46,8 @@
 #define MICROPY_EMIT_RV32                   (1)
 #if CONFIG_IDF_TARGET_ESP32P4
 #define MICROPY_EMIT_RV32_ZCMP              (1)
+#define MICROPY_EMIT_RV32_ZCMT              (1)
+#define MICROPY_NATIVE_FUN_TABLE_ALIGNMENT  (64)
 #endif
 #endif
 #else
```
### Trade-offs and Alternatives

This is not compatible with code (may it be from natmods, usermods, or the RTOS itself) that uses the `jvt` CSR for its own purposes.

### Generative AI

I did not use generative AI tools when creating this PR.

---

This alone won't get rid of the `REG_FUN_TABLE`register for selected RV32 targets, unfortunately.  There's an intermediate roadblock to achieve that goal, which is loading of constant objects (ie. `True`, `False`, `None`) in generated code.

Now, with `Zcmt` opcodes the function table is not stored in a regular CPU register but in a CSR.  This means `REG_FUN_TABLE` isn't used for generating `ASM_CALL_IND` sequences anymore and its only usage is to look up at runtime the values of `True`, `False`, and `None` (see `emit_native_mov_reg_const`).   Assuming that is somehow taken care of in a different way without using `REG_FUN_TABLE` (more on that later), this means the function prologue can be effectively reduced to a stack adjustment and registers saving.  If `Zcmp` opcodes are used, it means the prologue is a single 2-bytes opcode, since `REG_FUN_TABLE` isn't needed at runtime anymore, thus freeing up `S0` and `S1`, which are extra valuable as they're part of the compressed opcodes register window.

Back to `REG_FUN_TABLE`, for code that is generated by the emitter at runtime the values of the constants mentioned earlier are guaranteed to not change over the lifetime of the interpreter (`mp_fun_table` is most probably in ROM anyway).  If generating code at runtime, it's guaranteed we already know the value of those constants so they can be inlined using `ASM_MOV_REG_IMM` instead of `ASM_LOAD_REG_REG_OFFSET`.  This may have the nice side effect of reducing code size on a few targets (need to check though!), but chances are it will increase speed by a tiny bit as there's no need to hit memory too.

The main issue with that is code compiled with `mpy-cross`.  In theory there's no guarantee those three constants' values won't change across MicroPython versions (I guess they haven't changed in a bit, have they) but the possibility for incompatibility is there.  I don't think I have a solution for this that may work in all cases - there's always the option of forcing this via a command-line switch, but then if you don't rebuild your MPY files together with your interpreter you may end up with out-of-sync constants values (with hilarious results at runtime).

[1]  https://github.com/riscv/riscv-isa-manual/blob/c1e1e1eceed9ccdddaf2a7611ac20e1e4230c77b/src/unpriv/zcmt.adoc