### PR TITLE
alif: implement `machine.reset_cause()`

### DIFF
--- a/docs/library/machine.rst
+++ b/docs/library/machine.rst
@@ -111,7 +111,7 @@ To always read a positive integer
    ======  ===============================================  ===========  ==============
    Port    Backing storage                                  Total bytes  Battery-backed
    ======  ===============================================  ===========  ==============
-   alif    Backup SRAM                                      4096         yes
+   alif    Backup SRAM                                      4080         yes
    esp32   RTC slow memory                                  2048         no
    mimxrt  SNVS LPGPR registers (4 per chip)                12-16        yes
    nrf     POWER GPREGRET registers                         1-2          no

--- a/ports/alif/machine_mem_backup.c
+++ b/ports/alif/machine_mem_backup.c
@@ -27,10 +27,8 @@
 // This file is never compiled standalone, it's included directly from
 // extmod/machine_mem.c via MICROPY_PY_MACHINE_MEM_BACKUP_INCLUDEFILE.
 
-// Backup SRAM is in peripheral space; word writes only. No CMSIS macro exists.
-#define ALIF_BACKUP_SRAM_BASE  (0x4902C000U)
-#define ALIF_BACKUP_SRAM_BYTES (4096U)
+#include "modmachine.h"
 
 static const mp_obj_array_t machine_mem_backup_regions[] = {
-    BACKUP_MV('I', ALIF_BACKUP_SRAM_BYTES / 4, (void *)ALIF_BACKUP_SRAM_BASE),
+    BACKUP_MV('I', MP_BACKUP_SRAM_BYTES / 4, (void *)MP_BACKUP_SRAM_BASE),
 };

--- a/ports/alif/machine_wdt.c
+++ b/ports/alif/machine_wdt.c
@@ -30,6 +30,7 @@
 #include "cgu_ext.h"
 #include "wdt.h"
 #include "se_services.h"
+#include "modmachine.h"
 
 #if CORE_M55_HP
 #define WDT_CTRL (WDT_CTRL_Type *)(WDT_HP_CTRL_BASE)
@@ -50,6 +51,7 @@ static machine_wdt_obj_t machine_wdt = {{&machine_wdt_type}, 0};
 void NMI_Handler(void) {
     wdt_unlock(WDT_CTRL);
     wdt_stop(WDT_CTRL);
+    machine_set_wdt_reset();
     se_services_reset_soc();
 }
 

