### PR TITLE
psoc-edge: machine.UART flow control + fixes/improvements

### DIFF
--- a/docs/psoc-edge/quickref.rst
+++ b/docs/psoc-edge/quickref.rst
@@ -237,12 +237,6 @@ Constructor
    
    - ``bits``. Only 8 bits.
 
-   These are planned for future implementation, but yet unavailable:
-
-   - ``rts``
-   - ``cts``
-   - ``flow``
-       
 .. Note::
 
    These parameters are not implemented:

--- a/ports/psoc-edge/Makefile
+++ b/ports/psoc-edge/Makefile
@@ -300,7 +300,6 @@ MOD_SRC_C += \
 	machine_pin_irq.c \
 	machine_rtc.c \
 	modpsocedge.c \
-	machine_scb.c \
 
 ifeq ($(MICROPY_PY_EXT_FLASH),1)
 	CFLAGS += -DMICROPY_ENABLE_EXT_QSPI_FLASH=1
@@ -312,6 +311,7 @@ SRC_C += \
 	help.c \
 	main.c \
 	mphalport.c \
+	scb.c \
 	systick.c \
 	sys_int.c \
 

--- a/ports/psoc-edge/boards/make-pins.py
+++ b/ports/psoc-edge/boards/make-pins.py
@@ -275,7 +275,7 @@ class PSE84PinGenerator(boardgen.PinGenerator):
     def print_scb_defines(self, out_header):
         print(file=out_header)
         print(
-            f"#define MICROPY_PY_MACHINE_SCB_NUM_ENTRIES ({self._scb_max_index + 1})",
+            f"#define MICROPY_PY_SCB_NUM_ENTRIES ({self._scb_max_index + 1})",
             file=out_header,
         )
 
@@ -295,10 +295,10 @@ class PSE84PinGenerator(boardgen.PinGenerator):
         )
 
         print(file=out_header)
-        print("// The MICROPY_PY_MACHINE_FOR_ALL_SCB(DO) macro will", file=out_header)
+        print("// The MICROPY_PY_FOR_ALL_SCB(DO) macro will", file=out_header)
         print("// apply the DO macro to all user available SCB units.", file=out_header)
         print("// The DO macro takes the SCB unit as argument: DO(unit).", file=out_header)
-        print("#define MICROPY_PY_MACHINE_FOR_ALL_SCB(DO) \\", file=out_header)
+        print("#define MICROPY_PY_FOR_ALL_SCB(DO) \\", file=out_header)
 
         lines = [f"DO({scb})" for scb in self._unhidden_scb]
         macro_body = " \\\n".join(lines)

--- a/ports/psoc-edge/clk.c
+++ b/ports/psoc-edge/clk.c
@@ -181,26 +181,40 @@ static uint8_t  pclk_div_get_max_num_for_peri_group(en_clk_dst_t clk_dst, cy_en_
     return max_num;
 }
 
