### PR TITLE
webassembly: Add minimal JSPI support and tests for Pyodide parity.

### DIFF
--- a/ports/webassembly/Makefile
+++ b/ports/webassembly/Makefile
@@ -91,7 +91,11 @@ JSFLAGS += -s EXPORTED_RUNTIME_METHODS="\
 	cwrap,\
 	FS$(EXPORTED_RUNTIME_METHODS_EXTRA)"
 JSFLAGS += --js-library library.js
-JSFLAGS += -s SUPPORT_LONGJMP=emscripten
+# Longjmp support mode; the jspi variant overrides this to "wasm"
+# because the JS invoke_* trampolines used by the emscripten mode are
+# incompatible with JSPI stack suspension.
+SUPPORT_LONGJMP ?= emscripten
+JSFLAGS += -s SUPPORT_LONGJMP=$(SUPPORT_LONGJMP)
 JSFLAGS += -s MODULARIZE -s EXPORT_NAME=_createMicroPythonModule
 
 ################################################################################

--- a/ports/webassembly/api.js
+++ b/ports/webassembly/api.js
@@ -152,18 +152,28 @@ export async function loadMicroPython(options) {
             const buf = Module._malloc(len + 1);
             Module.stringToUTF8(code, buf, len + 1);
             const value = Module._malloc(3 * 4);
-            Module.ccall(
+            const done = Module.ccall(
                 "mp_js_do_exec_async",
                 "number",
                 ["pointer", "number", "pointer"],
                 [buf, len, value],
             );
-            Module._free(buf);
-            const ret = proxy_convert_mp_to_js_obj_jsside_with_free(value);
-            if (ret instanceof PyProxyThenable) {
-                return Promise.resolve(ret);
+            const finish = () => {
+                Module._free(buf);
+                const ret = proxy_convert_mp_to_js_obj_jsside_with_free(value);
+                if (ret instanceof PyProxyThenable) {
+                    return Promise.resolve(ret);
+                }
+                return ret;
+            };
+            if (done instanceof Promise) {
+                // On a jspi build this export is wrapped in
+                // WebAssembly.promising and execution may suspend (via
+                // jsffi.run_sync); the result slot is only valid once
+                // the returned promise resolves.
+                return done.then(finish);
             }
-            return ret;
+            return finish();
         },
         replInit() {
             Module.ccall("mp_js_repl_init", "null", ["null"]);

--- a/ports/webassembly/main.c
+++ b/ports/webassembly/main.c
@@ -73,6 +73,43 @@ void external_call_depth_dec(mp_obj_t root_obj) {
     #endif
 }
 
+#if MICROPY_JSPI
+
+// JSPI suspension gate.  A promising entry (mp_js_do_exec_async on a
+// jspi build) records the external call depth it runs at; run_sync()
+// may only suspend when execution is at exactly that depth, so that
+// nothing suspends from a nested synchronous entry (which has no
+// promising frame to unwind to).  suspension_active records the global
+// fact that a continuation is currently parked, so that a second,
+// overlapping promising entry cannot create a second suspension; two
+// parked continuations would interleave frames on the shared linear
+// stack and corrupt it when resumed out of order.  Note the jspi
+// variant enables MICROPY_GC_SPLIT_HEAP_AUTO, which both maintains
+// external_call_depth and defers garbage collection to depth zero, so
+// no collection can run while a suspension is parked.
+static size_t suspendable_entry_depth = 0;
+static bool suspension_active = false;
+
+bool mp_js_can_suspend(void) {
+    return suspendable_entry_depth != 0
+           && suspendable_entry_depth == external_call_depth
+           && !suspension_active;
+}
+
+bool mp_js_suspension_active(void) {
+    return suspension_active;
+}
+
+void mp_js_suspension_begin(void) {
+    suspension_active = true;
+}
+
+void mp_js_suspension_end(void) {
+    suspension_active = false;
+}
+
+#endif // MICROPY_JSPI
+
 void mp_js_init(int pystack_size, int heap_size) {
     mp_cstack_init_with_sp_here(CSTACK_SIZE);
 
@@ -168,7 +205,18 @@ void mp_js_do_exec(const char *src, size_t len, uint32_t *out) {
 
 void mp_js_do_exec_async(const char *src, size_t len, uint32_t *out) {
     mp_compile_allow_top_level_await = true;
+    #if MICROPY_JSPI
+    // This entry is wrapped in WebAssembly.promising by the build (see
+    // JSPI_EXPORTS in the jspi variant), so suspension is legal while
+    // execution remains at this entry's depth.  mp_js_do_exec() never
+    // raises out of this frame, so plain save/restore suffices.
+    size_t prev_depth = suspendable_entry_depth;
+    suspendable_entry_depth = external_call_depth + 1;
+    #endif
     mp_js_do_exec(src, len, out);
+    #if MICROPY_JSPI
+    suspendable_entry_depth = prev_depth;
+    #endif
     mp_compile_allow_top_level_await = false;
 }
 
@@ -178,7 +226,18 @@ void mp_js_repl_init(void) {
 
 int mp_js_repl_process_char(int c) {
     external_call_depth_inc();
+    #if MICROPY_JSPI
+    // The REPL entry is wrapped in WebAssembly.promising by the build
+    // (see JSPI_EXPORTS in the jspi variant) so that ccall's async
+    // path works, and marked suspendable so that run_sync() typed at
+    // the REPL can park this entry like any other promising one.
+    size_t prev_depth = suspendable_entry_depth;
+    suspendable_entry_depth = external_call_depth;
+    #endif
     int ret = pyexec_event_repl_process_char(c);
+    #if MICROPY_JSPI
+    suspendable_entry_depth = prev_depth;
+    #endif
     external_call_depth_dec(MP_OBJ_NULL);
     return ret;
 }

--- a/ports/webassembly/modjsffi.c
+++ b/ports/webassembly/modjsffi.c
@@ -100,6 +100,139 @@ static mp_obj_t mp_jsffi_mem_info(void) {
 }
 static MP_DEFINE_CONST_FUN_OBJ_0(mp_jsffi_mem_info_obj, mp_jsffi_mem_info);
 
+/******************************************************************************/
+// jsffi.run_sync / jsffi.can_run_sync
+//
+// Block synchronous-looking Python on a JS promise (or any awaitable)
+// by suspending the promising entry via JSPI, mirroring Pyodide's
+// pyodide.ffi.run_sync / can_run_sync API.  Both functions exist on
+// every build so that feature-detection code is portable; without
+// JSPI, run_sync() raises RuntimeError and can_run_sync() is False.
+
+#if MICROPY_JSPI
+
+// *FORMAT-OFF*
+
+// Adopt the converted object as a promise if it is thenable, recording
+// its settlement into a slot that C polls.  Returns a slot handle, or
+// zero when the object is not awaitable.  Slots are keyed by integer
+// rather than proxied because they are short-lived and self-cleaning.
+EM_JS(int, js_run_sync_start, (uint32_t * value), {
+    const obj = proxy_convert_mp_to_js_obj_jsside(value);
+    if (!obj || typeof obj.then !== "function") {
+        return 0;
+    }
+    if (!Module.runSyncPending) {
+        Module.runSyncPending = { nextId: 1, slots: new Map() };
+    }
+    const state = Module.runSyncPending;
+    const id = state.nextId++;
+    const slot = { done: false, rejected: false, value: undefined };
+    state.slots.set(id, slot);
+    Promise.resolve(obj).then(
+        (result) => { slot.done = true; slot.value = result; },
+        (error) => { slot.done = true; slot.rejected = true; slot.value = error; },
+    );
+    return id;
+});
+
+// Poll a slot: 0 pending, 1 resolved, 2 rejected.  On settlement the
+// value is converted into "value" and the slot is released.
+EM_JS(int, js_run_sync_poll, (int id, uint32_t * value), {
+    const slot = Module.runSyncPending.slots.get(id);
+    if (!slot.done) {
+        return 0;
+    }
+    Module.runSyncPending.slots.delete(id);
+    proxy_convert_js_to_mp_obj_jsside(slot.value, value);
+    return slot.rejected ? 2 : 1;
+});
+
+// Abandon a slot when an exception breaks the wait.
+EM_JS(void, js_run_sync_cancel, (int id), {
+    Module.runSyncPending.slots.delete(id);
+});
+
+// *FORMAT-ON*
+
+static mp_obj_t mp_jsffi_run_sync(mp_obj_t arg) {
+    if (!mp_js_can_suspend()) {
+        if (mp_js_suspension_active()) {
+            mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("run_sync: another run_sync is already pending"));
+        }
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("run_sync: no suspender in this context"));
+    }
+
+    // Convert the argument to its JS form: a JsProxy unwraps to the
+    // underlying JS object, and a Python generator/coroutine becomes a
+    // PyProxyThenable, so both are adopted uniformly by Promise.resolve
+    // on the JS side.
+    uint32_t value[PVN];
+    proxy_convert_mp_to_js_obj_cside(arg, value);
+    int id = js_run_sync_start(value);
+    if (id == 0) {
+        mp_raise_TypeError(MP_ERROR_TEXT("object is not awaitable"));
+    }
+
+    // Park this entry until the promise settles.  emscripten_sleep()
+    // suspends via JSPI, handing control to the event loop; pending
+    // events (e.g. KeyboardInterrupt) are serviced between polls.
+    mp_js_suspension_begin();
+    int status = 0;
+    nlr_buf_t nlr;
+    if (nlr_push(&nlr) == 0) {
+        for (;;) {
+            status = js_run_sync_poll(id, value);
+            if (status != 0) {
+                break;
+            }
+            emscripten_sleep(0);
+            mp_handle_pending(true);
+        }
+        nlr_pop();
+        mp_js_suspension_end();
+    } else {
+        // An exception (e.g. KeyboardInterrupt) broke the wait; tidy
+        // up and re-raise it.
+        js_run_sync_cancel(id);
+        mp_js_suspension_end();
+        nlr_jump(nlr.ret_val);
+    }
+
+    mp_obj_t result = proxy_convert_js_to_mp_obj_cside(value);
+    if (status == 2) {
+        // The promise rejected: raise the reason as Python sees it.
+        if (mp_obj_get_type(result) == &mp_type_jsproxy) {
+            nlr_raise(mp_obj_jsproxy_make_js_exception(result));
+        }
+        if (mp_obj_is_exception_instance(result)) {
+            nlr_raise(result);
+        }
+        mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("run_sync: promise rejected"));
+    }
+    return result;
+}
+
+#else // !MICROPY_JSPI
+
+static mp_obj_t mp_jsffi_run_sync(mp_obj_t arg) {
+    (void)arg;
+    mp_raise_msg(&mp_type_RuntimeError, MP_ERROR_TEXT("WebAssembly stack switching not supported in this build"));
+}
+
+#endif // MICROPY_JSPI
+
+static MP_DEFINE_CONST_FUN_OBJ_1(mp_jsffi_run_sync_obj, mp_jsffi_run_sync);
+
+static mp_obj_t mp_jsffi_can_run_sync(void) {
+    #if MICROPY_JSPI
+    return mp_obj_new_bool(mp_js_can_suspend());
+    #else
+    return mp_const_false;
+    #endif
+}
+static MP_DEFINE_CONST_FUN_OBJ_0(mp_jsffi_can_run_sync_obj, mp_jsffi_can_run_sync);
+
 static const mp_rom_map_elem_t mp_module_jsffi_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_jsffi) },
 
@@ -108,6 +241,8 @@ static const mp_rom_map_elem_t mp_module_jsffi_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_create_proxy), MP_ROM_PTR(&mp_jsffi_create_proxy_obj) },
     { MP_ROM_QSTR(MP_QSTR_to_js), MP_ROM_PTR(&mp_jsffi_to_js_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_info), MP_ROM_PTR(&mp_jsffi_mem_info_obj) },
