### PR TITLE
extmod/wasm: Add optional wasmmod submodule for WAMR packs.

### DIFF
--- a/.cursor/rules/modularize-at-scale.mdc
+++ b/.cursor/rules/modularize-at-scale.mdc
@@ -1,0 +1,11 @@
+---
+description: Hint — full modularize-at-scale rule lives in wasmmod package
+alwaysApply: true
+---
+
+# Modularize at scale (hint)
+
+Canonical rule: [`extmod/wasmmod/.cursor/rules/modularize-at-scale.mdc`](../../extmod/wasmmod/.cursor/rules/modularize-at-scale.mdc)
+(package checkout: `packages/wasmmod/.cursor/rules/modularize-at-scale.mdc`).
+
+**Threshold:** split before ~1000 LOC; rethink structure past ~500. Do not grow blobs.

--- a/.cursor/rules/use-monorepo-workspace.mdc
+++ b/.cursor/rules/use-monorepo-workspace.mdc
@@ -1,0 +1,10 @@
+---
+description: Hint — open os-sdk monorepo for constellation agents
+alwaysApply: true
+---
+
+# Workspace (hint)
+
+Agents that touch wasmmod + metal-cdn + tools: open **`/home/ladmin/Devel/os-sdk`**, not this package alone.
+
+Canonical rules live under `extmod/wasmmod/.cursor/rules/` after the submodule is current.

--- a/.cursor/rules/wasmmod-host-branches.mdc
+++ b/.cursor/rules/wasmmod-host-branches.mdc
@@ -1,0 +1,11 @@
+---
+description: Hint — host branch invariant; full rule in wasmmod package
+alwaysApply: true
+---
+
+# Host branches (hint)
+
+Canonical rule: [`extmod/wasmmod/.cursor/rules/wasmmod-host-branches.mdc`](../../extmod/wasmmod/.cursor/rules/wasmmod-host-branches.mdc)
+and [`extmod/wasmmod/BRANCHES.md`](../../extmod/wasmmod/BRANCHES.md).
+
+**Invariant:** metalpython `wasmmod` must stay a git ancestor of `master`. Bump `extmod/wasmmod` on host branch `wasmmod` first, then merge to `master`.

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build-*/
 docs/genrst/
 .mpy_ld_cache-*/
 
