### PR TITLE
stm32/mboot: Enable USB sleep clock for STM32N6.

### DIFF
--- a/ports/stm32/mboot/main.c
+++ b/ports/stm32/mboot/main.c
@@ -1590,6 +1590,12 @@ void stm32_main(uint32_t initial_r0) {
 
 enter_bootloader:
 
+    #if defined(STM32N6)
+    // Enable USB OTG peripherals during sleep, so they run during WFI.
+    LL_AHB5_GRP1_EnableClockLowPower(LL_AHB5_GRP1_PERIPH_OTG1);
+    LL_AHB5_GRP1_EnableClockLowPower(LL_AHB5_GRP1_PERIPH_OTG2);
+    #endif
+
     #if defined(STM32H5)
     // MPU is needed for H5 to access the unique id.
     mpu_init();


### PR DESCRIPTION
### Summary

Fixes #19505.

A regression was introduced in e48b985, where the USB sleep clock got enabled in stm32/main.c instead of the shared USB code, so mboot/main.c no longer enabled the USB sleep clock, causing failed enumeration in DFU mode.

### Testing

Before this change, enumeration failed in DFU mode as described in #19505. After this change, enumeration works fine, and I'm able to upload code entirely with mboot.

### Trade-offs and Alternatives

I'm uncertain if OTG2 should be enabled as well, or only OTG1. I'm guessing most boards use OTG1 as the primary interface for DFU purposes, so probably don't need OTG2.

### Generative AI

I did not use generative AI tools when creating this PR.