### PR TITLE
extmod/vfs_posix: Fix renaming with a non-empty VFS root.

### DIFF
--- a/extmod/vfs_posix.c
+++ b/extmod/vfs_posix.c
@@ -341,10 +341,14 @@ static mp_obj_t vfs_posix_rename(mp_obj_t self_in, mp_obj_t old_path_in, mp_obj_
     vfs_posix_require_writable(self_in);
     mp_obj_vfs_posix_t *self = MP_OBJ_TO_PTR(self_in);
     const char *old_path = vfs_posix_get_path_str(self, old_path_in);
+    size_t old_path_len = strlen(old_path) + 1;
+    char *old_path_copy = m_new(char, old_path_len);
+    memcpy(old_path_copy, old_path, old_path_len);
     const char *new_path = vfs_posix_get_path_str(self, new_path_in);
     MP_THREAD_GIL_EXIT();
-    int ret = rename(old_path, new_path);
+    int ret = rename(old_path_copy, new_path);
     MP_THREAD_GIL_ENTER();
+    m_del(char, old_path_copy, old_path_len);
     if (ret != 0) {
         mp_raise_OSError(errno);
     }

--- a/tests/extmod/vfs_posix.py
+++ b/tests/extmod/vfs_posix.py
@@ -97,6 +97,15 @@ for n in names + [basefd, nextfd]:
 os.rename(temp_dir + "/test", temp_dir + "/test2")
 print(os.listdir(temp_dir))
 
+# construct new VfsPosix with absolute path
+fs = vfs.VfsPosix(os.getcwd() + os.sep + temp_dir)
+f = fs.open("/test", "w")
+f.close()
+print(sorted(os.listdir(temp_dir)))
+fs.rename("/test", "/_test")
+print(sorted(os.listdir(temp_dir)))
+fs.remove("/_test")
+
 # construct new VfsPosix with path argument
 fs = vfs.VfsPosix(temp_dir)
 # when VfsPosix is used the intended way via vfs.mount(), it can only be called

--- a/tests/extmod/vfs_posix.py.exp
+++ b/tests/extmod/vfs_posix.py.exp
@@ -6,6 +6,8 @@ True
 hello
 next_file_no <= base_file_no True
 ['test2']
+['test', 'test2']
+['_test', 'test2']
 ['test2']
 <class 'tuple'>
 <class 'str'>


### PR DESCRIPTION
### Summary

This PR fixes an issue occurring when renaming a file through the POSIX VFS interface, if the internal VFS root is non-empty.

The code would translate the old and new logical file paths into their physical counterparts by reusing the same buffer to build the path data, and returning a pointer to the buffer in question.

These changes simply make a copy of the first path being built so it won't be replaced by the time the second path is built.

This fixes #7389.

### Testing

Tested on Linux/x64, with the updated test failing on regular git `master` but passing with these new changes.

### Trade-offs and Alternatives

I chose the most straightforward way to fix the issue, by cloning the old path so the new one could still point to the internal VFS buffer.  This unfortunately can come with a minor size increase, but unless I missed an alternative way to work around this there isn't much to be done about that.

### Generative AI

I did not use generative AI tools when creating this PR.