### PR TITLE
esp32/boards/esp32-p4: Support pre-v3 chip revisions as variants.

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.json
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.json
@@ -19,7 +19,10 @@
     "url": "https://www.espressif.com/en/products/modules",
     "variants": {
         "C5_WIFI": "Support for external C5 WiFi/BLE",
-        "C6_WIFI": "Support for external C6 WiFi/BLE"
+        "C6_WIFI": "Support for external C6 WiFi/BLE",
+        "PRE_REV3": "Boards with early 0.x and 1.x chip revisions",
+        "PRE_REV3_C5_WIFI": "0.x and 1.x chip revisions with external C5 WiFi/BLE",
+        "PRE_REV3_C6_WIFI": "0.x and 1.x chip revisions with external C6 WiFi/BLE"
     },
     "vendor": "Espressif"
 }

--- a/ports/esp32/boards/ESP32_GENERIC_P4/board.md
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/board.md
@@ -1,11 +1,24 @@
 The following firmware is applicable to most development boards based on ESP32-P4, and
 the development boards must be equipped with at least 16 MiB external SPI Flash.
 
-This board has multiple variants available:
+The P4 chip had major changes at chip revision 3.0, and these require that builds
+for earlier (`PRE_REV3`) chips are done as variants.
 
-* If your board has a standalone ESP32-P4 processor (or the board has a coprocessor but
-  you do not want to use it) then choose the generic variant (first heading below).
+Espressif denote the revision 3+ chips by appending an **`X`** to the part numbers:
+
+|part|revisions 0.x and 1.x|revisions 3.x and later|
+|----|---------------------|-----------------------|
+|ESP32-P4 16Mb PSRAM|ESP32-P4NRW16|ESP32-P4NRW16**X**|
+|ESP32-P4 32Mb PSRAM|ESP32-P4NRW32|ESP32-P4NRW32**X**|
+|Multimedia DEVBOARD|ESP32-P4-Function-EV-Board|ESP32-P4**X**-Function-EV-Board|
+
+etc..
+
+This board also has variants available to select the Wireless CoProcessor (if any):
+
+* If your board has a standalone revision 3.x or later ESP32-P4 processor (or the board has a coprocessor but you do not want to use it) then choose the generic variant (first heading below).
+* If you have an early (revisions 0.x and 1.x) chip revision choose the "PRE REV3" variants.
 * If your board has an external ESP32-C5 coprocessor for WiFi and BLE then choose the
-  "C5 WiFi/BLE" variant.
+  "C5 WiFi/BLE" variants.
 * If your board has an external ESP32-C6 coprocessor for WiFi and BLE then choose the
-  "C6 WiFi/BLE" variant.
+  "C6 WiFi/BLE" variants.

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3.cmake
@@ -1,0 +1,7 @@
+list(APPEND SDKCONFIG_DEFAULTS
+    boards/sdkconfig.p4_pre_rev3
+)
+
+list(APPEND MICROPY_DEF_BOARD
+    MICROPY_HW_BOARD_NAME="Generic ESP32P4 with pre revision 3 chip"
+)

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3_C5_WIFI.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3_C5_WIFI.cmake
@@ -1,0 +1,11 @@
+list(APPEND SDKCONFIG_DEFAULTS
+    boards/sdkconfig.p4_pre_rev3
+    boards/sdkconfig.p4_wifi_common
+    boards/sdkconfig.p4_wifi_c5
+)
+
+list(APPEND MICROPY_DEF_BOARD
+    MICROPY_HW_BOARD_NAME="Generic ESP32P4 module with pre revision 3 chip and ESP32C5 hosted WIFI"
+    MICROPY_PY_NETWORK_WLAN=1
+    MICROPY_PY_BLUETOOTH=1
+)

--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3_C6_WIFI.cmake
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigvariant_PRE_REV3_C6_WIFI.cmake
@@ -1,0 +1,11 @@
+list(APPEND SDKCONFIG_DEFAULTS
+    boards/sdkconfig.p4_pre_rev3
+    boards/sdkconfig.p4_wifi_common
+    boards/sdkconfig.p4_wifi_c6
+)
+
+list(APPEND MICROPY_DEF_BOARD
+    MICROPY_HW_BOARD_NAME="Generic ESP32P4 module with pre revision 3 chip and ESP32C6 hosted WIFI"
+    MICROPY_PY_NETWORK_WLAN=1
+    MICROPY_PY_BLUETOOTH=1
+)

--- a/ports/esp32/boards/sdkconfig.p4
+++ b/ports/esp32/boards/sdkconfig.p4
@@ -1,5 +1,7 @@
-# Select the minimum chip revision to cover all possible boards.
-CONFIG_ESP32P4_REV_MIN_0=y
+# By default only build for and support ESP32-P4 revisions 3.x and above
+# - Use the 'PRE_REV3' variants to build for earlier revisions
+# - https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/kconfig-reference.html
+CONFIG_ESP32P4_REV_MIN_300=y
 
 # Flash
 CONFIG_FLASHMODE_QIO=y

--- a/ports/esp32/boards/sdkconfig.p4_pre_rev3
+++ b/ports/esp32/boards/sdkconfig.p4_pre_rev3
@@ -1,0 +1,9 @@
+# ESP32-P4 sdkconfig variant for revision 0.x and 1.x chips
+# - https://docs.espressif.com/projects/esp-idf/en/stable/esp32p4/api-reference/kconfig-reference.html
+#
+# Override and set the minimum chip revision to cover all possible boards.
+CONFIG_ESP32P4_REV_MIN_300=n
+CONFIG_ESP32P4_REV_MIN_0=y
+#
+# Enable support for ESP32-P4 revisions 0.x and 1.x
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y


### PR DESCRIPTION
### Summary

ESP-IDF v5.5.4 appears to include a change to the way the P4 bootloader handles code for chip revisions less than 3.x. Refusing to load the firmware with the error:

```A fatal error occurred: bootloader/bootloader.bin requires chip revision in range [v3.1 - v3.99] (this chip is revision v1.3). Use --force to flash anyway.```

This PR creates 3 new variants for the esp32-p4 generic board, supporting compiling and loading compatible code for revision 0.x and 1.x chips. The default is to only build for revision 3.x and later.

See also PR #19506 and Issue #19454 for a more complete description.

### Testing

I have built all 6 variants with IDF 5.5.4 and 5.5.5 without error, and can deploy the three `PRE_REV3` variants to my TAB5 (v1.x chip), the default variants all refuse to deploy with the error as per the summary.

### Trade-offs and Alternatives

The alternative is broken P4 support ;-) (has been discussed in #19506 and others)

### Generative AI

I did not use generative AI tools when creating this PR.