### PR TITLE
py/objstr,unicode: Add support for ascii encode & decode, document encoding limits

### DIFF
--- a/docs/reference/unicode_support.rst
+++ b/docs/reference/unicode_support.rst
@@ -49,8 +49,10 @@ The :meth:`bytes.decode` and :meth:`str.encode` methods support the following en
 - UTF-8 (``'utf-8'`` or ``'utf8'``)
 - ASCII (``'ascii'``)
 
-Other encodings (such as ``'latin-1'``, ``'utf-16'``, etc.) are not supported and
-will raise ``LookupError``.
+Other encodings (such as ``'latin-1'``, ``'utf-16'``, etc.) are not supported
+and will raise ``LookupError``. The encoding argument must also match one of the
+supported strings exactly (for example, ``'utf8'`` is valid but ``'UTF8'``
+is not). `More details <cpydiff_types_bytes_decode_encoding>`.
 
 Example::
 
@@ -91,6 +93,21 @@ The same ``errors`` handling applies when decoding any bytes-like object, includ
 via the ``str()`` constructor (for example ``str(buf, 'utf-8', 'replace')`` where
 ``buf`` is a ``bytes``, ``bytearray``, ``memoryview`` or ``array`` object).
 
+Encoding to Bytes
+~~~~~~~~~~~~~~~~~
+
+Function ``str.encode()`` and the ``bytes()`` constructor accept an ``encoding``
+argument which can be ``'utf8'``, ``'utf-8'`` or ``'ascii'``::
+
+  >>> "abc".encode("ascii")
+  b'abc'
+
+If encoding ``'ascii'`` is specified then an exception is raised if the string
+contains non-ASCII characters.
+
+The ``'ignore'`` and ``'replace'`` ``errors`` values are not supported in these
+conversions from string to bytes and `any errors argument is ignored
+<cpydiff_types_str_encode_errors>`.
 
 String Methods
 --------------

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -188,11 +188,12 @@ static void str_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t
 }
 
 #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK && MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
-// Build a new string from data containing invalid UTF-8, either skipping the
+// Build a new string from data containing invalid UTF-8 or ASCII, either skipping the
 // invalid bytes (errors=="ignore") or replacing them with U+FFFD
 // (errors=="replace").
-static mp_obj_t str_from_invalid_utf8(const mp_obj_type_t *type, const byte *str_data, size_t str_len, qstr errors) {
+static mp_obj_t str_from_invalid(mp_encoding_t encoding, const mp_obj_type_t *type, const byte *str_data, size_t str_len, qstr errors) {
     bool do_replace = (errors == MP_QSTR_replace);
+    bool is_utf8 = (encoding == MP_ENCODING_UTF8);
     vstr_t vstr;
     vstr_init(&vstr, str_len);
     const byte *p = str_data;
@@ -204,7 +205,7 @@ static mp_obj_t str_from_invalid_utf8(const mp_obj_type_t *type, const byte *str
             // Valid ASCII
             vstr_add_byte(&vstr, c);
             p++;
-        } else if (c >= 0xc0 && c < 0xf8) {
+        } else if (is_utf8 && c >= 0xc0 && c < 0xf8) {
             // Potential multi-byte sequence
             uint8_t need = (0xe5 >> ((c >> 3) & 0x6)) & 3;
             const byte *seq_start = p;
@@ -230,11 +231,11 @@ static mp_obj_t str_from_invalid_utf8(const mp_obj_type_t *type, const byte *str
             }
             // For 'ignore' mode, do nothing (skip invalid bytes)
         } else if (do_replace) {
-            // Invalid start byte - replace with U+FFFD
+            // Invalid start byte or non-ascii char - replace with U+FFFD
             vstr_add_char(&vstr, 0xFFFD);
             p++;
         } else {
-            // Invalid start byte - skip for 'ignore' mode
+            // Invalid start byte or non-ascii char - skip for 'ignore' mode
             p++;
         }
     }
@@ -242,6 +243,22 @@ static mp_obj_t str_from_invalid_utf8(const mp_obj_type_t *type, const byte *str
     return mp_obj_new_str_type_from_vstr(type, &vstr);
 }
 #endif // MICROPY_PY_BUILTINS_STR_UNICODE_CHECK && MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
+
+#if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+static mp_encoding_t parse_encoding_arg(qstr encoding) {
+    if (encoding == MP_QSTR_utf_hyphen_8 || encoding == MP_QSTR_utf8) {
+        return MP_ENCODING_UTF8;
+    }
+    if (encoding == MP_QSTR_ascii) {
+        return MP_ENCODING_ASCII;
+    }
+    #if MICROPY_ERROR_REPORTING <= MICROPY_ERROR_REPORTING_TERSE
+    mp_raise_type(&mp_type_LookupError);
+    #else
+    mp_raise_msg_varg(&mp_type_LookupError, MP_ERROR_TEXT("unknown encoding: %q"), encoding);
+    #endif
+}
+#endif
 
 mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     #if MICROPY_CPYTHON_COMPAT
