### PR TITLE
docs/library/esp: Document esp.flash_read.

### DIFF
--- a/docs/library/esp.rst
+++ b/docs/library/esp.rst
@@ -58,6 +58,21 @@ Functions
 
 .. function:: flash_read(byte_offset, length_or_buffer)
 
+    Read from flash space from the given byte_offset.
+
+    This function is present in both ESP8266 and ESP32, albeit with different
+    meanings for the second argument.
+
+    On ESP8266 the second argument indicates how many bytes to read from the
+    given starting point, and will return a ``bytes`` object of the requested
+    length containing the requested data.  Requesting more data than what is
+    available will raise ``OSError(EIO)`` instead of returning a partial buffer.
+
+    On ESP32, the second argument must be a buffer object to fill in
+    (eg. ``bytearray``), using the allocated buffer size as the number of bytes
+    to read from flash.  If the array could not be filled, the function will
+    raise ``OSError(EIO)`` instead of partially filling the input buffer.
+
 .. function:: flash_write(byte_offset, bytes)
 
 .. function:: flash_erase(sector_no)


### PR DESCRIPTION
### Summary

This PR adds a documentation block for `esp.flash_read`, describing its usage and the discrepancies in its implementation between ESP8266 and ESP32.

This closes #6553.

### Testing

Some manual edge case testing was performed on both ESP8266 and ESP32 boards, and the documentation was built using `make html` to make sure no incorrect markup was detected.

### Generative AI

I did not use generative AI tools when creating this PR.
