### PR TITLE
esp32/machine_sdmmc: Set SDMMC slot width to 4 for esp32-p4 boards and allow setting via mpconfig.

### DIFF
--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -208,14 +208,14 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         #endif
         ARG_freq,
     };
-    #if SOC_SDMMC_HOST_SUPPORTED
-    static const int DEFAULT_SLOT = MICROPY_HW_SDMMC_DEFAULT_SLOT;
-    #else
-    static const int DEFAULT_SLOT = SD_SLOT_MAX;
-    #endif
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SLOT} },
+        #if SOC_SDMMC_HOST_SUPPORTED
+        { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_SDMMC_DEFAULT_SLOT} },
+        { MP_QSTR_width,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = MICROPY_HW_SDMMC_DEFAULT_WIDTH} },
+        #else
+        { MP_QSTR_slot,     MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = SD_SLOT_MAX} },
         { MP_QSTR_width,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1} },
+        #endif
         { MP_QSTR_cd,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         { MP_QSTR_wp,       MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = mp_const_none} },
         // These are only needed if using SPI mode

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -231,6 +231,13 @@
 #define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
 #endif
 #endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#if CONFIG_IDF_TARGET_ESP32P4
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
+#else
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)


### PR DESCRIPTION
<!--      https://github.com/micropython/micropython/wiki/ContributorGuidelines
     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

This PR allows the default `width` of the SDMMC card bus to be set to 4 for ESP32-P4 based boards in a similar manner to that used for the `slot` number.

Currently you need to use `sd = machine.SDCard(width=4)` to get the full card interface on P4 based boards, all the other parameters for the SDCard class default correctly except the width.

I took a few minutes to skim a load of schematics for Expressif and Waveshare esp32-p4 boards and they all conform to the same reference design that has the card interface on slot `0` with a quad bus, my Tab5 is the same.

This PR simply adapts the mechanism already used to specify the `slot` number for `P4` boards to specify the `width` in the same manner.

It also exposes a new `mpconfig` option: `MICROPY_HW_SDMMC_DEFAULT_WIDTH` that can be used in board configs to override this if needed.

### Testing

I have tested this on my Tab5 (esp32p4 based, adapts the same SD card reference design as the official P4 boards), and verified that this works and the default `SDCard()` speed now matches that for `SDCard(width=4)`, and that invoking with `SDCard(width=1)` makes the card slower ;-)

I adapted a short script (original source uncertain) that tests the speed and then ran it with different invocations on my modified firmware:
[sdspeed_tab5.py](https://github.com/user-attachments/files/30165792/sdspeed_tab5.py)

The test does 20 simple passes of writing 8K files then reading them and verifying contents; times are in `ms`
```python
sd = SDCard()
# With PR code defaulting the P4 bus width to 4 
write:  [26, 24, 26, 25, 25, 27, 25, 25, 27, 25, 25, 26, 25, 26, 25, 25, 27, 25, 26, 27]
read:   [6, 6, 6, 6, 6, 7, 6, 7, 6, 6, 6, 7, 7, 6, 7, 7, 6, 7, 7, 7]

sd = SDCard(width=1)
# Force width to 1 (current default for the P4 port)
write:  [30, 30, 29, 31, 29, 29, 31, 29, 29, 31, 29, 29, 32, 30, 31, 32, 30, 31, 30, 30]
read:   [9, 9, 9, 9, 9, 9, 10, 10, 9, 9, 9, 10, 10, 9, 10, 10, 10, 10, 10, 9]

sd = SDCard(slot=0, width=4, sck=43, cmd=44, data=(39, 40, 41, 42))
# Setting all values manually, width = 4
write:  [27, 24, 26, 24, 25, 26, 24, 24, 26, 25, 25, 27, 25, 27, 25, 25, 26, 25, 25, 27]
read:   [6, 6, 6, 6, 6, 7, 7, 7, 6, 6, 6, 6, 6, 7, 7, 7, 6, 7, 7, 7]
```

Note; for this example the speedup is minor.. but real and consistent.
- M5Stack did not use the default P4 trick of pulling the SD card pins to `ldo4` in the Tab5 :-1: , instead pulling them to `3.3v`, effectively preventing cards from using low-voltage modes. 
- The results in the file above reflect this (eg they are slower than other boards can deliver, my firmware is compiled with the `MICROPY_HW_SDMMC_LDO_CHAN_ID` option commented out in the board mpconfig.h)

### Trade-offs and Alternatives

I don't see any code size impacts, `mpconfig` gets another option but that is all.

The alternative is to document this somewhere and tell people to just manually specify the width on P4 boards.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.
