### PR TITLE
qemu: Refactor Cortex-M and RISC-V linkerscripts.

### DIFF
--- a/ports/qemu/Makefile
+++ b/ports/qemu/Makefile
@@ -229,7 +229,9 @@ CFLAGS += $(INC) -Wall -Wpointer-arith -Wdouble-promotion -Wfloat-conversion -We
 	 -ffunction-sections -fdata-sections
 CFLAGS += $(CFLAGS_EXTRA)
 
-LDFLAGS += -T $(LDSCRIPT) --gc-sections -Map=$(@:.elf=.map)
+LINKERSCRIPT = $(BUILD)/linkerscript.ld
+
+LDFLAGS += -T $(LINKERSCRIPT) --gc-sections -Map=$(@:.elf=.map)
 
 # Debugging/Optimization
 ifeq ($(DEBUG), 1)
@@ -344,7 +346,13 @@ test_natmod: $(BUILD)/firmware.elf
 		./run-natmodtests.py -t execpty:"$(QEMU_SYSTEM) $(QEMU_ARGS) -serial pty -kernel ../$(DIRNAME)/$<" $(RUN_TESTS_EXTRA) extmod/$$natmod*.py; \
 		done
 
-$(BUILD)/firmware.elf: $(LDSCRIPT) $(OBJ)
+$(BUILD):
+	$(Q)$(MKDIR) -p $(BUILD)
+
+$(LINKERSCRIPT): $(LDSCRIPT) | $(BUILD)
+	$(Q)$(CROSS_COMPILE)cpp $^ | grep -v '^#' > $@
+
+$(BUILD)/firmware.elf: $(LINKERSCRIPT) $(OBJ)
 	$(Q)$(LD) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
 	$(Q)$(SIZE) $@
 

--- a/ports/qemu/mcu/arm/cortex-m.ld
+++ b/ports/qemu/mcu/arm/cortex-m.ld
@@ -1,0 +1,49 @@
+/* This file is part of the MicroPython project, http://micropython.org/
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Damien P. George
+ */
+
+SECTIONS
+{
+    .isr_vector : {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > ISR
+
+    .text : {
+        . = ALIGN(4);
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
+        _etext = .;
+        _sidata = _etext;
+    } > TEXT
+
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > DATA
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > BSS
+}

--- a/ports/qemu/mcu/arm/cortex-m.ld
+++ b/ports/qemu/mcu/arm/cortex-m.ld
@@ -1,0 +1,71 @@
+/* This file is part of the MicroPython project, http://micropython.org/
+ * The MIT License (MIT)
+ * Copyright (c) 2018 Damien P. George
+ */
+
+#ifndef ISR_SECTION
+#define ISR_SECTION RAM
+#endif
+
+#ifndef TEXT_SECTION
+#define TEXT_SECTION RAM
+#endif
+
+#ifndef DATA_SECTION
+#define DATA_SECTION TEXT_SECTION
+#endif
+
+#ifndef BSS_SECTION
+#define BSS_SECTION RAM
+#endif
+
+#ifndef ESTACK
+#define ESTACK ORIGIN(RAM) + LENGTH(RAM)
+#endif
+
+_estack = ESTACK;
+
+SECTIONS
+{
+    .isr_vector : {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > ISR_SECTION
+
+    .text : {
+        . = ALIGN(4);
+        *(.text*)
+        *(.rodata*)
+        . = ALIGN(4);
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+        . = ALIGN(4);
+        __exidx_start = .;
+        *(.ARM.exidx*)
+        *(.gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+        . = ALIGN(4);
+        _etext = .;
+        _sidata = _etext;
+    } > TEXT_SECTION
+
+    .data : AT ( _sidata )
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > DATA_SECTION
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > BSS_SECTION
+}

--- a/ports/qemu/mcu/arm/mps2.ld
+++ b/ports/qemu/mcu/arm/mps2.ld
@@ -8,47 +8,11 @@ MEMORY
     RAM : ORIGIN = 0x00000000, LENGTH = 4M
 }
 
+REGION_ALIAS("ISR", RAM)
+REGION_ALIAS("TEXT", RAM)
+REGION_ALIAS("DATA", RAM)
+REGION_ALIAS("BSS", RAM)
+
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        _etext = .;
-    } > RAM
-
-    .ARM.exidx : AT ( _etext ) {
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        _sidata = __exidx_end;
-    } > RAM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+INCLUDE "mcu/arm/cortex-m.ld"

--- a/ports/qemu/mcu/arm/mps2.ld
+++ b/ports/qemu/mcu/arm/mps2.ld
@@ -8,47 +8,4 @@ MEMORY
     RAM : ORIGIN = 0x00000000, LENGTH = 4M
 }
 
