### PR TITLE
macos: Use setjmp GC helper on Intel.

### DIFF
--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -109,6 +109,11 @@ typedef long mp_off_t;
 
 #define MP_PLAT_PRINT_STRN(str, len) (void)0
 
+// Use setjmp/longjmp based GC helper on Intel-based Darwin
+#if defined(__APPLE__) && defined(__MACH__) && (defined(__i386__) || defined(__x86_64__))
+#define MICROPY_GCREGS_SETJMP       (1)
+#endif
+
 // We need to provide a declaration/definition of alloca()
 #if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <stdlib.h>

--- a/mpy-cross/mpconfigport.h
+++ b/mpy-cross/mpconfigport.h
@@ -82,9 +82,13 @@
 #define MICROPY_PY_TSTRINGS         (1)
 #define MICROPY_PY_BUILTINS_STR_UNICODE (1)
 
-#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__))
-// Fall back to setjmp() implementation for discovery of GC pointers in registers.
-#define MICROPY_GCREGS_SETJMP (1)
+// Fall back to setjmp() implementation for discovery of GC pointers in registers
+// if running on intel-based macOS, or on architectures for which there is no
+// specialised GC pointer discovery mechanism.
+#if (defined(__APPLE__) && defined(__MACH__) && (defined(__i386__) || defined(__x86_64__))) || \
+    (!(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || \
+    defined(__thumb2__) || defined(__thumb__) || defined(__arm__)))
+#define MICROPY_GCREGS_SETJMP       (1)
 #endif
 
 #define MICROPY_MODULE___FILE__     (0)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -63,6 +63,11 @@
 
 #define MP_STATE_PORT MP_STATE_VM
 
+// Use setjmp/longjmp based GC helper on Intel-based Darwin
+#if defined(__APPLE__) && defined(__MACH__) && (defined(__i386__) || defined(__x86_64__))
+#define MICROPY_GCREGS_SETJMP       (1)
+#endif
+
 // Configure which emitter to use for this target.
 #if !defined(MICROPY_EMIT_X64) && defined(__x86_64__)
     #define MICROPY_EMIT_X64        (1)

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -106,9 +106,12 @@ typedef long mp_off_t;
 // Always enable GC.
 #define MICROPY_ENABLE_GC           (1)
 
-#if !(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__) || (defined(__riscv) && __riscv_xlen <= 64) || (defined(__loongarch__) && defined(__loongarch64)))
-// Fall back to setjmp() implementation for discovery of GC pointers in registers.
-#define MICROPY_GCREGS_SETJMP (1)
+// Fall back to setjmp() implementation for discovery of GC pointers in registers
+// if running on intel-based macOS, or on architectures for which there is no
+// specialised GC pointer discovery mechanism.
+#if (defined(__APPLE__) && defined(__MACH__) && (defined(__i386__) || defined(__x86_64__))) || \
+    (!(defined(MICROPY_GCREGS_SETJMP) || defined(__x86_64__) || defined(__i386__) || defined(__thumb2__) || defined(__thumb__) || defined(__arm__) || (defined(__riscv) && __riscv_xlen <= 64) || (defined(__loongarch__) && defined(__loongarch64))))
+#define MICROPY_GCREGS_SETJMP       (1)
 #endif
 
 // Enable the VFS, and enable the posix "filesystem".


### PR DESCRIPTION
### Summary

This PR forces the setjmp/longjmp GC helper when building for macOS targeting Intel-based processors.

Modern versions of macOS development tools do not like the GC helper's usage of the EBP/RBP register and will raise an error since that register is now reserved for internal use.

This fixes #17450.

### Testing

These changes were built by CI in my local repo after replacing the macOS CI image with `macos-26-intel`.  See https://github.com/agatti/micropython/actions/runs/29580224091/job/87883931793 for the results of such a successful build/test run on x64.

### Generative AI

I did not use generative AI tools when creating this PR.