### PR TITLE
stm32/boards/OPENMV_N6: Fix MICROPY_HW_USRSW_PIN to use pyb_pin_SW.

### DIFF
--- a/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
+++ b/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
@@ -87,7 +87,7 @@
 // #define MICROPY_HW_CAN3_RX          (pyb_pin_CAN3_RX)
 
 // USER is pulled high, and pressing the button makes the input go low.
-#define MICROPY_HW_USRSW_PIN        (pyb_pin_BUTTON)
+#define MICROPY_HW_USRSW_PIN        (pyb_pin_SW)
 #define MICROPY_HW_USRSW_PULL       (GPIO_NOPULL)
 #define MICROPY_HW_USRSW_EXTI_MODE  (GPIO_MODE_IT_FALLING)
 #define MICROPY_HW_USRSW_PRESSED    (0)


### PR DESCRIPTION
### Summary

BUTTON was renamed to SW in 64c7045213514d7d57abeee8705f6b4e70222785.

### Testing

Built mboot for OPENMV_N6.  It previously failed, but now builds.

I did not test it on hardware.

### Generative AI

I did not use generative AI tools when creating this PR.