+    { MP_ROM_QSTR(MP_QSTR_run_sync), MP_ROM_PTR(&mp_jsffi_run_sync_obj) },
+    { MP_ROM_QSTR(MP_QSTR_can_run_sync), MP_ROM_PTR(&mp_jsffi_can_run_sync_obj) },
 };
 static MP_DEFINE_CONST_DICT(mp_module_jsffi_globals, mp_module_jsffi_globals_table);
 

--- a/ports/webassembly/mpconfigport.h
+++ b/ports/webassembly/mpconfigport.h
@@ -34,6 +34,13 @@
 // Variant-specific definitions.
 #include "mpconfigvariant.h"
 
+// Whether the build links with Emscripten JSPI (JavaScript Promise
+// Integration) support, enabling jsffi.run_sync() to suspend.  Set by
+// the jspi variant; see variants/jspi/.
+#ifndef MICROPY_JSPI
+#define MICROPY_JSPI (0)
+#endif
+
 #ifndef MICROPY_CONFIG_ROM_LEVEL
 #define MICROPY_CONFIG_ROM_LEVEL (MICROPY_CONFIG_ROM_LEVEL_EXTRA_FEATURES)
 #endif

--- a/ports/webassembly/proxy_c.h
+++ b/ports/webassembly/proxy_c.h
@@ -47,6 +47,17 @@ extern const mp_obj_type_t mp_type_JsException;
 void external_call_depth_inc(void);
 void external_call_depth_dec(mp_obj_t root_obj);
 
