### PR TITLE
py/mpz: Fix 3-arg pow() with zero exponent and negative modulus.

### DIFF
--- a/py/mpz.c
+++ b/py/mpz.c
@@ -1364,6 +1364,10 @@ void mpz_pow3_inpl(mpz_t *dest, const mpz_t *lhs, const mpz_t *rhs, const mpz_t 
     mpz_set_from_int(dest, 1);
 
     if (rhs->len == 0) {
+        // Python style modulo: 1 % mod is 1 + mod, as abs(mod) >= 2 here
+        if (mod->neg) {
+            mpz_add_inpl(dest, dest, mod);
+        }
         return;
     }
 

--- a/tests/basics/builtin_pow3.py
+++ b/tests/basics/builtin_pow3.py
@@ -13,6 +13,13 @@ print(pow(0, 1, 1))
 print(pow(1, 0, 1))
 print(pow(1, 0, 2))
 
+# a negative modulus gives a result with the sign of the modulus
+print(pow(1, 0, -1))
+print(pow(1, 0, -2))
+print(pow(3, 0, -5))
+print(pow(-3, 0, -5))
+print(pow(3, 4, -5))
+
 # 3 arg pow is defined to only work on integers
 try:
     print(pow("x", 5, 6))

--- a/tests/basics/builtin_pow3_intbig.py
+++ b/tests/basics/builtin_pow3_intbig.py
@@ -9,6 +9,9 @@ except NotImplementedError:
 
 print(pow(555557, 1000002, 1000003))
 
+# a zero exponent with a large negative modulus
+print(pow(3, 0, -(2**70)))
+
 # Tests for 3 arg pow with large values
 
 # This value happens to be prime


### PR DESCRIPTION
### Summary

The result of a 3-arg `pow()` takes the sign of the modulus, so `pow(3, 0, -5)` is `-4`. MicroPython returns `1` for any modulus when the exponent is zero.

#### AS-IS

```
>>> pow(3, 0, -5)
1
```

#### TO-BE

```
>>> pow(3, 0, -5)
-4
```
(matching CPython)

`mpz_pow3_inpl()` sets the accumulator to `1` and [returns before the square-and-multiply loop](https://github.com/micropython/micropython/blob/49fe1749a02ed0e339148608c439f1c53c8cf69d/py/mpz.c#L1366-L1368) when the exponent is zero, skipping the `mpz_divmod_inpl()` calls that are the only place the modulus is applied. A non-zero exponent is already correct, because `mpz_divmod_inpl()` [handles the sign](https://github.com/micropython/micropython/blob/49fe1749a02ed0e339148608c439f1c53c8cf69d/py/mpz.c#L1495-L1504) — `pow(3, 2, -5)` gives `-1`.

Independent of the zero-base fix in #19500: different condition, different line.

**Changes**

- Reduce the accumulator modulo `mod` before the zero-exponent early return in `mpz_pow3_inpl()`
- Add negative-modulus cases to `tests/basics/builtin_pow3.py` and `tests/basics/builtin_pow3_intbig.py`

### Testing

`./run-tests.py` on the `unix` port: 995 passed, same failures as `master`. Not run on hardware.

The new cases have no `.exp`, so they are checked against CPython. I also swept 1260 `pow(base, exp, mod)` combinations against CPython 3.11: mismatches drop from 90 to 13, all remaining ones being the `pow(0, 0, m)` case from #19500.

### Trade-offs and Alternatives

Costs 40 bytes of `text` on `unix` x64 `build-standard`.

Calling `mpz_divmod_inpl()` here instead would not depend on the entry guard having ruled out `abs(mod) == 1`, which is why that invariant is recorded in a comment. I used the addition because with `abs(mod) >= 2` the quotient is `0` and the remainder `1 + mod`, so the division would allocate and zero a quotient buffer to compute a value already known in closed form. On a GC heap that allocation costs more than the bytes it saves.

Dropping the now-redundant `abs(mod) == 1` guard clause would recover more bytes than this patch spends, but it makes `pow(x, y, ±1)` walk the whole exponent. Happy to do that separately if wanted.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.