### PR TITLE
stm32/eth: Move DHCP restart to end of poll and drop dead check.

### DIFF
--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -1149,6 +1149,9 @@ void eth_phy_link_status_poll(void) {
     uint16_t bsr = eth_phy_read(self->phy_addr, PHY_BSR);
     bool current_link_status = (bsr & PHY_BSR_LINK_STATUS) != 0;
 
+    // DHCP restart runs at end of function, after any MAC reconfig.
+    bool needs_dhcp_restart = false;
+
     // Handle link up/down transitions.
     if (current_link_status != self->last_link_status) {
         self->last_link_status = current_link_status;
@@ -1158,7 +1161,7 @@ void eth_phy_link_status_poll(void) {
             netif_set_link_up(netif);
             self->mac_speed_configured = false;
             self->autoneg_start_ms = mp_hal_ticks_ms();
-            eth_dhcp_restart_if_needed(netif);
+            needs_dhcp_restart = true;
         } else {
             netif_set_link_down(netif);
             self->mac_speed_configured = false;
@@ -1237,7 +1240,10 @@ void eth_phy_link_status_poll(void) {
         self->mac_reconfig_in_progress = false;
         self->mac_speed_configured = true;
 
-        // MAC was reconfigured; restart DHCP if needed.
+        needs_dhcp_restart = true;
+    }
+
+    if (needs_dhcp_restart) {
         struct netif *netif = &self->netif;
         MICROPY_PY_LWIP_ENTER
         eth_dhcp_restart_if_needed(netif);

--- a/ports/stm32/eth.c
+++ b/ports/stm32/eth.c
@@ -1179,11 +1179,6 @@ void eth_phy_link_status_poll(void) {
     // If link is up but MAC speed/duplex not yet configured, check if
     // autonegotiation has completed.
     if (current_link_status && !self->mac_speed_configured) {
-        // Re-verify link is still up before proceeding (it may have dropped).
-        if (!self->last_link_status) {
-            return;
-        }
-
         bsr = eth_phy_read(self->phy_addr, PHY_BSR);
         bool autoneg_timeout = (mp_hal_ticks_ms() - self->autoneg_start_ms) > PHY_AUTONEG_TIMEOUT_MS;
 


### PR DESCRIPTION
### Summary

Two small follow-ups to #17613 (stm32/eth link detection polling and DHCP hot-plug support).

First commit addresses a review comment from @dpgeorge on the original PR: `eth_phy_link_status_poll()` was calling `eth_dhcp_restart_if_needed()` twice in a row when both the link-up transition branch and the MAC-reconfig branch ran in the same poll iteration. Sets a local flag in each branch and calls once at end of function.

Second commit drops an unreachable `if (!self->last_link_status) return;` guard inside the MAC-reconfig branch. The surrounding `if (current_link_status && !self->mac_speed_configured)` already established the predicate, and the immediately-prior transition block unconditionally syncs `last_link_status = current_link_status`, so by the time the check runs it can never be false.

I think this should address the issue where starting the board and running `.active(1)` without the cable connected then plugging it in later resulting in it looking like it should be working but not actually get a working dhcp address.

### Testing

Tested on NUCLEO_H563ZI. DHCP acquires an IP as expected on cable-connected boot and after hot-plug. Not re-tested on the other boards touched by the parent PR (F429ZI, H743ZI, N657X0) but the change is in shared poll code.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.