### PR TITLE
tests/cpydiff: Document 3-arg `pow()` with a negative exponent.

### DIFF
--- a/tests/cpydiff/types_int_pow3_negexp.py
+++ b/tests/cpydiff/types_int_pow3_negexp.py
@@ -1,0 +1,17 @@
+"""
+categories: Types,int
+description: 3-argument ``pow()`` with a negative exponent returns ``0``.
+cause: MicroPython returns ``0`` for any negative exponent instead of computing the
+modular inverse of the base. Builds not configured with ``MICROPY_LONGINT_IMPL_MPZ``
+return a float instead.
+workaround: Compute the modular inverse explicitly, e.g. with the extended Euclidean algorithm.
+"""
+
+# invertible base
+print(pow(2, -1, 5))
+
+# non-invertible base
+try:
+    print(pow(2, -1, 4))
+except ValueError:
+    print("ValueError")


### PR DESCRIPTION
### Summary

Fixes #19143.

Adds a `tests/cpydiff/` entry documenting that a negative exponent passed to the 3-argument `pow()` returns `0` instead of the modular inverse of the base. CPython treats `pow(x, -n, m)` as a request for that inverse, so both of its outcomes are lost: the correct value when the base is invertible, and the `ValueError` when it is not.

```
>>> pow(2, -1, 5)                # invertible base
CPython:     3
MicroPython: 0

>>> pow(2, -1, 4)                # non-invertible base
CPython:     ValueError: base is not invertible for the given modulus
MicroPython: 0
```

The discussion in the issue concluded that implementing the modular inverse is not worth its size cost on a microcontroller, and that a `cpydiff` entry is the appropriate outcome.

### Testing

- Ran `tools/gen-cpydiff.py` against the `unix` port `build-standard` binary (MicroPython v1.28.0-619.g49fe1749a0, CPython 3.11.2) and confirmed the entry renders in `docs/genrst/builtin_types.rst` with the expected side-by-side output table.
- Confirmed the two interpreters disagree on both cases, which is what `gen-cpydiff.py` requires — it exits with an error when the outputs match.
- Pre-commit hooks (`tools/codeformat.py`, `ruff`, `ruff format`, `codespell`) all pass.
- Documentation only, so no port firmware is affected; only `unix` was exercised.

### Trade-offs and Alternatives

- **Alternative: implement the modular inverse.** There is no extended GCD to build on in `py/mpz.c` — `mpz_gcd` sits inside the `#if 0` unused block — so this means a new bignum routine, not a small patch. It would also buy little in practice: portable libraries gate the feature on `sys.version_info >= (3, 8)` while MicroPython reports 3.4, so they keep using their own extended-Euclid helper regardless.
- **Alternative: raise `ValueError` on a negative exponent.** This would at least replace a silently wrong value with a loud failure, but it would also raise for `pow(2, -1, 5)`, where CPython returns a perfectly good `3`. That trades one divergence for another rather than removing one, so it is not a reason to change long-standing behaviour.
- **Scope.** `gen-cpydiff.py` captures the output of a single binary, so the table shows the MPZ result. Builds not configured with `MICROPY_LONGINT_IMPL_MPZ` evaluate 3-argument `pow()` through `mp_binary_op` and return a float for a negative exponent, which is a different wrong answer; the entry's `cause` field says so, but that path is not exercised by any in-tree port with `MICROPY_PY_BUILTINS_POW3` enabled.
- **Categorisation.** Filed under `Types,int` with a `types_int_` prefix, matching the existing `types_int_*` entries, since the mechanism is how an `int` value is computed rather than anything about the `pow()` call itself.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
