### PR TITLE
rp2/modmachine: Restore original CPU speed after lightsleep.

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -100,6 +100,8 @@ static mp_obj_t mp_machine_get_freq(void) {
     return MP_OBJ_NEW_SMALL_INT(mp_hal_get_cpu_freq());
 }
 
+static mp_obj_t frequency_overrides[2] = {};
+
 static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
     mp_int_t freq = mp_obj_get_int(args[0]);
 
@@ -141,6 +143,10 @@ static void mp_machine_set_freq(size_t n_args, const mp_obj_t *args) {
         psram_reinitialize();
     }
     #endif
+
+    if (n_args > 0) {
+        memcpy(frequency_overrides, args, MIN(n_args, 2) * sizeof(mp_obj_t));
+    }
 }
 
 static void mp_machine_idle(void) {
@@ -363,6 +369,10 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
     // (higher up, inside the critical section)
     in_lightsleep = false;
     #endif
+
+    if (frequency_overrides[0] != MP_OBJ_NULL) {
+        mp_machine_set_freq(1 + (frequency_overrides[1] != NULL ? 1 : 0), frequency_overrides);
+    }
 }
 
 MP_NORETURN static void mp_machine_deepsleep(size_t n_args, const mp_obj_t *args) {

--- a/tests/ports/rp2/rp2_lightsleep.py
+++ b/tests/ports/rp2/rp2_lightsleep.py
@@ -27,4 +27,15 @@ for n in range(100):
     sys.stdout.write(chr(ord("a") + (n % 26)))
     lightsleep(2 ** (n % 10))
 
-print("\nDONE")
+old_freq = machine.freq()
+machine.freq(50_000_000)
+print("\n{}".format(machine.freq()))
+lightsleep(500)
+print(machine.freq())
+machine.freq(51_000_000, 48_000_000)
+print(machine.freq())
+lightsleep(500)
+print(machine.freq())
+machine.freq(old_freq)
+
+print("DONE")

--- a/tests/ports/rp2/rp2_lightsleep.py.exp
+++ b/tests/ports/rp2/rp2_lightsleep.py.exp
@@ -1,2 +1,6 @@
 abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv
+50000000
+50000000
+51000000
+51000000
 DONE


### PR DESCRIPTION
### Summary

This PR lets `machine.lightsleep` restore the original CPU and peripherals frequencies upon wakeup if they were previously set to different values than the defaults.

The original implementation of `machine.lightsleep` would restore the default speed for CPU and peripherals as part of the wakeup procedure, which would ignore previously set values.  These changes force an optional frequency values set once the MCU wakes up, by simply jumping into the internal implementation for `machine.freq`.

The relevant lightsleep test was also updated to verify the changes in question.

This fixes #14079 and #19433.

### Testing

The updated `ports/rp2/rp2_lightsleep.py` test was checked to be failing on RP2040 and RP2350 in both Arm and RV32 mode, then checked to pass said test with the changes in this PR.

### Trade-offs and Alternatives

There is a minor size increase, as usual :(

In theory the pre-lightsleep cpu/peripherals speed could be re-set from code once lightsleep ends.  However I believe there may be some expectations for this behaviour to either be clearly documented in `machine.lightsleep` reference docs entry or for the pre-sleep speed to be restored by MicroPython automatically on wakeup.

The latter option may have a bit more weight since the peripherals frequency can only be set via `machine.freq` but not retrieved, so to keep things portable it's not a simple matter of doing `oldspeed = machine.freq(); ...; machine.freq(oldspeed)`.

Regarding the internal implementation, I believe doing things the way proposed in this change (ie. the naive way) could take less space than adding conditional changes to `CLK_REF`, `CLK_SYS`, `CLK_RTC`, and `CLK_PERI` depending on what was previously set via `machine.freq`.  That, however, brings in a delay between the time the MCU wakes up and the interpreter/REPL is running user code, but that's probably less than a millisecond overall.

### Generative AI

I did not use generative AI tools when creating this PR.