### PR TITLE
alif/machine_can: Implement a software TX queue.

### DIFF
--- a/docs/library/machine.CAN.rst
+++ b/docs/library/machine.CAN.rst
@@ -194,10 +194,6 @@ Methods
    .. note:: This intentionally low-level implementation is designed so the
       caller can establish a software queue of outgoing messages.
 
-   .. note:: The **Alif** port always returns 0, since the transmit buffer index is not reported by
-       the CAN controller.
-
-
    .. important:: The CAN "transmit queue" is not a FIFO queue, it is priority
                   ordered, and although it can hold up to `CAN.TX_QUEUE_LEN`
                   items there may be other hardware restrictions on messages
@@ -341,10 +337,6 @@ Methods
    transmission is cancelled and then the same buffer is used to send another
    message (especially if the CAN controller IRQ is not "hard").
 
-   .. note:: The **Alif** port cannot address a specific message to be cancelled.
-      Instead all messages in the TX queue will be cancelled.
-
-
 .. method:: CAN.state()
 
    Returns an integer value indicating the current state of the controller.
@@ -377,8 +369,9 @@ Methods
   .. note:: If a controller doesn't support a particular counter, it will return
             ``None`` for that list element.
 
-  .. note:: The **Alif** port cannot report the exact number of pending RX or TX messages. It
-            will report a number > 0, if messages are pending.
+  .. note:: The **Alif** and **MIMXRT** ports cannot report the exact
+            number of pending RX messages. They will report a
+            number > 0, if messages are pending.
 
 .. method:: CAN.get_timings(list=None /)
 

--- a/ports/alif/machine_can.c
+++ b/ports/alif/machine_can.c
@@ -48,15 +48,14 @@
 #define CAN_SJW_MIN         1
 #define CAN_SJW_MAX         16
 
-#define CAN_TX_QUEUE_LEN    9
-#define CAN_TX_FIFO_LEN     16
-#define CAN_TX_FIFO_EMPTY   0
-#define CAN_TX_FIFO_LE_HALF_FULL 1
-#define CAN_TX_FIFO_GT_HALF_FULL 2
-#define CAN_TX_FIFO_FULL    3
+#define CAN_TX_QUEUE_LEN    32
 #define CAN_IRQ_RINGBUF_LEN ((CAN_TX_QUEUE_LEN + 16) * 2)
 
 #define CAN_HW_MAX_FILTER   3
+
+#define CAN_MB_STATUS_FREE  0
+#define CAN_MB_STATUS_READY 1
+#define CAN_MB_STATUS_BUSY  2
 
 #if RTE_CANFD_CLK_SOURCE
     #define CANFD_CLK_DIVISOR (CANFD_CLK_SRC_160MHZ_CLK / RTE_CANFD_CLK_SPEED)
@@ -74,18 +73,26 @@
 #define ARM_CAN_ID_IDE_Pos            31UL
 #define ARM_CAN_ID_IDE_Msk            (1UL << ARM_CAN_ID_IDE_Pos)
 
