### PR TITLE
tests/net_inet: Use "ascii" encoding for HTTP Host.

### DIFF
--- a/tests/net_inet/test_tls_nonblock.py
+++ b/tests/net_inet/test_tls_nonblock.py
@@ -61,7 +61,7 @@ def test_one(site, opts):
             # print("shook hands")
 
         # Write HTTP request
-        out = b"GET / HTTP/1.0\r\nHost: %s\r\n\r\n" % bytes(site, "latin")
+        out = b"GET / HTTP/1.0\r\nHost: %s\r\n\r\n" % bytes(site, "ascii")
         while len(out) > 0:
             n = s.write(out)
             if n is None:

--- a/tests/net_inet/test_tls_sites.py
+++ b/tests/net_inet/test_tls_sites.py
@@ -37,7 +37,7 @@ def test_one(site, opts):
         else:
             s = ssl_context.wrap_socket(s)
 
-        s.write(b"GET / HTTP/1.0\r\nHost: %s\r\n\r\n" % bytes(site, "latin"))
+        s.write(b"GET / HTTP/1.0\r\nHost: %s\r\n\r\n" % bytes(site, "ascii"))
         resp = s.read(4096)
         if resp[:7] != b"HTTP/1.":
             raise ValueError("response doesn't start with HTTP/1.")


### PR DESCRIPTION
### Summary

Instead of "latin" which is unsupported, and now an error since commit 770bb3b79b0df0b23f93ac9ccc0474f31a6ad650

### Testing

Tested locally running `./run-tests.py net_inet/*.py`.  These tests would fail without this change.

### Generative AI

I did not use generative AI tools when creating this PR.