+#if MICROPY_JSPI
+// JSPI suspension gate, maintained in main.c; see the comment there.
+bool mp_js_can_suspend(void);
+bool mp_js_suspension_active(void);
+void mp_js_suspension_begin(void);
+void mp_js_suspension_end(void);
+#endif
+
+// Wrap a JsProxy of a JS Error into a raisable JsException instance.
+mp_obj_t mp_obj_jsproxy_make_js_exception(mp_obj_t error);
+
 void proxy_c_init(void);
 mp_obj_t proxy_convert_js_to_mp_obj_cside(uint32_t *value);
 void proxy_convert_mp_to_js_obj_cside(mp_obj_t obj, uint32_t *out);

--- a/ports/webassembly/variants/jspi/manifest.py
+++ b/ports/webassembly/variants/jspi/manifest.py
@@ -1,0 +1,3 @@
+# The jspi variant is the pyscript variant plus JSPI: freeze exactly
+# what pyscript freezes.
+include("$(PORT_DIR)/variants/pyscript/manifest.py")

--- a/ports/webassembly/variants/jspi/mpconfigvariant.h
+++ b/ports/webassembly/variants/jspi/mpconfigvariant.h
@@ -1,0 +1,13 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ * The MIT License (MIT)
+ * Copyright (c) 2025 MicroPython contributors
+ */
+
+// The jspi variant is the pyscript variant plus JSPI: inherit its
+// configuration (full features, split heap - which the suspension
+// gate's depth counter relies on - and weakref) unchanged.
+#include "../pyscript/mpconfigvariant.h"
+
+// Enable the JSPI suspension gate and the real jsffi.run_sync().
+#define MICROPY_JSPI (1)

