### PR TITLE
py/gc: Track the min/max of the entire heap area when using split heap.

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -206,6 +206,10 @@ static void gc_setup_area(mp_state_mem_area_t *area, void *start, void *end) {
 
     #if MICROPY_GC_SPLIT_HEAP
     area->next = NULL;
+
+    // Update the global min/max region that covers all heaps
+    MP_STATE_MEM(area_pool_min) = MIN(MP_STATE_MEM(area_pool_min), area->gc_pool_start);
+    MP_STATE_MEM(area_pool_max) = MAX(MP_STATE_MEM(area_pool_max), area->gc_pool_end);
     #endif
 
     DEBUG_printf("GC layout:\n");
@@ -234,6 +238,13 @@ void gc_init(void *start, void *end) {
     // align end pointer on block boundary
     end = (void *)((uintptr_t)end & (~(BYTES_PER_BLOCK - 1)));
     DEBUG_printf("Initializing GC heap: %p..%p = " UINT_FMT " bytes\n", start, end, (byte *)end - (byte *)start);
+
+    #if MICROPY_GC_SPLIT_HEAP
+    // Note: min/max are deliberately swapped here, gc_setup_area() will update them to
+    // the correct values for the min/max of the first actual pool region
+    MP_STATE_MEM(area_pool_min) = end;
+    MP_STATE_MEM(area_pool_max) = start;
+    #endif
 
     gc_setup_area(&MP_STATE_MEM(area), start, end);
 
@@ -392,12 +403,24 @@ bool gc_is_locked(void) {
 }
 
 #if MICROPY_GC_SPLIT_HEAP
-// Returns the area to which this pointer belongs, or NULL if it isn't
-// allocated on the GC-managed heap.
-static inline mp_state_mem_area_t *gc_get_ptr_area(const void *ptr) {
-    if (((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) != 0) {   // must be aligned on a block
-        return NULL;
+static mp_state_mem_area_t *gc_get_ptr_area(const void *ptr);
+
+// Returns the area to which this arbitrary pointer belongs, or NULL if it isn't
+// allocated on the GC-managed heap. Contains "fast path" inline checks for invalid
+// data which isn't a pointer to the heap. Equivalent of VERIFY_PTR for the non-split-heap case.
+static inline MP_ALWAYSINLINE mp_state_mem_area_t *gc_verify_ptr_get_area(const void *ptr) {
+    // These inline checks are similar to VERIFY_PTR macro, below
+    if ((byte *)ptr < MP_STATE_MEM(area_pool_min) || (byte *)ptr > MP_STATE_MEM(area_pool_max)) {
+        return NULL;  // not in the overall pool region
     }
+    if (((uintptr_t)(ptr) & (BYTES_PER_BLOCK - 1)) != 0) {
+        return NULL;  // not aligned on a block boundary
+    }
+    return gc_get_ptr_area(ptr);
+}
+
+// Returns the area to which a pointer belongs. Assumes pointer is valid to a heap block.
+static mp_state_mem_area_t *gc_get_ptr_area(const void *ptr) {
     for (mp_state_mem_area_t *area = &MP_STATE_MEM(area); area != NULL; area = NEXT_AREA(area)) {
         if (ptr >= (void *)area->gc_pool_start   // must be above start of pool
             && ptr < (void *)area->gc_pool_end) {   // must be below end of pool
@@ -406,7 +429,7 @@ static inline mp_state_mem_area_t *gc_get_ptr_area(const void *ptr) {
     }
     return NULL;
 }
-#endif
+#else
 
 // ptr should be of type void*
 #define VERIFY_PTR(ptr) ( \
@@ -414,6 +437,8 @@ static inline mp_state_mem_area_t *gc_get_ptr_area(const void *ptr) {
     && ptr >= (void *)MP_STATE_MEM(area).gc_pool_start      /* must be above start of pool */ \
     && ptr < (void *)MP_STATE_MEM(area).gc_pool_end         /* must be below end of pool */ \
     )
+
+#endif
 
 #ifdef TRACE_MARK
 #error "TRACE_MARK is replaced by TRACE_MARK_R and TRACE_MARK_S"
@@ -470,7 +495,7 @@ void gc_collect_root(void **ptrs, size_t len) {
         MICROPY_GC_HOOK_LOOP(i);
         void *ptr = gc_get_ptr(ptrs, i);
         #if MICROPY_GC_SPLIT_HEAP
-        mp_state_mem_area_t *area = gc_get_ptr_area(ptr);
+        mp_state_mem_area_t *area = gc_verify_ptr_get_area(ptr);
         if (!area) {
             continue;
         }
@@ -527,7 +552,7 @@ static void gc_mark_subtree(size_t block)
             // If this is a heap pointer that hasn't been marked, mark it and push
             // it's children to the stack.
             #if MICROPY_GC_SPLIT_HEAP
-            mp_state_mem_area_t *ptr_area = gc_get_ptr_area(ptr);
+            mp_state_mem_area_t *ptr_area = gc_verify_ptr_get_area(ptr);
             if (!ptr_area) {
                 // Not a heap-allocated pointer (might even be random data).
                 continue;

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -129,6 +129,10 @@ typedef struct _mp_state_mem_t {
     #endif
 
     mp_state_mem_area_t area;
+    #if MICROPY_GC_SPLIT_HEAP
+    byte *area_pool_min;  // Min of all gc_pool_start values across all areas
+    byte *area_pool_max;  // Max of all gc_pool_end values across all areas
+    #endif
 
     int gc_stack_overflow;
     MICROPY_GC_STACK_ENTRY_TYPE gc_block_stack[MICROPY_ALLOC_GC_STACK_SIZE];


### PR DESCRIPTION
### Summary

On ports with split heap, this allows short-circuiting the `gc_get_ptr_area()` call for values which aren't in the overall range of any of the GC areas.

Without this, GC scanning is walking the linked list of areas for every word in every buffer (including all zeros, etc). Profiling some allocation-heavy code on ESP32 showed it was spending most of its time doing these checks.

This might be something we can revert if we later on add "no scan" allocations for byte arrays, etc. (i.e. #19367) as that will preempt the need to scan most of these structures.

*This work was funded through GitHub Sponsors.*

### Testing

*EDIT: Results below are outdated, new version should be marginally faster if anything.*

Ran perfbench on this PR vs master on a ESP32_GENERIC_S3 with octal SPIRAM:

```
diff of scores (higher is better)
N=168 M=100                esp32s3_oct_gc_master.txt -> esp32s3_oct_area_opt.txt         diff      diff% (error%)
bm_chaos.py                    561.09 ->     565.54 :      +4.45 =  +0.793% (+/-0.07%)
bm_fannkuch.py                 118.70 ->     118.68 :      -0.02 =  -0.017% (+/-0.04%)
bm_fft.py                     3839.92 ->    3849.50 :      +9.58 =  +0.249% (+/-0.01%)
bm_float.py                   7640.30 ->    7796.82 :    +156.52 =  +2.049% (+/-0.01%)
bm_hexiom.py                    66.76 ->      66.68 :      -0.08 =  -0.120% (+/-0.00%)
bm_nqueens.py                 5608.91 ->    5527.95 :     -80.96 =  -1.443% (+/-0.01%)
bm_pidigits.py                1034.59 ->    1036.14 :      +1.55 =  +0.150% (+/-0.08%)
bm_wordcount.py                102.12 ->     102.13 :      +0.01 =  +0.010% (+/-0.04%)
core_import_mpy_multi.py       722.17 ->     713.47 :      -8.70 =  -1.205% (+/-0.01%)
core_import_mpy_single.py      173.58 ->     173.10 :      -0.48 =  -0.277% (+/-0.11%)
core_locals.py                  67.13 ->      67.13 :      +0.00 =  +0.000% (+/-0.00%)
core_qstr.py                   319.57 ->     318.34 :      -1.23 =  -0.385% (+/-0.10%)
core_str.py                     45.08 ->      45.08 :      +0.00 =  +0.000% (+/-0.01%)
core_yield_from.py             190.95 ->     190.96 :      +0.01 =  +0.005% (+/-0.00%)
misc_aes.py                    608.75 ->     608.61 :      -0.14 =  -0.023% (+/-0.00%)
misc_mandel.py                5202.02 ->    5207.30 :      +5.28 =  +0.101% (+/-0.03%)
misc_pystone.py               3744.79 ->    3743.24 :      -1.55 =  -0.041% (+/-0.00%)
misc_raytrace.py               592.30 ->     593.47 :      +1.17 =  +0.198% (+/-0.01%)
viper_call0.py                 448.86 ->     448.84 :      -0.02 =  -0.004% (+/-0.00%)
viper_call1a.py                440.66 ->     440.63 :      -0.03 =  -0.007% (+/-0.00%)
viper_call1b.py                380.50 ->     380.47 :      -0.03 =  -0.008% (+/-0.00%)
viper_call1c.py                381.11 ->     381.08 :      -0.03 =  -0.008% (+/-0.00%)
viper_call2a.py                436.66 ->     436.62 :      -0.04 =  -0.009% (+/-0.00%)
viper_call2b.py                348.95 ->     348.92 :      -0.03 =  -0.009% (+/-0.00%)
```

No huge differences, but the biggest change is positive on a test which does a decent number of allocations.

Also ran basic test suite on the same board, verified all passing.

### Trade-offs and Alternatives

* We could restructure the `area` linked list to be something we could binary search. However at the moment the majority of values being looked up aren't valid pointers, so the min/max check should be even faster than a binary search for these.
* Could wait until a "no scan" patch like #19367 lands, as this should largely remove the need for this kind of optimisation.

### Generative AI

I did not use generative AI tools when creating this PR.