### PR TITLE
py/makeqstrdefs.py: Propagate out errors from parallel pp step.

### DIFF
--- a/py/makeqstrdefs.py
+++ b/py/makeqstrdefs.py
@@ -68,7 +68,8 @@ def preprocess():
         def run(files):
             try:
                 filtered_lines = []
-                with subprocess.Popen(args.pp + flags + files, stdout=subprocess.PIPE) as proc:
+                cmd = args.pp + flags + files
+                with subprocess.Popen(cmd, stdout=subprocess.PIPE) as proc:
                     recent_file = None
                     for line in proc.stdout:
                         if line.isspace():
@@ -80,6 +81,9 @@ def preprocess():
                                 filtered_lines.append(recent_file)
                                 recent_file = None
                             filtered_lines.append(line)
+                    proc.wait()
+                    if proc.returncode:
+                        raise PreprocessorError("command failed: " + " ".join(cmd))
                 return b"".join(filtered_lines)
             except subprocess.CalledProcessError as er:
                 raise PreprocessorError(str(er))


### PR DESCRIPTION
### Summary

Commit e6380fa15a4ddea6a80aeb557c159bc89c9507b1 changed the pp step from `subprocess.check_output()` to use `subprocess.Popen()`, but did not check the return code of the process.  That means any process errors (eg compiler error) are swallowed and do not stop the build.

This commit fixes that by explicitly checking `proc.returncode` once the process is complete, and raising an exception.

### Testing

RP2350 builds are currently broken in this qstr step, and CI should now fail with the change here (on master it's not failing as it should).  Then it'll pass again once the rp2 port is fixed.

### Generative AI

Not used.