--- a/ports/webassembly/variants/jspi/mpconfigvariant.mk
+++ b/ports/webassembly/variants/jspi/mpconfigvariant.mk
@@ -1,0 +1,23 @@
+# The jspi variant is the pyscript variant plus JavaScript Promise
+# Integration for stack suspension (jsffi.run_sync).  Nothing needs
+# removing from pyscript, which uses no Asyncify.  Requires an
+# Emscripten toolchain and JS engine with JSPI support.
+
+# Mirror of variants/pyscript/mpconfigvariant.mk, pointing at this
+# variant's manifest (which includes pyscript's).
+JSFLAGS += -s ALLOW_MEMORY_GROWTH
+FROZEN_MANIFEST ?= variants/jspi/manifest.py
+
+# The emscripten longjmp mode's JS invoke_* trampolines are
+# incompatible with JSPI suspension, so use native wasm exceptions for
+# longjmp at both compile and link time.
+SUPPORT_LONGJMP = wasm
+CFLAGS += -sSUPPORT_LONGJMP=wasm
+
+JSFLAGS += -s JSPI
+# The promising entries: runPythonAsync(), and the REPL character
+# processor (the CLI drives the REPL through ccall's async path, which
+# under JSPI requires a promising export; making it suspendable also
+# lets run_sync() work when typed at the REPL).  Everything else stays
+# synchronous, matching Pyodide's entry semantics.
+JSFLAGS += -s JSPI_EXPORTS=mp_js_do_exec_async,mp_js_repl_process_char

--- a/tests/ports/webassembly/filesystem.mjs
+++ b/tests/ports/webassembly/filesystem.mjs
@@ -1,9 +1,14 @@
 const mp = await (await import(process.argv[2])).loadMicroPython();
 
