### PR TITLE
esp32/boards: Raise default lwIP TCP window on PSRAM boards.

### DIFF
--- a/ports/esp32/boards/sdkconfig.spiram_oct
+++ b/ports/esp32/boards/sdkconfig.spiram_oct
@@ -1,3 +1,10 @@
 # Extra ESP-IDF config for Octal mode PSRAM (SPIRAM) support on ESP32-S3
 CONFIG_SPIRAM_MODE_QUAD=
 CONFIG_SPIRAM_MODE_OCT=y
+
+# Larger TCP window/buffers for higher WiFi throughput -- PSRAM provides the RAM
+# for the extra per-connection buffers. The lwIP default (~5760 B) caps a single
+# TCP connection to ~5 Mbit/s at typical WiFi RTT (throughput ~= window / RTT);
+# 64 KB lifts it toward the WiFi PHY limit.
+CONFIG_LWIP_TCP_SND_BUF_DEFAULT=65534
+CONFIG_LWIP_TCP_WND_DEFAULT=65534

--- a/ports/esp32/boards/sdkconfig.spiram_quad
+++ b/ports/esp32/boards/sdkconfig.spiram_quad
@@ -9,3 +9,10 @@ CONFIG_SPIRAM_USE_MALLOC=y
 # This is the threshold for preferring small allocations from internal memory
 # first, before failing over to PSRAM.
 CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=8192
+
+# Larger TCP window/buffers for higher WiFi throughput -- PSRAM provides the RAM
+# for the extra per-connection buffers. The lwIP default (~5760 B) caps a single
+# TCP connection to ~5 Mbit/s at typical WiFi RTT (throughput ~= window / RTT);
+# 64 KB lifts it toward the WiFi PHY limit.
+CONFIG_LWIP_TCP_SND_BUF_DEFAULT=65534
+CONFIG_LWIP_TCP_WND_DEFAULT=65534


### PR DESCRIPTION
Raises the default lwIP TCP window on esp32 boards with external PSRAM,
which currently run with a window too small to use the WiFi link.

### The problem
The esp32 port uses the lwIP default TCP send buffer / window of 5760
bytes. A single TCP connection is then limited to `window / RTT`; at a
typical WiFi RTT of ~5 ms that caps throughput at roughly 5-10 Mbit/s
**regardless of the WiFi PHY rate or band** -- the extra capacity of
5 GHz / 802.11ax is wasted. The ESP32-P4 board already raises this in its
own config; other boards don't.

### The fix
Set `CONFIG_LWIP_TCP_SND_BUF_DEFAULT` and `CONFIG_LWIP_TCP_WND_DEFAULT` to
65534 in `sdkconfig.spiram_oct` and `sdkconfig.spiram_quad`, covering the
S2/S3/C5 boards that use quad/octal PSRAM. It is gated on PSRAM
deliberately: the larger per-connection buffers cost internal RAM, so
non-PSRAM boards keep the small window (size over speed). The
original-ESP32 PSRAM config (`sdkconfig.spiram_esp32`) is left unchanged
for now -- those chips have a lower WiFi PHY and less RAM headroom and I
have not tested them; it can be a follow-up.

### Testing
Raw single-connection TCP TX throughput (RSSI -40..-48 dBm). The ESP32-C5
was on an 802.11ax (WiFi 6) AP; the S3 figure is a generic ESP32-S3
module:

| board             | before | after        |
|-------------------|--------|--------------|
| ESP32-C5, 2.4 GHz | 9.4    | 31.7 Mbit/s  |
| ESP32-C5, 5 GHz   | 6.6    | 34.7 Mbit/s  |
| ESP32-S3          | 5.0    | 11.0 Mbit/s  |

The cap was confirmed window-limited (effective in-flight data ~= 5760 B,
the default), and opening several parallel connections scaled aggregate
throughput before the fix -- i.e. the WiFi PHY had headroom a single
connection could not use.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.