-static uint8_t pclk_div_get_free_num(en_clk_dst_t clk_dst, cy_en_divider_types_t div_type) {
-    uint8_t peri_gr_div_max_num = pclk_div_get_max_num_for_peri_group(clk_dst, div_type);
-
-    for (uint8_t i = 0; i < peri_gr_div_max_num; i++) {
-        bool used = false;
-        for (uint8_t j = 0; j < PERI_PCLK_DIVIDER_MAX_NUM; j++) {
-            if (pclk_div_obj[j] != NULL) {
-                if (pclk_div_obj[j]->peri_inst == CLK_DEST_INST(clk_dst) &&
-                    pclk_div_obj[j]->group == CLK_DEST_GROUP(clk_dst) &&
-                    pclk_div_obj[j]->type == div_type &&
-                    pclk_div_obj[j]->number == i) {
-                    used = true;
-                    break;
+static uint8_t pclk_div_get_free_num(en_clk_dst_t clk_dst, cy_en_divider_types_t *div_type) {
+    /**
+     * Allow for usage of higher resolution divider when the
+     * required one is not free.
+     * An 8 bits can use 16 bits or 16.5 bits or 24.5 bits.
+     * A 16 bits can use 16.5 bits or 24.5 bits
+     * A 16.5 bits can use 24.5 bits.
+     * A 24.5 bits can only use 24.5 bits.
+     * As the cy_en_divider_types_t is an enum from 0 to 3,
+     * it can be used to iterate through the available divider types.
+     */
+    cy_en_divider_types_t min_available_div_type = *div_type;
+    do {
+        *div_type = min_available_div_type;
+        uint8_t peri_gr_div_max_num = pclk_div_get_max_num_for_peri_group(clk_dst, *div_type);
+        for (uint8_t i = 0; i < peri_gr_div_max_num; i++) {
+            bool used = false;
+            for (uint8_t j = 0; j < PERI_PCLK_DIVIDER_MAX_NUM; j++) {
+                if (pclk_div_obj[j] != NULL) {
+                    if (pclk_div_obj[j]->peri_inst == CLK_DEST_INST(clk_dst) &&
+                        pclk_div_obj[j]->group == CLK_DEST_GROUP(clk_dst) &&
+                        pclk_div_obj[j]->type == *div_type &&
+                        pclk_div_obj[j]->number == i) {
+                        used = true;
+                        break;
+                    }
                 }
             }
+            if (!used) {
+                return i;
+            }
         }
-        if (!used) {
-            return i;
-        }
-    }
+    } while (++min_available_div_type <= CY_SYSCLK_DIV_24_5_BIT);
+
 
     return PCLK_DIV_NO_FREE_DIVIDER;
 }
@@ -259,7 +273,7 @@ pclk_div_obj_t *pclk_div_init(en_clk_dst_t clk_dst, uint32_t divider, uint8_t di
     cy_en_divider_types_t div_type = pclk_div_get_type(divider, divider_frac);
 
     /* Get the a free peri-group divider number*/
-    uint8_t div_num = pclk_div_get_free_num(clk_dst, div_type);
+    uint8_t div_num = pclk_div_get_free_num(clk_dst, &div_type);
     if (div_num == PCLK_DIV_NO_FREE_DIVIDER) {
         return NULL;
     }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -838,11 +838,11 @@ void machine_uart_deinit_all() {
     CY_SCB_RX_INTR_UART_BREAK_DETECT | \
     CY_SCB_TX_INTR_UART_DONE)
 
-static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in);
-static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_rx_idle_soft_obj, machine_uart_rx_idle_soft);
+static mp_obj_t machine_uart_irq_rx_idle_soft(mp_obj_t self_in);
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_uart_irq_rx_idle_soft_obj, machine_uart_irq_rx_idle_soft);
 
 
-static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
+static mp_obj_t machine_uart_irq_rx_idle_soft(mp_obj_t self_in) {
     /**
      * The irq handle is only scheduled when no bytes
      * have been received within the frame time.
@@ -858,7 +858,7 @@ static mp_obj_t machine_uart_rx_idle_soft(mp_obj_t self_in) {
             }
             self->rx_idle_irq_pending = false;
         } else {
-            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_irq_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
         }
     }
 
@@ -886,7 +886,7 @@ static void machine_uart_irq_rx_idle(machine_uart_obj_t *self) {
         self->rx_idle_timeout = mp_hal_ticks_ms() + frame_time_ms * RX_IDLE_NUM_OF_FRAMES_MARGIN;
         if (!self->rx_idle_irq_pending) {
             self->rx_idle_irq_pending = true;
-            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
+            mp_sched_schedule(MP_OBJ_FROM_PTR(&machine_uart_irq_rx_idle_soft_obj), MP_OBJ_FROM_PTR(self));
         }
     }
 }

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -68,6 +68,10 @@
 #define UART_FLOW_CONTROL_NONE    (0)
 #define UART_FLOW_CONTROL_RTS     (1)
 #define UART_FLOW_CONTROL_CTS     (2)
+
+// The RX FIFO level at which the RTS pin is deasserted to throttle the sender.
+// Threshold is set to 112 bytes, which is fifo size (128) - 16 bytes (cushion).
+#define UART_RTS_RX_FIFO_LEVEL    (112UL)
 #define UART_IRQ_RXIDLE           (CY_SCB_RX_INTR_NOT_EMPTY)
 
 // Class-level constants exposed to Python
@@ -152,17 +156,38 @@ static void machine_uart_irq_rx_break(machine_uart_obj_t *self);
 static void machine_uart_irq_tx_idle(machine_uart_obj_t *self);
 #endif
 
+static inline void machine_uart_irq_rx_not_empty_config(machine_uart_obj_t *self, bool enable) {
+    uint32_t mask = Cy_SCB_GetRxInterruptMask(self->scb_obj->scb);
+    if (enable) {
+        mask |= CY_SCB_RX_INTR_NOT_EMPTY;
+    } else {
+        mask &= ~CY_SCB_RX_INTR_NOT_EMPTY;
+    }
+    Cy_SCB_SetRxInterruptMask(self->scb_obj->scb, mask);
+}
+
+static inline void machine_uart_irq_rx_pause(machine_uart_obj_t *self) {
+    machine_uart_irq_rx_not_empty_config(self, false);
+}
+
+static inline void machine_uart_irq_rx_resume(machine_uart_obj_t *self) {
+    machine_uart_irq_rx_not_empty_config(self, true);
+}
+
 static void machine_uart_fill_rx_ring_buff(machine_uart_obj_t *self) {
     uint32_t available_rx_frames = Cy_SCB_UART_GetNumInRxFifo(self->scb_obj->scb);
     for (uint32_t i = 0; i < available_rx_frames; i++) {
-        if (!ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb))) {
+        if (ringbuf_free(&self->rx_ringbuf) == 0) {
             /**
-             * No overflow handling.
-             * Just return and wait for next interrupt
-             * to read the remaining data.
+             * Pause rx irq to avoid interrupt storms while the
+             * ring buffer is full. Supports RTS flow control,
+             * if enabled, to throttle the sender.
              */
+            machine_uart_irq_rx_pause(self);
             return;
         }
+
+        ringbuf_put(&self->rx_ringbuf, (uint8_t)Cy_SCB_UART_Get(self->scb_obj->scb));
     }
 }
 
