### PR TITLE
boards/frdm_mcxn947: Enable on-board flash filesystem and MikroBus SPI

### DIFF
--- a/ports/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.conf
+++ b/ports/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.conf
@@ -1,0 +1,17 @@
+# File System Configuration
+# storage_partition (8 MiB on the on-board Winbond W25Q64JV QSPI flash)
+# is mounted at /flash as a LittleFS volume via boards/frdm_mcxn947.overlay.
+CONFIG_FLASH=y
+CONFIG_FLASH_MAP=y
+CONFIG_FILE_SYSTEM=y
+CONFIG_FILE_SYSTEM_LITTLEFS=y
+CONFIG_FILE_SYSTEM_MKFS=y
+CONFIG_MICROPY_VFS_FAT=y
+CONFIG_MICROPY_VFS_LFS1=n
+CONFIG_MICROPY_VFS_LFS2=n
+# Default heap for littlefs is too small
+CONFIG_FS_LITTLEFS_FC_HEAP_SIZE=8192
+
+# Manually added options
+CONFIG_I2C=y
+CONFIG_SPI=y

--- a/ports/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.overlay
+++ b/ports/zephyr/boards/frdm_mcxn947_mcxn947_cpu0.overlay
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs: lfs {
+			compatible = "zephyr,fstab,littlefs";
+			mount-point = "/flash";
+			partition = <&storage_partition>;
+			read-size = <16>;
+			prog-size = <256>;
+			cache-size = <1024>;
+			lookahead-size = <32>;
+			block-cycles = <4>;
+		};
+	};
+};
+
+/*
+ * Enable SPI on the MikroBus connector. Pinctrl is already defined by
+ * the board's common dtsi; it is left disabled there because two of its
+ * pins (MOSI/SCK) are shared with SAI1 (P3_20/P3_21). Not an issue here
+ * since this port does not use SAI1.
+ */
+&flexcomm6_lpspi6 {
+	status = "okay";
+};


### PR DESCRIPTION
### Summary

Adds board-specific configuration for the FRDM-MCXN947
(`frdm_mcxn947/mcxn947/cpu0`):

- Mounts the existing `storage_partition` (8 MiB on the on-board Winbond
  W25Q64JV QSPI flash) as a LittleFS volume at `/flash`.
- Enables MikroBus SPI (`flexcomm6_lpspi6`), which the board's common dtsi
  leaves disabled by default due to pin sharing with SAI1 (not used by this
  port). MikroBus I2C (`flexcomm3_lpi2c3`) is already enabled by default and
  needed no overlay change.
- Enables `CONFIG_I2C`/`CONFIG_SPI`.

### Testing

Built with `west build -b frdm_mcxn947/mcxn947/cpu0 ports/zephyr`, and tested
on physical FRDM-MCXN947 hardware:

- Flash filesystem: mounted `/flash`; `os.statvfs('/flash')` reports a
  2048-block, 4096-byte-block filesystem (8 MiB total, ~7.98 MiB usable
  after LittleFS overhead).
- GPIO: walking-1 output test across all Arduino header pins (D0-D18) and
  all MikroBus `gpio-map` signals, captured with a 16-channel logic
  analyzer to confirm each named pin toggles the correct physical pin.
- SPI: verified both Arduino SPI (`flexcomm1_lpspi1`, D10-D13) and MikroBus
  SPI (`flexcomm6_lpspi6`) by writing known byte patterns and capturing
  CS/SCK/MOSI with a logic analyzer.
- I2C: verified both Arduino I2C (`flexcomm2_lpi2c2`) and MikroBus I2C
  (`flexcomm3_lpi2c3`) via `I2C.scan()`, capturing SCL/SDA with a logic
  analyzer.

Not tested: USB and networking (unrelated to this change).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.