-_estack = ORIGIN(RAM) + LENGTH(RAM);
-
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        _etext = .;
-    } > RAM
-
-    .ARM.exidx : AT ( _etext ) {
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        _sidata = __exidx_end;
-    } > RAM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+#include "cortex-m.ld"

--- a/ports/qemu/mcu/arm/mps3.ld
+++ b/ports/qemu/mcu/arm/mps3.ld
@@ -9,47 +9,11 @@ MEMORY
     RAM  : ORIGIN = 0x01000000, LENGTH = 2M
 }
 
+REGION_ALIAS("ISR", ITCM)
+REGION_ALIAS("TEXT", RAM)
+REGION_ALIAS("DATA", RAM)
+REGION_ALIAS("BSS", RAM)
+
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
-SECTIONS
-{
-    .isr_vector : {
-        KEEP(*(.isr_vector))
-        . = ALIGN(4);
-    } > ITCM
-
-    .text : {
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > RAM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+INCLUDE "mcu/arm/cortex-m.ld"

--- a/ports/qemu/mcu/arm/mps3.ld
+++ b/ports/qemu/mcu/arm/mps3.ld
@@ -9,47 +9,6 @@ MEMORY
     RAM  : ORIGIN = 0x01000000, LENGTH = 2M
 }
 
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+#define ISR_SECTION ITCM
 
-SECTIONS
-{
-    .isr_vector : {
-        KEEP(*(.isr_vector))
-        . = ALIGN(4);
-    } > ITCM
-
-    .text : {
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > RAM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+#include "cortex-m.ld"

--- a/ports/qemu/mcu/arm/nrf51.ld
+++ b/ports/qemu/mcu/arm/nrf51.ld
@@ -9,44 +9,11 @@ MEMORY
     RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
+REGION_ALIAS("ISR", ROM)
+REGION_ALIAS("TEXT", ROM)
+REGION_ALIAS("DATA", RAM)
+REGION_ALIAS("BSS", RAM)
+
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > ROM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+INCLUDE "mcu/arm/cortex-m.ld"

--- a/ports/qemu/mcu/arm/nrf51.ld
+++ b/ports/qemu/mcu/arm/nrf51.ld
@@ -9,44 +9,8 @@ MEMORY
     RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+#define ISR_SECTION  ROM
+#define TEXT_SECTION ROM
+#define DATA_SECTION RAM
 
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        . = ALIGN(4);
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > ROM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+#include "cortex-m.ld"

--- a/ports/qemu/mcu/arm/stm32.ld
+++ b/ports/qemu/mcu/arm/stm32.ld
@@ -9,43 +9,11 @@ MEMORY
     RAM : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
+REGION_ALIAS("ISR", ROM)
+REGION_ALIAS("TEXT", ROM)
+REGION_ALIAS("DATA", RAM)
+REGION_ALIAS("BSS", RAM)
+
 _estack = ORIGIN(RAM) + LENGTH(RAM);
 
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > ROM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+INCLUDE "mcu/arm/cortex-m.ld"

--- a/ports/qemu/mcu/arm/stm32.ld
+++ b/ports/qemu/mcu/arm/stm32.ld
@@ -9,43 +9,8 @@ MEMORY
     RAM : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
-_estack = ORIGIN(RAM) + LENGTH(RAM);
+#define ISR_SECTION  ROM
+#define TEXT_SECTION ROM
+#define DATA_SECTION RAM
 
-SECTIONS
-{
-    .text : {
-        . = ALIGN(4);
-        KEEP(*(.isr_vector))
-        *(.text*)
-        *(.rodata*)
-        . = ALIGN(4);
-        *(.ARM.extab*)
-        *(.gnu.linkonce.armextab.*)
-        __exidx_start = .;
-        *(.ARM.exidx*)
-        *(.gnu.linkonce.armexidx.*)
-        __exidx_end = .;
-        . = ALIGN(4);
-        _etext = .;
-        _sidata = _etext;
-    } > ROM
-
-    .data : AT ( _sidata )
-    {
-        . = ALIGN(4);
-        _sdata = .;
-        *(.data*)
-        . = ALIGN(4);
-        _edata = .;
-    } >RAM
-
-    .bss :
-    {
-        . = ALIGN(4);
-        _sbss = .;
-        *(.bss*)
-        *(COMMON)
-        . = ALIGN(4);
-        _ebss = .;
-    } >RAM
-}
+#include "cortex-m.ld"

--- a/ports/qemu/mcu/riscv/virt.ld
+++ b/ports/qemu/mcu/riscv/virt.ld
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Alessandro Gatti
+ * Copyright (c) 2023 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,30 +24,53 @@
  * THE SOFTWARE.
  */
 
-/* Output format is 64 bits little endian. */
-OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv", "elf64-littleriscv");
-
-/*
- * Memory layout:
- *
- * 0x0000_0000_8000_0000: .text
- *             .........: .rodata
- * 0x0000_0000_8040_0000: .data
- *             .........: _global_pointer
- *             .........: .bss
- * 0x0000_0000_8060_0000: .stack
- * 0x0000_0000_8060_0000: _sstack
- * 0x0000_0000_8061_FFFF: _estack
- * 0x0000_0000_8062_0000: .romfs
- */
-MEMORY
+SECTIONS
 {
-    ROM   (xr)  : ORIGIN = 0x0000000080000000,            LENGTH = 4M
-    RAM   (xrw) : ORIGIN = ORIGIN(ROM) + LENGTH(ROM),     LENGTH = 2M
-    STACK (rw)  : ORIGIN = ORIGIN(RAM) + LENGTH(RAM),     LENGTH = 128K
-    ROMFS (xr)  : ORIGIN = ORIGIN(STACK) + LENGTH(STACK), LENGTH = 4M
+    /* Code + Read-Only data segment */
+
+    .text : ALIGN (4K)
+    {
+        *(.start)
+        *(.text)
+        . = ALIGN (4K);
+        *(.rodata)
+        _sirodata = .;
+    } > ROM
+
+    .rodata : AT (_sirodata) ALIGN (4K)
+    {
+        *(.rodata)
+    } > ROM
+
+    /* Data + BSS segment */
+
+    .data : ALIGN (4K)
+    {
+        *(.data)
+        _sibss = .;
+    } > RAM
+
+    .bss : AT (_sibss) ALIGN (4K)
+    {
+        /* Mark global pointer address. */
+        _global_pointer = .;
+
+        /* Mark BSS start. */
+        . = . + _pointer_size;
+        _sbss = .;
+        *(.bss)
+        /* Mark BSS end. */
+        _ebss = .;
+    } > RAM
+
+    /* Isolated stack segment. */
+
+    .stack : ALIGN(4K)
+    {
+        /* Mark stack start. */
+        _sstack = .;
+        . = . + LENGTH(STACK);
+        /* Mark stack end. */
+        _estack = .;
+    } > STACK
 }
-
-_pointer_size = 8;
-
-INCLUDE "mcu/riscv/virt.ld"

--- a/ports/qemu/mcu/riscv/virt.ld
+++ b/ports/qemu/mcu/riscv/virt.ld
@@ -3,7 +3,7 @@
  *
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Alessandro Gatti
+ * Copyright (c) 2023 Alessandro Gatti
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,30 +24,53 @@
  * THE SOFTWARE.
  */
 
-/* Output format is 64 bits little endian. */
-OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv", "elf64-littleriscv");
-
-/*
- * Memory layout:
- *
- * 0x0000_0000_8000_0000: .text
- *             .........: .rodata
- * 0x0000_0000_8040_0000: .data
- *             .........: _global_pointer
- *             .........: .bss
- * 0x0000_0000_8060_0000: .stack
- * 0x0000_0000_8060_0000: _sstack
- * 0x0000_0000_8061_FFFF: _estack
- * 0x0000_0000_8062_0000: .romfs
- */
-MEMORY
+SECTIONS
 {
-    ROM   (xr)  : ORIGIN = 0x0000000080000000,            LENGTH = 4M
-    RAM   (xrw) : ORIGIN = ORIGIN(ROM) + LENGTH(ROM),     LENGTH = 2M
-    STACK (rw)  : ORIGIN = ORIGIN(RAM) + LENGTH(RAM),     LENGTH = 128K
-    ROMFS (xr)  : ORIGIN = ORIGIN(STACK) + LENGTH(STACK), LENGTH = 4M
+    /* Code + Read-Only data segment */
+
+    .text : ALIGN (4K)
+    {
+        *(.start)
+        *(.text)
+        . = ALIGN (4K);
+        *(.rodata)
+        _sirodata = .;
+    } > ROM
+
+    .rodata : AT (_sirodata) ALIGN (4K)
+    {
+        *(.rodata)
+    } > ROM
+
+    /* Data + BSS segment */
+
+    .data : ALIGN (4K)
+    {
+        *(.data)
+        _sibss = .;
+    } > RAM
+
+    .bss : AT (_sibss) ALIGN (4K)
+    {
+        /* Mark global pointer address. */
+        _global_pointer = .;
+
+        /* Mark BSS start. */
+        . = . + POINTER_SIZE;
+        _sbss = .;
+        *(.bss)
+        /* Mark BSS end. */
+        _ebss = .;
+    } > RAM
+
+    /* Isolated stack segment. */
+
+    .stack : ALIGN(4K)
+    {
+        /* Mark stack start. */
+        _sstack = .;
+        . = . + LENGTH(STACK);
+        /* Mark stack end. */
+        _estack = .;
+    } > STACK
 }
-
-#define POINTER_SIZE (8)
-
-#include "../riscv/virt.ld"

--- a/ports/qemu/mcu/rv32/virt.ld
+++ b/ports/qemu/mcu/rv32/virt.ld
@@ -48,53 +48,6 @@ MEMORY
     ROMFS (xr)  : ORIGIN = ORIGIN(STACK) + LENGTH(STACK), LENGTH = 4M
 }
 
-SECTIONS
-{
-    /* Code + Read-Only data segment */
+_pointer_size = 4;
 
-    .text : ALIGN (4K)
-    {
-        *(.start)
-        *(.text)
-        . = ALIGN (4K);
-        *(.rodata)
-        _sirodata = .;
-    } > ROM
-
-    .rodata : AT (_sirodata) ALIGN (4K)
-    {
-        *(.rodata)
-    } > ROM
-
-    /* Data + BSS segment */
-
-    .data : ALIGN (4K)
-    {
-        *(.data)
-        _sibss = .;
-    } > RAM
-
-    .bss : AT (_sibss) ALIGN (4K)
-    {
-        /* Mark global pointer address. */
-        _global_pointer = .;
-
-        /* Mark BSS start. */
-        . = . + 4;
-        _sbss = .;
-        *(.bss)
-        /* Mark BSS end. */
-        _ebss = .;
-    } > RAM
-
-    /* Isolated stack segment. */
-
-    .stack : ALIGN(4K)
-    {
-        /* Mark stack start. */
-        _sstack = .;
-        . = LENGTH(STACK);
-        /* Mark stack end. */
-        _estack = .;
-    } > STACK
-}
+INCLUDE "mcu/riscv/virt.ld"

--- a/ports/qemu/mcu/rv32/virt.ld
+++ b/ports/qemu/mcu/rv32/virt.ld
@@ -48,53 +48,6 @@ MEMORY
     ROMFS (xr)  : ORIGIN = ORIGIN(STACK) + LENGTH(STACK), LENGTH = 4M
 }
 
-SECTIONS
-{
-    /* Code + Read-Only data segment */
+#define POINTER_SIZE (4)
 
-    .text : ALIGN (4K)
-    {
-        *(.start)
-        *(.text)
-        . = ALIGN (4K);
-        *(.rodata)
-        _sirodata = .;
-    } > ROM
-
-    .rodata : AT (_sirodata) ALIGN (4K)
-    {
-        *(.rodata)
-    } > ROM
-
-    /* Data + BSS segment */
-
-    .data : ALIGN (4K)
-    {
-        *(.data)
-        _sibss = .;
-    } > RAM
-
-    .bss : AT (_sibss) ALIGN (4K)
-    {
-        /* Mark global pointer address. */
-        _global_pointer = .;
-
-        /* Mark BSS start. */
-        . = . + 4;
-        _sbss = .;
-        *(.bss)
-        /* Mark BSS end. */
-        _ebss = .;
-    } > RAM
-
-    /* Isolated stack segment. */
-
-    .stack : ALIGN(4K)
-    {
-        /* Mark stack start. */
-        _sstack = .;
-        . = LENGTH(STACK);
-        /* Mark stack end. */
-        _estack = .;
-    } > STACK
-}
+#include "../riscv/virt.ld"


### PR DESCRIPTION
### Summary

This PR extracts common directives found in linkerscripts targeting Cortex-M and RISC-V processors, and modifies affected linkerscripts in order to refer to the common directives rather than replicating them (even with very little modifications).

If additional targets will be added to QEMU that use those two processor families, then these changes should help in bringing the target up faster.  In the case further flexibility is needed, more fine-grained directives reuse is still a possibility as the Makefile now unconditionally uses the C preprocessor to build the final linkerscript.

### Testing

The test suite passed on all affected QEMU targets, along with them being built with usermodules support in the case of Cortex-M targets.

CI should also check some of this as well.

### Trade-offs and Alternatives

Due to the limited external customisability of linkerscripts, the files have to go through the C preprocessor in order to build the final linkerscript.  This had the side-effect of making the Makefile a bit more complex (an explicit rule to make the output directory had to be created), but I believe that's unavoidable in order to not let the linkerscript being recreated on each build.

I left the QEMU/SABRELITE linkerscript alone as there's extra directives in the `.text` section that need to be further looked at to see if they can be folded into the Cortex-M shared file (in which case it will be renamed to `arm-common.ld` or something along those lines).

### Generative AI

I did not use generative AI tools when creating this PR.