@@ -282,7 +299,8 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
             }
 
             #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-            if (!utf8_check(str_data, str_len)) {
+            mp_encoding_t encoding = parse_encoding_arg(mp_obj_str_get_qstr(args[1]));
+            if (!unicode_encoding_check(encoding, str_data, str_len)) {
                 #if MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
                 // Check if error handler is specified (3rd argument)
                 qstr errors = MP_QSTR_; // default to ""
@@ -290,7 +308,7 @@ mp_obj_t mp_obj_str_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_
                     errors = mp_obj_str_get_qstr(args[2]);
                 }
                 if (errors == MP_QSTR_ignore || errors == MP_QSTR_replace) {
-                    return str_from_invalid_utf8(type, str_data, str_len, errors);
+                    return str_from_invalid(encoding, type, str_data, str_len, errors);
                 }
                 #endif // MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS
                 mp_raise_msg(&mp_type_UnicodeError, NULL);
@@ -2090,14 +2108,6 @@ MP_DEFINE_CONST_FUN_OBJ_1(str_islower_obj, str_islower);
 // These methods are superfluous in the presence of str() and bytes()
 // constructors.
 
-static void check_utf8_encoding(qstr encoding) {
-    if (!(encoding == MP_QSTR_utf_hyphen_8 || encoding == MP_QSTR_utf8 ||
-          encoding == MP_QSTR_ascii)) {
-        mp_raise_msg_varg(&mp_type_LookupError,
-            MP_ERROR_TEXT("encoding not supported: %q"), encoding);
-    }
-}
-
 // TODO: should accept kwargs too
 static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
     mp_obj_t new_args[2];
@@ -2106,8 +2116,6 @@ static mp_obj_t bytes_decode(size_t n_args, const mp_obj_t *args) {
         new_args[1] = MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8);
         args = new_args;
         n_args++;
-    } else if (n_args >= 2) {
-        check_utf8_encoding(mp_obj_str_get_qstr(args[1]));
     }
     return mp_obj_str_make_new(&mp_type_str, n_args, 0, args);
 }
@@ -2122,7 +2130,7 @@ static mp_obj_t str_encode(size_t n_args, const mp_obj_t *args) {
         args = new_args;
         n_args++;
     } else if (n_args >= 2) {
-        check_utf8_encoding(mp_obj_str_get_qstr(args[1]));
+        parse_encoding_arg(mp_obj_str_get_qstr(args[1]));
     }
     return bytes_make_new(NULL, n_args, 0, args);
 }
