### PR TITLE
tools/mpremote: Fix test_mount.sh

### DIFF
--- a/tools/mpremote/mpremote/transport.py
+++ b/tools/mpremote/mpremote/transport.py
@@ -48,6 +48,10 @@ def stdout_write_bytes(b: bytes):
     _stdout_buffer += b
 
     if hasattr(sys.stdout, "buffer"):
+        # The buffer might already contain some characters.
+        # Flush them before we start writing unbuffered.
+        sys.stdout.flush()
+
         # Try to decode to find complete UTF-8 sequences
         # Write only complete sequences, keep incomplete trailing bytes buffered
         try:

--- a/tools/mpremote/tests/test_eval_exec_run.sh
+++ b/tools/mpremote/tests/test_eval_exec_run.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Make sure we have access to /tmp/run.py
+rm -f /tmp/run.py
+trap 'rm -f /tmp/run.py' EXIT
+
 $MPREMOTE exec "print('mpremote')"
 
 $MPREMOTE exec "print('before sleep'); import time; time.sleep(0.1); print('after sleep')"

--- a/tools/mpremote/tests/test_filesystem.sh
+++ b/tools/mpremote/tests/test_filesystem.sh
@@ -4,6 +4,8 @@ set -e
 # Get the test directory (where this script and ramdisk.py are located)
 TEST_DIR=$(dirname $0)
 
+$MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
+
 echo -----
 $MPREMOTE run "${TEST_DIR}/ramdisk.py"
 $MPREMOTE resume ls

--- a/tools/mpremote/tests/test_fs_tree.sh
+++ b/tools/mpremote/tests/test_fs_tree.sh
@@ -4,6 +4,8 @@ set -e
 # Get the test directory (where this script and ramdisk.py are located)
 TEST_DIR=$(dirname $0)
 
+$MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
+
 # setup 
 echo -----
 $MPREMOTE run "${TEST_DIR}/ramdisk.py"

--- a/tools/mpremote/tests/test_mip_local_install.sh
+++ b/tools/mpremote/tests/test_mip_local_install.sh
@@ -13,6 +13,8 @@ MODULE_DIR=${PACKAGE_DIR}/${PACKAGE}
 # Get the test directory (where this script and ramdisk.py are located)
 TEST_DIR=$(dirname $0)
 
+$MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
+
 target=/__ramdisk
 
 echo ----- Setup

--- a/tools/mpremote/tests/test_mount.sh
+++ b/tools/mpremote/tests/test_mount.sh
@@ -22,6 +22,13 @@ cat << EOF > "${TMP}/mount_package/subpackage/y.py"
 def y():
   print("y")
 EOF
+
+output=$($MPREMOTE mount ${TMP} eval "'mounted successfully'" 2>&1) || true
+if [[ "$output" == *"MemoryError"* ]]; then
+    echo "SKIP ('MemoryError' insufficient memory)"
+    exit 0
+fi
+
 $MPREMOTE mount ${TMP} exec "import mount_package; mount_package.x(); mount_package.y()"
 
 # Write to a file on the device and see that it's written locally.

--- a/tools/mpremote/tests/test_mount.sh.exp
+++ b/tools/mpremote/tests/test_mount.sh.exp
@@ -1,17 +1,17 @@
 -----
+Local directory ${TMP} is mounted at /remote
 x
 y
-Local directory ${TMP} is mounted at /remote
 -----
 Local directory ${TMP} is mounted at /remote
 hello world
 -----
+Local directory ${TMP} is mounted at /remote
 ['hello world\n']
-Local directory ${TMP} is mounted at /remote
 -----
+Local directory ${TMP} is mounted at /remote
 100
-Local directory ${TMP} is mounted at /remote
 -----
+Local directory ${TMP} is mounted at /remote
 4
 [25185, 25699]
-Local directory ${TMP} is mounted at /remote

--- a/tools/mpremote/tests/test_resume.sh
+++ b/tools/mpremote/tests/test_resume.sh
@@ -7,7 +7,7 @@ $MPREMOTE exec "a = 'hello'" eval "a"
 
 # Automatic soft reset. `a` will trigger NameError.
 echo -----
-$MPREMOTE eval "a" || true
+$MPREMOTE eval "'a' in globals()" || true
 
 # Resume will skip soft reset.
 echo -----
@@ -16,7 +16,7 @@ $MPREMOTE resume eval "a"
 
 # The eval command will continue the state of the exec.
 echo -----
-$MPREMOTE exec "a = 'soft-reset'" eval "a" soft-reset eval "1+1" eval "a" || true
+$MPREMOTE exec "a = 'soft-reset'" eval "a" soft-reset eval "1+1" eval "'a' in globals()" || true
 
 # A disconnect will trigger auto-reconnect.
 echo -----

--- a/tools/mpremote/tests/test_resume.sh.exp
+++ b/tools/mpremote/tests/test_resume.sh.exp
@@ -1,17 +1,13 @@
 -----
 hello
 -----
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'a' isn't defined
+False
 -----
 resume
 -----
 soft-reset
 2
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-NameError: name 'a' isn't defined
+False
 -----
 3
 5

--- a/tools/mpremote/tests/test_unicode.sh
+++ b/tools/mpremote/tests/test_unicode.sh
@@ -12,6 +12,8 @@ set -e
 # Get the test directory (where this script and ramdisk.py are located)
 TEST_DIR=$(dirname $0)
 
+$MPREMOTE exec "import os; os.VfsFat" || { echo "SKIP (ramdisk not supported)"; exit 0; }
+
 # Initialize ramdisk for file tests
 $MPREMOTE run "${TEST_DIR}/ramdisk.py"
 

--- a/tools/mpremote/tests/test_unicode.sh.exp
+++ b/tools/mpremote/tests/test_unicode.sh.exp
@@ -17,10 +17,10 @@ sha256sum :unicode_content.txt
 8f22a7c6092948ff41897b28dca429cd6a3de87a5bd6e113d24adf91f3cbeeac
 8f22a7c6092948ff41897b28dca429cd6a3de87a5bd6e113d24adf91f3cbeeac  -
 -----
+Local directory ${TMP} is mounted at /remote
 🔢 Data
 🔢 Data
 
-Local directory ${TMP} is mounted at /remote
 -----
 a=b
 -----


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

This fixes a failure in mpremote/test_mount.sh.

**Obverved error**

Somehow the line order in `test_mount.sh.exp` was out of ordner.

Erroronous `test_mount.sh.exp`:
```bash
x
y
Local directory ${TMP} is mounted at /remote
```

Fixed `test_mount.sh.exp`:
```bash
Local directory ${TMP} is mounted at /remote
x
y
```

**Rationale**

I assume, this happend in

```bash
$MPREMOTE mount ${TMP} exec "import mount_package; mount_package.x(); mount_package.y()"
```
Where `mount` outputs `Local directory ${TMP} is mounted at /remote` and exec ouputs `x y`.

`mpremote` write to `sys.stdout.buffer` which caused the false reordering of lines. In this PR, we fix this by flushing the buffer.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Tested on linux in Octoprobe.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
