### PR TITLE
stm32/mpu: Reuse MPU_ATTRIBUTES_NUMBER0 for all non-cacheable uses.

### DIFF
--- a/ports/stm32/mpu.h
+++ b/ports/stm32/mpu.h
@@ -164,7 +164,8 @@ static inline void mpu_config_end(uint32_t irq_state) {
 #endif
 
 static inline void mpu_init(void) {
-    // Configure attribute 0, inner-outer non-cacheable (=0x44).
+    // Configure MPU_ATTRIBUTES_NUMBER0: inner-outer non-cacheable (=0x44).
+    // This attribute is used both here and in mpu_config_region().
     __DMB();
     MPU->MAIR0 = (MPU->MAIR0 & ~MPU_MAIR0_Attr0_Msk)
         | 0x44 << MPU_MAIR0_Attr0_Pos;
@@ -200,12 +201,6 @@ static inline void mpu_config_region(uint32_t region, uint32_t base_addr, uint32
     } else if (region == MPU_REGION_ETH || region == MPU_REGION_DMA_UNCACHED_1 || region == MPU_REGION_DMA_UNCACHED_2 || region == MPU_REGION_BKPSRAM) {
         // Configure region to make DMA memory non-cacheable.
 
-        __DMB();
-        // Configure attribute 1, inner-outer non-cacheable (=0x44).
-        MPU->MAIR0 = (MPU->MAIR0 & ~MPU_MAIR0_Attr1_Msk)
-            | 0x44 << MPU_MAIR0_Attr1_Pos;
-        __DMB();
-
         // RBAR
         //  BASE          Bits [31:5] of base address
         //  SH[4:3]  00 = Non-shareable
@@ -214,15 +209,16 @@ static inline void mpu_config_region(uint32_t region, uint32_t base_addr, uint32
 
         // RLAR
         //  LIMIT         Limit address. Contains bits[31:5] of the upper inclusive limit of the selected MPU memory region
-        //  AT[3:1] 001 = Attribute 1
+        //  AT[3:1] 000 = Attribute 0
         //  EN[0]     1 = Enabled
+        __DMB();
         MPU->RNR = region;
         MPU->RBAR = (base_addr & MPU_RBAR_BASE_Msk)
             | MPU_ACCESS_NOT_SHAREABLE << MPU_RBAR_SH_Pos
             | MPU_REGION_ALL_RW << MPU_RBAR_AP_Pos
             | MPU_INSTRUCTION_ACCESS_DISABLE << MPU_RBAR_XN_Pos;
         MPU->RLAR = ((base_addr + size - 1) & MPU_RLAR_LIMIT_Msk)
-            | MPU_ATTRIBUTES_NUMBER1 << MPU_RLAR_AttrIndx_Pos
+            | MPU_ATTRIBUTES_NUMBER0 << MPU_RLAR_AttrIndx_Pos
             | MPU_REGION_ENABLE << MPU_RLAR_EN_Pos;
     }
     __DMB();


### PR DESCRIPTION
### Summary

On H5 and N6 MCUs, `MPU_ATTRIBUTES_NUMBER0` is unconditionally set to non- cacheable (mode 0x44) in `mpu_init()`, and used for accessing the unique device signature.  `MPU_ATTRIBUTES_NUMBER1` is also configured to the same 0x44 mode in `mpu_config_region()` and used for ETH, uncached DMA and backup SRAM access.

This commit cleans that up by using `MPU_ATTRIBUTES_NUMBER0` in both cases, removing the need for `MPU_ATTRIBUTES_NUMBER1`.

History: the use of `MPU_ATTRIBUTES_NUMBER1` was added for H5 in commit 51da8cc28bb6073588e4938489194f2f937006df which could have at the time have reused `MPU_ATTRIBUTES_NUMBER0`.  The code was later extended to support N6 in eb3ea9ee13093d81053f5d07b8c96e4fc0e1383d, and backup SRAM in fb1375b57853202eb55c63741f1e6d927bc7bb64.

Fixes issue #19578.

### Testing

Tested on OPENMV_N6, running the full test suite.  No regressions detected.  In particular the following pass:
- `ports/stm32_hardware/spi_dma_align.py`
- `extmod_hardware/machine_sdcard_dma_align.py`

### Trade-offs and Alternatives

There are some alternative suggestions in #19578, but IMO the one here is the cleanest/simplest.

### Generative AI

I did not use generative AI tools when creating this PR.
