### PR TITLE
tools/mpremote: Fix fs_stat exception with namedtuples.

### DIFF
--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -101,7 +101,7 @@ class Transport:
     def fs_stat(self, src):
         try:
             self.exec("import os")
-            return os.stat_result(self.eval("os.stat(%s)" % ("'%s'" % src)))
+            return os.stat_result(self.eval("tuple(os.stat(%s))" % ("'%s'" % src)))
         except TransportExecError as e:
             raise _convert_filesystem_error(e, src) from None
 

--- a/tools/mpremote/tests/README.md
+++ b/tools/mpremote/tests/README.md
@@ -23,7 +23,7 @@ To run the tests do:
 
 To run a single test do:
 
-    $ ./run-mpremote-tests.sh test_filesystem.sh
+    $ ./run-mpremote-tests.sh ./test_filesystem.sh
 
 Each test should print "OK" if it passed.  Otherwise it will print "CRASH", or "FAIL"
 and a diff of the expected and actual test output.


### PR DESCRIPTION
Issue found by @snowkoli during MicroPython sprint hackathon at EuroPython/EuroScipy

This fixes exception when doing "mpremote cp file :" or "mpremote mip install os-path" when MicroPython `os.stat()` returns named tuples instead of plain tuples.
That is the case if one has installed `os-path` or `os` from micropython-lib, after commit https://github.com/micropython/micropython-lib/commit/f4cfc3c71a5e5ba56df586f8aecb833d8ab51269

Without this fix an exception happens when mpremote attempts to eval stat output with `ast.literal_eval()`:

    ValueError: malformed node or string on line 1: Call(func=Name(id='stat_result', ctx=Load()), args=[], keywords=[keyword(arg='st_mode', value=Constant(value=16384, kind=None)), ..., keyword(arg='st_ctime', value=Constant(value=0, kind=None))])

## Outdated info
EDIT: I originally thought this was port-specific, but that is incorrect

RPI Pico W 1.28 downloaded from offical website.

    os.stat('notes')
    stat_result(st_mode=16877, st_ino=32256697, st_dev=64768, st_nlink=2, st_uid=1000, st_gid=1000, st_size=4096, st_atime=1784301603, st_mtime=1784370583, st_ctime=1784370583)

where-as most other ports returns just

    os.stat('foo')
    (32768, 0, 0, 0, 0, 0, 4, 21, 21, 21)

### Testing
Tested on RPI Pico W which did have the issue. And tested on ESP32 (which does not have the issue).

### Trade-offs and Alternatives
No negative impact.

### Generative AI
I did not use generative AI tools when creating this PR.