### PR TITLE
Revert "stm32/main: Initialize network subsystem before boot.py.".

### DIFF
--- a/ports/stm32/main.c
+++ b/ports/stm32/main.c
@@ -673,12 +673,6 @@ soft_reset:
     pyexec_frozen_module(MICROPY_BOARD_FROZEN_BOOT_FILE, false);
     #endif
 
-    #if MICROPY_PY_NETWORK
-    // Initialize network subsystem before boot.py so that network
-    // interfaces can be instantiated in boot.py.
-    mod_network_init();
-    #endif
-
     // Run boot.py (or whatever else a board configures at this stage).
     if (MICROPY_BOARD_RUN_BOOT_PY(&state) == BOARDCTRL_GOTO_SOFT_RESET_EXIT) {
         goto soft_reset_exit;


### PR DESCRIPTION
### Summary

This reverts commit 4edef8717da3a107e27628b0765040e64a1928d7.

The `mod_network_init()` call was already moved before `boot.py` in commit 7d77d3e0dd1b883ddf80ac163a5990d16f938cb6.

### Testing

Built and ran tests on PYBD_SF6.

### Generative AI

Not used.