### PR TITLE
esp32/machine_sdcard: Board-configurable native SD/MMC pins

### DIFF
--- a/ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.h
+++ b/ports/esp32/boards/SEEED_XIAO_ESP32S3/mpconfigboard.h
@@ -16,3 +16,10 @@
 #define MICROPY_HW_SDCARD_SPI_MISO (8)
 #define MICROPY_HW_SDCARD_SPI_SCK  (7)
 #define MICROPY_HW_SDCARD_SPI_CS   (21)
+
+// The same microSD via native SD/MMC (1-bit): machine.SDCard(slot=1, width=1).
+// Noticeably faster than SPI (esp. reads). The slot is SPI-wired, so only D0 is
+// available (1-bit): CLK=SPI SCK, CMD=SPI MOSI, D0=SPI MISO.
+#define MICROPY_HW_SDMMC_CLK       (7)
+#define MICROPY_HW_SDMMC_CMD       (9)
+#define MICROPY_HW_SDMMC_D0        (8)

--- a/ports/esp32/machine_sdcard.c
+++ b/ports/esp32/machine_sdcard.c
@@ -407,7 +407,27 @@ static mp_obj_t machine_sdcard_make_new(const mp_obj_type_t *type, size_t n_args
         }
 
         #if SOC_SDMMC_USE_GPIO_MATRIX
-        // Optionally configure all the SDMMC pins, if chip supports this
+        // Apply board-level pin defaults (mpconfigboard.h), then let an explicit
+        // clk/cmd/data argument override below. Grouped by bus width and nested
+        // so each wider mode builds on the narrower one: CLK/CMD/D0 (1-bit), then
+        // D1-D3 (4-bit), then D4-D7 (8-bit eMMC). An unset group stays at the
+        // driver default (GPIO_NUM_NC).
+        if (MICROPY_HW_SDMMC_CLK != GPIO_NUM_NC) {
+            slot_config.clk = MICROPY_HW_SDMMC_CLK;
+            slot_config.cmd = MICROPY_HW_SDMMC_CMD;
+            slot_config.d0 = MICROPY_HW_SDMMC_D0;
+            if (MICROPY_HW_SDMMC_D1 != GPIO_NUM_NC) {
+                slot_config.d1 = MICROPY_HW_SDMMC_D1;
+                slot_config.d2 = MICROPY_HW_SDMMC_D2;
+                slot_config.d3 = MICROPY_HW_SDMMC_D3;
+                if (MICROPY_HW_SDMMC_D4 != GPIO_NUM_NC) {
+                    slot_config.d4 = MICROPY_HW_SDMMC_D4;
+                    slot_config.d5 = MICROPY_HW_SDMMC_D5;
+                    slot_config.d6 = MICROPY_HW_SDMMC_D6;
+                    slot_config.d7 = MICROPY_HW_SDMMC_D7;
+                }
+            }
+        }
         SET_CONFIG_PIN(slot_config, clk, ARG_sck); // reuse SPI SCK for CLK
         SET_CONFIG_PIN(slot_config, cmd, ARG_cmd);
         if (arg_vals[ARG_data].u_obj != mp_const_none) {

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -29,7 +29,7 @@
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.
-// SDMMC-mode pins (slots 0/1) are not affected.
+// Native SD/MMC pins (slots 0/1) have their own defaults, see below.
 #ifndef MICROPY_HW_SDCARD_SPI_SCK
 #if CONFIG_IDF_TARGET_ESP32
 #define MICROPY_HW_SDCARD_SPI_SCK (GPIO_NUM_18)
@@ -48,6 +48,29 @@
 #define MICROPY_HW_SDCARD_SPI_MISO (GPIO_NUM_NC)
 #define MICROPY_HW_SDCARD_SPI_CS (GPIO_NUM_NC)
 #endif
+#endif
+
+// Default pins for a native SD/MMC slot, for ESP32 variants whose SD/MMC host
+// uses the GPIO matrix (SOC_SDMMC_USE_GPIO_MATRIX) and so has assignable pins.
+// A board may override these in mpconfigboard.h so machine.SDCard(slot=1) needs
+// no pin arguments; an explicit clk/cmd/data still wins. Grouped by bus width
+// like the SPI defaults: define CLK/CMD/D0 (1-bit), optionally D1-D3 (4-bit)
+// and D4-D7 (8-bit eMMC), each group together (unset groups stay GPIO_NUM_NC).
+#ifndef MICROPY_HW_SDMMC_CLK
+#define MICROPY_HW_SDMMC_CLK (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_CMD (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D0 (GPIO_NUM_NC)
+#endif
+#ifndef MICROPY_HW_SDMMC_D1
+#define MICROPY_HW_SDMMC_D1 (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D2 (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D3 (GPIO_NUM_NC)
+#endif
+#ifndef MICROPY_HW_SDMMC_D4
+#define MICROPY_HW_SDMMC_D4 (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D5 (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D6 (GPIO_NUM_NC)
+#define MICROPY_HW_SDMMC_D7 (GPIO_NUM_NC)
 #endif
 
 #endif // MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H


### PR DESCRIPTION
This adds board-level default pins for the native SD/MMC host, so a board
with a fixed SD connector can use `machine.SDCard(slot=1)` (or a bare
`machine.SDCard()`) without passing pin arguments — the same convenience the
SPI-mode SD bus already has via `MICROPY_HW_SDCARD_SPI_*`.

It completes the board-configurable set for SD/MMC, which already had the slot
(`MICROPY_HW_SDMMC_DEFAULT_SLOT`) and width (`MICROPY_HW_SDMMC_DEFAULT_WIDTH`)
defaults — this adds the pins.

The new `MICROPY_HW_SDMMC_CLK/CMD/D0..D7` defaults are grouped by bus width:
CLK/CMD/D0 (1-bit), then D1-D3 (4-bit), then D4-D7 (8-bit eMMC). A board defines
the group(s) for the width it wires. They apply only on chips whose SD/MMC host
routes through the GPIO matrix (`SOC_SDMMC_USE_GPIO_MATRIX`); the original ESP32
(fixed IOMUX pins) and SPI mode (slots 2/3) are unaffected. An explicit
`clk`/`cmd`/`data` argument still overrides.

The second commit enables it for the SEEED XIAO ESP32-S3, whose Sense expansion
microSD is SPI-wired (only D0 broken out, so 1-bit), reusing the SPI pins as
CLK=SCK(7), CMD=MOSI(9), D0=MISO(8). As the ESP32-S3 default slot is 1 (SD/MMC)
and default width 1, a bare `machine.SDCard()` now uses the native host.

### Commits
- esp32/machine_sdcard: Make default SDMMC pins board-configurable.
- esp32/boards/SEEED_XIAO_ESP32S3: Use native SD/MMC for the microSD.

### Testing
Tested on hardware (SEEED XIAO ESP32-S3 with the Sense microSD):
- `machine.SDCard()` with no arguments mounts and reads/writes over native
  SD/MMC (1-bit).
- 1 MB raw block read vs SPI mode (`SDCard(slot=2)`): ~2.1 MB/s native vs
  ~0.6 MB/s SPI (~3.5x faster). Writes are card-limited, so comparable.

### Notes
- Only GPIO-matrix chips (ESP32-S3, ESP32-P4) are affected; other targets build
  unchanged.
- `LILYGO_T3_S3` (also ESP32-S3, SD SPI-wired) looks like another candidate for
  native SD/MMC, but I don't have that board to verify — happy to add it in a
  follow-up if a T3-S3 owner can test.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.