### PR TITLE
esp32: Make ESP-IDF v5.5.5 the recommended version.

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -20,7 +20,7 @@ concurrency:
 env:
    # Oldest and newest supported ESP-IDF versions, should match ports/esp32/README.md
    IDF_OLDEST_VER: &oldest "v5.3"
-   IDF_NEWEST_VER: &newest "v5.5.2"
+   IDF_NEWEST_VER: &newest "v5.5.5"
 
 jobs:
   build_idf:

--- a/ports/esp32/README.md
+++ b/ports/esp32/README.md
@@ -52,8 +52,8 @@ manage the ESP32 microcontroller, as well as a way to manage the required
 build environment and toolchains needed to build the firmware.
 
 The ESP-IDF changes quickly and MicroPython only supports certain versions. The
-current recommended version of ESP-IDF for MicroPython is v5.5.2. MicroPython
-also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1 and v5.5.4.
+current recommended version of ESP-IDF for MicroPython is v5.5.5. MicroPython
+also supports v5.3, v5.4, v5.4.1, v5.4.2, v5.5.1, v5.5.2 and v5.5.4.
 
 <!-- Important: If updating the above, please also update:
      * IDF_OLDEST_VER & IDF_NEWEST_VER in .github/workflows/port_esp32.yml

--- a/ports/esp32/lockfiles/dependencies.lock.esp32
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32
@@ -25,7 +25,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/lan867x
 - espressif/mdns

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c3
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c5
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c5
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32c6
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32c6
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32h2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32h2
@@ -12,7 +12,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - idf

--- a/ports/esp32/lockfiles/dependencies.lock.esp32p4
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32p4
@@ -81,7 +81,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_wifi_remote

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s2
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s2
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/ports/esp32/lockfiles/dependencies.lock.esp32s3
+++ b/ports/esp32/lockfiles/dependencies.lock.esp32s3
@@ -27,7 +27,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.5.2
+    version: 5.5.5
 direct_dependencies:
 - espressif/mdns
 - espressif/tinyusb

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -123,6 +123,7 @@ function ci_code_size_build {
             OUTFILE=$2
             IGNORE_ERRORS=$3
 
+            git restore ports/esp32/lockfiles/*  # esp32 port may update local lockfile
             git checkout --detach $COMMIT
             git submodule update --init $SUBMODULES
             git show -s


### PR DESCRIPTION
### Summary

This bumps the esp32 port's recommended (and CI newest) ESP-IDF version
from v5.5.2 to v5.5.5, following on from #19149 which set v5.5.2. The change
is only the version pin in `ports_esp32.yml`, the README, and the ESP-IDF
version recorded in the component lockfiles — no code changes are needed,
v5.5.5 builds as-is.

**Why it's safe to move now.** #19149 stayed on v5.5.2 because v5.5.3 had a
NimBLE regression and there was a stability report against v5.5.4. Both are
resolved:
- The v5.5.3 NimBLE host connection loss was fixed in v5.5.4 (confirmed by
  Espressif in espressif/esp-idf#18323).
- The v5.5.4 "MMU entry fault" report turned out to be a board-config issue,
  not an IDF regression (see the discussion in #19149).

v5.5.5 additionally brings two fixes relevant to common boards.

**SD card write speed on SPIRAM boards.** On ESP32/ESP32-S3 the SDMMC IDMAC
cannot DMA to/from PSRAM (`SOC_SDMMC_PSRAM_DMA_CAPABLE=0`), so `machine.SDCard`
transfers of a PSRAM buffer previously fell back to single-block transfers,
making writes extremely slow. v5.5.5's sdmmc driver does multi-block chunked
transfers through an internal DMA-capable bounce buffer, which MicroPython
picks up automatically via `SDMMC_HOST_DEFAULT()` / `SDSPI_HOST_DEFAULT()`
(no MicroPython change required). This also helps SPI mode and other SPIRAM
chips (S2, C5, …).

Measured on a SEEED_XIAO_ESP32S3 (8 MB octal PSRAM), sustained RAW
`writeblocks`/`readblocks` (4 MB, verify OK), KB/s:

| Card | Interface | write (v5.5.2) | write (v5.5.5) | read (v5.5.5) |
|---|---|---:|---:|---:|
| SanDisk Ultra 16 GB | SDMMC 1-bit 40 MHz | ~16 KB/s | **3032** KB/s | 3284 KB/s |
| SanDisk Ultra 16 GB | SPI 40 MHz | ~16 KB/s | **1179** KB/s | 1458 KB/s |
| SanDisk Extreme Pro 32 GB | SDMMC 1-bit 40 MHz | ~360 KB/s | **3271** KB/s | 3328 KB/s |
| SanDisk Extreme Pro 32GB | SPI 40 MHz | ~240 KB/s | **1205** KB/s | 1469 KB/s |

Writes go from unusable to ~3 MB/s on SDMMC (near the 1-bit bus ceiling);
reads also roughly double (multi-block vs single-block).

**ESP32-S3 UART2.** `uart_ll_is_enabled()` read the wrong clock/reset
register for UART2 (EN0 instead of EN1), so `machine.UART(2)` failed on the
S3. This is fixed upstream in v5.5.5.

### Testing

Built, flashed and booted against v5.5.5 on real hardware across both
architectures (all boards flash-erased before first deploy):

- **ESP32-S3** (SEEED_XIAO_ESP32S3, 8 MB octal PSRAM)
- **ESP32-C3 rev v0.4** (SEEED_XIAO_ESP32C3)
- **ESP32-C5 rev v1.2** (ESP32_GENERIC_C5, 8 MB octal PSRAM)
- **ESP32-C6 rev v0.2** (ESP32_GENERIC_C6)
- **ESP32-P4 rev v3.2** (ESP32_GENERIC_P4 / C6_WIFI, 16 MB flash, 32MB PSRAM)

### Trade-offs and Alternatives

None expected — this is a patch-level IDF bump. v5.5.4 and the older listed
versions remain supported and buildable; only the recommended/CI version
changes.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.