### PR TITLE
esp32/sdkconfig.p4: Allow P4 bootloader to load all revisions.

### DIFF
--- a/ports/esp32/boards/sdkconfig.p4
+++ b/ports/esp32/boards/sdkconfig.p4
@@ -1,5 +1,6 @@
 # Select the minimum chip revision to cover all possible boards.
 CONFIG_ESP32P4_REV_MIN_0=y
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
 
 # Flash
 CONFIG_FLASHMODE_QIO=y


### PR DESCRIPTION
### Summary

ESP-IDF v5.5.4 appears to include a change to the way the P4 bootloader handles code for chip revisions less than 3.x. Refusing to load the firmware with the error:

```
A fatal error occurred: bootloader/bootloader.bin requires chip revision in range [v3.1 - v3.99] (this chip is revision v1.3). Use --force to flash anyway.
```

This PR sets `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` in `boards/sdkconfig.p4`, this needed for first generation `P4` boards (such as my Tab5) with v1.3 chips. Without this option the P4 bootloader in esp-idf 5.5.4 (and later) refuses to load the firmware.

It is similar to, and applied at the same time as, the recently added SDK compile option `CONFIG_ESP32P4_REV_MIN_0=y` which enables pre-3.x chips in code.

See #19454 for a more complete description with relevant error messages etc.

### Testing

Tested by clean building the `generic-esp32-p4` build with both `esp-idf` `5.5.2` and `5.5.4`, and both with and without this flag in `sdkconfig.p4`. All builds succeeded, the idf 5.5.2 builds both deploy directly to the Tab5, the idf 5.5.4 build fails to deploy without the flag enabled, but succeeds with it.

### Trade-offs and Alternatives

The only workaround is to manually run `esptool` with `--force` to deploy the firmware, which is not a good solution.

### Generative AI

I did not use generative AI tools when creating this PR.