### PR TITLE
STM32: Add missing UARTs and Flow Control.

### DIFF
--- a/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
+++ b/ports/stm32/boards/NUCLEO_H563ZI/mpconfigboard.h
@@ -44,6 +44,10 @@
 #define MICROPY_HW_UART1_RX                 (pin_B7) // SB63: Arduino Connector CN10-Pin16 (D0)
 #define MICROPY_HW_UART3_TX                 (pin_D8) // SB23: ST-Link
 #define MICROPY_HW_UART3_RX                 (pin_D9) // SB18: ST-Link
+#define MICROPY_HW_UART11_TX                (pin_F3) // CN12-58
+#define MICROPY_HW_UART11_RX                (pin_F4) // CN12-38 Shared with yellow LED2.
+#define MICROPY_HW_UART12_TX                (pin_E10) // CN12-47
+#define MICROPY_HW_UART12_RX                (pin_E9) // CN12-52
 
 // Connect REPL to UART3 which is provided on ST-Link USB interface
 #define MICROPY_HW_UART_REPL                PYB_UART_3
@@ -70,7 +74,7 @@
 
 // LEDs
 #define MICROPY_HW_LED1                     (pin_B0) // Green
-#define MICROPY_HW_LED2                     (pin_F4) // Orange
+#define MICROPY_HW_LED2                     (pin_F4) // Yellow shared with UART11
 #define MICROPY_HW_LED3                     (pin_G4) // Red
 #define MICROPY_HW_LED_ON(pin)              (mp_hal_pin_high(pin))
 #define MICROPY_HW_LED_OFF(pin)             (mp_hal_pin_low(pin))