-/****** CAN Identifier encoding *****/
-#define ARM_CAN_STANDARD_ID(id)       (id & 0x000007FFUL)                         // < CAN identifier in standard format (11-bits)
-#define ARM_CAN_EXTENDED_ID(id)       ((id & 0x1FFFFFFFUL) | ARM_CAN_ID_IDE_Msk)  // < CAN identifier in extended format (29-bits)
+typedef struct machine_can_tx_queue {
+    uint8_t status;
+    uint32_t priority;
+    canfd_tx_info_t tx_header;
+    #if MICROPY_HW_ENABLE_FDCAN
+    uint8_t data[CANFD_FAST_DATA_FRAME_SIZE_MAX];
+    #else
+    uint8_t data[CANFD_NOM_DATA_FRAME_SIZE_MAX];
+    #endif
+} machine_can_tx_queue_t;
 
 typedef struct machine_can_port {
     uint8_t can_hw_id;
     CANFD_Type *canfd_base;
     CANFD_CNT_Type *canfd_cnt_base;
     machine_can_state_t can_state;
-    machine_can_mode_t can_mode;
     bool is_enabled;
-    int16_t id_sent;
+    bool reschedule_abort;
+    mp_int_t id_sent;
+    uint32_t last_id;
     uint16_t num_error_warning;
     uint16_t num_error_passive;
     uint16_t num_bus_off;
@@ -93,6 +100,7 @@ typedef struct machine_can_port {
     canfd_transfer_t data_transfer;
     canfd_acpt_fltr_t filter_config[CANFD_MAX_ACCEPTANCE_FILTERS];
     int num_canfd_acpt_fltr;
+    machine_can_tx_queue_t tx_queue[CAN_TX_QUEUE_LEN];
     ringbuf_t irq_flags_buffer;
 } machine_can_port_t;
 
@@ -103,6 +111,8 @@ static machine_can_port_t canfd_port = {
     .canfd_cnt_base = (CANFD_CNT_Type *)CANFD_CNT_BASE,
     .can_state = MP_CAN_STATE_STOPPED,
 };
+
+static mp_int_t machine_can_send_next(machine_can_port_t *port);
 
 void CANFD_IRQHandler(void) {
     // Just one CAN device at index 0
@@ -157,11 +167,33 @@ void CANFD_IRQHandler(void) {
         if (irq_event & CANFD_RBUF_AVAILABLE_EVENT) {
             irq_flags |= MP_CAN_IRQ_RX;
         }
-        if (irq_event & (CANFD_SECONDARY_BUF_TX_COMPLETE_EVENT | CANFD_PRIMARY_BUF_TX_COMPLETE_EVENT)) {
-            irq_flags |= MP_CAN_IRQ_TX;
+        if (irq_event & CANFD_PRIMARY_BUF_TX_COMPLETE_EVENT) {
+            irq_flags |= (MP_CAN_IRQ_TX | (port->id_sent << 16));
+            // Release the MB
+            if (port->id_sent >= 0) {
+                port->tx_queue[port->id_sent].status = CAN_MB_STATUS_FREE;
+            }
+            // Attempt to send the next from the queue
+            port->id_sent = machine_can_send_next(port);
+            // Reset the flag, in case that a cancel attempt failed and the message
+            // was sent.
+            port->reschedule_abort = false;
         }
         if (irq_event & CANFD_TX_ABORT_EVENT) {
-            irq_flags |= (MP_CAN_IRQ_TX_FAILED | MP_CAN_IRQ_TX);
+            if (port->reschedule_abort) {
+                // This abort of re-schedule must not call a MP IRQ handler.
+                if (port->id_sent >= 0) {
+                    port->tx_queue[port->id_sent].status = CAN_MB_STATUS_READY;
+                }
+                port->reschedule_abort = false;
+            } else {
+                irq_flags = (irq_flags & 0xffff) | MP_CAN_IRQ_TX_FAILED | MP_CAN_IRQ_TX | (port->id_sent << 16);
+                if (port->id_sent >= 0) {
+                    port->tx_queue[port->id_sent].status = CAN_MB_STATUS_FREE;
+                }
+            }
+            // Since the active message was cancelled, try to send the next one.
+            port->id_sent = machine_can_send_next(port);
         }
 
         // Call the MP callback if the events match the trigger.
@@ -300,9 +332,13 @@ static void machine_can_port_init(machine_can_obj_t *self) {
     // Clear the TEC/REC error counters & leave a bus-off state
     port->canfd_base->CANFD_CFG_STAT |= CANFD_CFG_STAT_BUSOFF;
     port->can_state = MP_CAN_STATE_ACTIVE;
+    port->id_sent = -1;
+    port->reschedule_abort = false;
+    memset(port->tx_queue, 0, sizeof(port->tx_queue));
     if (port->irq_flags_buffer.buf == NULL) {
         ringbuf_alloc(&(port->irq_flags_buffer), CAN_IRQ_RINGBUF_LEN);
     }
+    ringbuf_reset(&(port->irq_flags_buffer));
 
     // Configure the Controller
     canfd_reset(port->canfd_base);
@@ -376,8 +412,68 @@ static void machine_can_port_deinit(machine_can_obj_t *self) {
     }
 }
 
+// Send the next message from the queue
+static mp_int_t machine_can_send_next(machine_can_port_t *port) {
+    machine_can_tx_queue_t *mb;
+    mp_int_t tx_mb = -1;
+
+    // Find the message with the highest priority (== lowest value)
+    uint32_t priority = UINT32_MAX;
+    for (mp_uint_t i = 0; i < CAN_TX_QUEUE_LEN; i++) {
+        mb = &port->tx_queue[i];
+        if ((mb->status == CAN_MB_STATUS_READY) && (mb->priority < priority)) {
+            tx_mb = i;
+            priority = mb->priority;
+        }
+    }
+
+    if (tx_mb >= 0) {
+        // MB found to be sent
+        machine_can_tx_queue_t *mb = &port->tx_queue[tx_mb];
+
+        // Invokes the low level functions to prepare and send the message
+        canfd_select_tx_buf(port->canfd_base, mb->tx_header.buf_type);
+        // Invokes interrupt mode send function
+        canfd_send(port->canfd_base, mb->tx_header, mb->data, mb->tx_header.dlc);
+
+        mb->status = CAN_MB_STATUS_BUSY;  // In transmission
+
+        // Enable TX interrupt, just in case it was not.
+        canfd_enable_tx_interrupts(port->canfd_base);
+    }
+    return tx_mb;
+}
+
+// Compare ID value only
+#define IS_MATCHING_ID(mb, priority) (mb->priority == priority)
+#define IS_MB_EMPTY(mb) (mb->status == CAN_MB_STATUS_FREE)
+
+static mp_int_t can_find_txmb(machine_can_port_t *port, uint32_t priority, mp_uint_t flags) {
+    machine_can_tx_queue_t *mb;
+    mp_int_t tx_mb = -1;
+
+    for (mp_uint_t i = 0; i < CAN_TX_QUEUE_LEN; i++) {
+        mb = &port->tx_queue[i];
+        if (tx_mb == -1 && IS_MB_EMPTY(mb)) {
+            tx_mb = i; // First free slot
+            // Keep scanning, in case a higher numbered mbox has the same priority
+            // Except if CAN_MSG_FLAG_UNORDERED
+            if (flags & CAN_MSG_FLAG_UNORDERED) {
+                break;
+            }
+        } else if (tx_mb >= 0 && IS_MATCHING_ID(mb, priority) && !IS_MB_EMPTY(mb)) {
+            // This mailbox has a pending tx with the same id & flags, so we can only pick a higher number
+            // mbox to ensure correct ordering
+            tx_mb = -1;
+        }
+    }
+    return tx_mb;
+}
+
 static mp_int_t machine_can_port_send(machine_can_obj_t *self, mp_uint_t id, const byte *data, size_t data_len, mp_uint_t flags) {
     struct machine_can_port *port = self->port;
+    mp_int_t tx_mb = -1;
+    uint32_t priority;
 
     // If the node is in other than below modes, returns an error
     if ((self->mode != MP_CAN_MODE_NORMAL) &&
@@ -385,55 +481,90 @@ static mp_int_t machine_can_port_send(machine_can_obj_t *self, mp_uint_t id, con
         (self->mode != MP_CAN_MODE_SILENT_LOOPBACK)) {
         return -1;
     }
-    // Check if the FIFO is more than half full. If yes, return an error.
-    // If the check is made for FIFO being full, then the sending gets
-    // corrupted under heavy load. Reason to be determined.
-    if ((port->canfd_base->CANFD_TCTRL & CANFD_TCTRL_TSSTAT_Msk) >= CAN_TX_FIFO_GT_HALF_FULL) {
+
+    // Create a priority tag with Ext ID and RTR flags for fast comparison.
+    // Following the format at the BUS during transmit.
+    // Format Std: IIII.IIII.IIIR.X000.0000.0000.0000.0000
+    // Format Ext: IIII.IIII.IIIS.XIII.IIII.IIII.IIII.IIIR
+    //
+    // I: ID bit
+    // R: RTR bit
+    // X: IDE bit - 0 for Std, 1 for Ext.
+    // S: SRR bit, always 1
+
+    if (flags & CAN_MSG_FLAG_EXT_ID) {
+        priority = ((id & 0x1FFC0000UL) << 3) | ((id & 0x3FFFFUL) << 1)
+            | ARM_CAN_ID_IDE_Msk | 0x180000UL;
+        if (flags & CAN_MSG_FLAG_RTR) {
+            priority |= 0x1UL;
+        }
+    } else {
+        priority = (id & 0x000007FFUL) << 21;
+        if (flags & CAN_MSG_FLAG_RTR) {
+            priority |= 0x100000UL;
+        }
+    }
+
+    // Check if space is available in the TX Queue.
+    tx_mb = can_find_txmb(port, priority, flags);
+    if (tx_mb < 0) {
         return -1;
     }
 
-    memset(&port->data_transfer.tx_header, 0x0, sizeof(canfd_tx_info_t));
-    port->data_transfer.tx_header.buf_type = CANFD_BUF_TYPE_SECONDARY;
+    machine_can_tx_queue_t *mb = &port->tx_queue[tx_mb];
+    memset(mb, 0x0, sizeof(machine_can_tx_queue_t));
+    mb->priority = priority;
 
-    // Stores the message id based on message frame ID type
-    port->data_transfer.tx_header.frame_type = !!(flags & CAN_MSG_FLAG_EXT_ID);
+    // Set up the message header and copy the data
+    mb->tx_header.frame_type = !!(flags & CAN_MSG_FLAG_EXT_ID);
+    mb->tx_header.id = id & 0x1FFFFFFFUL; // Cut off any extra flags
+    mb->tx_header.buf_type = CANFD_BUF_TYPE_PRIMARY;
+    mb->tx_header.edl = 0;
+    mb->tx_header.brs = !!(flags & CAN_MSG_FLAG_BRS);
+    mb->tx_header.dlc = data_len;
+    mb->tx_header.rtr = !!(flags & CAN_MSG_FLAG_RTR);
+    memcpy(mb->data, data, data_len);
 
-    if (port->data_transfer.tx_header.frame_type) {
-        port->data_transfer.tx_header.id = (ARM_CAN_EXTENDED_ID(id) & (~ARM_CAN_ID_IDE_Msk));
+    mb->status = CAN_MB_STATUS_READY;  // Ready to be sent.
+
+    // Try to send the message
+    if (port->id_sent < 0) {
+        // No active TX message, send one
+        port->id_sent = machine_can_send_next(port);
     } else {
-        port->data_transfer.tx_header.id = ARM_CAN_STANDARD_ID(id);
+        // TX in progress, may have to be replaced.
+        if ((priority < port->tx_queue[port->id_sent].priority) &&
+            (port->tx_queue[port->id_sent].status == CAN_MB_STATUS_BUSY) &&
+            port->reschedule_abort == false) {
+            // The new message has a higher priority than the actual TX
+            // message. Cancel the actual message.
+            port->reschedule_abort = true;
+            canfd_abort_tx(port->canfd_base, CANFD_BUF_TYPE_PRIMARY);
+        }
     }
 
-    // Copies the message header
-    port->data_transfer.tx_header.edl = 0;
-    port->data_transfer.tx_header.brs = !!(flags & CAN_MSG_FLAG_BRS);
-    port->data_transfer.tx_header.dlc = data_len;
-    port->data_transfer.tx_header.rtr = !!(flags & CAN_MSG_FLAG_RTR);
-
-    // Invokes the low level functions to prepare and send the message
-    canfd_select_tx_buf(port->canfd_base, port->data_transfer.tx_header.buf_type);
-    // Invokes interrupt mode send function
-    canfd_send(port->canfd_base, port->data_transfer.tx_header, data, data_len);
-
-    // Enable TX interrupt.
-    canfd_enable_tx_interrupts(port->canfd_base);
-
-    // The alif CAN controller provides no information about the slot where the
-    // message is stored. So the return value is always 0.
-
-    return 0;
+    return tx_mb;
 }
 
 static bool machine_can_port_cancel_send(machine_can_obj_t *self, mp_uint_t idx) {
-    if (canfd_stb_empty(self->port->canfd_base)) {
-        // Nothing to cancel
-        return false;
-    } else {
-        // Cancel ALL queued messages, since a specific message cannot be selected.
-        canfd_abort_tx(self->port->canfd_base, CANFD_BUF_TYPE_SECONDARY);
-        // tbd: wait until the flag is set?
+    struct machine_can_port *port = self->port;
+    machine_can_tx_queue_t *mb = &port->tx_queue[idx];
+    port->reschedule_abort = false;
+
+    if (mb->status == CAN_MB_STATUS_READY) {
+        mb->status = CAN_MB_STATUS_FREE;
+        if (self->mp_irq_trigger & MP_CAN_IRQ_TX) {
+            ringbuf_put(&port->irq_flags_buffer, MP_CAN_IRQ_TX | MP_CAN_IRQ_TX_FAILED);
+            ringbuf_put(&port->irq_flags_buffer, idx);
+            mp_irq_handler(self->mp_irq_obj);
+        }
+        return true;
+    } else if (mb->status == CAN_MB_STATUS_BUSY) {
+        // Cancel messages waiting for transmission
+        canfd_abort_tx(self->port->canfd_base, CANFD_BUF_TYPE_PRIMARY);
         return true;
     }
+    return false;
 }
 
 static bool machine_can_port_recv(machine_can_obj_t *self, void *data, size_t *dlen, mp_uint_t *id, mp_uint_t *flags, mp_uint_t *errors) {
@@ -478,7 +609,7 @@ static void machine_can_port_restart(machine_can_obj_t *self) {
     // Disable IRQ preventing IRQ from cancelling messages.
     canfd_disable_tx_interrupts(self->port->canfd_base);
     // Cancel ALL queued messages, since a specific message cannot be selected.
-    canfd_abort_tx(self->port->canfd_base, CANFD_BUF_TYPE_SECONDARY);
+    canfd_abort_tx(self->port->canfd_base, CANFD_BUF_TYPE_PRIMARY);
     // init() clears the error counters, leave a bus-off state and
     // set the bus state to ACTIVE again.
     machine_can_port_init(self);
@@ -486,21 +617,26 @@ static void machine_can_port_restart(machine_can_obj_t *self) {
 
 // Updates values in self->counters (which counters are updated by this
 // function versus from ISRs and the like is port specific.
-// For tx_pending value only rough numbers of the queue size are available:
-// Empty->0, up to half full->1, more than half full->9, full->16.
 // For rx_pending value only the fact of pending messages is known.
 
 static void machine_can_port_update_counters(machine_can_obj_t *self) {
-    static uint8_t tx_queue_sizes[4] = { 0, 1, CAN_TX_FIFO_LEN / 2 + 1, CAN_TX_FIFO_LEN };
     struct machine_can_port *port = self->port;
+
     machine_can_counters_t *counters = &self->counters;
+
+    int tx_pending = 0;
+    for (mp_uint_t i = 0; i < CAN_TX_QUEUE_LEN; i++) {
+        if (port->tx_queue[i].status != CAN_MB_STATUS_FREE) {
+            tx_pending++;
+        }
+    }
 
     counters->tec = canfd_get_tx_error_count(port->canfd_base);
     counters->rec = canfd_get_rx_error_count(port->canfd_base);
     counters->num_warning = port->num_error_warning;
     counters->num_passive = port->num_error_passive;
     counters->num_bus_off = port->num_bus_off;
-    counters->tx_pending = tx_queue_sizes[(port->canfd_base->CANFD_TCTRL & CANFD_TCTRL_TSSTAT_Msk)];
+    counters->tx_pending = tx_pending;
     counters->rx_pending = canfd_rx_msg_available(port->canfd_base);
     counters->rx_overruns = port->num_rx_overrun;
 }

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -200,7 +200,7 @@ void nlr_jump_fail(void *val) {
 
 #ifndef NDEBUG
 void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
-    printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
+    mp_printf(&mp_plat_print, "Assertion '%s' failed, at file %s:%d\n", expr, file, line);
     panic("Assertion failed");
 }
 #endif

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -202,7 +202,7 @@ void nlr_jump_fail(void *val) {
 
 #ifndef NDEBUG
 void MP_WEAK __assert_func(const char *file, int line, const char *func, const char *expr) {
-    printf("Assertion '%s' failed, at file %s:%d\n", expr, file, line);
+    mp_printf(&mp_plat_print, "Assertion '%s' failed, at file %s:%d\n", expr, file, line);
     panic("Assertion failed");
 }
 #endif

--- a/tests/multi_extmod/machine_can_04_tx_order.py
+++ b/tests/multi_extmod/machine_can_04_tx_order.py
@@ -5,15 +5,6 @@ import sys
 
 import micropython
 
-# The Alif port has an opaque send queue. The Alif CAN controller
-# provides no information about the slot number where the message
-# is stored, and it does not allow to cancel specific messages.
-# This test needs the slot number, which is not available.
-
-if "alif" in sys.platform:
-    print("SKIP")
-    raise SystemExit
-
 micropython.alloc_emergency_exception_buf(256)
 seed(0)
 

--- a/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
+++ b/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
@@ -2,16 +2,6 @@ from machine import CAN
 import time
 import sys
 
-# The Alif port has an opaque send queue. The Alif CAN controller
-# provides no information about the slot number where the message
-# is stored, and it does not allow to cancel specific messages.
-# This test needs both the slot number, and uses cancel_send() for
-# dedicated messages, which both is not available.
-
-if "alif" in sys.platform:
-    print("SKIP")
-    raise SystemExit
-
 # Check that cancelling a low priority outgoing message and replacing it with a
 # high priority message causes it to be transmitted successfully onto a busy bus
 
@@ -47,7 +37,8 @@ def instance0():
     # instance1() from sending anything lower priority than this
     while len(recv) < ITERS:
         for id in range(0x5000, 0x6000):
-            can.send(id, b"BABBLE", CAN.FLAG_EXT_ID)
+            while can.send(id, b"BABBLE", CAN.FLAG_EXT_ID) is None:
+                pass
             if len(recv) >= ITERS:
                 break
 

--- a/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
+++ b/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
@@ -2,16 +2,6 @@ from machine import CAN
 import time
 import sys
 
-# The Alif port has an opaque send queue. The Alif CAN controller
-# provides no information about the slot number where the message
-# is stored, and it does not allow to cancel specific messages.
-# This test needs both the slot number, and uses cancel_send() for
-# dedicated messages, which both is not available.
-
-if "alif" in sys.platform:
-    print("SKIP")
-    raise SystemExit
-
 # Check that cancelling a low priority outgoing message and replacing it with a
 # high priority message causes it to be transmitted successfully onto a busy bus
 
@@ -49,7 +39,8 @@ def instance0():
     # instance1() from sending anything lower priority than this
     while len(recv) < ITERS:
         for id in range(0x5000, 0x6000):
-            can.send(id, b"BABBLE", CAN.FLAG_EXT_ID)
+            while can.send(id, b"BABBLE", CAN.FLAG_EXT_ID) is None:
+                pass
             if len(recv) >= ITERS:
                 break
             if bcast_countdown > 0:


### PR DESCRIPTION
### Summary

The current implementation of the CAN protocol uses the hardware TX queue of the controller, which is opaque. It does not tell the index of a message buffer for a message. That prevents canceling specific messages and does not support two of the multi-tests, which need this index for cross check and specific cancelling.

This limitations is revoked by a software TX queue. The software queue:

- provides the slot number for a TX message,
- allows to cancel a specific message, and
- allows to count the number of pending messages in the TX queue and report it
  with CAN.get_counters().

The bit sequence in the tag to determine a message priority is identical to the transmission sequence for proper arbitration.
A mechanism is implemented to replace a message waiting to be sent, if a message with higher priority is added to the queue.

With these changes, CAN support passes all CAN tests from tests/multi_extmod for the Alif port either as instance 0 or instance 1: 
~~In about 1 of 100 attempts test machine_can_05_tx_prio_cancel.py  "failed" with the Alif board as instance 0, which is the uncritical instance. The fail pattern shows a low prio message which was sent ahead of the hi-prio ones. Messages that already started the transmission cannot be cancelled any more.~~

### Testing

Tested with a Alif AE3 board as one instance and a MIMXRT (Teensy 4.1), Alif AE3 or PYBV11 board as second instance, with the Alif board working either as instance 0 or instance 1 of the multi_extmod/machine_can*.py tests. The test set was repeated 10 times.

### Generative AI

I did not use generative AI tools when creating this PR.

