### PR TITLE
py/mpz: Fix 3-arg pow() with zero base and zero exponent.

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1356,7 +1356,7 @@ void mpz_pow_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs) {
    can have dest, lhs, rhs the same; mod can't be the same as dest
 */
 void mpz_pow3_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs, const mpz_t *mod) {
-    if (lhs->len == 0 || rhs->neg != 0 || (mod->len == 1 && mod->dig[0] == 1)) {
+    if (rhs->neg != 0 || (mod->len == 1 && mod->dig[0] == 1)) {
         mpz_set_from_int(dest, 0);
         return;
     }
@@ -1364,6 +1364,11 @@ void mpz_pow3_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs, const mpz_t 
     mpz_set_from_int(dest, 1);
 
     if (rhs->len == 0) {
+        return;
+    }
+
+    if (lhs->len == 0) {
+        mpz_set_from_int(dest, 0);
         return;
     }
 

--- a/tests/basics/builtin_pow3.py
+++ b/tests/basics/builtin_pow3.py
@@ -12,6 +12,9 @@ print(pow(1, 1, 1))
 print(pow(0, 1, 1))
 print(pow(1, 0, 1))
 print(pow(1, 0, 2))
+print(pow(0, 0, 5))
+print(pow(0, 1, 5))
+print(pow(0, 0, 1))
 
 # 3 arg pow is defined to only work on integers
 try:


### PR DESCRIPTION
### Summary

`pow(0, 0, m)` returns `0` instead of `1`. The entry guard in `mpz_pow3_inpl()` folds "base is zero" into the short-circuit that returns `0`, so it fires before the zero-exponent branch a few lines below ever runs. That clause is only an optimization — the square-and-multiply loop produces `0` for a zero base anyway — but sitting ahead of the exponent check made it change the result.

Everything else in MicroPython already agrees with CPython here: `0 ** 0` and `pow(3, 0, 5)` both give `1`. Only this combination diverges, and silently, so a wrong value just propagates.

#### AS-IS

```
>>> pow(0, 0, 5)
0
```

#### TO-BE

```
>>> pow(0, 0, 5)
1
```

(matching CPython)

**Changes**

- Move the zero-base short-circuit below the zero-exponent early return.
- Add `pow(0, 0, 5)`, `pow(0, 1, 5)` and `pow(0, 0, 1)` to `tests/basics/builtin_pow3.py`.

The `mod == 1` clause still runs first, so `pow(0, 0, 1)` stays `0` as CPython gives.

### Testing

Built and tested on the `unix` port only (`build-standard`, Debian 12, 64-bit). The change is in portable code, and 3-arg `pow()` reaches `mpz_pow3_inpl()` only under `MICROPY_LONGINT_IMPL_MPZ`; the other long-int implementations evaluate `(x ** y) % z` and are unaffected.

- `./run-tests.py`: 996 performed, 995 passed. The one failure, `extmod/select_poll_fd.py`, fails the same way on unmodified `master` here.
- `builtin_pow3.py` has no `.exp` file, so the added cases are compared against CPython directly.
- Swept 1287 `pow(base, exp, mod)` combinations (negative and multi-digit bases, exponents to `2**70`, negative moduli) against CPython 3.11.15. Mismatches drop 33 → 26, and diffing the sweep before/after shows exactly 9 results change, all `base == 0 and exp == 0`.
- The 26 remaining are all `exp == 0` with a negative modulus (`pow(3, 0, -5)` gives `1`, CPython `-4`) — a separate pre-existing issue, left alone. This patch does make `pow(0, 0, -5)` behave like every other base instead of special-casing zero.

### Trade-offs and Alternatives

No size cost: `text` is unchanged for both `py/mpz.o` (8832) and the binary (755415), since dropping the clause from the compound guard offsets the new branch.

Deleting the clause outright instead is 8 bytes smaller again, and correct, because `mpz_mul_inpl()` fast-paths a zero operand. I kept the check because it guards allocation more than arithmetic — past it, `mpz_clone()` copies the exponent, allocating in proportion to its bit count. With it deleted, `pow(0, (1 << 20000) - 1, 97)` took 7709 us instead of 1 us.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.
