### PR TITLE
Avoid hardcoded socket count in WIZNET5K

### DIFF
--- a/extmod/network_wiznet5k.c
+++ b/extmod/network_wiznet5k.c
@@ -802,7 +802,7 @@ static mp_obj_t wiznet5k_regs(mp_obj_t self_in) {
         #endif
         printf(" %02x", WIZCHIP_READ(reg));
     }
-    for (int sn = 0; sn < 4; ++sn) {
+    for (int sn = 0; sn < _WIZCHIP_SOCK_NUM_; ++sn) {
         printf("\nWiz SREG[%d]:", sn);
         for (int i = 0; i < 0x30; ++i) {
             if (i % 16 == 0) {


### PR DESCRIPTION
### Summary
The regs() debug method on network.WIZNET5K dumps per-socket registers
used a hardcoded loop bound of 4. 
On a W5500 (8 hardware sockets), this means regs() never shows
sockets 4-7. The function already has access to WIZCHIP_SOCK_NUM
which is used correctly elsewhere for this purpose, just not in this loop.

This fix was provided by @DoubleVee73 in https://github.com/orgs/micropython/discussions/19521

### Testing

This fix has been reported to work in the above Discussion.
This code has no associated regression tests, and I do not have the relevant hardware to verify.

### Generative AI
I did not use generative AI tools when creating this PR.