--- a/ports/alif/main.c
+++ b/ports/alif/main.c
@@ -82,6 +82,7 @@ int main(void) {
     MICROPY_BOARD_EARLY_INIT();
 
     lptimer_init();
+    machine_init();
     machine_rtc_init();
 
     #if MICROPY_HW_ENABLE_UART_REPL
@@ -179,6 +180,7 @@ int main(void) {
         soft_timer_deinit();
         machine_pwm_deinit_all();
         machine_pin_irq_deinit();
+        machine_set_soft_reset();
         gc_sweep_all();
         mp_deinit();
     }

--- a/ports/alif/modmachine.c
+++ b/ports/alif/modmachine.c
@@ -32,12 +32,54 @@
 #include "se_services.h"
 #include "tusb.h"
 
+// Use 4 bytes of backup SRAM to store the reset cause state.
+// Note that this will be reset to a random value upon power on.
+#define RESET_CAUSE_STATE_PTR ((uint32_t *)MP_BACKUP_STATE_BASE)
+#define RESET_CAUSE_VALID_MASK (0xfffffff0)
+#define RESET_CAUSE_VALID (0xa170)
+
 extern void dcd_uninit(void);
 
 #define MICROPY_PY_MACHINE_EXTRA_GLOBALS \
     { MP_ROM_QSTR(MP_QSTR_Pin),                 MP_ROM_PTR(&machine_pin_type) }, \
     { MP_ROM_QSTR(MP_QSTR_Timer),               MP_ROM_PTR(&machine_timer_type) }, \
     { MP_ROM_QSTR(MP_QSTR_RTC),                 MP_ROM_PTR(&machine_rtc_type) }, \
+    \
+    { MP_ROM_QSTR(MP_QSTR_PWRON_RESET),         MP_ROM_INT(MACHINE_RESET_PWRON) }, \
+    { MP_ROM_QSTR(MP_QSTR_HARD_RESET),          MP_ROM_INT(MACHINE_RESET_HARD) }, \
+    { MP_ROM_QSTR(MP_QSTR_WDT_RESET),           MP_ROM_INT(MACHINE_RESET_WDT) }, \
+    { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_RESET),     MP_ROM_INT(MACHINE_RESET_DEEPSLEEP) }, \
+    { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MACHINE_RESET_SOFT) }, \
+
+enum {
+    MACHINE_RESET_PWRON = 1,
+    MACHINE_RESET_HARD,
+    MACHINE_RESET_WDT,
+    MACHINE_RESET_DEEPSLEEP,
+    MACHINE_RESET_SOFT,
+};
+
+static uint8_t reset_cause;
+
+void machine_init(void) {
+    // Get the current reset cause.
+    if ((*RESET_CAUSE_STATE_PTR & RESET_CAUSE_VALID_MASK) == RESET_CAUSE_VALID) {
+        reset_cause = *RESET_CAUSE_STATE_PTR & 0xf;
+    } else {
+        reset_cause = MACHINE_RESET_PWRON;
+    }
+
+    // Set the reset cause state in case there is a spontaneous hard reset.
+    *RESET_CAUSE_STATE_PTR = RESET_CAUSE_VALID | MACHINE_RESET_HARD;
+}
+
+void machine_set_wdt_reset(void) {
+    *RESET_CAUSE_STATE_PTR = RESET_CAUSE_VALID | MACHINE_RESET_WDT;
+}
+
+void machine_set_soft_reset(void) {
+    reset_cause = MACHINE_RESET_SOFT;
+}
 
 static void mp_machine_idle(void) {
     mp_event_wait_indefinite();
@@ -50,7 +92,12 @@ static mp_obj_t mp_machine_unique_id(void) {
 }
 
 MP_NORETURN static void mp_machine_reset(void) {
+    *RESET_CAUSE_STATE_PTR = RESET_CAUSE_VALID | MACHINE_RESET_HARD;
     se_services_reset_soc();
+}
+
+static mp_int_t mp_machine_reset_cause(void) {
+    return reset_cause;
 }
 
 MP_NORETURN void mp_machine_bootloader(size_t n_args, const mp_obj_t *args) {
@@ -61,11 +108,6 @@ MP_NORETURN void mp_machine_bootloader(size_t n_args, const mp_obj_t *args) {
     while (1) {
         ;
     }
-}
-
-static mp_int_t mp_machine_reset_cause(void) {
-    // TODO
-    return 0;
 }
 
 static mp_obj_t mp_machine_get_freq(void) {
@@ -163,6 +205,9 @@ MP_NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args
     __disable_irq();
 
     mp_machine_config_wakeup(sleep_ms, true);
+
+    // Set the reset cause for when the device wakes up.
+    *RESET_CAUSE_STATE_PTR = RESET_CAUSE_VALID | MACHINE_RESET_DEEPSLEEP;
 
     // If power is removed from the subsystem, the function does
     // not return, and the CPU will reboot when/if the subsystem

--- a/ports/alif/modmachine.h
+++ b/ports/alif/modmachine.h
@@ -32,6 +32,10 @@
 #define MP_BACKUP_SRAM_BYTES (4096U - 16U)
 #define MP_BACKUP_STATE_BASE (0x4902C000U + MP_BACKUP_SRAM_BYTES)
 
+void machine_init(void);
+void machine_set_wdt_reset(void);
+void machine_set_soft_reset(void);
+
 void machine_rtc_init(void);
 void machine_rtc_set_wakeup(uint32_t seconds);
 void machine_rtc_cancel_wakeup(void);

--- a/ports/alif/modmachine.h
+++ b/ports/alif/modmachine.h
@@ -26,6 +26,12 @@
 #ifndef MICROPY_INCLUDED_ALIF_MODMACHINE_H
 #define MICROPY_INCLUDED_ALIF_MODMACHINE_H
 
+// Backup SRAM is in peripheral space; word writes only. No CMSIS macro exists.
+// 16 bytes are reserved for MicroPython alif system use.
+#define MP_BACKUP_SRAM_BASE  (0x4902C000U)
+#define MP_BACKUP_SRAM_BYTES (4096U - 16U)
+#define MP_BACKUP_STATE_BASE (0x4902C000U + MP_BACKUP_SRAM_BYTES)
+
 void machine_rtc_init(void);
 void machine_rtc_set_wakeup(uint32_t seconds);
 void machine_rtc_cancel_wakeup(void);


### PR DESCRIPTION
### Summary

Implement `machine.reset_cause()` on the alif port.  Supporting all 5 possible states: PWRON, HARD, WDT, DEEPSLEEP and SOFT resets.

Follows the standard machine API.

### Testing

Tested on OPENMV_AE3.  All 5 reset causes work.

### Trade-offs and Alternatives

Due to hardware limitations (basically, the hardware cannot tell you what the reset cause was), I've taken 4 bytes from the backup SRAM to store the reset cause state: this state is set before doing a reset and read back when the firmware starts up again.

(I actually reserved 16 byts of backup SRAM for system use, but so far only 4 bytes are used.  This takes away from the bytes available to `machine.mem_backup()`.)

### Generative AI

I did not use generative AI tools when creating this PR.
