### PR TITLE
unix: Build DEBUG as -ggdb3.

### DIFF
--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -65,7 +65,7 @@ CFLAGS += -D_TIME_BITS=64
 
 # Debug info flag is added if either DEBUG=1 or STRIP= is passed to make
 # (to produce a debug binary, or a release binary with all symbols, respectively.)
-DEBUG_INFO = -g
+DEBUG_INFO = -ggdb3
 
 # Debugging/Optimization
 ifdef DEBUG

--- a/ports/unix/Makefile
+++ b/ports/unix/Makefile
@@ -63,20 +63,24 @@ CFLAGS += -D_FILE_OFFSET_BITS=64
 # This option has no effect on 64-bit builds.
 CFLAGS += -D_TIME_BITS=64
 
+# Debug info flag is added if either DEBUG=1 or STRIP= is passed to make
+# (to produce a debug binary, or a release binary with all symbols, respectively.)
+DEBUG_INFO = -g
+
 # Debugging/Optimization
 ifdef DEBUG
 COPT ?= -Og
+CFLAGS += $(DEBUG_INFO)
 else
 COPT ?= -Os
 COPT += -DNDEBUG
+ifndef STRIP
+CFLAGS += $(DEBUG_INFO)
 endif
+endif  # ifdef DEBUG
 
 # Remove unused sections.
 COPT += -fdata-sections -ffunction-sections
-
-# Note: Symbols and debug information will still be stripped from the final binary
-# unless "DEBUG=1" or "STRIP=" is passed to make, see README.md for details.
-CFLAGS += -g
 
 ifndef DEBUG
 # _FORTIFY_SOURCE is a feature in gcc/glibc which is intended to provide extra

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -53,7 +53,7 @@ endif
 # QSTR generation uses the same CFLAGS, with these modifications.
 QSTR_GEN_FLAGS = -DNO_QSTR
 # Note: := to force evaluation immediately.
-QSTR_GEN_CFLAGS := $(CFLAGS)
+QSTR_GEN_CFLAGS := $(filter-out -g%,$(CFLAGS))
 QSTR_GEN_CFLAGS += $(QSTR_GEN_FLAGS)
 QSTR_GEN_CXXFLAGS := $(CXXFLAGS)
 QSTR_GEN_CXXFLAGS += $(QSTR_GEN_FLAGS)


### PR DESCRIPTION
### Summary

Two commits:

* Change the debug flag to `-ggdb3` for unix port.
  - `-g3` adds macro definitions to the debug info, which is very useful.
  - Unclear of exact benefit of changing `-g` to `-ggdb` here (on Linux `-g` is already using DWARF with some GDB extensions, `-ggdb` may or may not add extra GDB extensions.)
* Tweak the unix makefile so debug info is not produced if the binary is going to be stripped. This speeds up the default build configuration (which is a stripped release binary) by about 10% compared to master, and more than 10% compared to `-ggdb3` (the difference seems to be time spent stripping the binary, not time spent compiling.)

First commit includes a tweak in makeqstrdefs as -g3 causes the preprocessor to output a lot of extra macro definitions, some of which were being parsed by makeqstrdefs.

*This work was funded through GitHub Sponsors.*

### Testing

* Built and ran the unix port with `DEBUG=1`, ran it under gdb.

### Trade-offs and Alternatives

* Building with debug info generates a larger binary, but as `DEBUG=0` is the default this only affects someone who is looking to generate a debugging binary.
* Any build time cost from the extra debug info flag is offset by not generating debug symbols for the default build config.

### Generative AI

I did not use generative AI tools when creating this PR.
