### PR TITLE
ports/esp32: Treat Pin mode -1 as unchanged.

### DIFF
--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -160,11 +160,11 @@ static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_prin
     mp_printf(print, ")");
 }
 
-// pin.init(mode=None, pull=-1, *, value, drive, hold)
+// pin.init(mode=-1, pull=-1, *, value, drive, hold)
 static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_mode, ARG_pull, ARG_value, ARG_drive, ARG_hold };
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = mp_const_none}},
+        { MP_QSTR_mode, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(-1)}},
         { MP_QSTR_pull, MP_ARG_OBJ, {.u_obj = MP_OBJ_NEW_SMALL_INT(-1)}},
         { MP_QSTR_value, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
         { MP_QSTR_drive, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL}},
@@ -176,9 +176,13 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
     gpio_num_t index = PIN_OBJ_PTR_INDEX(self);
+    mp_int_t pin_io_mode = -1;
+    if (args[ARG_mode].u_obj != mp_const_none) {
+        pin_io_mode = mp_obj_get_int(args[ARG_mode].u_obj);
+    }
 
     // reset the pin to digital if this is a mode-setting init (grab it back from ADC)
-    if (args[ARG_mode].u_obj != mp_const_none) {
+    if (pin_io_mode != -1) {
         if (rtc_gpio_is_valid_gpio(index)) {
             #if !(CONFIG_IDF_TARGET_ESP32C2 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C5 || CONFIG_IDF_TARGET_ESP32C6 || CONFIG_IDF_TARGET_ESP32H2)
             rtc_gpio_deinit(index);
@@ -224,8 +228,7 @@ static mp_obj_t machine_pin_obj_init_helper(const machine_pin_obj_t *self, size_
     }
 
     // configure mode
-    if (args[ARG_mode].u_obj != mp_const_none) {
-        mp_int_t pin_io_mode = mp_obj_get_int(args[ARG_mode].u_obj);
+    if (pin_io_mode != -1) {
         #ifdef GPIO_FIRST_NON_OUTPUT
         if (index >= GPIO_FIRST_NON_OUTPUT && (pin_io_mode & GPIO_MODE_DEF_OUTPUT)) {
             mp_raise_ValueError(MP_ERROR_TEXT("pin can only be input"));

--- a/tests/ports/esp32/machine_pin_mode.py
+++ b/tests/ports/esp32/machine_pin_mode.py
@@ -1,0 +1,12 @@
+from machine import Pin
+
+
+pin = Pin(2, Pin.IN)
+mode = repr(pin)
+Pin(2, mode=-1)
+print(repr(pin) == mode)
+
+pin.init(Pin.IN)
+mode = repr(pin)
+pin.init(mode=-1)
+print(repr(pin) == mode)

--- a/tests/ports/esp32/machine_pin_mode.py.exp
+++ b/tests/ports/esp32/machine_pin_mode.py.exp
@@ -1,0 +1,2 @@
+True
+True


### PR DESCRIPTION
### Summary

On the ESP32 port, `machine.Pin` documents `mode=-1` as the sentinel for
leaving the current pin mode unchanged. The implementation instead forwarded
`-1` to `gpio_set_direction()`, where its set bits could enable input, output,
and open-drain mode together.

This change:

- uses `-1` as the constructor's mode default;
- treats both `mode=-1` and `mode=None` as no-change values;
- skips RTC deinitialization and `gpio_set_direction()` for the sentinel; and
- adds ESP32 tests for both constructor and `Pin.init()` paths.

Fixes #19456.

### Testing

- All ESP32 IDF build matrices passed in the first upstream CI run.
- Code formatting, codespell, ruff, coverage, and the remaining build/test
  matrices passed.
- The code-size report shows no size change.
- `tools/ci.sh commit_formatting_run` passes after correcting the commit
  prefix, message wrapping, author email, and sign-off.
- The C source was formatted with the repository's uncrustify configuration.
- The Python test passes `ruff format --check` and `py_compile`.

No ESP32 hardware was available locally, so the new hardware regression has not
been run on a physical board.

### Trade-offs and Alternatives

The fix is limited to the documented no-change sentinel and preserves
`mode=None` compatibility. It has no reported code-size impact. Passing `-1`
through to ESP-IDF was rejected because it is not a valid no-change operation
there.

### Generative AI

Generative AI tools were used to investigate, implement, test, and prepare this
PR. 
