### PR TITLE
ports/webassembly/main: Fix unused-variable build error in standard.

### DIFF
--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -47,7 +47,9 @@
 // This counter tracks the current depth of calls into C code that originated
 // externally, ie from JavaScript.  When the counter is 0 that corresponds to
 // the top-level call into C.
+#if MICROPY_GC_SPLIT_HEAP_AUTO
 static size_t external_call_depth = 0;
+#endif
 
 // Emscripten defaults to a 64k C-stack, so our limit should be less than that.
 #define CSTACK_SIZE (32 * 1024)
@@ -57,12 +59,14 @@ static void gc_collect_top_level(mp_obj_t root_obj);
 #endif
 
 void external_call_depth_inc(void) {
+    #if MICROPY_GC_SPLIT_HEAP_AUTO
     ++external_call_depth;
+    #endif
 }
 
 void external_call_depth_dec(mp_obj_t root_obj) {
-    --external_call_depth;
     #if MICROPY_GC_SPLIT_HEAP_AUTO
+    --external_call_depth;
     if (external_call_depth == 0) {
         gc_collect_top_level(root_obj);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

external_call_depth is only read back (to detect the top-level call boundary) when MICROPY_GC_SPLIT_HEAP_AUTO is enabled. The "standard" variant does not enable this option, so its build was failing with:

    main.c:50:15: error: variable 'external_call_depth' set but not
    used [-Werror,-Wunused-but-set-global]

Fix by guarding the variable's declaration, increment, and decrement all under the same #if, instead of leaving the decrement outside the guard while the increment and declaration were inside/outside inconsistently.

Fixes #19112

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

### Testing

Built WebAssembly port in standard variant. It now builds.


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
