### PR TITLE
esp32: Fix gptimer error log line on deinit, error log if callback not specified.

### DIFF
--- a/ports/esp32/machine_timer.c
+++ b/ports/esp32/machine_timer.c
@@ -219,9 +219,11 @@ mp_obj_t machine_timer_deinit(mp_obj_t self_in) {
     machine_timer_obj_t *self = self_in;
     machine_timer_stop(self);
     if (self->id >= 0) {
-        esp_err_t result = gptimer_disable(self->handle.hardware);
-        if (result != ESP_ERR_INVALID_STATE) {
-            check_esp_err(result);
+        if (self->handler != NULL) {
+            esp_err_t result = gptimer_disable(self->handle.hardware);
+            if (result != ESP_ERR_INVALID_STATE) {
+                check_esp_err(result);
+            }
         }
     } else {
         // Virtual timers may be immediately garbage collected


### PR DESCRIPTION
### Summary

This PR has a very minor fix for the esp32 `machine.Timer` support using GPTimer (follows #19163). The bug is an error log on soft reset:

```
MicroPython v1.29.0-preview.654.ga7eb15b382 on 2026-07-30; ESP32C5 module with ESP32-C5
Type "help()" for more information.
>>> import machine
>>> t = machine.Timer(1)
>>> (Ctrl-D to soft reset)
E (41263) gptimer: gptimer_disable(372): timer not in enable state
E (41263) gptimer: gptimer_disable(372): timer not in enable state
MPY: soft reboot
```

Calling `gptimer_disable()` on a timer which hasn't been enabled caused this log line to appear. Checking the `handler` field of the struct is enough to know whether it's been enabled or not.

The two log lines appear because instantiating `machine.Timer(1)` requires also instantiating the GPTimer instance for `machine.Timer(0)` in the background, so this log line could appear even when all timers the Python code instantiated were in use.

### Testing

* Verified the fix manually on an ESP32-C5.
* Also ran the `extmod/machine_timer.py` unit tests to verify no regression.

### Trade-offs and Alternatives

* Could ignore this as it's very low impact, but it's also easy to fix.

### Generative AI

I did not use generative AI tools when creating this PR.
