### PR TITLE
Fix gcc 16 build issues

### DIFF
--- a/ports/mimxrt/irq.h
+++ b/ports/mimxrt/irq.h
@@ -28,6 +28,14 @@
 
 #define NVIC_PRIORITYGROUP_4    ((uint32_t)0x00000003)
 
+// Use this macro together with NVIC_SetPriority to indicate that an IRQn is
+// non-negative, which helps the compiler optimise the resulting inline function.
+#if NUMBER_OF_INT_VECTORS < 128 + 16
+#define IRQn_NONNEG(irq_num) ((irq_num) & 0x7f)
+#else
+#define IRQn_NONNEG(irq_num) ((irq_num) & 0xff)
+#endif
+
 static inline uint32_t query_irq(void) {
     return __get_PRIMASK();
 }

--- a/ports/mimxrt/machine_can.c
+++ b/ports/mimxrt/machine_can.c
@@ -491,12 +491,7 @@ static void machine_can_port_set_filter_done(machine_can_obj_t *self) {
 // Update interrupt configuration based on the new contents of 'self'
 static void machine_can_update_irqs(machine_can_obj_t *self) {
     struct machine_can_port *port = self->port;
-    uint16_t triggers = self->mp_irq_trigger;
-    uint64_t irq_flags = 0;
     uint64_t irq_tx_mask = ~((1ULL << port->flexcan_txmb_start) - 1);
-    if (triggers & MP_CAN_IRQ_RX) {
-        irq_flags |= kFLEXCAN_RxFifoFrameAvlFlag;
-    }
     // Clear all pending MB interrupt flags
     FLEXCAN_ClearMbStatusFlags(port->can_inst,
         irq_tx_mask | (kFLEXCAN_RxFifoOverflowFlag | kFLEXCAN_RxFifoWarningFlag | kFLEXCAN_RxFifoFrameAvlFlag));

--- a/ports/mimxrt/machine_pin.c
+++ b/ports/mimxrt/machine_pin.c
@@ -249,7 +249,8 @@ void machine_pin_config(const machine_pin_obj_t *self, uint8_t mode,
         GPIO_PortEnableInterrupts(self->gpio, 1U << self->pin);
         GPIO_PortClearInterruptFlags(self->gpio, ~0);
 
-        NVIC_SetPriority(irq_num, IRQ_PRI_EXTINT);
+        assert(irq_num >= 0); // possible values include NotAvail_IRQn=-128, but in practice that never occurs
+        NVIC_SetPriority(IRQn_NONNEG(irq_num), IRQ_PRI_EXTINT);
         EnableIRQ(irq_num);
     }
 }

--- a/ports/nrf/modules/machine/uart.c
+++ b/ports/nrf/modules/machine/uart.c
@@ -511,17 +511,16 @@ static mp_uint_t mp_machine_uart_write(mp_obj_t self_in, const void *buf, mp_uin
 
 static mp_uint_t mp_machine_uart_ioctl(mp_obj_t self_in, mp_uint_t request, uintptr_t arg, int *errcode) {
     machine_uart_obj_t *self = self_in;
-    (void)self;
-    mp_uint_t ret = 0;
-
     if (request == MP_STREAM_POLL) {
         uintptr_t flags = arg;
+        mp_uint_t ret = 0;
         if ((flags & MP_STREAM_POLL_RD) && uart_rx_any(self) != 0) {
             ret |= MP_STREAM_POLL_RD;
         }
         if ((flags & MP_STREAM_POLL_WR) && !nrfx_uart_tx_in_progress(self->p_uart)) {
             ret |= MP_STREAM_POLL_WR;
         }
+        return ret;
     } else if (request == MP_STREAM_FLUSH) {
         while (nrfx_uart_tx_in_progress(self->p_uart)) {
             MICROPY_EVENT_POLL_HOOK;

--- a/ports/renesas-ra/ra/ra_adc.c
+++ b/ports/renesas-ra/ra/ra_adc.c
@@ -332,7 +332,7 @@ void ra_adc_set_resolution(uint8_t res) {
         adcer = adc_reg->ADCER;
         adcer &= (uint16_t) ~0x0006;
         adcer |= (uint16_t)adprc;
-        adc_reg->ADCER;
+        adc_reg->ADCER = adcer;
         resolution = res;
     }
     #else
@@ -347,7 +347,7 @@ void ra_adc_set_resolution(uint8_t res) {
         adcer = adc_reg->ADCER;
         adcer &= (uint16_t) ~0x0006;
         adcer |= (uint16_t)adprc;
-        adc_reg->ADCER;
+        adc_reg->ADCER = adcer;
         resolution = res;
     }
     #endif

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -372,6 +372,10 @@ HAL_SRC_C += $(addprefix $(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_,\
 	hal_pcd_ex.c \
 	ll_usb.c \
 	)
+ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),f4 f7))
+# HAL F4-1.16.0 and F7-1.7.0 have an unused debug variable in USB_ActivateDedicatedEndpoint.
+$(BUILD)/$(STM32LIB_HAL_BASE)/Src/stm32$(MCU_SERIES)xx_ll_usb.o: CFLAGS += -Wno-error=unused-but-set-variable
+endif
 endif
 
 ifeq ($(MCU_SERIES),$(filter $(MCU_SERIES),n6))


### PR DESCRIPTION
### Summary

I updated Arch Linux and now have `arm-none-eabi-gcc (Arch Repository) 16.1.0`.  There were some corresponding build errors, now fixed by this PR.

Please see individual commit messages for reasoning for changes.

### Testing

Built all relevant boards from all ports with `arm-none-eabi-gcc` 16: alif, bare-arm, cc3200, mimxrt, nrf, psoc-edge, qemu, renesas-ra, samd, stm32.  They all now build.

Hardware tests:
- octoprobe automated run
- full test suite on: TEENSY40, PYBD_SF6, ARDUINO_NANO_33

### Trade-offs and Alternatives

The mimxrt IRQ fix was tricky, gcc 16 is very clever about finding array-out-of-bounds errors.  But it matches how stm32 handles IRQ numbers.

The stm32 HAL issue can eventually be fixed in stm32lib, but for now just work around it by disabling the error (it'll still emit a warning though).

### Generative AI

I did not use generative AI tools when creating this PR.

