### PR TITLE
ci: Build esp32 port ESP32_GENERIC variant D2WD in CI.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -31,8 +31,8 @@ jobs:
           - *oldest
           - *newest
         ci_func:  # names are functions in ci.sh
-          - esp32_build_cmod_spiram_s2
-          - esp32_build_s3_c3
+          - esp32_build_cmod_spiram_d2wd
+          - esp32_build_s2_s3_c3
           - esp32_build_c2_c5_c6
           - esp32_build_h2_p4
         exclude:

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -251,7 +251,7 @@ function ci_esp32_build_common {
     make ${MAKEOPTS} -C ports/esp32 submodules
 }
 
-function ci_esp32_build_cmod_spiram_s2 {
+function ci_esp32_build_cmod_spiram_d2wd {
     ci_esp32_build_common
 
     # Combined USER_C_MODULES + freeze manifest test on ESP32_GENERIC.
@@ -265,12 +265,15 @@ function ci_esp32_build_cmod_spiram_s2 {
     # Test the c_module() codepath on the SPIRAM variant.
     make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC BOARD_VARIANT=SPIRAM \
         FROZEN_MANIFEST="$(pwd)/tests/tools/manifest_c_module.py"
-    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S2
+
+    # D2WD is the variant with smallest application partition in flash
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC BOARD_VARIANT=D2WD
 }
 
-function ci_esp32_build_s3_c3 {
+function ci_esp32_build_s2_s3_c3 {
     ci_esp32_build_common
 
+    make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S2
     make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_S3
     make ${MAKEOPTS} -C ports/esp32 BOARD=ESP32_GENERIC_C3
 }


### PR DESCRIPTION
### Summary

This variant has the smallest application partition in flash.

*This work was funded through GitHub Sponsors.*

### Testing

Done by the PR CI run.

### Trade-offs and Alternatives

Until now we've dealt with any binary size overflow in this variant manually (first sign would be nightly failing), but this way it's verified before the change merges. Cost is yet more CI compute time (and maybe some wall time, unclear as the jobs run in parallel).

### Generative AI

I did not use generative AI tools when creating this PR.
