### PR TITLE
webassembly/main: Fix unused-variable build error in standard.

### DIFF
--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/board_init.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "py/mphal.h"
 #include "shared/tinyusb/mp_usbd_cdc.h"
+#include "modmachine.h"
 
 #include <esp_system.h>
 #include <esp_ota_ops.h>
@@ -66,7 +67,13 @@ static void rgb_pulse_delay() {
     mp_hal_pin_write(LED_BLUE, 1);
 }
 
-void NANO_ESP32_enter_bootloader(void) {
+NORETURN void NANO_ESP32_enter_bootloader(size_t n_args, const void *args) {
+    mp_int_t mode;
+    if (n_args == 1 && mp_obj_get_int_maybe(*(const mp_obj_t *)args, &mode) && mode == 1) {
+        // jump to hardware bootloader (does not return)
+        machine_bootloader_rtc();
+    }
+
     if (!_recovery_active) {
         // check for valid partition scheme
         const esp_partition_t *ota_part = esp_ota_get_next_update_partition(NULL);
@@ -104,7 +111,7 @@ void NANO_ESP32_board_startup(void) {
     _recovery_marker_found = double_tap_check_match();
     if (_recovery_marker_found && !_recovery_active) {
         // double tap detected in user application, reboot to factory
-        NANO_ESP32_enter_bootloader();
+        NANO_ESP32_enter_bootloader(0, NULL);
     }
 
     // delay with mark set then proceed

--- a/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
+++ b/ports/esp32/boards/ARDUINO_NANO_ESP32/mpconfigboard.h
@@ -1,3 +1,5 @@
+#include <stddef.h> // for size_t
+
 #define MICROPY_HW_BOARD_NAME               "Arduino Nano ESP32"
 #define MICROPY_HW_MCU_NAME                 "ESP32-S3"
 
@@ -27,8 +29,12 @@
 #define MICROPY_HW_USB_MANUFACTURER_STRING "Arduino"
 #define MICROPY_HW_USB_PRODUCT_FS_STRING "Nano ESP32"
 
+// Custom bootloader function may fall back to the default one
+#define MICROPY_ESP32_USE_BOOTLOADER_RTC    (1)
+
 #define MICROPY_BOARD_STARTUP                           NANO_ESP32_board_startup
 void NANO_ESP32_board_startup(void);
 
-#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)     NANO_ESP32_enter_bootloader()
-void NANO_ESP32_enter_bootloader(void);
+// args is an array of mp_obj_t, but that type isn't yet defined when this file is parsed
+#define MICROPY_BOARD_ENTER_BOOTLOADER(nargs, args)     NANO_ESP32_enter_bootloader(nargs, args)
+void NANO_ESP32_enter_bootloader(size_t n_args, const void *args);

--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -47,7 +47,9 @@
 // This counter tracks the current depth of calls into C code that originated
 // externally, ie from JavaScript.  When the counter is 0 that corresponds to
 // the top-level call into C.
+#if MICROPY_GC_SPLIT_HEAP_AUTO
 static size_t external_call_depth = 0;
+#endif
 
 // Emscripten defaults to a 64k C-stack, so our limit should be less than that.
 #define CSTACK_SIZE (32 * 1024)
@@ -57,12 +59,14 @@ static void gc_collect_top_level(mp_obj_t root_obj);
 #endif
 
 void external_call_depth_inc(void) {
+    #if MICROPY_GC_SPLIT_HEAP_AUTO
     ++external_call_depth;
+    #endif
 }
 
 void external_call_depth_dec(mp_obj_t root_obj) {
-    --external_call_depth;
     #if MICROPY_GC_SPLIT_HEAP_AUTO
+    --external_call_depth;
     if (external_call_depth == 0) {
         gc_collect_top_level(root_obj);
     }


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

external_call_depth is only read back (to detect the top-level call boundary) when MICROPY_GC_SPLIT_HEAP_AUTO is enabled. The "standard" variant does not enable this option, so its build was failing with:

    main.c:50:15: error: variable 'external_call_depth' set but not
    used [-Werror,-Wunused-but-set-global]

Fix by guarding the variable's declaration, increment, and decrement all under the same #if, instead of leaving the decrement outside the guard while the increment and declaration were inside/outside inconsistently.

Fixes #19112

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

### Testing

Built WebAssembly port in standard variant. It now builds.


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