--- a/ports/stm32/machine_uart.c
+++ b/ports/stm32/machine_uart.c
@@ -367,6 +367,14 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
         } else if (strcmp(port, MICROPY_HW_UART10_NAME) == 0) {
             uart_id = PYB_UART_10;
         #endif
+        #ifdef MICROPY_HW_UART11_NAME
+        } else if (strcmp(port, MICROPY_HW_UART11_NAME) == 0) {
+            uart_id = PYB_UART_11;
+        #endif
+        #ifdef MICROPY_HW_UART12_NAME
+        } else if (strcmp(port, MICROPY_HW_UART12_NAME) == 0) {
+            uart_id = PYB_UART_12;
+        #endif
         #ifdef MICROPY_HW_LPUART1_NAME
         } else if (strcmp(port, MICROPY_HW_LPUART1_NAME) == 0) {
             uart_id = PYB_LPUART_1;

--- a/ports/stm32/stm32_it.c
+++ b/ports/stm32/stm32_it.c
@@ -1044,6 +1044,22 @@ void USART10_IRQHandler(void) {
 }
 #endif
 
+#if defined(USART11)
+void USART11_IRQHandler(void) {
+    IRQ_ENTER(USART11_IRQn);
+    uart_irq_handler(11);
+    IRQ_EXIT(USART11_IRQn);
+}
+#endif
+
+#if defined(UART12)
+void UART12_IRQHandler(void) {
+    IRQ_ENTER(UART12_IRQn);
+    uart_irq_handler(12);
+    IRQ_EXIT(UART12_IRQn);
+}
+#endif
+
 #endif
 
 #if defined(LPUART1)

--- a/ports/stm32/uart.c
+++ b/ports/stm32/uart.c
@@ -248,6 +248,16 @@ bool uart_exists(int uart_id) {
             return true;
         #endif
 
+        #if defined(MICROPY_HW_UART11_TX) && defined(MICROPY_HW_UART11_RX)
+        case PYB_UART_11:
+            return true;
+        #endif
+
+        #if defined(MICROPY_HW_UART12_TX) && defined(MICROPY_HW_UART12_RX)
+        case PYB_UART_12:
+            return true;
+        #endif
+
         #if defined(MICROPY_HW_LPUART1_TX) && defined(MICROPY_HW_LPUART1_RX)
         case PYB_LPUART_1:
             return true;
@@ -557,8 +567,21 @@ bool uart_init(machine_uart_obj_t *uart_obj,
             __HAL_RCC_UART9_CLK_ENABLE();
             pins[0] = MICROPY_HW_UART9_TX;
             pins[1] = MICROPY_HW_UART9_RX;
+            #if defined(MICROPY_HW_UART9_RTS)
+            if (flow & UART_HWCONTROL_RTS) {
+                pins[2] = MICROPY_HW_UART9_RTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART9_CTS)
+            if (flow & UART_HWCONTROL_CTS) {
+                pins[3] = MICROPY_HW_UART9_CTS;
+            }
+            #endif
             #if defined(MICROPY_HW_UART9_RX_PULL)
             pins_pull[1] = MICROPY_HW_UART9_RX_PULL;
+            #endif
+            #if defined(MICROPY_HW_UART9_CTS_PULL)
+            pins_pull[3] = MICROPY_HW_UART9_CTS_PULL;
             #endif
             break;
         #endif
@@ -577,8 +600,75 @@ bool uart_init(machine_uart_obj_t *uart_obj,
             #endif
             pins[0] = MICROPY_HW_UART10_TX;
             pins[1] = MICROPY_HW_UART10_RX;
+            #if defined(MICROPY_HW_UART10_RTS)
+            if (flow & UART_HWCONTROL_RTS) {
+                pins[2] = MICROPY_HW_UART10_RTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART10_CTS)
+            if (flow & UART_HWCONTROL_CTS) {
+                pins[3] = MICROPY_HW_UART10_CTS;
+            }
+            #endif
             #if defined(MICROPY_HW_UART10_RX_PULL)
             pins_pull[1] = MICROPY_HW_UART10_RX_PULL;
+            #endif
+            #if defined(MICROPY_HW_UART10_CTS_PULL)
+            pins_pull[3] = MICROPY_HW_UART10_CTS_PULL;
+            #endif
+            break;
+        #endif
+
+        #if defined(MICROPY_HW_UART11_TX) && defined(MICROPY_HW_UART11_RX)
+        case PYB_UART_11:
+            uart_unit = 11;
+            UARTx = USART11;
+            irqn = USART11_IRQn;
+            __HAL_RCC_USART11_CLK_ENABLE();
+            pins[0] = MICROPY_HW_UART11_TX;
+            pins[1] = MICROPY_HW_UART11_RX;
+            #if defined(MICROPY_HW_UART11_RTS)
+            if (flow & UART_HWCONTROL_RTS) {
+                pins[2] = MICROPY_HW_UART11_RTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART11_CTS)
+            if (flow & UART_HWCONTROL_CTS) {
+                pins[3] = MICROPY_HW_UART11_CTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART11_RX_PULL)
+            pins_pull[1] = MICROPY_HW_UART11_RX_PULL;
+            #endif
+            #if defined(MICROPY_HW_UART11_CTS_PULL)
+            pins_pull[3] = MICROPY_HW_UART11_CTS_PULL;
+            #endif
+            break;
+        #endif
+
+        #if defined(MICROPY_HW_UART12_TX) && defined(MICROPY_HW_UART12_RX)
+        case PYB_UART_12:
+            uart_unit = 12;
+            UARTx = UART12;
+            irqn = UART12_IRQn;
+            __HAL_RCC_UART12_CLK_ENABLE();
+            pins[0] = MICROPY_HW_UART12_TX;
+            pins[1] = MICROPY_HW_UART12_RX;
+            #if defined(MICROPY_HW_UART12_RTS)
+            if (flow & UART_HWCONTROL_RTS) {
+                pins[2] = MICROPY_HW_UART12_RTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART12_CTS)
+            if (flow & UART_HWCONTROL_CTS) {
+                pins[3] = MICROPY_HW_UART12_CTS;
+            }
+            #endif
+            #if defined(MICROPY_HW_UART12_RX_PULL)
+            pins_pull[1] = MICROPY_HW_UART12_RX_PULL;
+            #endif
+            #if defined(MICROPY_HW_UART12_CTS_PULL)
+            pins_pull[3] = MICROPY_HW_UART12_CTS_PULL;
             #endif
             break;
         #endif

--- a/ports/stm32/uart.h
+++ b/ports/stm32/uart.h
@@ -41,6 +41,8 @@ typedef enum {
     PYB_UART_8 = 8,
     PYB_UART_9 = 9,
     PYB_UART_10 = 10,
+    PYB_UART_11 = 11,
+    PYB_UART_12 = 12,
     #ifdef LPUART1
     PYB_LPUART_1 = MICROPY_HW_MAX_UART + 1,
     #endif


### PR DESCRIPTION
For STM32H5 add USART11 and UART12 with flow control.
For STM32H7 add flow control for UART9 and USART10.


### Summary

This may solve https://github.com/orgs/micropython/discussions/18477

### Testing

USART11 and UART12 tested on NUCLEO_H563ZI with modified mpconfigboard.h.
Hardware loppback tests passed at 38400, 115200 and 921600 baud (Tx linked to Tx).
Bit times measured with oscilloscope were with 1% at each baud rate (limit of accuracy).

Flow control was not tested, but code was a direct copy and carefuly inspected.

### Generative AI

I did not use generative AI tools when creating this PR.

Signed-off-by: Chris Mason <c.mason@inchipdesign.com.au>