### PR TITLE
shared/runtime/pyexec: Don't execute empty line in event driven REPL.

### DIFF
--- a/shared/runtime/pyexec.c
+++ b/shared/runtime/pyexec.c
@@ -470,6 +470,8 @@ static int pyexec_friendly_repl_process_char(int c) {
             vstr_reset(MP_STATE_VM(repl_line));
             repl.paste_mode = true;
             return 0;
+        } else if (vstr_len(MP_STATE_VM(repl_line)) == 0) {
+            goto input_restart;
         }
 
         if (ret < 0) {


### PR DESCRIPTION
### Summary

Commit 617c7dba3b7163996ff49f99839f40041d76591a exposed a bug in the event driven REPL code: an empty input line (user pressing enter without entering anything else) would pass a zero-length string to `parse_compile_execute()` and this is not valid input to `mp_lexer_new_from_str_len()`, which requires at least one character in the input string.

Fix that by restarting the input REPL state machine when nothing is entered.  This follows how the non-event-driver REPL code works.

Fixes issue #19583.

### Testing

Tested with webassembly port:
```
$ make VARIANT=pyscript repl
```
then pressing enter many times in a row.  It now correctly just reissues `>>>`, rather than raising `SyntaxError`.

### Trade-offs and Alternatives

Could fix it in `mp_lexer_new()` by making that handle a zero-length input stream.  But that adds code to ports which don't need the fix, and fixing it in `pyexec.c` follows exactly how the non-event-driver REPL works.

### Generative AI

I did not use generative AI tools when creating this PR.
