### PR TITLE
rp2/CMakeLists.txt: Include hardware_powman in list of components.

### DIFF
--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -258,6 +258,11 @@ elseif(PICO_RISCV)
         hardware_riscv
     )
 endif()
+if(PICO_RP2350)
+    list(APPEND PICO_SDK_COMPONENTS
+        hardware_powman
+    )
+endif()
 
 # Use our custom pico_float_micropython float implementation.  This is needed for two reasons:
 # - to fix inf handling in pico-sdk's __wrap___aeabi_fadd();


### PR DESCRIPTION
### Summary

The combination of 8d6ce0f56f6694c5e4e6aad77d36ea7bbec9b486 and 111d2e970393fa5db0302626027507305516396c produced a build failure for RP2350 targets.  But it did not actually fail the build due to a regression introduced by e6380fa15a4ddea6a80aeb557c159bc89c9507b1 (which is fixed by #19490).

Fix the rp2 build issue by including `hardware_powman`.

### Testing

Built RPI_PICO, RPI_PICO2 and RPI_PICO2_W-RISCV locally.  They all build without any error messages.

### Generative AI

I did not use generative AI tools when creating this PR.
