### PR TITLE
esp32: Fix ESP32-C2 virtual timer support and unit test.

### DIFF
--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -89,7 +89,7 @@ static bool machine_timer_handler(machine_timer_obj_t *self) {
 
 machine_timer_obj_t *machine_timer_create(mp_int_t id) {
     // Check hardware timer ID is valid
-    if (id >= SOC_TIMER_GROUP_TOTAL_TIMERS) {
+    if (id >= (mp_int_t)SOC_TIMER_GROUP_TOTAL_TIMERS) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("Timer(%d) doesn't exist, there are only %d hardware timers"), id, SOC_TIMER_GROUP_TOTAL_TIMERS);
     }
 

--- a/tests/extmod/machine_timer.py
+++ b/tests/extmod/machine_timer.py
@@ -17,7 +17,14 @@ if sys.platform == "nrf":
 import unittest
 
 # Hardware timers are only supported on the esp32 port
-SUPPORTS_HARDWARE_TIMERS = sys.platform == "esp32"
+NUM_HARDWARE_TIMERS = 0
+if sys.platform == "esp32":
+    if "ESP32-C2" in sys.implementation._machine:
+        # Only one hardware timer on ESP32-C2
+        NUM_HARDWARE_TIMERS = 1
+    else:
+        # at least two on other ESP32 SoCs
+        NUM_HARDWARE_TIMERS = 2
 
 # Hard IRQs are not supported on the esp32 port
 SUPPORTS_HARD_IRQ = sys.platform != "esp32"
@@ -28,9 +35,12 @@ class Test(unittest.TestCase):
         self._test_create(-1)
         self._test_create_multiple(-1, -1)
 
-    @unittest.skipUnless(SUPPORTS_HARDWARE_TIMERS, "no hardware timers")
+    @unittest.skipUnless(NUM_HARDWARE_TIMERS > 0, "no hardware timers")
     def test_hardware_create(self):
         self._test_create(0)
+
+    @unittest.skipUnless(NUM_HARDWARE_TIMERS >= 2, "less than 2 hardware timers")
+    def test_hardware_create_multiple(self):
         self._test_create_multiple(0, 1)
 
     def test_virtual_softirq(self):
@@ -42,12 +52,12 @@ class Test(unittest.TestCase):
         self._test_all_freq_period(-1, Timer.ONE_SHOT, True)
         self._test_all_freq_period(-1, Timer.PERIODIC, True)
 
-    @unittest.skipUnless(SUPPORTS_HARDWARE_TIMERS, "no hardware timers")
+    @unittest.skipUnless(NUM_HARDWARE_TIMERS > 0, "no hardware timers")
     def test_hardware_softirq(self):
         self._test_all_freq_period(0, Timer.ONE_SHOT, False)
         self._test_all_freq_period(0, Timer.PERIODIC, False)
 
-    @unittest.skipUnless(SUPPORTS_HARDWARE_TIMERS, "no hardware timers")
+    @unittest.skipUnless(NUM_HARDWARE_TIMERS > 0, "no hardware timers")
     @unittest.skipUnless(SUPPORTS_HARD_IRQ, "no hard-irq support")
     def test_hardware_hardirq(self):
         self._test_all_freq_period(0, Timer.ONE_SHOT, True)


### PR DESCRIPTION
### Summary

* Fixes the virtual timer support on ESP32-C2. Virtual timer support was added in #19163 but for some reason the macro which defines the number of timers is unsigned on ESP32-C2 and signed everywhere else, so the handling of `machine.Timer(-1)` would fail on C2 only.
* Also updates `tests/extmod/machine_timer.py` to pass on ESP32-C2 which has only one hardware timer.

Found while testing #19558.

### Testing

* `tests/extmod/machine_timer.py` fails on ESP32-C2 without these changes, and passes with these changes.
* Also ran this test on ESP32-C5 to ensure no regression and that all the expected tests were run.

### Generative AI

I did not use generative AI tools when creating this PR.