+// Render a PyProxy identically across Node versions: newer Node's
+// util.inspect annotates Proxy wrappers, so build the string from the
+// stable _ref property instead of letting console.log render it.
+const showPyProxy = (p) => `PyProxy { _ref: ${p._ref} }`;
+
 mp.FS.mkdir("/lib/");
 mp.FS.writeFile("/lib/testmod.py", "x = 1; print(__name__, x)");
 mp.runPython("import testmod");
 
 mp.runPython("import sys; sys.modules.clear()");
 const testmod = mp.pyimport("testmod");
-console.log("testmod:", testmod, testmod.x);
+console.log("testmod:", showPyProxy(testmod), testmod.x);

--- a/tests/ports/webassembly/jsffi_create_proxy.mjs
+++ b/tests/ports/webassembly/jsffi_create_proxy.mjs
@@ -2,6 +2,11 @@
 
 const mp = await (await import(process.argv[2])).loadMicroPython();
 
+// Render a PyProxy identically across Node versions: newer Node's
+// util.inspect annotates Proxy wrappers, so build the string from the
+// stable _ref property instead of letting console.log render it.
+const showPyProxy = (p) => `PyProxy { _ref: ${p._ref} }`;
+
 mp.runPython(`
 import jsffi
 x = jsffi.create_proxy(1)
@@ -11,5 +16,5 @@ print(y)
 `);
 console.log(mp.globals.get("x"));
 console.log(mp.PyProxy.toJs(mp.globals.get("x")));
-console.log(mp.globals.get("y"));
+console.log(showPyProxy(mp.globals.get("y")));
 console.log(mp.PyProxy.toJs(mp.globals.get("y")));

--- a/tests/ports/webassembly/jspi_entry_gating.mjs
+++ b/tests/ports/webassembly/jspi_entry_gating.mjs
@@ -1,0 +1,28 @@
+// Test the entry rule: suspension is legal only inside the promising
+// entry (runPythonAsync); runPython is synchronous and run_sync there
+// raises RuntimeError, matching Pyodide.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(
+    "import jsffi\nimport js\njs.jspiProbe = jsffi.can_run_sync()",
+);
+if (!globalThis.jspiProbe) {
+    console.log("SKIP");
+    process.exit(0);
+}
+delete globalThis.jspiProbe;
+
+await mp.runPythonAsync(`
+import jsffi
+print("async entry:", jsffi.can_run_sync())
+`);
+
+mp.runPython(`
+import jsffi
+print("sync entry:", jsffi.can_run_sync())
+try:
+    jsffi.run_sync(None)
+except RuntimeError as exc:
+    print("RuntimeError:", "no suspender" in str(exc))
+`);

--- a/tests/ports/webassembly/jspi_entry_gating.mjs
+++ b/tests/ports/webassembly/jspi_entry_gating.mjs
@@ -11,7 +11,6 @@ if (!globalThis.jspiProbe) {
     console.log("SKIP");
     process.exit(0);
 }
