### PR TITLE
py/emitnative: Generate shorter positional args check.

### DIFF
--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -534,8 +534,12 @@ static void emit_native_start_pass(emit_t *emit, pass_kind_t pass, scope_t *scop
 
         // Check number of args matches this function, and call mp_arg_check_num_sig if not
         ASM_JUMP_IF_REG_NONZERO(emit->as, REG_ARG_2, *emit->label_slot + 4, true);
-        ASM_MOV_REG_IMM(emit->as, REG_ARG_3, scope->num_pos_args);
-        ASM_JUMP_IF_REG_EQ(emit->as, REG_ARG_1, REG_ARG_3, *emit->label_slot + 5);
+        if (scope->num_pos_args > 0) {
+            ASM_MOV_REG_IMM(emit->as, REG_ARG_3, scope->num_pos_args);
+            ASM_JUMP_IF_REG_EQ(emit->as, REG_ARG_1, REG_ARG_3, *emit->label_slot + 5);
+        } else {
+            ASM_JUMP_IF_REG_ZERO(emit->as, REG_ARG_1, *emit->label_slot + 5, false);
+        }
         mp_asm_base_label_assign(&emit->as->base, *emit->label_slot + 4);
         ASM_MOV_REG_IMM(emit->as, REG_ARG_3, MP_OBJ_FUN_MAKE_SIG(scope->num_pos_args, scope->num_pos_args, false));
         ASM_CALL_IND(emit->as, MP_F_ARG_CHECK_NUM_SIG);


### PR DESCRIPTION
### Summary

This PR performs a minor optimisation when generating the check for the number of positional arguments for an emitted function.

The original code performed a constant load into a temporary register and then used that register for a comparison indicating whether to jump elsewhere.  Since the expected number of positional arguments is known at compile time, and that it is a common occurrence for a function to not have positional arguments, if that is the case a single "jump if register is zero" opcode sequence is emitted instead.

Savings are minor and this took me a few minutes, so if the increased footprint isn't worth the savings feel free to scrap this.

Final savings are calculated as usual, by compiling the whole `/tests` directory with `-X emit=native` and ignoring errors:

| Architecture  | Before  | After   | Δ    | %       |
| ------------- | ------- | ------- | ---- | ------- |
| x86           | 4841626 | 4841501 | -125 | -0.0026 |
| x64           | 4933602 | 4933477 | -125 | -0.0025 |
| ArmV6         | 2661955 | 2661855 | -100 | -0.0038 |
| ArmV7         | 2423235 | 2423185 | -50  | -0.0021 |
| RV32          | 3027845 | 3027795 | -50  | -0.0017 |
| RV32+Zba      | 3029256 | 3029206 | -50  | -0.0017 |
| RV32+Zcmp     | 2923197 | 2923147 | -50  | -0.0017 |
| RV32+Zba+Zcmp | 2923173 | 2923123 | -50  | -0.0017 |
| Xtensa        | 2976456 | 2976396 | -60  | -0.002  |
| Xtensawin     | 2943468 | 2943408 | -60  | -0.002  |

Figures have been computed with https://gist.github.com/agatti/5466e548a61a4cd451125389cfb5bf96 - if needed I can clean that up and plug it into CI somehow.

### Testing

Some preliminary testing was carried out on x64, RP2040, ESP32S3, and ESP32C3 by running the test suite via `--via-mpy --emit=native`, CI should also test QEMU targets.  Hopefully Octoprobe-bot will confirm that I didn't get things wrong.

### Trade-offs and Alternatives

There is going some minor size increase but that should stay as low as it can get whilst keeping the code changes as simple as possible.

Rather than touching one particular instance of the `LOAD_IMM` + `JUMP_IF_EQ` sequence, that could be fused together into a new meta-opcode that may be a bit smarter w.r.t. the immediate being compared against.

Not sure if that will save more size in the final binary, but compiled code could be a bit shorter for at least Xtensawin (could use `BEQI` if the immediate is short) once the LX4+ opcodes PR gets in so I can have MPY flags for Xtensa too.  This may also apply to other architectures but haven't looked into that yet.

### Generative AI

I did not use generative AI tools when creating this PR.