@@ -340,12 +365,9 @@ static void machine_uart_hw_init(machine_uart_obj_t *self) {
         .receiverAddressMask = 0UL,
         .acceptAddrInFifo = false,
 
-        /**
-         * TODO: Enable CTS/RTS based on user config.
-         */
-        .enableCts = false,
+        .enableCts = (self->flow & UART_FLOW_CONTROL_CTS) != 0,
         .ctsPolarity = CY_SCB_UART_ACTIVE_LOW,
-        .rtsRxFifoLevel = 0UL,
+        .rtsRxFifoLevel = (self->flow & UART_FLOW_CONTROL_RTS) ? UART_RTS_RX_FIFO_LEVEL : 0UL,
         .rtsPolarity = CY_SCB_UART_ACTIVE_LOW,
 
         .rxFifoTriggerLevel = 0UL,
@@ -498,14 +520,17 @@ static void machine_uart_init_impl(machine_uart_obj_t **self_ptr, int uart_id, s
     /* -- Flow control pins -- */
     uint32_t flow = (uint32_t)args[ARG_flow].u_int;
 
-    /** TODO: Currently throw error if flow is not NONE.
-     * This needs to be implemented
-     * {
-     */
-    if (flow != UART_FLOW_CONTROL_NONE) {
-        mp_raise_ValueError(MP_ERROR_TEXT("flow control not supported yet. Keep flow=0"));
+    if ((flow & ~(UART_FLOW_CONTROL_RTS | UART_FLOW_CONTROL_CTS)) != 0U) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must be UART.RTS, UART.CTS or both"));
     }
-    /** } */
+
+    if ((args[ARG_rts].u_obj != mp_const_none) && ((flow & UART_FLOW_CONTROL_RTS) == 0U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must include UART.RTS when rts pin is provided"));
+    }
+
+    if ((args[ARG_cts].u_obj != mp_const_none) && ((flow & UART_FLOW_CONTROL_CTS) == 0U)) {
+        mp_raise_ValueError(MP_ERROR_TEXT("flow must include UART.CTS when cts pin is provided"));
+    }
 
     #define PIN_AF_CONFIG_INDEX_NONE (0xFF)
     uint8_t pin_af_conf_rts_index = PIN_AF_CONFIG_INDEX_NONE;
@@ -696,7 +721,9 @@ static void mp_machine_uart_sendbreak(machine_uart_obj_t *self) {
 #if MICROPY_PY_MACHINE_UART_READCHAR_WRITECHAR
 static mp_int_t mp_machine_uart_readchar(machine_uart_obj_t *self) {
     if (machine_uart_rx_wait(self, self->timeout_ms)) {
-        return (uint8_t)ringbuf_get(&self->rx_ringbuf);
+        uint8_t data = (uint8_t)ringbuf_get(&self->rx_ringbuf);
+        machine_uart_irq_rx_resume(self);
+        return data;
     }
 
     return MP_STREAM_ERROR;
@@ -732,6 +759,7 @@ static mp_uint_t mp_machine_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t 
         ringbuf_memcpy_get_internal(&self->rx_ringbuf, (uint8_t *)buf_in + read_count, to_read);
         read_count += to_read;
         size -= to_read;
+        machine_uart_irq_rx_resume(self);
     } while (size > 0 && machine_uart_rx_wait(self, self->timeout_char_ms));
 
     return read_count;

--- a/ports/psoc-edge/machine_uart.c
+++ b/ports/psoc-edge/machine_uart.c
@@ -47,7 +47,7 @@
 #include "genhdr/pins_af.h"
 #include "modmachine.h"
 #include "mphalport.h"
-#include "machine_scb.h"
+#include "scb.h"
 #include "sys_int.h"
 #include "clk.h"
 
@@ -87,7 +87,7 @@
 typedef struct _machine_uart_obj_t {
     mp_obj_base_t base;
     int id;                         // id matches the SCB id.
-    machine_scb_obj_t *scb_obj;
+    scb_obj_t *scb_obj;
     pclk_div_obj_t *pclk_div;
     mp_hal_pin_obj_t tx;
     mp_hal_pin_obj_t rx;
@@ -239,11 +239,11 @@ static void machine_uart_obj_make_or_reuse(machine_uart_obj_t **self_ptr, uint8_
 
     if (*self_ptr == NULL) {
         /* Create a new object and allocate the scb instance if free.*/
-        if (machine_scb_is_free(id)) {
+        if (scb_is_free(id)) {
             (*self_ptr) = mp_machine_uart_obj_alloc();
             (*self_ptr)->id = id;
             (*self_ptr)->pclk_div = NULL;
-            (*self_ptr)->scb_obj = machine_scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
+            (*self_ptr)->scb_obj = scb_obj_alloc(id, *self_ptr, machine_uart_scb_isr);
             pclk_div_slave_init((*self_ptr)->scb_obj->clk, (*self_ptr)->scb_obj->mmio_slave_nr);
         } else {
             mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by a machine.I2C or machine.SPI instance."), id);
@@ -676,7 +676,7 @@ static mp_obj_t mp_machine_uart_make_new(const mp_obj_type_t *type, size_t n_arg
     const mp_obj_t *init_args = args;
     if (n_args > 0 && mp_obj_is_int(args[0])) {
         uart_id = mp_obj_get_int(args[0]);
-        if (uart_id < 0 || uart_id >= MICROPY_PY_MACHINE_SCB_NUM_ENTRIES) {
+        if (uart_id < 0 || uart_id >= MICROPY_PY_SCB_NUM_ENTRIES) {
             mp_raise_ValueError(MP_ERROR_TEXT("UART id out of range"));
         }
         init_n_args = n_args - 1;
@@ -696,7 +696,7 @@ static void mp_machine_uart_deinit(machine_uart_obj_t *self) {
     machine_uart_hw_deinit(self);
     m_del(uint8_t, self->rx_ringbuf.buf, self->rx_ringbuf.size);
     pclk_div_slave_deinit(self->scb_obj->clk, self->scb_obj->mmio_slave_nr);
-    machine_scb_obj_free(self->scb_obj);
+    scb_obj_free(self->scb_obj);
     mp_machine_uart_obj_free(self);
 }
 
@@ -1015,7 +1015,7 @@ void machine_uart_repl_init() {
 
     uint8_t scb_unit = uart_pins_config[0].af->unit;
 
-    repl_uart_obj.scb_obj = machine_scb_obj_alloc(scb_unit, &repl_uart_obj, machine_uart_scb_isr);
+    repl_uart_obj.scb_obj = scb_obj_alloc(scb_unit, &repl_uart_obj, machine_uart_scb_isr);
     repl_uart_obj.id = scb_unit;
     mp_hal_periph_pins_af_init(uart_pins_config, 2);
 

--- a/ports/psoc-edge/scb.c
+++ b/ports/psoc-edge/scb.c
@@ -26,24 +26,24 @@
 
 #include "mpconfigport.h"
 
-#if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_UART
+#if MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART
 
 #include "py/runtime.h"
 #include "genhdr/pins_af.h"
-#include "machine_scb.h"
+#include "scb.h"
 
 /* Forward declaration */
-static void machine_scb_irq_handler(uint8_t scb);
+static void scb_irq_handler(uint8_t scb);
 
 #define DEFINE_SCB_IRQ_HANDLER(scb) \
     void SCB##scb##_IRQ_Handler(void) { \
-        machine_scb_irq_handler(scb); \
+        scb_irq_handler(scb); \
     }
 
 /**
  * The file build-<board>/genhdr/pins_af.h contains the macro
  *
- *  MICROPY_PY_MACHINE_FOR_ALL_SCB(DO)
+ *  MICROPY_PY_FOR_ALL_SCB(DO)
  *
  *  which uses the X-macro (as argument) pattern to pass a worker
  *  macro DO(port) for the list of all user available ports.
@@ -58,9 +58,9 @@ static void machine_scb_irq_handler(uint8_t scb);
  * for more information.
  */
 
-MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
+MICROPY_PY_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
 
-#define MAP_SCB_IRQ_CONFIG(scb) \
+#define MAP_SCB_CONFIG(scb) \
     [scb] = { \
         scb, \
         SCB##scb, \
@@ -75,34 +75,36 @@ MICROPY_PY_MACHINE_FOR_ALL_SCB(DEFINE_SCB_IRQ_HANDLER)
         NULL, \
     },
 
-static machine_scb_obj_t machine_scb_obj[MICROPY_PY_MACHINE_SCB_NUM_ENTRIES] = {
-    MICROPY_PY_MACHINE_FOR_ALL_SCB(MAP_SCB_IRQ_CONFIG)
+static scb_obj_t scb_obj[MICROPY_PY_SCB_NUM_ENTRIES] = {
+    MICROPY_PY_FOR_ALL_SCB(MAP_SCB_CONFIG)
 };
 
-static void machine_scb_irq_handler(uint8_t scb) {
-    machine_scb_obj_t *scb_obj = &machine_scb_obj[scb];
-    if (scb_obj->parent != NULL && scb_obj->parent_handler != NULL) {
-        scb_obj->parent_handler(scb_obj->parent);
+static void scb_irq_handler(uint8_t scb) {
+    scb_obj_t *obj = &scb_obj[scb];
+    if (obj->parent != NULL && obj->parent_handler != NULL) {
+        obj->parent_handler(obj->parent);
     }
 }
 
-machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler) {
-    machine_scb_obj_t *obj = &machine_scb_obj[scb];
+scb_obj_t *scb_obj_alloc(uint8_t scb, mp_obj_t parent, scb_parent_irq_handler_t handler) {
+    scb_obj_t *obj = &scb_obj[scb];
     if (obj->parent != NULL) {
         mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("SCB %u is already in use by another I2C, SPI or UART instance."), scb);
     }
+
     obj->parent = parent;
     obj->parent_handler = handler;
-    return &machine_scb_obj[scb];
+    return &scb_obj[scb];
 }
 
-void machine_scb_obj_free(machine_scb_obj_t *scb) {
+void scb_obj_free(scb_obj_t *scb) {
     scb->parent = NULL;
     scb->parent_handler = NULL;
 }
 
-bool machine_scb_is_free(uint8_t scb) {
-    return machine_scb_obj[scb].parent == NULL;
+bool scb_is_free(uint8_t scb) {
+    return scb_obj[scb].parent == NULL;
+
 }
 
-#endif // MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_UART
+#endif // MICROPY_PY_MACHINE_I2C || MICROPY_PY_MACHINE_I2C_TARGET || MICROPY_PY_MACHINE_SPI || MICROPY_PY_MACHINE_SPI_TARGET || MICROPY_PY_MACHINE_UART

--- a/ports/psoc-edge/scb.h
+++ b/ports/psoc-edge/scb.h
@@ -24,26 +24,26 @@
  * THE SOFTWARE.
  */
 
-#ifndef MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
-#define MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
+#ifndef MICROPY_INCLUDED_PSOC_EDGE_SCB_H
+#define MICROPY_INCLUDED_PSOC_EDGE_SCB_H
 
 #include "sys_int.h"
 #include "py/obj.h"
 
-typedef void (*machine_scb_parent_irq_handler_t)(mp_obj_t scb_obj);
+typedef void (*scb_parent_irq_handler_t)(mp_obj_t scb_obj);
 
-typedef struct _machine_scb_obj_t {
+typedef struct _scb_obj_t {
     int8_t id;
     CySCB_Type *scb;
     sys_int_cfg_t irq;
     en_clk_dst_t clk;
     uint8_t mmio_slave_nr;
     mp_obj_t parent;
-    machine_scb_parent_irq_handler_t parent_handler;
-} machine_scb_obj_t;
+    scb_parent_irq_handler_t parent_handler;
+} scb_obj_t;
 
-machine_scb_obj_t *machine_scb_obj_alloc(uint8_t scb, mp_obj_t parent, machine_scb_parent_irq_handler_t handler);
-void machine_scb_obj_free(machine_scb_obj_t *scb);
-bool machine_scb_is_free(uint8_t scb);
+scb_obj_t *scb_obj_alloc(uint8_t scb, mp_obj_t parent, scb_parent_irq_handler_t handler);
+void scb_obj_free(scb_obj_t *scb);
+bool scb_is_free(uint8_t scb);
 
-#endif // MICROPY_INCLUDED_PSOC_EDGE_MACHINE_SCB_H
+#endif // MICROPY_INCLUDED_PSOC_EDGE_SCB_H

--- a/tests/extmod/machine_uart_tx.py
+++ b/tests/extmod/machine_uart_tx.py
@@ -27,7 +27,7 @@ elif "mimxrt" in sys.platform:
 elif "nrf" in sys.platform:
     timing_margin_us = 130
 elif "psoc-edge" in sys.platform:
-    timing_margin_us = 190
+    timing_margin_us = 300
 elif "pyboard" in sys.platform:
     initial_delay_ms = 50  # UART sends idle frame after init, so wait for that
     bit_margin = 1  # first start-bit must wait to sync with the UART clock


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

This PR adds hardware flow control to `machine.UART()` class and includes a set of related internal fixes and refactors.

The `clk` fix is not a must for the current `machine.UART()`, but still enables the instantiation/usage of a larger number of `UART` instances with different baud rates at the same time. 

The `scb`rename and function prefix fix are low-risk housekeeping changes. We are removing the `machine_` for integration libraries and modules between the PSOC Edge PDL libraries and the MPY API modules. This feels like a clearer and appropriate naming.

If required, I can open separate PRs for the `clk` and `scb` lib rename. 

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

The [whole suite has been run (including --via-mpy and --emit-native, and excluding some failing tests)](https://github.com/Infineon/micropython-psoc-edge/blob/master%2Bci-hil/tools/ci.sh#L473C1-L512C2) in our ci hil before opening this PR. See [CI run](https://github.com/Infineon/micropython-psoc-edge/actions/runs/31159575167/job/92807016259).

Additionally, with board UART loopback, these tests have been run:

```
$ ./run-tests.py -t a0 -d extmod_hardware/machine_uart*.py
$ ./run-tests.py -t a0 -d extmod/machine_uart*.py
$ ./serial_test.py -t a0
```

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->