-delete globalThis.jspiProbe;
 
 await mp.runPythonAsync(`
 import jsffi

--- a/tests/ports/webassembly/jspi_entry_gating.mjs.exp
+++ b/tests/ports/webassembly/jspi_entry_gating.mjs.exp
@@ -1,0 +1,3 @@
+async entry: True
+sync entry: False
+RuntimeError: True

--- a/tests/ports/webassembly/jspi_interrupt.mjs
+++ b/tests/ports/webassembly/jspi_interrupt.mjs
@@ -10,7 +10,6 @@ if (!globalThis.jspiProbe) {
     console.log("SKIP");
     process.exit(0);
 }
-delete globalThis.jspiProbe;
 
 globalThis.never = new Promise(() => {});
 

--- a/tests/ports/webassembly/jspi_interrupt.mjs
+++ b/tests/ports/webassembly/jspi_interrupt.mjs
@@ -1,0 +1,29 @@
+// Test that KeyboardInterrupt breaks a pending run_sync(): pending
+// events are serviced between suspension polls.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(
+    "import jsffi\nimport js\njs.jspiProbe = jsffi.can_run_sync()",
+);
+if (!globalThis.jspiProbe) {
+    console.log("SKIP");
+    process.exit(0);
+}
+delete globalThis.jspiProbe;
+
+globalThis.never = new Promise(() => {});
+
+setTimeout(() => {
+    mp._module.ccall("mp_sched_keyboard_interrupt", "null", [], []);
+}, 50);
+
+await mp.runPythonAsync(`
+import jsffi
+import js
+try:
+    jsffi.run_sync(js.never)
+    print("not reached")
+except KeyboardInterrupt:
+    print("KeyboardInterrupt")
+`);

--- a/tests/ports/webassembly/jspi_interrupt.mjs.exp
+++ b/tests/ports/webassembly/jspi_interrupt.mjs.exp
@@ -1,0 +1,1 @@
+KeyboardInterrupt

--- a/tests/ports/webassembly/jspi_not_supported.mjs
+++ b/tests/ports/webassembly/jspi_not_supported.mjs
@@ -1,0 +1,24 @@
+// Test graceful degradation on builds without JSPI: the functions
+// still exist, can_run_sync() is False and run_sync() raises
+// RuntimeError, so Pyodide-style feature detection is portable.
+// Skips on jspi builds (where run_sync works).
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(
+    "import jsffi\nimport js\njs.jspiProbe = jsffi.can_run_sync()",
+);
+if (globalThis.jspiProbe) {
+    console.log("SKIP");
+    process.exit(0);
+}
+delete globalThis.jspiProbe;
+
+mp.runPython(`
+import jsffi
+print("can_run_sync:", jsffi.can_run_sync())
+try:
+    jsffi.run_sync(None)
+except RuntimeError as exc:
+    print("RuntimeError:", "not supported" in str(exc))
+`);

--- a/tests/ports/webassembly/jspi_not_supported.mjs
+++ b/tests/ports/webassembly/jspi_not_supported.mjs
@@ -12,7 +12,6 @@ if (globalThis.jspiProbe) {
     console.log("SKIP");
     process.exit(0);
 }
-delete globalThis.jspiProbe;
 
 mp.runPython(`
 import jsffi

--- a/tests/ports/webassembly/jspi_not_supported.mjs.exp
+++ b/tests/ports/webassembly/jspi_not_supported.mjs.exp
@@ -1,0 +1,2 @@
+can_run_sync: False
+RuntimeError: True

--- a/tests/ports/webassembly/jspi_overlap.mjs
+++ b/tests/ports/webassembly/jspi_overlap.mjs
@@ -11,7 +11,6 @@ if (!globalThis.jspiProbe) {
     console.log("SKIP");
     process.exit(0);
 }
-delete globalThis.jspiProbe;
 
 let release;
 globalThis.gate = new Promise((resolve) => {

--- a/tests/ports/webassembly/jspi_overlap.mjs
+++ b/tests/ports/webassembly/jspi_overlap.mjs
@@ -1,0 +1,44 @@
+// Test the single-suspension rule: while one run_sync() is parked, a
+// second overlapping promising entry may run but its run_sync() is
+// refused with a distinct RuntimeError.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(
+    "import jsffi\nimport js\njs.jspiProbe = jsffi.can_run_sync()",
+);
+if (!globalThis.jspiProbe) {
+    console.log("SKIP");
+    process.exit(0);
+}
+delete globalThis.jspiProbe;
+
+let release;
+globalThis.gate = new Promise((resolve) => {
+    release = resolve;
+});
+
+// First entry parks on the gate.
+const first = mp.runPythonAsync(`
+import jsffi
+import js
+print("first:", jsffi.run_sync(js.gate))
+`);
+
+// Let the first suspension settle in.
+await new Promise((resolve) => setTimeout(resolve, 10));
+
+// Second entry runs while the first is parked; its run_sync must be
+// refused (and can_run_sync must say so beforehand).
+await mp.runPythonAsync(`
+import jsffi
+import js
+print("second can_run_sync:", jsffi.can_run_sync())
+try:
+    jsffi.run_sync(js.Promise.resolve(1))
+except RuntimeError as exc:
+    print("second RuntimeError:", "pending" in str(exc))
+`);
+
+release(99);
+await first;

--- a/tests/ports/webassembly/jspi_overlap.mjs.exp
+++ b/tests/ports/webassembly/jspi_overlap.mjs.exp
@@ -1,0 +1,3 @@
+second can_run_sync: False
+second RuntimeError: True
+first: 99

--- a/tests/ports/webassembly/jspi_run_sync.mjs
+++ b/tests/ports/webassembly/jspi_run_sync.mjs
@@ -11,7 +11,6 @@ if (!globalThis.jspiProbe) {
     console.log("SKIP");
     process.exit(0);
 }
-delete globalThis.jspiProbe;
 
 globalThis.slowValue = new Promise((resolve) => {
     setTimeout(() => resolve(42), 10);

--- a/tests/ports/webassembly/jspi_run_sync.mjs
+++ b/tests/ports/webassembly/jspi_run_sync.mjs
@@ -1,0 +1,44 @@
+// Test jsffi.run_sync(): resolution, Python-awaitable arguments,
+// rejection, and non-awaitable rejection.  Requires a jspi build on a
+// JSPI-capable engine; skips otherwise.
+
+const mp = await (await import(process.argv[2])).loadMicroPython();
+
+await mp.runPythonAsync(
+    "import jsffi\nimport js\njs.jspiProbe = jsffi.can_run_sync()",
+);
+if (!globalThis.jspiProbe) {
+    console.log("SKIP");
+    process.exit(0);
+}
+delete globalThis.jspiProbe;
+
+globalThis.slowValue = new Promise((resolve) => {
+    setTimeout(() => resolve(42), 10);
+});
+
+await mp.runPythonAsync(`
+import jsffi
+import js
+
+# A JS promise resolves to its value.
+print(jsffi.run_sync(js.slowValue))
+
+# A Python awaitable (coroutine) is accepted, as in Pyodide.
+async def answer():
+    return 7
+
+print(jsffi.run_sync(answer()))
+
+# A non-awaitable is a TypeError.
+try:
+    jsffi.run_sync(123)
+except TypeError:
+    print("TypeError")
+
+# A rejected promise raises JsException carrying the JS error.
+try:
+    jsffi.run_sync(js.Promise.reject(js.Error("boom")))
+except jsffi.JsException as exc:
+    print("JsException", "boom" in str(exc))
+`);

--- a/tests/ports/webassembly/jspi_run_sync.mjs.exp
+++ b/tests/ports/webassembly/jspi_run_sync.mjs.exp
@@ -1,0 +1,4 @@
+42
+7
+TypeError
+JsException True

--- a/tests/ports/webassembly/py_proxy_identity.mjs
+++ b/tests/ports/webassembly/py_proxy_identity.mjs
@@ -2,13 +2,18 @@
 
 const mp = await (await import(process.argv[2])).loadMicroPython();
 
+// Render a PyProxy identically across Node versions: newer Node's
+// util.inspect annotates Proxy wrappers, so build the string from the
+// stable _ref property instead of letting console.log render it.
+const showPyProxy = (p) => `PyProxy { _ref: ${p._ref} }`;
+
 mp.runPython(`
 l = []
 `);
 
 const l1 = mp.globals.get("l");
 const l2 = mp.globals.get("l");
-console.log(l1, l2);
+console.log(showPyProxy(l1), showPyProxy(l2));
 console.log(l1 === l2);
 
 globalThis.eventTarget = new EventTarget();

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1143,10 +1143,18 @@ function ci_webassembly_build {
     source emsdk/emsdk_env.sh
     make ${MAKEOPTS} -C ports/webassembly VARIANT=pyscript submodules
     make ${MAKEOPTS} -C ports/webassembly VARIANT=pyscript
+    make ${MAKEOPTS} -C ports/webassembly VARIANT=jspi
 }
 
 function ci_webassembly_run_tests {
     make -C ports/webassembly VARIANT=pyscript test_min
+    # The jspi variant needs a JSPI-capable node: >= 24 with
+    # --experimental-wasm-jspi, or a version with JSPI on by default.
+    if node -e "process.exit(typeof WebAssembly.promising === 'function' ? 0 : 1)"; then
+        make -C ports/webassembly VARIANT=jspi test
+    else
+        echo "Skipping jspi variant tests: node lacks JSPI support"
+    fi
 }
 
 ########################################################################################


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Related to @Gadgetoid's work in #19427 which formed the basis of a technical investigation found [in this gist](https://gist.github.com/ntoll/88634f27175c585729e619287d008871).

This PR adds minimal JavaScript Promise Integration (JSPI) to MicroPython's webassembly port. This feature will only work with browsers that support JSPI or recent versions of Node (24+) that also support it.

JavaScript Promise Integration (JSPI) is a WebAssembly standard, now shipping in V8-based browsers and coming soon to Firefox and Safari. It lets a running WebAssembly computation suspend on a JavaScript Promise and resume when it resolves. Synchronous-looking Python appears to safely block in the asynchronous browser world (`result = run_sync(fetch(...))`) without actually blocking the main thread or incurring Asyncify's historical penalty in binary size and speed. It is the standards-based mechanism that efficiently lets sync-shaped code interoperate cleanly with the promise-based web platform.

The PR adds `jsffi.run_sync()` and `jsffi.can_run_sync()` with Pyodide API parity, delivered as a new `jspi` build variant. `runPythonAsync()` is the sole promising entry; one suspension in flight, enforced globally; both functions exist on every build with graceful degradation.  

**Note: this proposal permits exactly one suspension in flight at a time - a deliberate, justified divergence from Pyodide (see the decision in section C2 of the linked gist) that trades an exotic capability for a drastically simpler / smaller implementation.**

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->
     
Testing is entirely contained within the `webassembly` port.

**Prerequisits**

Emscripten:

```
git clone https://github.com/emscripten-core/emsdk.git
cd emsdk
./emsdk install latest
./emsdk activate latest
source ./emsdk_env.sh
emcc --version           # confirms emcc is on PATH
```

Node (25 or later):

```
# Install nvm if absent; see https://github.com/nvm-sh/nvm for
# the current install command, or use your existing copy.
nvm install 26
nvm use 26
```

**Build and test**

```
cd ports/webassembly
make VARIANT=jspi submodules
make VARIANT=jspi
make VARIANT=jspi test
```

Expect `emcc: warning: -sJSPI (ASYNCIFY=2) is still experimental` during the build. This labels Emscripten's toolchain integration, not the JSPI standard itself (which is W3C Phase 4 and shipping in all three engine families).

NB: If you're using Node24 you'll need to add `--experimental-wasm-jspi` to all `node` commands.

**Smoke tests**

Start the REPL:

```
make VARIANT=jspi repl
```

Then try this:

```python
import jsffi, js
jsffi.run_sync(js.Promise.resolve(42))
```

A picture is worth a thousand words:

https://github.com/user-attachments/assets/7de086cd-b14e-4c0d-b50e-4ba4411b7a0f

**Note: CTRL-C and `exit()` don't appear to work with the node based REPL.**

I've also attached `xterm-input-demo.zip`. Copy `micropython.mjs` and `micropython.wasm` from `ports/webassembly/build-jspi/` into the `assets` directory inside the unzipped directory, then serve the project root over HTTP (e.g. `python3 -m http.server`) and open `index.html` in a JSPI-capable browser via http://localhost:8000 (e.g. recent Chrome).

[:package: xterm-input-demo.zip](https://github.com/user-attachments/files/30837549/xterm-input-demo.zip)

This demonstrates the use of JSPI in the browser to run blocking Python code on the browser's main thread without blocking the main thread. I replace the builtin `input` function with one that interacts with Xterm via a promise, resolved when the user's input is submitted.

It's the canonical impossible thing - blocking `input()` on the browser's main thread beloved by literally every introduction to Python - working in stock-shaped Python, with no worker, no Asyncify, no SharedArrayBuffer faffing about, or incomprehensible HTTP headers. Nice'n'simple. :slightly_smiling_face: 

```python
name = input("What is your name? ")
print(f"Hello, {name}!")
```

**It's the two-line argument for the whole PR, and the seed of BFP's need to avoid all the web-worker complexity of PyScript via JSPI.** :tada: :hugs: :muscle: :rocket: 

Again, a picture is worth a thousand words:

https://github.com/user-attachments/assets/d83adcca-3d5b-4f41-8da0-a7f6707ca5f7

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

The resulting assets are going to be marginally bigger, but within what I suspect are acceptable limits.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the code and the description above.

Specifically:

* Claude was used to read and do an initial analysis of @Gadgetoid's work in #19427. This was substantially re-written and edited by @ntoll into [this gist](https://gist.github.com/ntoll/88634f27175c585729e619287d008871).
* Once given the go-ahead, Claude was used to extract Phil's code and do an initial refactor to the smallest cut of JSPI support. This was extensively reviewed and tested by @ntoll who added revisions to the commentary contained within the code (which could/should be removed?).
* I wrote this PR description by hand.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