@@ -2428,7 +2436,7 @@ static mp_obj_t mp_obj_new_str_type_from_vstr(const mp_obj_type_t *type, vstr_t 
 
 mp_obj_t mp_obj_new_str_from_vstr(vstr_t *vstr) {
     #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-    if (!utf8_check((byte *)vstr->buf, vstr->len)) {
+    if (!unicode_encoding_check(MP_ENCODING_UTF8, (byte *)vstr->buf, vstr->len)) {
         mp_raise_msg(&mp_type_UnicodeError, NULL);
     }
     #endif // MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
@@ -2448,7 +2456,7 @@ mp_obj_t mp_obj_new_bytes_from_vstr(vstr_t *vstr) {
 
 mp_obj_t mp_obj_new_str(const char *data, size_t len) {
     #if MICROPY_PY_BUILTINS_STR_UNICODE && MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
-    if (!utf8_check((byte *)data, len)) {
+    if (!unicode_encoding_check(MP_ENCODING_UTF8, (byte *)data, len)) {
         mp_raise_msg(&mp_type_UnicodeError, NULL);
     }
     #endif

--- a/py/objstr.c
+++ b/py/objstr.c
@@ -366,11 +366,20 @@ static mp_obj_t bytes_make_new(const mp_obj_type_t *type_in, size_t n_args, size
             mp_raise_TypeError(MP_ERROR_TEXT("string argument without an encoding"));
             #endif
         }
+
         GET_STR_DATA_LEN(args[0], str_data, str_len);
         GET_STR_HASH(args[0], str_hash);
         if (str_hash == 0) {
             str_hash = qstr_compute_hash(str_data, str_len);
         }
+
+        #if MICROPY_PY_BUILTINS_STR_UNICODE_CHECK
+        mp_encoding_t encoding = parse_encoding_arg(mp_obj_str_get_qstr(args[1]));
+        if (encoding == MP_ENCODING_ASCII && !unicode_encoding_check(MP_ENCODING_ASCII, str_data, str_len)) {
+            mp_raise_msg(&mp_type_UnicodeError, NULL);
+        }
+        #endif
+
         mp_obj_str_t *o = MP_OBJ_TO_PTR(mp_obj_new_str_copy(&mp_type_bytes, NULL, str_len));
         o->data = str_data;
         o->hash = str_hash;
@@ -2129,8 +2138,6 @@ static mp_obj_t str_encode(size_t n_args, const mp_obj_t *args) {
         new_args[1] = MP_OBJ_NEW_QSTR(MP_QSTR_utf_hyphen_8);
         args = new_args;
         n_args++;
-    } else if (n_args >= 2) {
-        parse_encoding_arg(mp_obj_str_get_qstr(args[1]));
     }
     return bytes_make_new(NULL, n_args, 0, args);
 }

--- a/py/unicode.c
+++ b/py/unicode.c
@@ -180,7 +180,7 @@ mp_uint_t unichar_xdigit_value(unichar c) {
 
 #if MICROPY_PY_BUILTINS_STR_UNICODE
 
-bool utf8_check(const byte *p, size_t len) {
+bool unicode_encoding_check(mp_encoding_t encoding, const byte *p, size_t len) {
     uint8_t need = 0;
     const byte *end = p + len;
     for (; p < end; p++) {
@@ -193,7 +193,7 @@ bool utf8_check(const byte *p, size_t len) {
                 return 0;
             }
         } else {
-            if (c >= 0xc0) {
+            if (encoding == MP_ENCODING_UTF8 && c >= 0xc0) {
                 if (c >= 0xf8) {
                     // mismatch
                     return 0;

--- a/py/unicode.h
+++ b/py/unicode.h
@@ -29,7 +29,14 @@
 #include "py/mpconfig.h"
 #include "py/misc.h"
 
+typedef enum {
+    MP_ENCODING_UTF8,
+    MP_ENCODING_ASCII,
+} mp_encoding_t;
+
 mp_uint_t utf8_ptr_to_index(const byte *s, const byte *ptr);
-bool utf8_check(const byte *p, size_t len);
+
+// Returns true if bytes in buffer 'p' are valid according to encoding.
+bool unicode_encoding_check(mp_encoding_t encoding, const byte *p, size_t len);
 
 #endif // MICROPY_INCLUDED_PY_UNICODE_H

--- a/tests/cpydiff/types_bytes_encoding.py
+++ b/tests/cpydiff/types_bytes_encoding.py
@@ -1,0 +1,21 @@
+"""
+categories: Types,bytes
+description: bytes() constructor only supports encoding arguments 'utf8', 'utf-8' and 'ascii'. Other encodings like 'latin-1' are not supported. Other string forms such as 'UTF8' are not supported.
+cause: MicroPython is optimised for embedded systems and has limited codec support to save code size. `A similar restriction applies to str.encode() <cpydiff_types_str_encode_encoding>`. See also `unicode_support`.
+workaround: Implement other encoding conversions manually by parsing the result of str.encode() or bytes() constructor.
+"""
+
+# Both CPython and MicroPython can encode this emoji as UTF-8 bytes
+print(bytes("😀", "utf8"))
+
+# Both CPython and MicroPython will fail to encode this emoji as ASCII bytes
+try:
+    print(bytes("😀", "ascii"))
+except UnicodeError:
+    print("UnicodeError")
+
+# Other encodings or string formats aren't accepted by MicroPython
+try:
+    print(bytes("😀", "UTF-8"))
+except LookupError:
+    print("LookupError")

--- a/tests/cpydiff/types_str_encode_encoding.py
+++ b/tests/cpydiff/types_str_encode_encoding.py
@@ -1,0 +1,21 @@
+"""
+categories: Types,str
+description: str.encode() constructor only supports encoding arguments 'utf8', 'utf-8' and 'ascii'. Other encodings like 'latin-1' are not supported. Other string forms such as 'UTF8' are not supported.
+cause: MicroPython is optimised for embedded systems and has limited codec support to save code size. `A similar restriction applies to bytes constructor <cpydiff_types_bytes_encoding>`. See also `unicode_support`.
+workaround: Implement encoding conversions manually by parsing the result of str.encode() or bytes() constructor.
+"""
+
+# Both CPython and MicroPython can encode this emoji as UTF-8 bytes
+print("😀".encode("utf8"))
+
+# Both CPython and MicroPython will fail to encode this emoji as ASCII bytes
+try:
+    print("😀".encode("ascii"))
+except UnicodeError:
+    print("UnicodeError")
+
+# Other encodings or string formats aren't accepted by MicroPython:
+try:
+    print("😀".encode("UTF-8"))
+except LookupError:
+    print("LookupError")

--- a/tests/cpydiff/types_str_encode_errors.py
+++ b/tests/cpydiff/types_str_encode_errors.py
@@ -1,0 +1,19 @@
+"""
+categories: Types,str
+description: str.encode() and bytes() constructor ignore any ``errors`` argument specified. If the encoding is specified as ``'ascii'`` and a non-ASCII byte is found in the string then an exception is always raised.
+cause: MicroPython is optimised for embedded systems and has limited codec support to save code size. See also `unicode_support`.
+workaround: Handle encoding errors manually by parsing the result of str.encode() or bytes() constructor.
+"""
+
+# CPython will replace the emoji with an ASCII '?' but MicroPython will
+# raise an exception
+try:
+    print("😀".encode("ascii", "replace"))
+except UnicodeError:
+    print("UnicodeError")
+
+# CPython will ignore the emoji in the result but MicroPython will raise an exception
+try:
+    print("😀".encode("ascii", "ignore"))
+except UnicodeError:
+    print("UnicodeError")

--- a/tests/cpydiff/types_str_encoding.py
+++ b/tests/cpydiff/types_str_encoding.py
@@ -1,30 +1,30 @@
 """
-categories: Types,bytes
-description: bytes.decode() only supports encoding arguments 'utf8', 'utf-8' and 'ascii'. Other encodings like 'latin-1' are not supported. Other string forms such as 'UTF8' are not supported.
-cause: MicroPython is optimised for embedded systems and only includes UTF-8 and ASCII codec support with simple matching to save memory and code size. `The same restriction applies to str constructor <cpydiff_types_str_encoding>`. See also `unicode_support`.
+categories: Types,str
+description: str() constructor only supports encoding arguments 'utf8', 'utf-8' and 'ascii'. Other encodings like 'latin-1' are not supported. Other string forms such as 'UTF8' are not supported.
+cause: MicroPython is optimised for embedded systems and only includes UTF-8 and ASCII codec support with simple matching to save memory and code size. `The same restriction applies to bytes.decode() <cpydiff_types_bytes_decode_encoding>`. See also `unicode_support`.
 workaround: Convert data to UTF-8 before processing, or implement custom encoding/decoding if needed. Ensure encoding argument is one of the accepted forms.
 """
 
 # Both CPython and MicroPython support utf8 and ascii encodings
-print(b"caf\xc3\xa9".decode("utf8"))  # codespell:ignore caf
-print(b"cafe".decode("ascii"))
+print(str(b"caf\xc3\xa9", "utf8"))  # codespell:ignore caf
+print(str(b"cafe", "ascii"))
 
 # MicroPython does not support additional encodings
 try:
-    b"\xe9".decode("latin-1")  # 'é' in latin-1
+    str(b"\xe9", "latin-1")  # 'é' in latin-1
     print("latin-1 supported")
 except (ValueError, NotImplementedError, LookupError) as e:
     print("latin-1 not supported:", type(e).__name__)
 
 try:
-    b"\x80".decode("cp1252")  # Euro sign in cp1252
+    str(b"\x80", "cp1252")  # Euro sign in cp1252
     print("cp1252 supported")
 except (ValueError, NotImplementedError, LookupError) as e:
     print("cp1252 not supported:", type(e).__name__)
 
 # Encoding arguments must match exactly in MicroPython
 try:
-    b"hello".decode("ASCII")
+    str(b"hello", "ASCII")
     print("Capital letters ASCII supported")
 except (ValueError, NotImplementedError, LookupError) as e:
     print("Capital letters ASCII not supported:", type(e).__name__)

--- a/tests/unicode/ascii.py
+++ b/tests/unicode/ascii.py
@@ -1,4 +1,4 @@
-# Test conversions from ASCII to UTF8 strings via constructor
+# Test conversions from ASCII to/from UTF8 strings via constructor
 
 # Invalid ASCII characters via constructor
 try:
@@ -8,5 +8,15 @@ except UnicodeError:
 
 try:
     str(b"\xff\xee\xff", "ascii")  # Totally invalid
+except UnicodeError:
+    print("UnicodeError")
+
+
+bytes("😀", "utf8")
+bytes("abcd", "ascii")
+
+# Conversion should fail if non-ASCII characters in string
+try:
+    bytes("😀", "ascii")
 except UnicodeError:
     print("UnicodeError")

--- a/tests/unicode/ascii.py
+++ b/tests/unicode/ascii.py
@@ -1,0 +1,12 @@
+# Test conversions from ASCII to UTF8 strings via constructor
+
+# Invalid ASCII characters via constructor
+try:
+    str(b"ni\xe5\xa5\xbd", "ascii")  # Valid utf8, invalid ascii
+except UnicodeError:
+    print("UnicodeError")
+
+try:
+    str(b"\xff\xee\xff", "ascii")  # Totally invalid
+except UnicodeError:
+    print("UnicodeError")

--- a/tests/unicode/bytes_decode_encoding.py
+++ b/tests/unicode/bytes_decode_encoding.py
@@ -32,6 +32,9 @@ print("©".encode("utf-8"))
 print(b"\xf0\x9f\x91\x8d".decode("utf-8"))
 print("👍".encode("utf-8"))
 
+# Test ascii encode
+print("abcde".encode("ascii"))
+
 # Test invalid decoded code points in repr fallback path.
 print(repr(b"\xf4\x90\x80\x80".decode("utf-8")))
 print(repr(b"\xf5\x80\x80\x80".decode("utf-8")))
@@ -64,3 +67,9 @@ for encoding in invalid_encodings:
         print("UNEXPECTED:", encoding, "should raise LookupError")
     except LookupError as e:
         print("LookupError:", encoding)
+
+# Test invalid ascii characters in str.encode()
+try:
+    "你好".encode("ascii")
+except UnicodeError:
+    print("UnicodeError")

--- a/tests/unicode/bytes_decode_encoding.py
+++ b/tests/unicode/bytes_decode_encoding.py
@@ -36,6 +36,12 @@ print("👍".encode("utf-8"))
 print(repr(b"\xf4\x90\x80\x80".decode("utf-8")))
 print(repr(b"\xf5\x80\x80\x80".decode("utf-8")))
 
+# Test invalid ASCII characters in decode
+try:
+    print(repr(b"ni\xe5\xa5\xbd".decode("ascii")))
+except UnicodeError:
+    print("UnicodeError")
+
 # Test invalid encodings for bytes.decode()
 # These should raise LookupError
 invalid_encodings = ["latin-1", "latin1", "utf-16", "utf-32", "iso-8859-1", "cp1252"]

--- a/tests/unicode/bytes_decode_encoding.py.exp
+++ b/tests/unicode/bytes_decode_encoding.py.exp
@@ -11,6 +11,7 @@ b'\xc2\xa9'
 b'\xf0\x9f\x91\x8d'
 '\U00110000'
 '\U00140000'
+UnicodeError
 LookupError: latin-1
 LookupError: latin1
 LookupError: utf-16

--- a/tests/unicode/bytes_decode_encoding.py.exp
+++ b/tests/unicode/bytes_decode_encoding.py.exp
@@ -9,6 +9,7 @@ test
 b'\xc2\xa9'
 👍
 b'\xf0\x9f\x91\x8d'
+b'abcde'
 '\U00110000'
 '\U00140000'
 UnicodeError
@@ -26,3 +27,4 @@ LookupError: utf-16
 LookupError: utf-32
 LookupError: iso-8859-1
 LookupError: cp1252
+UnicodeError

--- a/tests/unicode/bytes_decode_ignore.py
+++ b/tests/unicode/bytes_decode_ignore.py
@@ -103,3 +103,7 @@ print(repr(b"\xff\xe4\xb8\x80".decode("utf-8", "ignore")))  # 一 preserved afte
 
 # Test multiple incomplete sequences in a row
 print(repr(b"\xe4\xf0\xe4".decode("utf-8", "ignore")))
+
+# Test ignoring invalid ASCII
+print(repr(b"\xe5\xa5\xbd".decode("ascii", "ignore")))  # valid utf8, not valid ascii
+print(repr(b"a\xbb\xcc\xddef\x01".decode("ascii", "ignore")))  # fully invalid

--- a/tests/unicode/bytes_decode_replace.py
+++ b/tests/unicode/bytes_decode_replace.py
@@ -124,3 +124,7 @@ print(repr(b"hello\xf0world".decode("utf-8", "replace")))
 
 # Test multiple incomplete sequences in a row
 print(repr(b"\xe4\xf0\xe4".decode("utf-8", "replace")))
+
+# Test replacing invalid ASCII
+print(repr(b"\xe5\xa5\xbd".decode("ascii", "replace")))  # valid utf8, not valid ascii
+print(repr(b"a\xbb\xcc\xddef\x01".decode("ascii", "replace")))  # fully invalid


### PR DESCRIPTION
### Summary

This work was started following @fojie's [comment here](https://github.com/micropython/micropython/pull/19168#issuecomment-4925454963) noting that some values of the `encoding` argument are no longer accepted after Unicode support was improved by #18854.

This is something of a "good" change because the encoding argument was mostly ignored before and now it actually does things!

This PR does two things:

* Adds support for `bytes.decode("ascii")` including `"ignore"` and `"replace"` behaviour that matches CPython. Previously the bytes were treated as UTF-8 in this case.
* Adds support for `str.encode("ascii")` raising an exception if the string contains non-ASCII characters. `"ignore"` and `"replace"` are not implemented for encoding.
* Document CPython differences for the `encoding` and `errors` arguments for `str.encode()`, `bytes.decode()` and the `str()` and `bytes()` constructors. Specifically:
  - The encoding argument must match exactly, MicroPython can't do the same "fuzzy" parsing of different encoding strings that CPython does.
  - The `str.encode()` and `bytes()` constructor ignore any `errors` argument.

*This work was funded through GitHub Sponsors.*

### Testing

* Ran unit tests on the unix port (including new tests for the new behaviour).

### Trade-offs and Alternatives

* Could choose to not update `str.encode("ascii")` and either keep the same behaviour which ignores the argument, or immediately fail if `"ascii"` is provided. This would use a bit less code size, but I think this change should not have a large impact as it mostly reuses existing checks.

### Generative AI

I did not use generative AI tools when creating this PR.
