### PR TITLE
py/emitnative: Allow jump sequences' size variations between passes.

### DIFF
--- a/py/asmbase.c
+++ b/py/asmbase.c
@@ -55,6 +55,7 @@ void mp_asm_base_start_pass(mp_asm_base_t *as, int pass) {
         MP_PLAT_ALLOC_EXEC(as->code_offset, (void **)&as->code_base, &as->code_size);
         assert(as->code_size == 0 || as->code_base != NULL);
     }
+    as->stable = true;
     as->pass = pass;
     as->suppress = false;
     as->code_offset = 0;
@@ -71,7 +72,12 @@ uint8_t *mp_asm_base_get_cur_to_write_bytes(void *as_in, size_t num_bytes_to_wri
         return c;
     }
     if (as->pass == MP_ASM_PASS_EMIT) {
-        assert(as->code_offset + num_bytes_to_write <= as->code_size);
+        if (as->code_offset + num_bytes_to_write > as->code_size) {
+            // Track the extra amount of bytes to request on next pass.
+            as->stable = false;
+            as->code_offset += num_bytes_to_write;
+            return NULL;
+        }
         c = as->code_base + as->code_offset;
     }
     as->code_offset += num_bytes_to_write;
@@ -90,8 +96,11 @@ void mp_asm_base_label_assign(mp_asm_base_t *as, size_t label) {
         assert(as->label_offsets[label] == (size_t)-1);
         as->label_offsets[label] = as->code_offset;
     } else {
-        // ensure label offset has not changed from PASS_COMPUTE to PASS_EMIT
-        assert(as->label_offsets[label] == as->code_offset);
+        if (as->label_offsets[label] != as->code_offset) {
+            as->stable = false;
+        }
+        as->label_offsets[label] = as->code_offset;
+
         #if MICROPY_DYNAMIC_COMPILER && MICROPY_EMIT_NATIVE_DEBUG
         if (mp_dynamic_compiler.native_arch == MP_NATIVE_ARCH_DEBUG) {
             mp_printf(MICROPY_EMIT_NATIVE_DEBUG_PRINTER, "label(label_%u)\n", (unsigned int)label);

--- a/py/asmbase.h
+++ b/py/asmbase.h
@@ -39,6 +39,7 @@ typedef struct _mp_asm_base_t {
     // Set to true using mp_asm_base_suppress_code() if the code generator
     // should suppress emitted code due to it being dead code.
     bool suppress;
+    bool stable;
 
     size_t code_offset;
     size_t code_size;

--- a/py/asmrv32.c
+++ b/py/asmrv32.c
@@ -300,12 +300,9 @@ static void emit_compressed_function_epilogue(asm_rv32_t *state, mp_uint_t regis
     asm_rv32_opcode_cmpopret(state, MIN(3 + sequence_length, 15), state->stack_size & 0x03);
 }
 
-static bool calculate_displacement_for_label(asm_rv32_t *state, mp_uint_t label, ptrdiff_t *displacement) {
-    assert(displacement != NULL && "Displacement pointer is NULL");
-
+static ptrdiff_t calculate_displacement_for_label(asm_rv32_t *state, mp_uint_t label) {
     mp_uint_t label_offset = state->base.label_offsets[label];
-    *displacement = (ptrdiff_t)(label_offset - state->base.code_offset);
-    return (label_offset != (mp_uint_t)-1) && (*displacement < 0);
+    return (ptrdiff_t)(label_offset - state->base.code_offset);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -371,10 +368,9 @@ void asm_rv32_emit_call_ind(asm_rv32_t *state, mp_uint_t index) {
 }
 
 void asm_rv32_emit_jump_if_reg_eq(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs2, mp_uint_t label) {
-    ptrdiff_t displacement = 0;
-    bool can_emit_short_jump = calculate_displacement_for_label(state, label, &displacement);
+    ptrdiff_t displacement = calculate_displacement_for_label(state, label);
 
-    if (can_emit_short_jump && FIT_SIGNED(displacement, 13)) {
+    if (FIT_SIGNED(displacement, 13)) {
         // beq rs1, rs2, displacement
         asm_rv32_opcode_beq(state, rs1, rs2, displacement);
         return;
@@ -397,16 +393,15 @@ void asm_rv32_emit_jump_if_reg_eq(asm_rv32_t *state, mp_uint_t rs1, mp_uint_t rs
 }
 
 void asm_rv32_emit_jump_if_reg_nonzero(asm_rv32_t *state, mp_uint_t rs, mp_uint_t label) {
-    ptrdiff_t displacement = 0;
-    bool can_emit_short_jump = calculate_displacement_for_label(state, label, &displacement);
+    ptrdiff_t displacement = calculate_displacement_for_label(state, label);
 
-    if (can_emit_short_jump && FIT_SIGNED(displacement, 8) && RV32_IS_IN_C_REGISTER_WINDOW(rs)) {
+    if (FIT_SIGNED(displacement, 8) && RV32_IS_IN_C_REGISTER_WINDOW(rs)) {
         // c.bnez rs', displacement
         asm_rv32_opcode_cbnez(state, RV32_MAP_IN_C_REGISTER_WINDOW(rs), displacement);
         return;
     }
 
-    if (can_emit_short_jump && FIT_SIGNED(displacement, 13)) {
+    if (FIT_SIGNED(displacement, 13)) {
         // bne rs, zero, displacement
         asm_rv32_opcode_bne(state, rs, ASM_RV32_REG_ZERO, displacement);
         return;
@@ -423,7 +418,7 @@ void asm_rv32_emit_jump_if_reg_nonzero(asm_rv32_t *state, mp_uint_t rs, mp_uint_
     //    jalr   zero, temporary, LO(displacement) ; PC + 8
     //    ...                                      ; PC + 12
 
-    if (can_emit_short_jump && RV32_IS_IN_C_REGISTER_WINDOW(rs)) {
+    if (RV32_IS_IN_C_REGISTER_WINDOW(rs)) {
         asm_rv32_opcode_cbeqz(state, RV32_MAP_IN_C_REGISTER_WINDOW(rs), 10);
         // Compensate for the C.BEQZ opcode.
         displacement -= ASM_HALFWORD_SIZE;
@@ -548,10 +543,9 @@ void asm_rv32_emit_load_reg_reg_offset(asm_rv32_t *state, mp_uint_t rd, mp_uint_
 }
 
 void asm_rv32_emit_jump(asm_rv32_t *state, mp_uint_t label) {
-    ptrdiff_t displacement = 0;
-    bool can_emit_short_jump = calculate_displacement_for_label(state, label, &displacement);
+    ptrdiff_t displacement = calculate_displacement_for_label(state, label);
 
-    if (can_emit_short_jump && FIT_SIGNED(displacement, 12)) {
+    if (FIT_SIGNED(displacement, 12)) {
         // c.j displacement
         asm_rv32_opcode_cj(state, displacement);
         return;

--- a/py/asmthumb.c
+++ b/py/asmthumb.c
@@ -508,50 +508,36 @@ void asm_thumb_b_label(asm_thumb_t *as, uint label) {
     mp_int_t rel = dest - as->base.code_offset;
     rel -= 4; // account for instruction prefetch, PC is 4 bytes ahead of this instruction
 
-    if (dest != (mp_uint_t)-1 && rel <= -4) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 12 bit relative jump
-        if (SIGNED_FIT12(rel)) {
-            asm_thumb_op16(as, OP_B_N(rel));
-            return;
-        }
+    // calculate rel assuming 12 bit relative jump
+    if (SIGNED_FIT12(rel)) {
+        asm_thumb_op16(as, OP_B_N(rel));
+        return;
     }
 
-    // is a large backwards jump, or a forwards jump (that must be assumed large)
+    // is a large jump
 
     if (asm_thumb_allow_armv7m(as)) {
         asm_thumb_op32(as, OP_BW_HI(rel), OP_BW_LO(rel));
     } else {
-        // this code path has to be the same instruction size irrespective of the value of rel
-        bool need_align = as->base.code_offset & 2u;
-        if (SIGNED_FIT12(rel)) {
-            asm_thumb_op16(as, OP_B_N(rel));
-            asm_thumb_op16(as, ASM_THUMB_OP_NOP);
-            asm_thumb_op16(as, ASM_THUMB_OP_NOP);
-            asm_thumb_op16(as, ASM_THUMB_OP_NOP);
-            if (need_align) {
-                asm_thumb_op16(as, ASM_THUMB_OP_NOP);
-            }
-        } else {
-            // do a large jump using:
-            //     (nop)
-            //     ldr r1, [pc, _data]
-            //     add pc, r1
-            // _data: .word rel
-            //
-            // note: can't use r0 as a temporary because native code can have the return value
-            // in that register and use a large jump to get to the exit point of the function
+        // do a large jump using:
+        //     (nop)
+        //     ldr r1, [pc, _data]
+        //     add pc, r1
+        // _data: .word rel
+        //
+        // note: can't use r0 as a temporary because native code can have the return value
+        // in that register and use a large jump to get to the exit point of the function
 
-            rel -= 2; // account for the "ldr r1, [pc, _data]"
-            if (need_align) {
-                asm_thumb_op16(as, ASM_THUMB_OP_NOP);
-                rel -= 2; // account for this nop
-            }
-            asm_thumb_ldr_rlo_pcrel_i8(as, ASM_THUMB_REG_R1, 0);
-            asm_thumb_add_reg_reg(as, ASM_THUMB_REG_R15, ASM_THUMB_REG_R1);
-            asm_thumb_op16(as, rel & 0xffff);
-            asm_thumb_op16(as, rel >> 16);
+        bool need_align = as->base.code_offset & 2u;
+        rel -= 2; // account for the "ldr r1, [pc, _data]"
+        if (need_align) {
+            asm_thumb_op16(as, ASM_THUMB_OP_NOP);
+            rel -= 2; // account for this nop
         }
+        asm_thumb_ldr_rlo_pcrel_i8(as, ASM_THUMB_REG_R1, 0);
+        asm_thumb_add_reg_reg(as, ASM_THUMB_REG_R15, ASM_THUMB_REG_R1);
+        asm_thumb_op16(as, rel & 0xffff);
+        asm_thumb_op16(as, rel >> 16);
     }
 }
 
@@ -561,13 +547,10 @@ void asm_thumb_bcc_label(asm_thumb_t *as, int cond, uint label) {
     mp_int_t rel = dest - as->base.code_offset;
     rel -= 4; // account for instruction prefetch, PC is 4 bytes ahead of this instruction
 
-    if (dest != (mp_uint_t)-1 && rel <= -4) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 9 bit relative jump
-        if (SIGNED_FIT9(rel)) {
-            asm_thumb_op16(as, OP_BCC_N(cond, rel));
-            return;
-        }
+    // calculate rel assuming 9 bit relative jump
+    if (SIGNED_FIT9(rel)) {
+        asm_thumb_op16(as, OP_BCC_N(cond, rel));
+        return;
     }
 
     // is a large backwards jump, or a forwards jump (that must be assumed large)

--- a/py/asmx64.c
+++ b/py/asmx64.c
@@ -498,20 +498,12 @@ static mp_uint_t get_label_dest(asm_x64_t *as, mp_uint_t label) {
 void asm_x64_jmp_label(asm_x64_t *as, mp_uint_t label) {
     mp_uint_t dest = get_label_dest(as, label);
     mp_int_t rel = dest - as->base.code_offset;
-    if (dest != (mp_uint_t)-1 && rel < 0) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 8 bit relative jump
-        rel -= 2;
-        if (SIGNED_FIT8(rel)) {
-            asm_x64_write_byte_2(as, OPCODE_JMP_REL8, rel & 0xff);
-        } else {
-            rel += 2;
-            goto large_jump;
-        }
+    // calculate rel assuming 8 bit relative jump
+    rel -= 2;
+    if (SIGNED_FIT8(rel)) {
+        asm_x64_write_byte_2(as, OPCODE_JMP_REL8, rel & 0xff);
     } else {
-        // is a forwards jump, so need to assume it's large
-    large_jump:
-        rel -= 5;
+        rel -= 3;
         asm_x64_write_byte_1(as, OPCODE_JMP_REL32);
         asm_x64_write_word32(as, rel);
     }
@@ -520,20 +512,12 @@ void asm_x64_jmp_label(asm_x64_t *as, mp_uint_t label) {
 void asm_x64_jcc_label(asm_x64_t *as, int jcc_type, mp_uint_t label) {
     mp_uint_t dest = get_label_dest(as, label);
     mp_int_t rel = dest - as->base.code_offset;
-    if (dest != (mp_uint_t)-1 && rel < 0) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 8 bit relative jump
-        rel -= 2;
-        if (SIGNED_FIT8(rel)) {
-            asm_x64_write_byte_2(as, OPCODE_JCC_REL8 | jcc_type, rel & 0xff);
-        } else {
-            rel += 2;
-            goto large_jump;
-        }
+    // calculate rel assuming 8 bit relative jump
+    rel -= 2;
+    if (SIGNED_FIT8(rel)) {
+        asm_x64_write_byte_2(as, OPCODE_JCC_REL8 | jcc_type, rel & 0xff);
     } else {
-        // is a forwards jump, so need to assume it's large
-    large_jump:
-        rel -= 6;
+        rel -= 4;
         asm_x64_write_byte_2(as, OPCODE_JCC_REL32_A, OPCODE_JCC_REL32_B | jcc_type);
         asm_x64_write_word32(as, rel);
     }

--- a/py/asmx86.c
+++ b/py/asmx86.c
@@ -371,20 +371,12 @@ static mp_uint_t get_label_dest(asm_x86_t *as, mp_uint_t label) {
 void asm_x86_jmp_label(asm_x86_t *as, mp_uint_t label) {
     mp_uint_t dest = get_label_dest(as, label);
     mp_int_t rel = dest - as->base.code_offset;
-    if (dest != (mp_uint_t)-1 && rel < 0) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 8 bit relative jump
-        rel -= 2;
-        if (SIGNED_FIT8(rel)) {
-            asm_x86_write_byte_2(as, OPCODE_JMP_REL8, rel & 0xff);
-        } else {
-            rel += 2;
-            goto large_jump;
-        }
+    // calculate rel assuming 8 bit relative jump
+    rel -= 2;
+    if (SIGNED_FIT8(rel)) {
+        asm_x86_write_byte_2(as, OPCODE_JMP_REL8, rel & 0xff);
     } else {
-        // is a forwards jump, so need to assume it's large
-    large_jump:
-        rel -= 5;
+        rel -= 3;
         asm_x86_write_byte_1(as, OPCODE_JMP_REL32);
         asm_x86_write_word32(as, rel);
     }
@@ -393,20 +385,12 @@ void asm_x86_jmp_label(asm_x86_t *as, mp_uint_t label) {
 void asm_x86_jcc_label(asm_x86_t *as, mp_uint_t jcc_type, mp_uint_t label) {
     mp_uint_t dest = get_label_dest(as, label);
     mp_int_t rel = dest - as->base.code_offset;
-    if (dest != (mp_uint_t)-1 && rel < 0) {
-        // is a backwards jump, so we know the size of the jump on the first pass
-        // calculate rel assuming 8 bit relative jump
-        rel -= 2;
-        if (SIGNED_FIT8(rel)) {
-            asm_x86_write_byte_2(as, OPCODE_JCC_REL8 | jcc_type, rel & 0xff);
-        } else {
-            rel += 2;
-            goto large_jump;
-        }
+    // calculate rel assuming 8 bit relative jump
+    rel -= 2;
+    if (SIGNED_FIT8(rel)) {
+        asm_x86_write_byte_2(as, OPCODE_JCC_REL8 | jcc_type, rel & 0xff);
     } else {
-        // is a forwards jump, so need to assume it's large
-    large_jump:
-        rel -= 6;
+        rel -= 4;
         asm_x86_write_byte_2(as, OPCODE_JCC_REL32_A, OPCODE_JCC_REL32_B | jcc_type);
         asm_x86_write_word32(as, rel);
     }

--- a/py/asmxtensa.c
+++ b/py/asmxtensa.c
@@ -161,21 +161,23 @@ void asm_xtensa_j_label(asm_xtensa_t *as, uint label) {
     asm_xtensa_op_j(as, rel);
 }
 
-static bool calculate_branch_displacement(asm_xtensa_t *as, uint label, ptrdiff_t *displacement) {
-    assert(displacement != NULL && "Displacement pointer is NULL");
-
+static ptrdiff_t calculate_branch_displacement(asm_xtensa_t *as, uint label) {
     uint32_t label_offset = get_label_dest(as, label);
-    *displacement = (ptrdiff_t)(label_offset - as->base.code_offset - 4);
-    return (label_offset != (uint32_t)-1) && (*displacement < 0);
+    return (ptrdiff_t)(label_offset - as->base.code_offset - 4);
 }
 
 void asm_xtensa_bccz_reg_label(asm_xtensa_t *as, uint cond, uint reg, uint label) {
-    ptrdiff_t rel = 0;
-    bool can_emit_short_jump = calculate_branch_displacement(as, label, &rel);
+    ptrdiff_t rel = calculate_branch_displacement(as, label);
 
-    if (can_emit_short_jump && SIGNED_FIT12(rel)) {
-        // Backwards BCCZ opcodes with an offset that fits in 12 bits can
-        // be emitted without any change.
+    // Emit BEQZ.N/BNEZ.N if possible.
+    if (cond < 2 && MP_FIT_UNSIGNED(6, rel)) {
+        asm_xtensa_op16(as, ASM_XTENSA_ENCODE_RI6(0x0c, reg, rel) | 0x80 | ((cond & 1) << 6));
+        return;
+    }
+
+    if (SIGNED_FIT12(rel)) {
+        // BCCZ opcodes with an offset that fits in 12 bits can be emitted
+        // without any change.
         asm_xtensa_op_bccz(as, cond, reg, rel);
         return;
     }
@@ -194,12 +196,11 @@ void asm_xtensa_bccz_reg_label(asm_xtensa_t *as, uint cond, uint reg, uint label
 }
 
 void asm_xtensa_bcc_reg_reg_label(asm_xtensa_t *as, uint cond, uint reg1, uint reg2, uint label) {
-    ptrdiff_t rel = 0;
-    bool can_emit_short_jump = calculate_branch_displacement(as, label, &rel);
+    ptrdiff_t rel = calculate_branch_displacement(as, label);
 
-    if (can_emit_short_jump && SIGNED_FIT8(rel)) {
-        // Backwards BCC opcodes with an offset that fits in 8 bits can
-        // be emitted without any change.
+    if (SIGNED_FIT8(rel)) {
+        // BCC opcodes with an offset that fits in 8 bits can be emitted
+        // without any change.
         asm_xtensa_op_bcc(as, cond, reg1, reg2, rel);
         return;
     }

--- a/py/asmxtensa.h
+++ b/py/asmxtensa.h
@@ -105,6 +105,8 @@
     (((imm12) << 12) | ((s) << 8) | ((m) << 6) | ((n) << 4) | (op0))
 #define ASM_XTENSA_ENCODE_RRRN(op0, r, s, t) \
     (((r) << 12) | ((s) << 8) | ((t) << 4) | (op0))
+#define ASM_XTENSA_ENCODE_RI6(op0, s, imm6) \
+    ((((imm6) & 0xf) << 12) | ((s) << 8) | ((imm6) & 0x30) | (op0))
 #define ASM_XTENSA_ENCODE_RI7(op0, s, imm7) \
     ((((imm7) & 0xf) << 12) | ((s) << 8) | ((imm7) & 0x70) | (op0))
 

--- a/py/emitnative.c
+++ b/py/emitnative.c
@@ -736,6 +736,10 @@ static bool emit_native_end_pass(emit_t *emit) {
     assert(emit->exc_stack_size == 0);
 
     if (emit->pass == MP_PASS_EMIT) {
+        if (!emit->as->base.stable) {
+            return false;
+        }
+
         void *f = mp_asm_base_get_code(&emit->as->base);
         mp_uint_t f_len = mp_asm_base_get_code_size(&emit->as->base);
 


### PR DESCRIPTION
### Summary

This PR lets the native emitter framework to handle cases in which due to code sequences of different lengths emitted between the compute and emit passes.  

Said limitation did force certain design decision in the processors backend, as things like forward jumps whose size may differ due to the new offset had to be discarded in favour of potentially unoptimised fixed-size code sequences.  
  
Now the emitter will keep track of labels that have been moved around in the emit pass as well, and in such case it will re-request the pass from the compiler until all labels are stable.  In theory this could also allow things like jump elision if the target is adjacent to the virtual program counter, although this has not been tested yet.

This PR also contains the necessary changes to all relevant emitters to optimise all jumps, forwards and backwards, to test the emitter changes on a live target.

With these changes applied, I've done some measurements w.r.t. output size when compiling the whole `/tests` directory:

|Profile|Files|Baseline size|New size|Δ files|Δ bytes|Δ bytes / file|Δ bytes %|
|:--|--:|--:|--:|--:|--:|--:|--:|
|armv6|1587|4688435|4688435|0|0|0.00|0.00 %|
|armv6m|1587|3002164|2775877|0|-226287|-142.59|-7.54 %|
|armv7m|1592|2724418|2669971|0|-54447|-34.20|-2.00 %|
|rv32|1593|3288191|3090192|0|-197999|-124.29|-6.02 %|
|rv32_zba|1594|3290344|3092315|0|-198029|-124.23|-6.02 %|
|rv32_zba_zcmp|1595|3179668|2981434|0|-198234|-124.28|-6.23 %|
|rv32_zcmp|1594|3179128|2980924|0|-198204|-124.34|-6.23 %|
|x64|1580|5619100|5540760|0|-78340|-49.58|-1.39 %|
|x86|1580|5501911|5423203|0|-78708|-49.82|-1.43 %|
|xtensa|1587|3366952|3309611|0|-57341|-36.13|-1.70 %|
|xtensawin|1587|3329879|3272607|0|-57272|-36.09|-1.72 %|
|Total / Average||41170190|39825329||-1344861|-76.87|-3.66 %|

If this goes through there are a couple more optimisations in the RV32 emitter that I can add, as I had to discard them due to the code sequence size constraints.

I assumed Xtensa would get bigger savings, but turns out that conditional jumps ranges are actually quite small, and aren't really used that much in generated code.  However I was able to squeeze in support for emitting `BEQZ.N` and `BNEZ.N` small forward jumps.  Adding those in the long jump sequence (to go past ±18-bits range) saves 16 bytes *total*, so I just left those alone for now.

Same for ArmV7, but having a 32-bits jump opcode really helps.  There wasn't much I could do for that target except for adding support for extended shifted/rotated constants encoding but that would increase footprint for something that won't be used as much as it should have been (tagging integers with the LSB set makes this almost useless).

### Testing

The whole test suite was executed successfully on QEMU/MPS2_AN385, QEMU/VIRT_RV32, ESP32, ESP32C3, RP2040, RP2350, Linux/x86, and Linux/x64 using `--via-mpy --emit=native`, same for the `micropython/{native,viper}*` tests using the on-device emitter.

### Trade-offs and Alternatives

This is highly experimental, and I've limited changes to the RV32 emitter for the sole purpose of making sure the approach could be testable.  There may be a few edge cases I didn't consider, but for regular testing this seems to work.

Unfortunately this also comes with a minor footprint increase, which I believe isn't really avoidable, however the compiled code size savings ought to make up for the increased footprint.

### Generative AI

I did not use generative AI tools when creating this PR.