### PR TITLE
esp32: Fix native code Instruction Access Faults on ESP32-C2.

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -333,7 +333,10 @@
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
 #if SOC_CPU_IDRAM_SPLIT_USING_PMP && !CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT
-// On targets with this configuration all RAM is executable so no need for a custom commit function.
+// On targets with this configuration all heap is executable (IRAM region), provided we allocate it as such
+// (on many targets the malloc() function already returns instruction memory in this config so this macro is
+// redundant, but on ESP32-C2 it does not - and it may change in a future ESP-IDF.)
+#define MP_PLAT_ALLOC_HEAP(size) heap_caps_malloc(size, MALLOC_CAP_EXEC)
 #else
 void *esp_native_code_commit(void *, size_t, void *);
 #define MP_PLAT_COMMIT_EXEC(buf, len, reloc) esp_native_code_commit(buf, len, reloc)

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -332,7 +332,7 @@
 // type definitions for the specific machine
 
 #define MICROPY_MAKE_POINTER_CALLABLE(p) ((void *)((mp_uint_t)(p)))
-#if SOC_CPU_IDRAM_SPLIT_USING_PMP && !CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT
+#if SOC_CPU_IDRAM_SPLIT_USING_PMP && !CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT && !CONFIG_IDF_TARGET_ESP32C2
 // On targets with this configuration all RAM is executable so no need for a custom commit function.
 #else
 void *esp_native_code_commit(void *, size_t, void *);


### PR DESCRIPTION
### Summary

Specifically the `micropython/import_mpy_native_gc.py` test would crash during the native code import, with an MEPC address pointing to a native code function in the data region (i.e. 0x3fcbc810).

On other RISC-V ESP32 SoCs with PMP and config `CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT` unset, regular malloc() returns pointers to the IRAM region already, so heap pointers are already executable.

On ESP32-C2, regular malloc() returns pointers to the DRAM region instead so executing native code trips a PMP protection fault.

Fix is to explicitly allocate MALLOC_CAP_EXEC for the heap.

(I think the root cause reason for this difference is whether the soc_memory_regions array in the ESP-IDF components/heap/port/SOC/memory_layout.c gives the instructions in the Instruction or the Data space... i.e. [c6 regions](https://github.com/espressif/esp-idf/blob/master/components/heap/port/esp32c6/memory_layout.c#L75) vs [c2 regions](https://github.com/espressif/esp-idf/blob/master/components/heap/port/esp32c2/memory_layout.c#L62

### Still To Do

* [ ] Look at whether we can have the heap in data space (less trivial for buffer overflow code execution) and only swap pointers we want to execute into their instruction forms.
* [ ] Test for regressions on other SoCs

*This work was funded through GitHub Sponsors.*

### Testing

* `./run-tests.py -t u0 micropython/*.py` to verify the failing test and related native import tests were fixed.
* `./run-tests.py -t u0 --via-mpy --emit native` to verify no regressions when using native emitter. The only test which failed was `machine_timer.py` (fixed in #19561).

### Trade-offs and Alternatives

* TBD

### Generative AI

I did not use generative AI tools when creating this PR.