+# rust-analyzer / flycheck (metalpython is not a Cargo root)
+/target/
+
 # Test failure outputs and intermediate artefacts
 tests/results/*
 tests/ports/unix/ffi_lib.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -104,3 +104,6 @@
 [submodule "lib/psoc-edge/async-transfer"]
 	path = lib/psoc-edge/async-transfer
 	url = https://github.com/Infineon/async-transfer.git
+[submodule "extmod/wasmmod"]
+	path = extmod/wasmmod
+	url = https://github.com/pymergetic/wasmmod.git

--- a/examples/wasmmod
+++ b/examples/wasmmod
@@ -1,0 +1,1 @@
+../extmod/wasmmod/examples

--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -105,6 +105,15 @@ set(MICROPY_SOURCE_LIB_LIBM
 set(MICROPY_SOURCE_LIB_LIBM_SQRT_SW ${MICROPY_DIR}/lib/libm/ef_sqrt.c)
 set(MICROPY_SOURCE_LIB_LIBM_SQRT_HW ${MICROPY_DIR}/lib/libm/thumb_vfp_sqrtf.c)
 
+# Guest WASM loader — https://github.com/pymergetic/wasmmod — EXPERIMENTAL
+# Pre-release / alpha submodule; default-off. API and pin may change.
+# Submodule: extmod/wasmmod (Rouven Raudzus <raudzus@pymergetic.com>)
+# Runtime: nested WAMR (https://github.com/bytecodealliance/wasm-micro-runtime, Apache-2.0)
+
+if(MICROPY_PY_WASM)
+    include(${MICROPY_DIR}/extmod/wasmmod/ports/micropython/micropython.cmake)
+endif()
+
 # Library for btree module and associated code
 
 if(MICROPY_PY_BTREE)

--- a/extmod/extmod.mk
+++ b/extmod/extmod.mk
@@ -419,6 +419,16 @@ endif
 endif
 
 ################################################################################
+# wasm (guest loader — https://github.com/pymergetic/wasmmod) — EXPERIMENTAL
+# Pre-release / alpha submodule; default-off. API and pin may change.
+# Submodule: extmod/wasmmod (Rouven Raudzus <raudzus@pymergetic.com>)
+# Runtime: nested WAMR (https://github.com/bytecodealliance/wasm-micro-runtime, Apache-2.0)
+
+ifeq ($(MICROPY_PY_WASM),1)
+include $(TOP)/extmod/wasmmod/ports/micropython/micropython.mk
+endif
+
+################################################################################
 # btree
 
 ifeq ($(MICROPY_PY_BTREE),1)

--- a/tools/wasmmod.py
+++ b/tools/wasmmod.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# This file is part of wasmmod, https://github.com/pymergetic/wasmmod
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2026 Rouven Raudzus <raudzus@pymergetic.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+"""
+Thin host trampoline for the wasmmod CLI.
+
+Experimental: the ``extmod/wasmmod`` submodule is pre-release (alpha). This
+script only re-execs the submodule CLI; see that package README for status.
+
+MetalPython (and other MicroPython trees) keep this script at ``tools/wasmmod.py``
+so you can run the usual commands from the host tree without ``cd`` into the
+submodule. It does not implement pack/sign/embed-ca/httpd itself — it locates
+``extmod/wasmmod/tools/wasmmod.py`` and re-executes that entry point with the
+same argv.
+
+Requires the ``extmod/wasmmod`` submodule
+(https://github.com/pymergetic/wasmmod). Init with::
+
+    git submodule update --init --recursive extmod/wasmmod
+
+Usage (from the host repo root)::
+
+    python3 tools/wasmmod.py pack …
+    python3 tools/wasmmod.py sign …
+    python3 tools/wasmmod.py embed-ca …
+    python3 tools/wasmmod.py httpd …
+
+See the submodule README / tools docstring for full command help.
+"""
+
+import runpy
+import sys
+from pathlib import Path
+
+t = Path(__file__).resolve().parents[1] / "extmod/wasmmod/tools/wasmmod.py"
+if not t.is_file():
+    sys.exit("error: needs extmod/wasmmod — git submodule update --init extmod/wasmmod")
+sys.argv[0] = str(t)
+runpy.run_path(str(t), run_name="__main__")


### PR DESCRIPTION
### Summary

Add an opt-in guest WASM pack loader as submodule `extmod/wasmmod`
([pymergetic/wasmmod](https://github.com/pymergetic/wasmmod) `v0.1.1-alpha`),
using nested [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime).

Problem this addresses: there is no first-class way in MicroPython to load
multi-language `.wasm` “packs” (C/Rust/pack-local Python), resolve imports
between packs, and call back into the host from guests.

This PR only adds thin, **default-off** host glue (`MICROPY_PY_WASM` unset/0):

- `.gitmodules` + `extmod/wasmmod`
- guarded includes in `extmod/extmod.mk` / `extmod/extmod.cmake`
- `examples/wasmmod` → submodule examples
- `tools/wasmmod.py` trampoline to the submodule CLI

Ports that never enable the flag should not build or link any of this.

The feature is explicitly **experimental / alpha** (also called out in the
wasmmod READMEs). APIs, pack layout, and the submodule pin may still move.
Happy to keep this as a Draft / RFC-style PR if the nested WAMR pin or the
`wasm` module name needs discussion before a full review.

### What it can do (call matrix)

One `.wasm` pack can ship **C + Rust + pack-local Python**. The examples
exercise a full lang×lang matrix (host↔guest and guest↔guest), plus richer
numeric types and host callbacks — on the order of **~64 cases** via
`make -C extmod/wasmmod/examples test` / `test-engines`.

| caller \\ callee | Py | C | RS |
| --- | --- | --- | --- |
| Py | ✓ | ✓ | ✓ |
| C | ✓ | ✓ | ✓ |
| RS | ✓ | ✓ | ✓ |

Also: guest→guest, guest→host, i64/f32/f64, nested pack FQNs + import hook,
optional HTTP fetch / X.509 signed packs, and the same packs across
Interp · AOT · Fast JIT · LLVM JIT.

Package README / screenshots: https://github.com/pymergetic/wasmmod

### Testing

- Unix port only so far (Linux host).
- Default unix build without `MICROPY_PY_WASM` (unchanged path).
- `make -C extmod/wasmmod/examples test` (interpreter matrix).
- `make -C extmod/wasmmod/examples test-engines` (interp / AOT / Fast JIT / LLVM JIT).
- Optional: `test-signed`, `test-http`, `test-http-verify`.
- Interactive: `make -C extmod/wasmmod/examples repl`.
- Not tested on MCU ports / boards in this PR.

### Trade-offs and Alternatives

- **Code size / CI:** feature is default-off so minimal ports should not grow;
  cost appears only when `MICROPY_PY_WASM=1` and the submodule (with nested
  WAMR) is initialized.
- **Repo weight:** nested WAMR is large; alternative would be system WAMR /
  package manager, or keeping the whole loader out-of-tree forever.
- **New `wasm` module:** MicroPython-first for now (there is no CPython `wasm`
  module yet). A CPython path is planned later; happy to bikeshed the name
  or keep this unix/experimental if maintainers prefer.
- **Alpha API** (`0.1.1-alpha`): may still move; landing as Draft/experimental
  is acceptable.

### Generative AI

I used generative AI tools extensively when creating this PR — essentially all
of the host glue and the linked wasmmod package were drafted with AI assistance
in a fast iteration loop. I built this in my spare time with too much coffee and
too little sleep: I reviewed the changes, ran the unix example matrix / engine
tests, and I am responsible for the code and this description. Please treat the
feature as experimental / alpha.

### Models / tools used

Via Cursor Agent:

- Composer 2.5
- GPT-5.6
- Claude Sonnet 5

—
Rouven Raudzus