### PR TITLE
docs: Update CPython differences.

### DIFF
--- a/docs/differences/index_template.txt
+++ b/docs/differences/index_template.txt
@@ -3,8 +3,12 @@
 MicroPython differences from CPython
 ====================================
 
-MicroPython implements Python 3.4 and some select features of Python 3.5 and
-above.  The sections below describe the current status of these features.
+MicroPython implements Python 3.4, and select features from later versions are
+added over time as they are implemented.  This adoption is not strictly
+version-ordered: for example, template strings (:pep:`750`, added in Python
+3.14) are implemented, while structural pattern matching (:pep:`634`, added in
+Python 3.10) is not.  The sections below describe the current status of
+features from each version of Python since 3.5.
 
 .. toctree::
 
@@ -14,6 +18,10 @@ above.  The sections below describe the current status of these features.
     ../differences/python_38.rst
     ../differences/python_39.rst
     ../differences/python_310.rst
+    ../differences/python_311.rst
+    ../differences/python_312.rst
+    ../differences/python_313.rst
+    ../differences/python_314.rst
 
 For the features of Python that are implemented by MicroPython, there are
 sometimes differences in their behaviour compared to standard Python.  The

--- a/docs/differences/python_310.rst
+++ b/docs/differences/python_310.rst
@@ -11,48 +11,61 @@ and a detailed description of the changes can be found in
 .. table::
   :widths: 20 60 20
 
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | **New syntax features**                                                                                     | **Status**              |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ | Structural Pattern Matching: Specification         | Not implemented [#spm]_ |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 635 <https://www.python.org/dev/peps/pep-0635/>`_ | Structural Pattern Matching: Motivation and        | Not implemented [#spm]_ |
-  |                                                        | Rationale                                          |                         |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 636 <https://www.python.org/dev/peps/pep-0636/>`_ | Structural Pattern Matching: Tutorial              | Not implemented [#spm]_ |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `bpo-12782                                             | Parenthesized context managers are now officially  | Not implemented         |
-  | <https://github.com/python/cpython/issues/56991>`_     | allowed                                            |                         |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | **New features in the standard library**                                                                                              |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 618 <https://www.python.org/dev/peps/pep-0618/>`_ | Add Optional Length-Checking To zip                | Not implemented         |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | **Interpreter improvements**                                                                                                          |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 626 <https://www.python.org/dev/peps/pep-0626/>`_ | Precise line numbers for debugging and other tools | Not implemented         |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | **New typing features**                                                                                                               |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`_ | Allow writing union types as X | Y                 | Not implemented [#ann]_ |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 613 <https://www.python.org/dev/peps/pep-0613/>`_ | Explicit Type Aliases                              | Not implemented [#ann]_ |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 612 <https://www.python.org/dev/peps/pep-0612/>`_ | Parameter Specification Variables                  | Not implemented [#ann]_ |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | **Important deprecations, removals or restrictions**                                                                                  |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 644 <https://www.python.org/dev/peps/pep-0644/>`_ | Require OpenSSL 1.1.1 or newer                     | Not relevant            |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 632 <https://www.python.org/dev/peps/pep-0632/>`_ | Deprecate distutils module.                        | Not relevant            |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 623 <https://www.python.org/dev/peps/pep-0623/>`_ | Deprecate and prepare for the removal of the wstr  | Not relevant            |
-  |                                                        | member in PyUnicodeObject.                         |                         |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 624 <https://www.python.org/dev/peps/pep-0624/>`_ | Remove Py_UNICODE encoder APIs                     | Not relevant            |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
-  | `PEP 597 <https://www.python.org/dev/peps/pep-0597/>`_ | Add optional EncodingWarning                       | Not relevant            |
-  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | **New syntax features**                                                                                     | **Status**   |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ | Structural Pattern Matching: Specification         | Not          |
+  |                                                        |                                                    | implemented  |
+  |                                                        |                                                    | [#spm]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 635 <https://www.python.org/dev/peps/pep-0635/>`_ | Structural Pattern Matching: Motivation and        | Not          |
+  |                                                        | Rationale                                          | implemented  |
+  |                                                        |                                                    | [#spm]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 636 <https://www.python.org/dev/peps/pep-0636/>`_ | Structural Pattern Matching: Tutorial              | Not          |
+  |                                                        |                                                    | implemented  |
+  |                                                        |                                                    | [#spm]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `bpo-12782                                             | Parenthesized context managers are now officially  | Not          |
+  | <https://github.com/python/cpython/issues/56991>`_     | allowed                                            | implemented  |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | **New features in the standard library**                                                                                   |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 618 <https://www.python.org/dev/peps/pep-0618/>`_ | Add Optional Length-Checking To zip                | Not          |
+  |                                                        |                                                    | implemented  |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | **Interpreter improvements**                                                                                               |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 626 <https://www.python.org/dev/peps/pep-0626/>`_ | Precise line numbers for debugging and other tools | Not          |
+  |                                                        |                                                    | implemented  |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | **New typing features**                                                                                                    |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`_ | Allow writing union types as X | Y                 | Not          |
+  |                                                        |                                                    | implemented  |
+  |                                                        |                                                    | [#ann]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 613 <https://www.python.org/dev/peps/pep-0613/>`_ | Explicit Type Aliases                              | Not          |
+  |                                                        |                                                    | implemented  |
+  |                                                        |                                                    | [#ann]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 612 <https://www.python.org/dev/peps/pep-0612/>`_ | Parameter Specification Variables                  | Not          |
+  |                                                        |                                                    | implemented  |
+  |                                                        |                                                    | [#ann]_      |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | **Important deprecations, removals or restrictions**                                                                       |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 644 <https://www.python.org/dev/peps/pep-0644/>`_ | Require OpenSSL 1.1.1 or newer                     | Not relevant |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 632 <https://www.python.org/dev/peps/pep-0632/>`_ | Deprecate distutils module.                        | Not relevant |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 623 <https://www.python.org/dev/peps/pep-0623/>`_ | Deprecate and prepare for the removal of the wstr  | Not relevant |
+  |                                                        | member in PyUnicodeObject.                         |              |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 624 <https://www.python.org/dev/peps/pep-0624/>`_ | Remove Py_UNICODE encoder APIs                     | Not relevant |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  | `PEP 597 <https://www.python.org/dev/peps/pep-0597/>`_ | Add optional EncodingWarning                       | Not relevant |
+  +--------------------------------------------------------+----------------------------------------------------+--------------+
 
 
 Other Language Changes:
@@ -60,177 +73,181 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | The :class:`int` type has a new method :meth:`int.bit_count`, returning the                                 | Not implemented |
-  | number of ones in the binary expansion of a given integer, also known                                       |                 |
-  | as the population count.                                                                                    |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | The views returned by :meth:`dict.keys`, :meth:`dict.values` and                                            | Not implemented |
-  | :meth:`dict.items` now all have a ``mapping`` attribute that gives a                                        |                 |
-  | :class:`types.MappingProxyType` object wrapping the original                                                |                 |
-  | dictionary.                                                                                                 |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | :pep:`618`: The :func:`zip` function now has an optional ``strict`` flag, used                              | Not implemented |
-  | to require that all the iterables have an equal length.                                                     |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Builtin and extension functions that take integer arguments no longer accept                                | Not implemented |
-  | :class:`~decimal.Decimal`\ s, :class:`~fractions.Fraction`\ s and other                                     |                 |
-  | objects that can be converted to integers only with a loss (e.g. that have                                  |                 |
-  | the :meth:`~object.__int__` method but do not have the                                                      |                 |
-  | :meth:`~object.__index__` method).                                                                          |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | If :func:`object.__ipow__` returns :const:`NotImplemented`, the operator will                               | Complete        |
-  | correctly fall back to :func:`object.__pow__` and :func:`object.__rpow__` as expected.                      |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Assignment expressions can now be used unparenthesized within set literals                                  | Complete        |
-  | and set comprehensions, as well as in sequence indexes (but not slices).                                    |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Functions have a new ``__builtins__`` attribute which is used to look for                                   | Not implemented |
-  | builtin symbols when a function is executed, instead of looking into                                        |                 |
-  | ``__globals__['__builtins__']``. The attribute is initialized from                                          |                 |
-  | ``__globals__["__builtins__"]`` if it exists, else from the current builtins.                               |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Two new builtin functions -- :func:`aiter` and :func:`anext` have been added                                | Not implemented |
-  | to provide asynchronous counterparts to :func:`iter` and :func:`next`,                                      |                 |
-  | respectively.                                                                                               |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Static methods (:func:`@staticmethod <staticmethod>`) and class methods                                     | Not implemented |
-  | (:func:`@classmethod <classmethod>`) now inherit the method attributes                                      |                 |
-  | (``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,                                               |                 |
-  | ``__annotations__``) and have a new ``__wrapped__`` attribute.                                              |                 |
-  | Moreover, static methods are now callable as regular functions.                                             |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Annotations for complex targets (everything beside ``simple name`` targets                                  | Partial [#ann]_ |
-  | defined by :pep:`526`) no longer cause any runtime effects with ``from __future__ import annotations``.     |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Class and module objects now lazy-create empty annotations dicts on demand.                                 | Not implemented |
-  | The annotations dicts are stored in the object’s ``__dict__`` for                                           |                 |
-  | backwards compatibility.  This improves the best practices for working                                      |                 |
-  | with ``__annotations__``.                                                                                   |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Annotations consist of ``yield``, ``yield from``, ``await`` or named expressions                            | Not implemented |
-  | are now forbidden under ``from __future__ import annotations`` due to their side                            |                 |
-  | effects.                                                                                                    |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Usage of unbound variables, ``super()`` and other expressions that might                                    | Partial [#ann]_ |
-  | alter the processing of symbol table as annotations are now rendered                                        |                 |
-  | effectless under ``from __future__ import annotations``.                                                    |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Hashes of NaN values of both :class:`float` type and                                                        | Not implemented |
-  | :class:`decimal.Decimal` type now depend on object identity. Formerly, they                                 |                 |
-  | always hashed to ``0`` even though NaN values are not equal to one another.                                 |                 |
-  | This caused potentially quadratic runtime behavior due to excessive hash                                    |                 |
-  | collisions when creating dictionaries and sets containing multiple NaNs.                                    |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting                           | Complete        |
-  | the :const:`__debug__` constant.                                                                            |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | :exc:`SyntaxError` exceptions now have ``end_lineno`` and                                                   | Not implemented |
-  | ``end_offset`` attributes.  They will be ``None`` if not determined.                                        |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | The :class:`int` type has a new method :meth:`int.bit_count`, returning the                                 | Not           |
+  | number of ones in the binary expansion of a given integer, also known                                       | implemented   |
+  | as the population count.                                                                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | The views returned by :meth:`dict.keys`, :meth:`dict.values` and                                            | Not           |
+  | :meth:`dict.items` now all have a ``mapping`` attribute that gives a                                        | implemented   |
+  | :class:`types.MappingProxyType` object wrapping the original                                                |               |
+  | dictionary.                                                                                                 |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | :pep:`618`: The :func:`zip` function now has an optional ``strict`` flag, used                              | Not           |
+  | to require that all the iterables have an equal length.                                                     | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Builtin and extension functions that take integer arguments no longer accept                                | Not           |
+  | :class:`~decimal.Decimal`\ s, :class:`~fractions.Fraction`\ s and other                                     | implemented   |
+  | objects that can be converted to integers only with a loss (e.g. that have                                  |               |
+  | the :meth:`~object.__int__` method but do not have the                                                      |               |
+  | :meth:`~object.__index__` method).                                                                          |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | If :func:`object.__ipow__` returns :const:`NotImplemented`, the operator will                               | Complete      |
+  | correctly fall back to :func:`object.__pow__` and :func:`object.__rpow__` as expected.                      |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Assignment expressions can now be used unparenthesized within set literals                                  | Complete      |
+  | and set comprehensions, as well as in sequence indexes (but not slices).                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Functions have a new ``__builtins__`` attribute which is used to look for                                   | Not           |
+  | builtin symbols when a function is executed, instead of looking into                                        | implemented   |
+  | ``__globals__['__builtins__']``. The attribute is initialized from                                          |               |
+  | ``__globals__["__builtins__"]`` if it exists, else from the current builtins.                               |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Two new builtin functions -- :func:`aiter` and :func:`anext` have been added                                | Not           |
+  | to provide asynchronous counterparts to :func:`iter` and :func:`next`,                                      | implemented   |
+  | respectively.                                                                                               |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Static methods (:func:`@staticmethod <staticmethod>`) and class methods                                     | Not           |
+  | (:func:`@classmethod <classmethod>`) now inherit the method attributes                                      | implemented   |
+  | (``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,                                               |               |
+  | ``__annotations__``) and have a new ``__wrapped__`` attribute.                                              |               |
+  | Moreover, static methods are now callable as regular functions.                                             |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Annotations for complex targets (everything beside ``simple name`` targets                                  | Partial       |
+  | defined by :pep:`526`) no longer cause any runtime effects with ``from __future__ import annotations``.     | [#ann]_       |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Class and module objects now lazy-create empty annotations dicts on demand.                                 | Not           |
+  | The annotations dicts are stored in the object’s ``__dict__`` for                                           | implemented   |
+  | backwards compatibility.  This improves the best practices for working                                      |               |
+  | with ``__annotations__``.                                                                                   |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Annotations consist of ``yield``, ``yield from``, ``await`` or named expressions                            | Not           |
+  | are now forbidden under ``from __future__ import annotations`` due to their side                            | implemented   |
+  | effects.                                                                                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Usage of unbound variables, ``super()`` and other expressions that might                                    | Partial       |
+  | alter the processing of symbol table as annotations are now rendered                                        | [#ann]_       |
+  | effectless under ``from __future__ import annotations``.                                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Hashes of NaN values of both :class:`float` type and                                                        | Not           |
+  | :class:`decimal.Decimal` type now depend on object identity. Formerly, they                                 | implemented   |
+  | always hashed to ``0`` even though NaN values are not equal to one another.                                 |               |
+  | This caused potentially quadratic runtime behavior due to excessive hash                                    |               |
+  | collisions when creating dictionaries and sets containing multiple NaNs.                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting                           | Complete      |
+  | the :const:`__debug__` constant.                                                                            |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | :exc:`SyntaxError` exceptions now have ``end_lineno`` and                                                   | Not           |
+  | ``end_offset`` attributes.  They will be ``None`` if not determined.                                        | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.10.html#asyncio>`_                                                               |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add missing :meth:`~asyncio.events.AbstractEventLoop.connect_accepted_socket`                                 | Not implemented |
-  | method.                                                                                                       |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `array <https://docs.python.org/3/whatsnew/3.10.html#array>`_                                                                   |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The :meth:`~array.array.index` method of :class:`array.array` now has                                         | Not implemented |
-  | optional *start* and *stop* parameters.                                                                       |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.10.html#gc>`_                                                                         |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add audit hooks for :func:`gc.get_objects`, :func:`gc.get_referrers` and                                      | Not relevant    |
-  | :func:`gc.get_referents`.                                                                                     |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `hashlib <https://docs.python.org/3/whatsnew/3.10.html#hashlib>`_                                                               |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The hashlib module requires OpenSSL 1.1.1 or newer.                                                           | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The hashlib module has preliminary support for OpenSSL 3.0.0.                                                 | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The pure-Python fallback of :func:`~hashlib.pbkdf2_hmac` is deprecated. In                                    | Not relevant    |
-  | the future PBKDF2-HMAC will only be available when Python has been built with                                 |                 |
-  | OpenSSL support.                                                                                              |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `os <https://docs.python.org/3/whatsnew/3.10.html#os>`_                                                                         |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :func:`os.cpu_count()` support for VxWorks RTOS.                                                          | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add a new function :func:`os.eventfd` and related helpers to wrap the                                         | Not relevant    |
-  | ``eventfd2`` syscall on Linux.                                                                                |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :func:`os.splice()` that allows to move data between two file                                             | Not relevant    |
-  | descriptors without copying between kernel address space and user                                             |                 |
-  | address space, where one of the file descriptors must refer to a                                              |                 |
-  | pipe.                                                                                                         |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`                                         | Not relevant    |
-  | and :data:`~os.O_NOFOLLOW_ANY` for macOS.                                                                     |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `platform <https://docs.python.org/3/whatsnew/3.10.html#platform>`_                                                             |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :func:`platform.freedesktop_os_release()` to retrieve operation system                                    | Not relevant    |
-  | identification from `freedesktop.org os-release                                                               |                 |
-  | <https://www.freedesktop.org/software/systemd/man/os-release.html>`_ standard file.                           |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `socket <https://docs.python.org/3/whatsnew/3.10.html#socket>`_                                                                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The exception :exc:`socket.timeout` is now an alias of :exc:`TimeoutError`.                                   | Not implemented |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add option to create MPTCP sockets with ``IPPROTO_MPTCP``.                                                    | Not implemented |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add ``IP_RECVTOS`` option to receive the type of service (ToS) or DSCP/ECN fields.                            | Not implemented |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `ssl <https://docs.python.org/3/whatsnew/3.10.html#ssl>`_                                                                       |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The ssl module requires OpenSSL 1.1.1 or newer.                                                               | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The ssl module has preliminary support for OpenSSL 3.0.0 and new option                                       | Not relevant    |
-  | :data:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.                                                                        |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Deprecated function and use of deprecated constants now result in                                             | Not relevant    |
-  | a :exc:`DeprecationWarning`. :attr:`ssl.SSLContext.options` has                                               |                 |
-  | :data:`~ssl.OP_NO_SSLv2` and :data:`~ssl.OP_NO_SSLv3` set by default and                                      |                 |
-  | therefore cannot warn about setting the flag again.                                                           |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The ssl module now has more secure default settings. Ciphers without forward                                  | Not relevant    |
-  | secrecy or SHA-1 MAC are disabled by default. Security level 2 prohibits                                      |                 |
-  | weak RSA, DH, and ECC keys with less than 112 bits of security.                                               |                 |
-  | :class:`~ssl.SSLContext` defaults to minimum protocol version TLS 1.2.                                        |                 |
-  | Settings are based on Hynek Schlawack's research.                                                             |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The deprecated protocols SSL 3.0, TLS 1.0, and TLS 1.1 are no longer                                          | Partial [#tls]_ |
-  | officially supported. Python does not block them actively. However                                            |                 |
-  | OpenSSL build options, distro configurations, vendor patches, and cipher                                      |                 |
-  | suites may prevent a successful handshake.                                                                    |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add a *timeout* parameter to the :func:`ssl.get_server_certificate` function.                                 | Not implemented |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | The ssl module uses heap-types and multi-phase initialization.                                                | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | A new verify flag :data:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.                                      | Not relevant    |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.10.html#sys>`_                                                                       |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :data:`sys.orig_argv` attribute: the list of the original command line                                    | Not implemented |
-  | arguments passed to the Python executable.                                                                    |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | Add :data:`sys.stdlib_module_names`, containing the list of the standard library                              | Not implemented |
-  | module names.                                                                                                 |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | `_thread <https://docs.python.org/3/whatsnew/3.10.html#_thread>`_                                                               |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
-  | :func:`_thread.interrupt_main` now takes an optional signal number to                                         | Not relevant    |
-  | simulate (the default is still :data:`signal.SIGINT`).                                                        |                 |
-  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.10.html#asyncio>`_                                                             |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add missing :meth:`~asyncio.events.AbstractEventLoop.connect_accepted_socket`                                 | Not           |
+  | method.                                                                                                       | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `array <https://docs.python.org/3/whatsnew/3.10.html#array>`_                                                                 |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The :meth:`~array.array.index` method of :class:`array.array` now has                                         | Not           |
+  | optional *start* and *stop* parameters.                                                                       | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.10.html#gc>`_                                                                       |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add audit hooks for :func:`gc.get_objects`, :func:`gc.get_referrers` and                                      | Not relevant  |
+  | :func:`gc.get_referents`.                                                                                     |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `hashlib <https://docs.python.org/3/whatsnew/3.10.html#hashlib>`_                                                             |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The hashlib module requires OpenSSL 1.1.1 or newer.                                                           | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The hashlib module has preliminary support for OpenSSL 3.0.0.                                                 | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The pure-Python fallback of :func:`~hashlib.pbkdf2_hmac` is deprecated. In                                    | Not relevant  |
+  | the future PBKDF2-HMAC will only be available when Python has been built with                                 |               |
+  | OpenSSL support.                                                                                              |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `os <https://docs.python.org/3/whatsnew/3.10.html#os>`_                                                                       |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :func:`os.cpu_count()` support for VxWorks RTOS.                                                          | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add a new function :func:`os.eventfd` and related helpers to wrap the                                         | Not relevant  |
+  | ``eventfd2`` syscall on Linux.                                                                                |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :func:`os.splice()` that allows to move data between two file                                             | Not relevant  |
+  | descriptors without copying between kernel address space and user                                             |               |
+  | address space, where one of the file descriptors must refer to a                                              |               |
+  | pipe.                                                                                                         |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`                                         | Not relevant  |
+  | and :data:`~os.O_NOFOLLOW_ANY` for macOS.                                                                     |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `platform <https://docs.python.org/3/whatsnew/3.10.html#platform>`_                                                           |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :func:`platform.freedesktop_os_release()` to retrieve operation system                                    | Not relevant  |
+  | identification from `freedesktop.org os-release                                                               |               |
+  | <https://www.freedesktop.org/software/systemd/man/os-release.html>`_ standard file.                           |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `socket <https://docs.python.org/3/whatsnew/3.10.html#socket>`_                                                               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The exception :exc:`socket.timeout` is now an alias of :exc:`TimeoutError`.                                   | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add option to create MPTCP sockets with ``IPPROTO_MPTCP``.                                                    | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add ``IP_RECVTOS`` option to receive the type of service (ToS) or DSCP/ECN fields.                            | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `ssl <https://docs.python.org/3/whatsnew/3.10.html#ssl>`_                                                                     |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The ssl module requires OpenSSL 1.1.1 or newer.                                                               | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The ssl module has preliminary support for OpenSSL 3.0.0 and new option                                       | Not relevant  |
+  | :data:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.                                                                        |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Deprecated function and use of deprecated constants now result in                                             | Not relevant  |
+  | a :exc:`DeprecationWarning`. :attr:`ssl.SSLContext.options` has                                               |               |
+  | :data:`~ssl.OP_NO_SSLv2` and :data:`~ssl.OP_NO_SSLv3` set by default and                                      |               |
+  | therefore cannot warn about setting the flag again.                                                           |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The ssl module now has more secure default settings. Ciphers without forward                                  | Not relevant  |
+  | secrecy or SHA-1 MAC are disabled by default. Security level 2 prohibits                                      |               |
+  | weak RSA, DH, and ECC keys with less than 112 bits of security.                                               |               |
+  | :class:`~ssl.SSLContext` defaults to minimum protocol version TLS 1.2.                                        |               |
+  | Settings are based on Hynek Schlawack's research.                                                             |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The deprecated protocols SSL 3.0, TLS 1.0, and TLS 1.1 are no longer                                          | Partial       |
+  | officially supported. Python does not block them actively. However                                            | [#tls]_       |
+  | OpenSSL build options, distro configurations, vendor patches, and cipher                                      |               |
+  | suites may prevent a successful handshake.                                                                    |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add a *timeout* parameter to the :func:`ssl.get_server_certificate` function.                                 | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The ssl module uses heap-types and multi-phase initialization.                                                | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | A new verify flag :data:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.                                      | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.10.html#sys>`_                                                                     |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :data:`sys.orig_argv` attribute: the list of the original command line                                    | Not           |
+  | arguments passed to the Python executable.                                                                    | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Add :data:`sys.stdlib_module_names`, containing the list of the standard library                              | Not           |
+  | module names.                                                                                                 | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `_thread <https://docs.python.org/3/whatsnew/3.10.html#_thread>`_                                                             |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | :func:`_thread.interrupt_main` now takes an optional signal number to                                         | Not relevant  |
+  | simulate (the default is still :data:`signal.SIGINT`).                                                        |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
 
 .. rubric:: Notes
 

--- a/docs/differences/python_310.rst
+++ b/docs/differences/python_310.rst
@@ -11,48 +11,48 @@ and a detailed description of the changes can be found in
 .. table::
   :widths: 20 60 20
 
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | **New syntax features**                                                                                     | **Status**   |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ | Structural Pattern Matching: Specification         | [#spm]_      |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 635 <https://www.python.org/dev/peps/pep-0635/>`_ | Structural Pattern Matching: Motivation and        | [#spm]_      |
-  |                                                        | Rationale                                          |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 636 <https://www.python.org/dev/peps/pep-0636/>`_ | Structural Pattern Matching: Tutorial              | [#spm]_      |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `bpo-12782                                             | Parenthesized context managers are now officially  |              |
-  | <https://github.com/python/cpython/issues/56991>`_     | allowed                                            |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | **New features in the standard library**                                                                                   |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 618 <https://www.python.org/dev/peps/pep-0618/>`_ | Add Optional Length-Checking To zip                |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | **Interpreter improvements**                                                                                               |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 626 <https://www.python.org/dev/peps/pep-0626/>`_ | Precise line numbers for debugging and other tools |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | **New typing features**                                                                                                    |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`_ | Allow writing union types as X | Y                 |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 613 <https://www.python.org/dev/peps/pep-0613/>`_ | Explicit Type Aliases                              |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 612 <https://www.python.org/dev/peps/pep-0612/>`_ | Parameter Specification Variables                  |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | **Important deprecations, removals or restrictions**                                                                       |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 644 <https://www.python.org/dev/peps/pep-0644/>`_ | Require OpenSSL 1.1.1 or newer                     |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 632 <https://www.python.org/dev/peps/pep-0632/>`_ | Deprecate distutils module.                        | Not relevant |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 623 <https://www.python.org/dev/peps/pep-0623/>`_ | Deprecate and prepare for the removal of the wstr  | Not relevant |
-  |                                                        | member in PyUnicodeObject.                         |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 624 <https://www.python.org/dev/peps/pep-0624/>`_ | Remove Py_UNICODE encoder APIs                     | Not relevant |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
-  | `PEP 597 <https://www.python.org/dev/peps/pep-0597/>`_ | Add optional EncodingWarning                       |              |
-  +--------------------------------------------------------+----------------------------------------------------+--------------+
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | **New syntax features**                                                                                     | **Status**              |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ | Structural Pattern Matching: Specification         | Not implemented [#spm]_ |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 635 <https://www.python.org/dev/peps/pep-0635/>`_ | Structural Pattern Matching: Motivation and        | Not implemented [#spm]_ |
+  |                                                        | Rationale                                          |                         |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 636 <https://www.python.org/dev/peps/pep-0636/>`_ | Structural Pattern Matching: Tutorial              | Not implemented [#spm]_ |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `bpo-12782                                             | Parenthesized context managers are now officially  | Not implemented         |
+  | <https://github.com/python/cpython/issues/56991>`_     | allowed                                            |                         |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | **New features in the standard library**                                                                                              |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 618 <https://www.python.org/dev/peps/pep-0618/>`_ | Add Optional Length-Checking To zip                | Not implemented         |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | **Interpreter improvements**                                                                                                          |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 626 <https://www.python.org/dev/peps/pep-0626/>`_ | Precise line numbers for debugging and other tools | Not implemented         |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | **New typing features**                                                                                                               |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 604 <https://www.python.org/dev/peps/pep-0604/>`_ | Allow writing union types as X | Y                 | Not implemented [#ann]_ |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 613 <https://www.python.org/dev/peps/pep-0613/>`_ | Explicit Type Aliases                              | Not implemented [#ann]_ |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 612 <https://www.python.org/dev/peps/pep-0612/>`_ | Parameter Specification Variables                  | Not implemented [#ann]_ |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | **Important deprecations, removals or restrictions**                                                                                  |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 644 <https://www.python.org/dev/peps/pep-0644/>`_ | Require OpenSSL 1.1.1 or newer                     | Not relevant            |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 632 <https://www.python.org/dev/peps/pep-0632/>`_ | Deprecate distutils module.                        | Not relevant            |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 623 <https://www.python.org/dev/peps/pep-0623/>`_ | Deprecate and prepare for the removal of the wstr  | Not relevant            |
+  |                                                        | member in PyUnicodeObject.                         |                         |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 624 <https://www.python.org/dev/peps/pep-0624/>`_ | Remove Py_UNICODE encoder APIs                     | Not relevant            |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
+  | `PEP 597 <https://www.python.org/dev/peps/pep-0597/>`_ | Add optional EncodingWarning                       | Not relevant            |
+  +--------------------------------------------------------+----------------------------------------------------+-------------------------+
 
 
 Other Language Changes:
@@ -60,179 +60,187 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | The :class:`int` type has a new method :meth:`int.bit_count`, returning the                                 |               |
-  | number of ones in the binary expansion of a given integer, also known                                       |               |
-  | as the population count.                                                                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | The views returned by :meth:`dict.keys`, :meth:`dict.values` and                                            |               |
-  | :meth:`dict.items` now all have a ``mapping`` attribute that gives a                                        |               |
-  | :class:`types.MappingProxyType` object wrapping the original                                                |               |
-  | dictionary.                                                                                                 |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | :pep:`618`: The :func:`zip` function now has an optional ``strict`` flag, used                              |               |
-  | to require that all the iterables have an equal length.                                                     |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Builtin and extension functions that take integer arguments no longer accept                                |               |
-  | :class:`~decimal.Decimal`\ s, :class:`~fractions.Fraction`\ s and other                                     |               |
-  | objects that can be converted to integers only with a loss (e.g. that have                                  |               |
-  | the :meth:`~object.__int__` method but do not have the                                                      |               |
-  | :meth:`~object.__index__` method).                                                                          |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | If :func:`object.__ipow__` returns :const:`NotImplemented`, the operator will                               |               |
-  | correctly fall back to :func:`object.__pow__` and :func:`object.__rpow__` as expected.                      |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Assignment expressions can now be used unparenthesized within set literals                                  |               |
-  | and set comprehensions, as well as in sequence indexes (but not slices).                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Functions have a new ``__builtins__`` attribute which is used to look for                                   |               |
-  | builtin symbols when a function is executed, instead of looking into                                        |               |
-  | ``__globals__['__builtins__']``. The attribute is initialized from                                          |               |
-  | ``__globals__["__builtins__"]`` if it exists, else from the current builtins.                               |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Two new builtin functions -- :func:`aiter` and :func:`anext` have been added                                |               |
-  | to provide asynchronous counterparts to :func:`iter` and :func:`next`,                                      |               |
-  | respectively.                                                                                               |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Static methods (:func:`@staticmethod <staticmethod>`) and class methods                                     |               |
-  | (:func:`@classmethod <classmethod>`) now inherit the method attributes                                      |               |
-  | (``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,                                               |               |
-  | ``__annotations__``) and have a new ``__wrapped__`` attribute.                                              |               |
-  | Moreover, static methods are now callable as regular functions.                                             |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Annotations for complex targets (everything beside ``simple name`` targets                                  |               |
-  | defined by :pep:`526`) no longer cause any runtime effects with ``from __future__ import annotations``.     |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Class and module objects now lazy-create empty annotations dicts on demand.                                 |               |
-  | The annotations dicts are stored in the object’s ``__dict__`` for                                           |               |
-  | backwards compatibility.  This improves the best practices for working                                      |               |
-  | with ``__annotations__``.                                                                                   |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Annotations consist of ``yield``, ``yield from``, ``await`` or named expressions                            |               |
-  | are now forbidden under ``from __future__ import annotations`` due to their side                            |               |
-  | effects.                                                                                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Usage of unbound variables, ``super()`` and other expressions that might                                    |               |
-  | alter the processing of symbol table as annotations are now rendered                                        |               |
-  | effectless under ``from __future__ import annotations``.                                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Hashes of NaN values of both :class:`float` type and                                                        |               |
-  | :class:`decimal.Decimal` type now depend on object identity. Formerly, they                                 |               |
-  | always hashed to ``0`` even though NaN values are not equal to one another.                                 |               |
-  | This caused potentially quadratic runtime behavior due to excessive hash                                    |               |
-  | collisions when creating dictionaries and sets containing multiple NaNs.                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting                           |               |
-  | the :const:`__debug__` constant.                                                                            |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | :exc:`SyntaxError` exceptions now have ``end_lineno`` and                                                   |               |
-  | ``end_offset`` attributes.  They will be ``None`` if not determined.                                        |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | The :class:`int` type has a new method :meth:`int.bit_count`, returning the                                 | Not implemented |
+  | number of ones in the binary expansion of a given integer, also known                                       |                 |
+  | as the population count.                                                                                    |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | The views returned by :meth:`dict.keys`, :meth:`dict.values` and                                            | Not implemented |
+  | :meth:`dict.items` now all have a ``mapping`` attribute that gives a                                        |                 |
+  | :class:`types.MappingProxyType` object wrapping the original                                                |                 |
+  | dictionary.                                                                                                 |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | :pep:`618`: The :func:`zip` function now has an optional ``strict`` flag, used                              | Not implemented |
+  | to require that all the iterables have an equal length.                                                     |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Builtin and extension functions that take integer arguments no longer accept                                | Not implemented |
+  | :class:`~decimal.Decimal`\ s, :class:`~fractions.Fraction`\ s and other                                     |                 |
+  | objects that can be converted to integers only with a loss (e.g. that have                                  |                 |
+  | the :meth:`~object.__int__` method but do not have the                                                      |                 |
+  | :meth:`~object.__index__` method).                                                                          |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | If :func:`object.__ipow__` returns :const:`NotImplemented`, the operator will                               | Complete        |
+  | correctly fall back to :func:`object.__pow__` and :func:`object.__rpow__` as expected.                      |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Assignment expressions can now be used unparenthesized within set literals                                  | Complete        |
+  | and set comprehensions, as well as in sequence indexes (but not slices).                                    |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Functions have a new ``__builtins__`` attribute which is used to look for                                   | Not implemented |
+  | builtin symbols when a function is executed, instead of looking into                                        |                 |
+  | ``__globals__['__builtins__']``. The attribute is initialized from                                          |                 |
+  | ``__globals__["__builtins__"]`` if it exists, else from the current builtins.                               |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Two new builtin functions -- :func:`aiter` and :func:`anext` have been added                                | Not implemented |
+  | to provide asynchronous counterparts to :func:`iter` and :func:`next`,                                      |                 |
+  | respectively.                                                                                               |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Static methods (:func:`@staticmethod <staticmethod>`) and class methods                                     | Not implemented |
+  | (:func:`@classmethod <classmethod>`) now inherit the method attributes                                      |                 |
+  | (``__module__``, ``__name__``, ``__qualname__``, ``__doc__``,                                               |                 |
+  | ``__annotations__``) and have a new ``__wrapped__`` attribute.                                              |                 |
+  | Moreover, static methods are now callable as regular functions.                                             |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Annotations for complex targets (everything beside ``simple name`` targets                                  | Partial [#ann]_ |
+  | defined by :pep:`526`) no longer cause any runtime effects with ``from __future__ import annotations``.     |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Class and module objects now lazy-create empty annotations dicts on demand.                                 | Not implemented |
+  | The annotations dicts are stored in the object’s ``__dict__`` for                                           |                 |
+  | backwards compatibility.  This improves the best practices for working                                      |                 |
+  | with ``__annotations__``.                                                                                   |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Annotations consist of ``yield``, ``yield from``, ``await`` or named expressions                            | Not implemented |
+  | are now forbidden under ``from __future__ import annotations`` due to their side                            |                 |
+  | effects.                                                                                                    |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Usage of unbound variables, ``super()`` and other expressions that might                                    | Partial [#ann]_ |
+  | alter the processing of symbol table as annotations are now rendered                                        |                 |
+  | effectless under ``from __future__ import annotations``.                                                    |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Hashes of NaN values of both :class:`float` type and                                                        | Not implemented |
+  | :class:`decimal.Decimal` type now depend on object identity. Formerly, they                                 |                 |
+  | always hashed to ``0`` even though NaN values are not equal to one another.                                 |                 |
+  | This caused potentially quadratic runtime behavior due to excessive hash                                    |                 |
+  | collisions when creating dictionaries and sets containing multiple NaNs.                                    |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | A :exc:`SyntaxError` (instead of a :exc:`NameError`) will be raised when deleting                           | Complete        |
+  | the :const:`__debug__` constant.                                                                            |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | :exc:`SyntaxError` exceptions now have ``end_lineno`` and                                                   | Not implemented |
+  | ``end_offset`` attributes.  They will be ``None`` if not determined.                                        |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.10.html#asyncio>`_                                                             |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add missing :meth:`~asyncio.events.AbstractEventLoop.connect_accepted_socket`                                 |               |
-  | method.                                                                                                       |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `array <https://docs.python.org/3/whatsnew/3.10.html#array>`_                                                                 |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The :meth:`~array.array.index` method of :class:`array.array` now has                                         |               |
-  | optional *start* and *stop* parameters.                                                                       |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.10.html#gc>`_                                                                       |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add audit hooks for :func:`gc.get_objects`, :func:`gc.get_referrers` and                                      |               |
-  | :func:`gc.get_referents`.                                                                                     |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `hashlib <https://docs.python.org/3/whatsnew/3.10.html#hashlib>`_                                                             |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The hashlib module requires OpenSSL 1.1.1 or newer.                                                           |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The hashlib module has preliminary support for OpenSSL 3.0.0.                                                 |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The pure-Python fallback of :func:`~hashlib.pbkdf2_hmac` is deprecated. In                                    |               |
-  | the future PBKDF2-HMAC will only be available when Python has been built with                                 |               |
-  | OpenSSL support.                                                                                              |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `os <https://docs.python.org/3/whatsnew/3.10.html#os>`_                                                                       |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :func:`os.cpu_count()` support for VxWorks RTOS.                                                          |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add a new function :func:`os.eventfd` and related helpers to wrap the                                         |               |
-  | ``eventfd2`` syscall on Linux.                                                                                |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :func:`os.splice()` that allows to move data between two file                                             |               |
-  | descriptors without copying between kernel address space and user                                             |               |
-  | address space, where one of the file descriptors must refer to a                                              |               |
-  | pipe.                                                                                                         |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`                                         |               |
-  | and :data:`~os.O_NOFOLLOW_ANY` for macOS.                                                                     |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `platform <https://docs.python.org/3/whatsnew/3.10.html#platform>`_                                                           |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :func:`platform.freedesktop_os_release()` to retrieve operation system                                    |               |
-  | identification from `freedesktop.org os-release                                                               |               |
-  | <https://www.freedesktop.org/software/systemd/man/os-release.html>`_ standard file.                           |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `socket <https://docs.python.org/3/whatsnew/3.10.html#socket>`_                                                               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The exception :exc:`socket.timeout` is now an alias of :exc:`TimeoutError`.                                   |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add option to create MPTCP sockets with ``IPPROTO_MPTCP``.                                                    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add ``IP_RECVTOS`` option to receive the type of service (ToS) or DSCP/ECN fields.                            |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `ssl <https://docs.python.org/3/whatsnew/3.10.html#ssl>`_                                                                     |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The ssl module requires OpenSSL 1.1.1 or newer.                                                               |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The ssl module has preliminary support for OpenSSL 3.0.0 and new option                                       |               |
-  | :data:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.                                                                        |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Deprecated function and use of deprecated constants now result in                                             |               |
-  | a :exc:`DeprecationWarning`. :attr:`ssl.SSLContext.options` has                                               |               |
-  | :data:`~ssl.OP_NO_SSLv2` and :data:`~ssl.OP_NO_SSLv3` set by default and                                      |               |
-  | therefore cannot warn about setting the flag again.                                                           |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The ssl module now has more secure default settings. Ciphers without forward                                  |               |
-  | secrecy or SHA-1 MAC are disabled by default. Security level 2 prohibits                                      |               |
-  | weak RSA, DH, and ECC keys with less than 112 bits of security.                                               |               |
-  | :class:`~ssl.SSLContext` defaults to minimum protocol version TLS 1.2.                                        |               |
-  | Settings are based on Hynek Schlawack's research.                                                             |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The deprecated protocols SSL 3.0, TLS 1.0, and TLS 1.1 are no longer                                          |               |
-  | officially supported. Python does not block them actively. However                                            |               |
-  | OpenSSL build options, distro configurations, vendor patches, and cipher                                      |               |
-  | suites may prevent a successful handshake.                                                                    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add a *timeout* parameter to the :func:`ssl.get_server_certificate` function.                                 |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The ssl module uses heap-types and multi-phase initialization.                                                |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | A new verify flag :data:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.                                      |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.10.html#sys>`_                                                                     |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :data:`sys.orig_argv` attribute: the list of the original command line                                    |               |
-  | arguments passed to the Python executable.                                                                    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Add :data:`sys.stdlib_module_names`, containing the list of the standard library                              |               |
-  | module names.                                                                                                 |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `_thread <https://docs.python.org/3/whatsnew/3.10.html#_thread>`_                                                             |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | :func:`_thread.interrupt_main` now takes an optional signal number to                                         |               |
-  | simulate (the default is still :data:`signal.SIGINT`).                                                        |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.10.html#asyncio>`_                                                               |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add missing :meth:`~asyncio.events.AbstractEventLoop.connect_accepted_socket`                                 | Not implemented |
+  | method.                                                                                                       |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `array <https://docs.python.org/3/whatsnew/3.10.html#array>`_                                                                   |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The :meth:`~array.array.index` method of :class:`array.array` now has                                         | Not implemented |
+  | optional *start* and *stop* parameters.                                                                       |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.10.html#gc>`_                                                                         |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add audit hooks for :func:`gc.get_objects`, :func:`gc.get_referrers` and                                      | Not relevant    |
+  | :func:`gc.get_referents`.                                                                                     |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `hashlib <https://docs.python.org/3/whatsnew/3.10.html#hashlib>`_                                                               |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The hashlib module requires OpenSSL 1.1.1 or newer.                                                           | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The hashlib module has preliminary support for OpenSSL 3.0.0.                                                 | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The pure-Python fallback of :func:`~hashlib.pbkdf2_hmac` is deprecated. In                                    | Not relevant    |
+  | the future PBKDF2-HMAC will only be available when Python has been built with                                 |                 |
+  | OpenSSL support.                                                                                              |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `os <https://docs.python.org/3/whatsnew/3.10.html#os>`_                                                                         |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :func:`os.cpu_count()` support for VxWorks RTOS.                                                          | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add a new function :func:`os.eventfd` and related helpers to wrap the                                         | Not relevant    |
+  | ``eventfd2`` syscall on Linux.                                                                                |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :func:`os.splice()` that allows to move data between two file                                             | Not relevant    |
+  | descriptors without copying between kernel address space and user                                             |                 |
+  | address space, where one of the file descriptors must refer to a                                              |                 |
+  | pipe.                                                                                                         |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :data:`~os.O_EVTONLY`, :data:`~os.O_FSYNC`, :data:`~os.O_SYMLINK`                                         | Not relevant    |
+  | and :data:`~os.O_NOFOLLOW_ANY` for macOS.                                                                     |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `platform <https://docs.python.org/3/whatsnew/3.10.html#platform>`_                                                             |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :func:`platform.freedesktop_os_release()` to retrieve operation system                                    | Not relevant    |
+  | identification from `freedesktop.org os-release                                                               |                 |
+  | <https://www.freedesktop.org/software/systemd/man/os-release.html>`_ standard file.                           |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `socket <https://docs.python.org/3/whatsnew/3.10.html#socket>`_                                                                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The exception :exc:`socket.timeout` is now an alias of :exc:`TimeoutError`.                                   | Not implemented |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add option to create MPTCP sockets with ``IPPROTO_MPTCP``.                                                    | Not implemented |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add ``IP_RECVTOS`` option to receive the type of service (ToS) or DSCP/ECN fields.                            | Not implemented |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `ssl <https://docs.python.org/3/whatsnew/3.10.html#ssl>`_                                                                       |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The ssl module requires OpenSSL 1.1.1 or newer.                                                               | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The ssl module has preliminary support for OpenSSL 3.0.0 and new option                                       | Not relevant    |
+  | :data:`~ssl.OP_IGNORE_UNEXPECTED_EOF`.                                                                        |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Deprecated function and use of deprecated constants now result in                                             | Not relevant    |
+  | a :exc:`DeprecationWarning`. :attr:`ssl.SSLContext.options` has                                               |                 |
+  | :data:`~ssl.OP_NO_SSLv2` and :data:`~ssl.OP_NO_SSLv3` set by default and                                      |                 |
+  | therefore cannot warn about setting the flag again.                                                           |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The ssl module now has more secure default settings. Ciphers without forward                                  | Not relevant    |
+  | secrecy or SHA-1 MAC are disabled by default. Security level 2 prohibits                                      |                 |
+  | weak RSA, DH, and ECC keys with less than 112 bits of security.                                               |                 |
+  | :class:`~ssl.SSLContext` defaults to minimum protocol version TLS 1.2.                                        |                 |
+  | Settings are based on Hynek Schlawack's research.                                                             |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The deprecated protocols SSL 3.0, TLS 1.0, and TLS 1.1 are no longer                                          | Partial [#tls]_ |
+  | officially supported. Python does not block them actively. However                                            |                 |
+  | OpenSSL build options, distro configurations, vendor patches, and cipher                                      |                 |
+  | suites may prevent a successful handshake.                                                                    |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add a *timeout* parameter to the :func:`ssl.get_server_certificate` function.                                 | Not implemented |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | The ssl module uses heap-types and multi-phase initialization.                                                | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | A new verify flag :data:`~ssl.VERIFY_X509_PARTIAL_CHAIN` has been added.                                      | Not relevant    |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.10.html#sys>`_                                                                       |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :data:`sys.orig_argv` attribute: the list of the original command line                                    | Not implemented |
+  | arguments passed to the Python executable.                                                                    |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | Add :data:`sys.stdlib_module_names`, containing the list of the standard library                              | Not implemented |
+  | module names.                                                                                                 |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | `_thread <https://docs.python.org/3/whatsnew/3.10.html#_thread>`_                                                               |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
+  | :func:`_thread.interrupt_main` now takes an optional signal number to                                         | Not relevant    |
+  | simulate (the default is still :data:`signal.SIGINT`).                                                        |                 |
+  +---------------------------------------------------------------------------------------------------------------+-----------------+
 
 .. rubric:: Notes
 
 .. [#spm] The structural pattern matching feature is discussed in `issue #7847 <https://github.com/micropython/micropython/issues/7847>`_.
+
+.. [#ann] MicroPython parses type annotations but never evaluates them, so annotations produce no runtime
+   effects and no ``__annotations__`` attributes are created.  There is also no ``typing`` module and no
+   ``__future__`` module, so these features cannot be used other than as inert annotations.
+
+.. [#tls] MicroPython's ``ssl`` module is implemented on top of Mbed TLS (axTLS on a few ports), not
+   OpenSSL.  Ports using Mbed TLS 3.x support TLS 1.2 and later only, so the deprecated protocols are
+   already unavailable there, but ports using axTLS support only the older protocols.
 

--- a/docs/differences/python_311.rst
+++ b/docs/differences/python_311.rst
@@ -229,7 +229,7 @@ Changes to built-in modules:
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
   | `re <https://docs.python.org/3/whatsnew/3.11.html#re>`_                                                                              |
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
-  | Atomic grouping (``(?>...)``) and possessive quantifiers (``*+``, ``++``, ``?+``, ``{m,n}+``)    | Not implemented [#re]_            |
+  | Atomic grouping (``(?>...)``) and possessive quantifiers (``*+``, ``++``, ``?+``, ``{m,n}+``)    | Not implemented [#relib]_         |
   | are now supported in regular expressions.                                                        |                                   |
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
   | `shutil <https://docs.python.org/3/whatsnew/3.11.html#shutil>`_                                                                      |
@@ -285,7 +285,7 @@ Changes to built-in modules:
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
   | `unicodedata <https://docs.python.org/3/whatsnew/3.11.html#unicodedata>`_                                                            |
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
-  | The Unicode database has been updated to version 14.0.0.                                         | Not relevant [#unicodedata]_      |
+  | The Unicode database has been updated to version 14.0.0.                                         | Not relevant [#udata]_            |
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
   | `unittest <https://docs.python.org/3/whatsnew/3.11.html#unittest>`_                                                                  |
   +--------------------------------------------------------------------------------------------------+-----------------------------------+
@@ -334,7 +334,7 @@ machinery [#warnmod]_, so none of these produce a diagnostic:
   +---------------------------------------------------------------------------------------------------------+----------------------------+
   | The :func:`locale.getdefaultlocale` and ``locale.resetlocale()`` functions are deprecated.              | Not relevant               |
   +---------------------------------------------------------------------------------------------------------+----------------------------+
-  | Stricter rules will now be applied for numerical group references and group names in regular            | Not relevant [#re]_        |
+  | Stricter rules will now be applied for numerical group references and group names in regular            | Not relevant [#relib]_     |
   | expressions.                                                                                            |                            |
   +---------------------------------------------------------------------------------------------------------+----------------------------+
   | In the :mod:`re` module, the ``re.template()`` function and the corresponding ``re.TEMPLATE`` and       | Not relevant               |
@@ -362,7 +362,7 @@ Removals:
 
   +-----------------------------------------------------------------------------------------------------+--------------------------------+
   | Removed the ``@asyncio.coroutine`` decorator enabling legacy generator-based coroutines to be       | Not relevant                   |
-  | compatible with :keyword:`async` / :keyword:`await` code, and ``asyncio.coroutines.CoroWrapper``.   |                                |
+  | compatible with ``async`` / ``await`` code, and ``asyncio.coroutines.CoroWrapper``.                 |                                |
   +-----------------------------------------------------------------------------------------------------+--------------------------------+
   | The *reuse_address* parameter of :meth:`asyncio.loop.create_datagram_endpoint` is now entirely      | Not relevant                   |
   | removed.                                                                                            |                                |
@@ -451,7 +451,7 @@ Removals:
 .. [#glob] micropython-lib's ``pathlib.Path.glob()`` and ``rglob()`` support only a single ``*``
    wildcard and always yield entries of any kind, so a trailing separator has no special meaning.
 
-.. [#re] MicroPython's ``re`` module is based on `re1.5 <https://github.com/pfalcon/re1.5>`_, a
+.. [#relib] MicroPython's ``re`` module is based on `re1.5 <https://github.com/pfalcon/re1.5>`_, a
    compact backtracking engine that is unrelated to CPython's.  It has no atomic groups, possessive
    quantifiers, named groups or group references; unsupported syntax raises ``ValueError: regex too
    complex``.
@@ -478,7 +478,7 @@ Removals:
    ``print_*()`` functions; there are no ``StackSummary``, ``FrameSummary`` or ``TracebackException``
    classes.
 
-.. [#unicodedata] MicroPython has no ``unicodedata`` module and no Unicode character database.  Only
+.. [#udata] MicroPython has no ``unicodedata`` module and no Unicode character database.  Only
    the ASCII range is handled for case conversion and character classification.
 
 .. [#warnmod] micropython-lib's ``warnings`` module provides only a ``warn()`` function that prints

--- a/docs/differences/python_311.rst
+++ b/docs/differences/python_311.rst
@@ -1,0 +1,508 @@
+.. _python_311:
+
+Python 3.11
+===========
+
+Python 3.11.0 (final) was released on the 24 October 2022.  Unlike Python 3.10 there is no PEP
+enumerating the features for this release -- `PEP 664 <https://peps.python.org/pep-0664/>`_ only
+defines the release schedule -- so the tables below follow `What's New in Python 3.11
+<https://docs.python.org/3/whatsnew/3.11.html>`_ instead.
+
+Unlike the pages for Python 3.5 to 3.10, this page also covers modules that MicroPython provides
+only as pure-Python packages in `micropython-lib
+<https://github.com/micropython/micropython-lib>`_, such as ``contextlib``, ``datetime``,
+``functools``, ``inspect``, ``locale``, ``logging``, ``operator``, ``pathlib``, ``shutil``,
+``string``, ``threading``, ``traceback``, ``unittest`` and ``warnings``.  Those packages are
+installed with ``mip`` or frozen into a firmware build, they are not part of the interpreter
+itself.  Rows that concern them are marked with [#mplib]_, or their note names the micropython-lib
+package explicitly.
+
+Note that MicroPython's coverage of CPython does not advance strictly in version order.  Some much
+later features are already available -- for example :pep:`750` template strings from Python 3.14
+are implemented on builds with ``MICROPY_PY_TSTRINGS`` enabled -- while several 3.11 features such
+as ``except*`` are not.
+
+.. table::
+  :widths: 20 60 20
+
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **New syntax features**                                                                               | **Status**                   |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 654 <https://peps.python.org/pep-0654/>`_       | Exception Groups and ``except*``               | Not implemented              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **New built-in features**                                                                                                            |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 678 <https://peps.python.org/pep-0678/>`_       | Enriching Exceptions with Notes                | Not implemented              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **New standard library modules**                                                                                                     |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 680 <https://peps.python.org/pep-0680/>`_       | ``tomllib``: Support for Parsing TOML in the   | Not implemented              |
+  |                                                      | Standard Library                               |                              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **Interpreter improvements**                                                                                                         |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 657 <https://peps.python.org/pep-0657/>`_       | Fine-grained Error Locations in Tracebacks     | Not implemented [#pep657]_   |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `gh-57684                                            | New ``-P`` command line option and             | Not implemented [#safepath]_ |
+  | <https://github.com/python/cpython/issues/57684>`_   | ``PYTHONSAFEPATH`` environment variable to     |                              |
+  |                                                      | disable automatically prepending potentially   |                              |
+  |                                                      | unsafe paths to ``sys.path``                   |                              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **New typing features**                                                                                                              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 646 <https://peps.python.org/pep-0646/>`_       | Variadic Generics                              | Not implemented [#ann]_      |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 655 <https://peps.python.org/pep-0655/>`_       | Marking individual TypedDict items as required | Not implemented [#ann]_      |
+  |                                                      | or potentially-missing                         |                              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 673 <https://peps.python.org/pep-0673/>`_       | Self type                                      | Not implemented [#ann]_      |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 675 <https://peps.python.org/pep-0675/>`_       | Arbitrary Literal String Type                  | Not implemented [#ann]_      |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 681 <https://peps.python.org/pep-0681/>`_       | Data Class Transforms                          | Not implemented [#ann]_      |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | **Important deprecations, removals or restrictions**                                                                                 |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 594 <https://peps.python.org/pep-0594/>`_       | Many legacy standard library modules have been | Not implemented [#pep594]_   |
+  |                                                      | deprecated and will be removed in Python 3.13  |                              |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 624 <https://peps.python.org/pep-0624/>`_       | Py_UNICODE encoder APIs have been removed      | Not relevant                 |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+  | `PEP 670 <https://peps.python.org/pep-0670/>`_       | Macros converted to static inline functions    | Not relevant                 |
+  +------------------------------------------------------+------------------------------------------------+------------------------------+
+
+
+Other Language Changes:
+
+.. table::
+  :widths: 90 10
+
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | Starred unpacking expressions can now be used in :keyword:`for` statements.                       | Not implemented [#starunpack]_   |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | Asynchronous :ref:`comprehensions <comprehensions>` are now allowed inside comprehensions in      | Not implemented [#asyncgen]_     |
+  | :ref:`asynchronous functions <async def>`. Outer comprehensions implicitly become asynchronous in |                                  |
+  | this case.                                                                                        |                                  |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | A :exc:`TypeError` is now raised instead of an :exc:`AttributeError` in :keyword:`with`           | Not implemented [#withtype]_     |
+  | statements and :meth:`contextlib.ExitStack.enter_context` for objects that do not support the     |                                  |
+  | context manager protocol, and in :keyword:`async with` statements and                             |                                  |
+  | :meth:`contextlib.AsyncExitStack.enter_async_context` for objects not supporting the asynchronous |                                  |
+  | context manager protocol.                                                                         |                                  |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | Added :meth:`object.__getstate__`, which provides the default implementation of the               | Not implemented [#getstate]_     |
+  | ``__getstate__()`` method.  Copying and pickling instances of subclasses of builtin types now     |                                  |
+  | also copies and pickles instance attributes implemented as slots.                                 |                                  |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | A ``"z"`` option was added to the format specification mini-language that coerces negative to     | Not implemented                  |
+  | positive zero after rounding to the format precision.  See :pep:`682` for more details.           |                                  |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | Bytes are no longer accepted on :data:`sys.path`.                                                 | Not implemented [#syspathbytes]_ |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+  | :meth:`int.to_bytes` and :meth:`int.from_bytes` gained default argument values, so ``length``     | Complete [#notwhatsnew]_         |
+  | defaults to ``1`` and ``byteorder`` defaults to ``"big"``.                                        |                                  |
+  +---------------------------------------------------------------------------------------------------+----------------------------------+
+
+Changes to built-in modules:
+
+.. table::
+  :widths: 90 10
+
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.11.html#asyncio>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added the :class:`~asyncio.TaskGroup` class, an asynchronous context manager holding a group of  | Not implemented                   |
+  | tasks that will wait for all of them upon exit.                                                  |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added :func:`~asyncio.timeout`, an asynchronous context manager for setting a timeout on         | Not implemented                   |
+  | asynchronous operations.                                                                         |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added the :class:`~asyncio.Runner` class, which exposes the machinery used by                    | Not implemented                   |
+  | :func:`~asyncio.run`.                                                                            |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added the :class:`~asyncio.Barrier` class to the synchronization primitives, and the related     | Not implemented                   |
+  | :exc:`~asyncio.BrokenBarrierError` exception.                                                    |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added keyword argument *all_errors* to :meth:`asyncio.loop.create_connection` so that multiple   | Not implemented                   |
+  | connection errors can be raised as an :exc:`ExceptionGroup`.                                     |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added the :meth:`asyncio.StreamWriter.start_tls` method for upgrading existing stream-based      | Not implemented                   |
+  | connections to TLS.                                                                              |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added raw datagram socket functions to the event loop: :meth:`~asyncio.loop.sock_sendto`,        | Not implemented                   |
+  | :meth:`~asyncio.loop.sock_recvfrom` and :meth:`~asyncio.loop.sock_recvfrom_into`.                |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added :meth:`~asyncio.Task.cancelling` and :meth:`~asyncio.Task.uncancel` methods to             | Not implemented                   |
+  | :class:`~asyncio.Task`.                                                                          |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `binascii <https://docs.python.org/3/library/binascii.html>`_                                                                        |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`binascii.a2b_base64` gained a *strict_mode* keyword argument that rejects invalid padding | Not implemented [#notwhatsnew]_   |
+  | and non-base64 characters.                                                                       |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `contextlib <https://docs.python.org/3/whatsnew/3.11.html#contextlib>`_                                                              |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added non parallel-safe :func:`~contextlib.chdir` context manager to change the current working  | Not implemented [#mplib]_         |
+  | directory and then restore it on exit.                                                           |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `datetime <https://docs.python.org/3/whatsnew/3.11.html#datetime>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :const:`datetime.UTC`, a convenience alias for :attr:`datetime.timezone.utc`.                | Not implemented [#mplib]_         |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :meth:`datetime.date.fromisoformat`, :meth:`datetime.time.fromisoformat` and                     | Not implemented [#mplib]_         |
+  | :meth:`datetime.datetime.fromisoformat` can now be used to parse most ISO 8601 formats.          |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `functools <https://docs.python.org/3/whatsnew/3.11.html#functools>`_                                                                |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`functools.singledispatch` now supports :class:`types.UnionType` and :data:`typing.Union`  | Not implemented [#mplib]_ [#ann]_ |
+  | as annotations to the dispatch argument.                                                         |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `gzip <https://docs.python.org/3/whatsnew/3.11.html#gzip>`_                                                                          |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | The :func:`gzip.compress` function is now faster when used with the ``mtime=0`` argument as it   | Not relevant [#gzipmtime]_        |
+  | delegates the compression entirely to a single :func:`zlib.compress` operation.                  |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `hashlib <https://docs.python.org/3/whatsnew/3.11.html#hashlib>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`hashlib.blake2b` and :func:`hashlib.blake2s` now prefer libb2 over Python's vendored      | Not relevant [#hashalgo]_         |
+  | copy.                                                                                            |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | The internal ``_sha3`` module with SHA3 and SHAKE algorithms now uses *tiny_sha3* instead of the | Not relevant [#hashalgo]_         |
+  | *Keccak Code Package* to reduce code and binary size.                                            |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`hashlib.file_digest`, a helper function for efficient hashing of files or file-like   | Not implemented                   |
+  | objects.                                                                                         |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `inspect <https://docs.python.org/3/whatsnew/3.11.html#inspect>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`~inspect.getmembers_static` to return all members without triggering dynamic lookup   | Not implemented [#mplib]_         |
+  | via the descriptor protocol.                                                                     |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`~inspect.ismethodwrapper` for checking if the type of an object is a                  | Not implemented [#mplib]_         |
+  | :class:`~types.MethodWrapperType`.                                                               |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Change the frame-related functions to return new :class:`~inspect.FrameInfo` and                 | Not implemented [#mplib]_         |
+  | :class:`~inspect.Traceback` class instances that include the extended :pep:`657` position        |                                   |
+  | information.                                                                                     |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `locale <https://docs.python.org/3/whatsnew/3.11.html#locale>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`locale.getencoding` to get the current locale encoding.                               | Not implemented [#mplib]_         |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `logging <https://docs.python.org/3/whatsnew/3.11.html#logging>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added :func:`~logging.getLevelNamesMapping` to return a mapping from logging level names to the  | Not implemented [#mplib]_         |
+  | values of their corresponding logging levels.                                                    |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added a :meth:`~logging.handlers.SysLogHandler.createSocket` method to                           | Not relevant [#mplib]_            |
+  | :class:`~logging.handlers.SysLogHandler`.                                                        |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.11.html#math>`_                                                                          |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`math.exp2`: return 2 raised to the power of x.                                        | Not implemented                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`math.cbrt`: return the cube root of x.                                                | Not implemented                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | The behaviour of two :func:`math.pow` corner cases was changed, for consistency with the IEEE    | Complete [#mathpow]_              |
+  | 754 specification.  The operations ``math.pow(0.0, -math.inf)`` and ``math.pow(-0.0,             |                                   |
+  | -math.inf)`` now return ``inf``.  Previously they raised :exc:`ValueError`.                      |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | The :data:`math.nan` value is now always available.                                              | Complete                          |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `operator <https://docs.python.org/3/whatsnew/3.11.html#operator>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | A new function ``operator.call`` has been added, such that ``operator.call(obj, *args, **kwargs) | Not implemented [#mplib]_         |
+  | == obj(*args, **kwargs)``.                                                                       |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `os <https://docs.python.org/3/whatsnew/3.11.html#os>`_                                                                              |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | On Windows, :func:`os.urandom` now uses ``BCryptGenRandom()``, instead of ``CryptGenRandom()``   | Not relevant                      |
+  | which is deprecated.                                                                             |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | As of 3.11.10, :func:`os.mkdir` and :func:`os.makedirs` on Windows now support passing a *mode*  | Not relevant                      |
+  | value of ``0o700`` to apply access control to the new directory.                                 |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `pathlib <https://docs.python.org/3/whatsnew/3.11.html#pathlib>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :meth:`~pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` return only directories if *pattern*  | Not implemented [#glob]_          |
+  | ends with a pathname components separator.                                                       |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `re <https://docs.python.org/3/whatsnew/3.11.html#re>`_                                                                              |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Atomic grouping (``(?>...)``) and possessive quantifiers (``*+``, ``++``, ``?+``, ``{m,n}+``)    | Not implemented [#re]_            |
+  | are now supported in regular expressions.                                                        |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `shutil <https://docs.python.org/3/whatsnew/3.11.html#shutil>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add optional parameter *dir_fd* in :func:`shutil.rmtree`.                                        | Not implemented [#mplib]_         |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `socket <https://docs.python.org/3/whatsnew/3.11.html#socket>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add CAN Socket support for NetBSD.                                                               | Not relevant                      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`~socket.create_connection` has an option to raise, in case of failure to connect, an      | Not implemented                   |
+  | :exc:`ExceptionGroup` containing all errors instead of only raising the last error.              |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `string <https://docs.python.org/3/whatsnew/3.11.html#string>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :meth:`~string.Template.get_identifiers` and :meth:`~string.Template.is_valid` to            | Not implemented [#template]_      |
+  | :class:`string.Template`.                                                                        |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.11.html#sys>`_                                                                            |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`sys.exc_info` now derives the ``type`` and ``traceback`` fields from the ``value`` (the   | Complete [#excinfo]_              |
+  | exception instance), so when an exception is modified while it is being handled, the changes are |                                   |
+  | reflected in the results of subsequent calls to ``exc_info()``.                                  |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`sys.exception` which returns the active exception instance (equivalent to             | Not implemented                   |
+  | ``sys.exc_info()[1]``).                                                                          |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add the ``sys.flags.safe_path`` flag.                                                            | Not implemented [#safepath]_      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `threading <https://docs.python.org/3/whatsnew/3.11.html#threading>`_                                                                |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | On Unix, if the ``sem_clockwait()`` function is available in the C library, the                  | Not relevant [#locktimeout]_      |
+  | :meth:`threading.Lock.acquire` method now uses the monotonic clock for the timeout, rather than  |                                   |
+  | using the system clock, to not be affected by system clock changes.                              |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `time <https://docs.python.org/3/whatsnew/3.11.html#time>`_                                                                          |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | On Unix, :func:`time.sleep` now uses the ``clock_nanosleep()`` or ``nanosleep()`` function, if   | Not implemented [#sleep]_         |
+  | available, which has a resolution of 1 nanosecond, rather than using ``select()`` which has a    |                                   |
+  | resolution of 1 microsecond.                                                                     |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | On Windows 8.1 and newer, :func:`time.sleep` now uses a waitable timer based on high-resolution  | Not implemented [#sleep]_         |
+  | timers which has a resolution of 100 nanoseconds.  Previously, it had a resolution of 1          |                                   |
+  | millisecond.                                                                                     |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `traceback <https://docs.python.org/3/whatsnew/3.11.html#traceback>`_                                                                |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`traceback.StackSummary.format_frame_summary` to allow users to override which frames  | Not implemented [#tbmod]_         |
+  | appear in the traceback, and how they are formatted.                                             |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Add :func:`traceback.TracebackException.print`, which prints the formatted                       | Not implemented [#tbmod]_         |
+  | :exc:`~traceback.TracebackException` instance to a file.                                         |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `unicodedata <https://docs.python.org/3/whatsnew/3.11.html#unicodedata>`_                                                            |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | The Unicode database has been updated to version 14.0.0.                                         | Not relevant [#unicodedata]_      |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `unittest <https://docs.python.org/3/whatsnew/3.11.html#unittest>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | Added methods :meth:`~unittest.TestCase.enterContext` and                                        | Not implemented [#mplib]_         |
+  | :meth:`~unittest.TestCase.enterClassContext`, method                                             |                                   |
+  | :meth:`~unittest.IsolatedAsyncioTestCase.enterAsyncContext` and function                         |                                   |
+  | :func:`unittest.enterModuleContext`.                                                             |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | `warnings <https://docs.python.org/3/whatsnew/3.11.html#warnings>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+  | :func:`warnings.catch_warnings` now accepts arguments for :func:`warnings.simplefilter`,         | Not implemented [#warnmod]_       |
+  | providing a more concise way to locally ignore warnings or convert them to errors.               |                                   |
+  +--------------------------------------------------------------------------------------------------+-----------------------------------+
+
+Deprecations.  MicroPython has no warning categories and no warning
+machinery [#warnmod]_, so none of these produce a diagnostic:
+
+.. table::
+  :widths: 90 10
+
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Chaining :class:`classmethod` descriptors is now deprecated.  It can no longer be used to wrap other    | Not relevant [#cmchain]_   |
+  | descriptors such as :class:`property`.                                                                  |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Octal escapes in string and bytes literals with values larger than ``0o377`` (255 in decimal) now       | Not implemented [#octal]_  |
+  | produce a :exc:`DeprecationWarning`.                                                                    |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The delegation of :func:`int` to :meth:`~object.__trunc__` is now deprecated.                           | Not relevant [#trunc]_     |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | :pep:`594` led to the deprecation of ``aifc``, ``audioop``, ``cgi``, ``cgitb``, ``chunk``, ``crypt``,   | Not implemented [#pep594]_ |
+  | ``imghdr``, ``mailcap``, ``msilib``, ``nis``, ``nntplib``, ``ossaudiodev``, ``pipes``, ``sndhdr``,      |                            |
+  | ``spwd``, ``sunau``, ``telnetlib``, ``uu`` and ``xdrlib``.                                              |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The ``asynchat``, ``asyncore`` and ``smtpd`` modules have been deprecated since at least Python 3.6,    | Not relevant               |
+  | and will be removed in Python 3.12.                                                                     |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The ``lib2to3`` package and ``2to3`` tool are now deprecated.                                           | Not relevant               |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Undocumented modules ``sre_compile``, ``sre_constants`` and ``sre_parse`` are now deprecated.           | Not relevant               |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Several long-deprecated :mod:`configparser` names (``SafeConfigParser``, ``ParsingError.filename``,     | Not relevant               |
+  | ``RawConfigParser.readfp()`` and ``LegacyInterpolation``) are now scheduled for removal.                |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The older set of :mod:`importlib.resources` functions were deprecated in favour of the replacements     | Not relevant               |
+  | added in Python 3.9.                                                                                    |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The :func:`locale.getdefaultlocale` and ``locale.resetlocale()`` functions are deprecated.              | Not relevant               |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Stricter rules will now be applied for numerical group references and group names in regular            | Not relevant [#re]_        |
+  | expressions.                                                                                            |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | In the :mod:`re` module, the ``re.template()`` function and the corresponding ``re.TEMPLATE`` and       | Not relevant               |
+  | ``re.T`` flags are deprecated.                                                                          |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | ``turtle.settiltangle()`` has been deprecated since Python 3.1; it now emits a deprecation warning.     | Not relevant               |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | :class:`typing.Text` is now deprecated, as is the keyword argument syntax for constructing              | Not relevant [#ann]_       |
+  | :data:`typing.TypedDict` types.                                                                         |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | ``webbrowser.MacOSX`` is deprecated.                                                                    | Not relevant               |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | The behavior of returning a value from a :class:`~unittest.TestCase` and                                | Not implemented [#mplib]_  |
+  | :class:`~unittest.IsolatedAsyncioTestCase` test method (other than the default ``None`` value) is now   |                            |
+  | deprecated.                                                                                             |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+  | Deprecated the not-formally-documented :mod:`unittest` functions ``findTestCases()``, ``makeSuite()``,  | Not relevant               |
+  | ``getTestCaseNames()`` and ``TestProgram.usageExit()``.                                                 |                            |
+  +---------------------------------------------------------------------------------------------------------+----------------------------+
+
+Removals:
+
+.. table::
+  :widths: 90 10
+
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the ``@asyncio.coroutine`` decorator enabling legacy generator-based coroutines to be       | Not relevant                   |
+  | compatible with :keyword:`async` / :keyword:`await` code, and ``asyncio.coroutines.CoroWrapper``.   |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | The *reuse_address* parameter of :meth:`asyncio.loop.create_datagram_endpoint` is now entirely      | Not relevant                   |
+  | removed.                                                                                            |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the ``binhex`` module and the related ``binascii`` functions ``a2b_hqx()``, ``b2a_hqx()``,  | Not relevant [#binhex]_        |
+  | ``rlecode_hqx()`` and ``rldecode_hqx()``.  The ``binascii.crc_hqx()`` function remains available.   |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the :mod:`distutils` ``bdist_msi`` command.                                                 | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the :meth:`~object.__getitem__` methods of ``xml.dom.pulldom.DOMEventStream``,              | Not relevant                   |
+  | ``wsgiref.util.FileWrapper`` and ``fileinput.FileInput``.                                           |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the deprecated :mod:`gettext` functions ``lgettext()``, ``ldgettext()``, ``lngettext()``,   | Not relevant                   |
+  | ``ldngettext()`` and ``bind_textdomain_codeset()``, and related methods and parameters.             |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed ``inspect.getargspec()``, ``inspect.formatargspec()`` and the undocumented                  | Not implemented [#getargspec]_ |
+  | ``Signature.from_builtin()`` and ``Signature.from_function()`` methods.                             |                                |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the :meth:`~object.__class_getitem__` method from ``pathlib.PurePath``.                     | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the ``MailmanProxy`` class in the ``smtpd`` module.                                         | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the deprecated ``split()`` method of ``_tkinter.TkappType``.                                | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed namespace package support from :mod:`unittest` discovery.                                   | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Removed the undocumented private ``float.__set_format__()`` method.                                 | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | The ``--experimental-isolated-subinterpreters`` configure flag has been removed.                    | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+  | Pynche, the Pythonically Natural Color and Hue Editor, has been moved out of ``Tools/scripts``.     | Not relevant                   |
+  +-----------------------------------------------------------------------------------------------------+--------------------------------+
+
+.. rubric:: Notes
+
+.. [#mplib] This module is not built into MicroPython.  It is provided as a pure-Python package by
+   `micropython-lib <https://github.com/micropython/micropython-lib>`_, which can be installed with
+   ``mip`` or frozen into a firmware build.  These packages implement a useful subset of the CPython
+   module rather than the full API.
+
+.. [#ann] MicroPython parses type annotations but never evaluates them, so annotations produce no
+   runtime effects and no ``__annotations__`` attributes are created.  There is no ``typing`` module,
+   and micropython-lib's ``__future__`` package only defines the feature-flag constants -- the
+   compiler ignores them.  These features can therefore only be used as inert annotations.
+
+.. [#pep657] MicroPython tracebacks list only the file name, line number and function name for each
+   frame.  Neither the source line nor the fine-grained column information added by :pep:`657` is
+   available, because the source text is not retained after compilation.
+
+.. [#safepath] MicroPython has no ``-P`` option, no ``PYTHONSAFEPATH`` handling and no ``sys.flags``
+   object at all.  The unix port does prepend the script's directory to ``sys.path``, so it is
+   subject to the same module shadowing that ``-P`` was added to avoid.
+
+.. [#pep594] Of the modules deprecated by :pep:`594`, only ``uu`` exists for MicroPython, as a
+   micropython-lib package.  It is not deprecated there.  None of the others were ever implemented.
+
+.. [#starunpack] MicroPython does not support starred unpacking in displays at all (the :pep:`448`
+   feature from Python 3.5), so neither ``for x in *a, *b:`` nor ``(*a, *b)`` can be compiled; both
+   raise ``SyntaxError: *x must be assignment target``.
+
+.. [#asyncgen] MicroPython does not support asynchronous generators at all.  An ``async def``
+   function containing ``yield`` produces an ordinary generator with no ``__aiter__`` method, so it
+   cannot be used with ``async for``, and asynchronous comprehensions cannot be written in the first
+   place.
+
+.. [#withtype] MicroPython still raises ``AttributeError`` for objects that do not implement the
+   context manager protocol, both for ``with``/``async with`` statements and for micropython-lib's
+   ``contextlib.ExitStack.enter_context()``.
+
+.. [#getstate] MicroPython has no ``object.__getstate__()``, and neither ``copy`` nor ``pickle``
+   support ``__slots__``.  The ``copy`` and ``pickle`` modules are micropython-lib packages.
+
+.. [#syspathbytes] MicroPython still accepts ``bytes`` entries on ``sys.path`` and imports from them
+   successfully; no error or warning is produced.
+
+.. [#notwhatsnew] This change is not listed in *What's New in Python 3.11* but is recorded as a
+   3.11 change in the CPython library reference.
+
+.. [#gzipmtime] micropython-lib's ``gzip.compress()`` has no *mtime* parameter at all; it always
+   delegates to the built-in ``deflate`` module, which writes a fixed gzip header.
+
+.. [#hashalgo] MicroPython's ``hashlib`` provides only MD5, SHA-1 and SHA-256 (with SHA-224, SHA-384
+   and SHA-512 available from micropython-lib).  There is no BLAKE2 or SHA-3 implementation, and no
+   OpenSSL dependency.
+
+.. [#glob] micropython-lib's ``pathlib.Path.glob()`` and ``rglob()`` support only a single ``*``
+   wildcard and always yield entries of any kind, so a trailing separator has no special meaning.
+
+.. [#re] MicroPython's ``re`` module is based on `re1.5 <https://github.com/pfalcon/re1.5>`_, a
+   compact backtracking engine that is unrelated to CPython's.  It has no atomic groups, possessive
+   quantifiers, named groups or group references; unsupported syntax raises ``ValueError: regex too
+   complex``.
+
+.. [#template] micropython-lib's ``string`` package provides only the character-class constants and
+   a ``translate()`` helper; there is no ``Template`` class.
+
+.. [#excinfo] MicroPython stores only the exception instance, so ``sys.exc_info()`` has always
+   derived the type from the value, matching the Python 3.11 behaviour.  MicroPython exceptions have
+   no ``__traceback__`` attribute, however, and the third element of the tuple is always ``None``.
+
+.. [#mathpow] MicroPython's ``math.pow()`` delegates to the C library ``pow()`` and has never had
+   CPython's pre-3.11 special case, so these corner cases have always returned ``inf``.
+
+.. [#locktimeout] MicroPython's ``_thread`` lock has no timeout support: ``acquire()`` accepts a
+   timeout argument for compatibility but silently ignores it, so a blocking acquire never times
+   out.  micropython-lib's ``threading`` module provides only ``Thread``, not ``Lock``.
+
+.. [#sleep] MicroPython's ``time.sleep()`` resolution is port-specific.  The unix port still uses
+   ``select()`` and the windows port uses ``Sleep()``, which has millisecond resolution.  All ports
+   additionally provide ``time.sleep_ms()`` and ``time.sleep_us()``.
+
+.. [#tbmod] micropython-lib's ``traceback`` module provides only the module-level ``format_*()`` and
+   ``print_*()`` functions; there are no ``StackSummary``, ``FrameSummary`` or ``TracebackException``
+   classes.
+
+.. [#unicodedata] MicroPython has no ``unicodedata`` module and no Unicode character database.  Only
+   the ASCII range is handled for case conversion and character classification.
+
+.. [#warnmod] micropython-lib's ``warnings`` module provides only a ``warn()`` function that prints
+   to ``stderr``.  There is no filter machinery, no ``catch_warnings()`` and no warning category
+   classes -- ``Warning`` and ``DeprecationWarning`` are not built in -- so none of the deprecations
+   listed below produce a warning in MicroPython.
+
+.. [#cmchain] MicroPython never supported chaining ``classmethod`` with another descriptor.
+   ``@classmethod`` applied to a ``property`` yields a bound method wrapping the property object
+   rather than the property's value, so it matches neither the pre-3.11 nor the deprecated
+   behaviour.
+
+.. [#octal] MicroPython has no warning machinery, so no diagnostic is produced.  In string literals
+   MicroPython produces the same character as CPython (``"\777"`` is ``chr(0o777)``); in bytes
+   literals it is stricter than CPython and rejects escapes above ``\377`` with a ``SyntaxError``
+   rather than truncating them.
+
+.. [#trunc] MicroPython has never delegated ``int()`` to ``__trunc__()``.  Calling ``int(a)`` when
+   ``type(a)`` implements only ``__trunc__()`` raises ``TypeError``.
+
+.. [#binhex] MicroPython's ``binascii`` implements only ``a2b_base64()``, ``b2a_base64()``,
+   ``crc32()``, ``hexlify()`` and ``unhexlify()``.  The ``hqx`` functions and ``crc_hqx()`` were
+   never implemented, and there is no ``binhex`` module.
+
+.. [#getargspec] micropython-lib's ``inspect`` still defines ``getargspec()``, although it is a stub
+   that raises ``NotImplementedError`` when called.  ``formatargspec()`` and the ``Signature``
+   class methods were never implemented.

--- a/docs/differences/python_312.rst
+++ b/docs/differences/python_312.rst
@@ -1,0 +1,446 @@
+.. _python_312:
+
+Python 3.12
+===========
+
+Python 3.12.0 (final) was released on the 2 October 2023.  Unlike earlier releases there is no
+PEP enumerating the features for 3.12, so the list below follows the release highlights and the
+detailed description of the changes in
+`What's New in Python 3.12 <https://docs.python.org/3/whatsnew/3.12.html>`_.
+
+The headline language change, :pep:`701`, is largely supported by MicroPython: f-strings may reuse
+the enclosing quote character, nest arbitrarily, contain backslashes, span multiple lines and
+contain comments.  MicroPython does not track CPython versions strictly and occasionally implements
+a newer feature early -- t-strings (:pep:`750`, a Python 3.14 feature) are also implemented, gated
+behind ``MICROPY_PY_TSTRINGS``.
+
+Unlike the pages for Python 3.5 to 3.10, this page also covers modules that are not built into the
+firmware but are distributed as pure-Python packages in `micropython-lib
+<https://github.com/micropython/micropython-lib>`__ (for example ``itertools``, ``pathlib``,
+``os.path``, ``shutil``, ``inspect``, ``types``, ``tarfile``, ``tempfile`` and ``unittest``).  Rows
+concerning those modules are marked with a footnote, because they are optional installable packages
+with a reduced API rather than part of the interpreter.
+
+.. table::
+  :widths: 20 60 20
+
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **New syntax features**                                                                                                 | **Status**                |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 695 <https://peps.python.org/pep-0695/>`_         | Type Parameter Syntax and the ``type`` statement               | Not implemented [#p695]_  |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **New grammar features**                                                                                                                            |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 701 <https://peps.python.org/pep-0701/>`_         | Syntactic formalization of f-strings                           | Partial [#f701]_          |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **Interpreter improvements**                                                                                                                        |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 684 <https://peps.python.org/pep-0684/>`_         | A unique per-interpreter GIL                                   | Not relevant              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 669 <https://peps.python.org/pep-0669/>`_         | Low impact monitoring for CPython                              | Not implemented [#trace]_ |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `gh-98763                                              | Improved ``Did you mean ...`` suggestions for                  | Not implemented           |
+  | <https://github.com/python/cpython/issues/98763>`_     | :exc:`NameError`, :exc:`ImportError` and :exc:`SyntaxError`    |                           |
+  |                                                        | exceptions                                                     |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **Python data model improvements**                                                                                                                  |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 688 <https://peps.python.org/pep-0688/>`_         | Making the buffer protocol accessible in Python                | Not implemented [#buf]_   |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **Security improvements**                                                                                                                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `gh-99108                                              | Replace the builtin :mod:`hashlib` implementations of SHA1,    | Not relevant              |
+  | <https://github.com/python/cpython/issues/99108>`_     | SHA3, SHA2-384, SHA2-512 and MD5 with formally verified code   |                           |
+  |                                                        | from the HACL* project                                         |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **CPython implementation improvements**                                                                                                             |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 709 <https://peps.python.org/pep-0709/>`_         | Comprehension inlining                                         | Not implemented [#p709]_  |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `gh-96123                                              | CPython support for the Linux ``perf`` profiler                | Not relevant              |
+  | <https://github.com/python/cpython/issues/96123>`_     |                                                                |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `gh-91079                                              | Implement stack overflow protection on supported platforms     | Complete [#stk]_          |
+  | <https://github.com/python/cpython/issues/91079>`_     |                                                                |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **C API improvements**                                                                                                                              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 697 <https://peps.python.org/pep-0697/>`_         | Unstable C API tier                                            | Not relevant              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 683 <https://peps.python.org/pep-0683/>`_         | Immortal objects, using a fixed refcount                       | Not relevant              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **New typing features**                                                                                                                             |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 692 <https://peps.python.org/pep-0692/>`_         | Using TypedDict to annotate ``**kwargs``                       | Not implemented [#ann]_   |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 698 <https://peps.python.org/pep-0698/>`_         | The ``@typing.override`` decorator                             | Not implemented [#ann]_   |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | **Important deprecations, removals or restrictions**                                                                                                |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 623 <https://peps.python.org/pep-0623/>`_         | Remove ``wstr`` from Unicode objects in Python's C API         | Not relevant              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 632 <https://peps.python.org/pep-0632/>`_         | Remove the ``distutils`` package                               | Not relevant              |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `PEP 594 <https://peps.python.org/pep-0594/>`_         | Remove the ``asynchat``, ``asyncore`` and ``smtpd`` dead       | Not relevant              |
+  |                                                        | batteries; the ``imp`` module and several                      |                           |
+  |                                                        | :class:`unittest.TestCase` method aliases are also removed     |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+  | `gh-95299                                              | Do not pre-install ``setuptools`` in virtual environments      | Not relevant              |
+  | <https://github.com/python/cpython/issues/95299>`_     | created with ``venv``                                          |                           |
+  +--------------------------------------------------------+----------------------------------------------------------------+---------------------------+
+
+
+Other Language Changes:
+
+.. table::
+  :widths: 90 10
+
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The parser now raises :exc:`SyntaxError` when parsing source code containing null bytes.            | Not implemented [#nul]_   |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | A backslash-character pair that is not a valid escape sequence now generates a                      | Not implemented [#warn]_  |
+  | :exc:`SyntaxWarning`, instead of a :exc:`DeprecationWarning`.  For example,                         |                           |
+  | ``re.compile("\d+\.\d+")`` now emits a :exc:`SyntaxWarning`.                                        |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Octal escapes with a value larger than ``0o377`` (e.g. ``"\477"``), deprecated in Python 3.11, now  | Not implemented [#warn]_  |
+  | produce a :exc:`SyntaxWarning` instead of a :exc:`DeprecationWarning`.                              |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Variables used in the target part of comprehensions that are not stored to can now be used in       | Not implemented           |
+  | assignment expressions (``:=``).  For example, in ``[(b := 1) for a, b.prop in some_iter]``, the    |                           |
+  | assignment to ``b`` is now allowed.                                                                 |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Exceptions raised in a class or type's :meth:`~object.__set_name__` method are no longer wrapped by | Partial [#note]_          |
+  | a :exc:`RuntimeError`.  Context information is added to the exception as a :pep:`678` note.         |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | When a ``try-except*`` construct handles the entire :exc:`ExceptionGroup` and raises one other      | Not implemented           |
+  | exception, that exception is no longer wrapped in an :exc:`ExceptionGroup`.                         |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The Garbage Collector now runs only on the eval breaker mechanism of the Python bytecode evaluation | Not relevant              |
+  | loop instead of on object allocations.                                                              |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | All builtin and extension callables expecting boolean parameters now accept arguments of any type   | Complete                  |
+  | instead of just :class:`bool` and :class:`int`.                                                     |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :class:`memoryview` now supports the half-float type (the ``"e"`` format code).                     | Not implemented [#mv]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :class:`slice` objects are now hashable, allowing them to be used as dict keys and set items.       | Not implemented [#slice]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`sum` now uses Neumaier summation to improve accuracy and commutativity when summing floats   | Not implemented           |
+  | or mixed ints and floats.                                                                           |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`ast.parse` now raises :exc:`SyntaxError` instead of :exc:`ValueError` when parsing source    | Not relevant [#nomod]_    |
+  | code containing null bytes.                                                                         |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :pep:`706`: The extraction methods in :mod:`tarfile`, and :func:`shutil.unpack_archive`, have a new | Not implemented [#mplib]_ |
+  | ``filter`` argument that allows limiting tar features that may be surprising or dangerous.          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :class:`types.MappingProxyType` instances are now hashable if the underlying mapping is hashable.   | Not implemented [#mplib]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add support for the ``perf`` profiler through the new environment variable                          | Not relevant              |
+  | :envvar:`PYTHONPERFSUPPORT`, the ``-X perf`` command-line option, and the new                       |                           |
+  | :func:`sys.activate_stack_trampoline`, :func:`sys.deactivate_stack_trampoline` and                  |                           |
+  | :func:`sys.is_stack_trampoline_active` functions.                                                   |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+
+Changes to built-in modules:
+
+.. table::
+  :widths: 90 10
+
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `array <https://docs.python.org/3/whatsnew/3.12.html#array>`_                                                                   |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The :class:`array.array` class now supports subscripting, making it a generic type.                 | Not implemented           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.12.html#asyncio>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The performance of writing to sockets in :mod:`asyncio` has been significantly improved;            | Not relevant              |
+  | unnecessary copying is avoided and ``sendmsg()`` is used if the platform supports it.               |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`asyncio.eager_task_factory` and :func:`asyncio.create_eager_task_factory` to allow       | Not implemented           |
+  | opting an event loop in to eager task execution.                                                    |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | On Linux, :mod:`asyncio` uses :class:`asyncio.PidfdChildWatcher` by default if                      | Not relevant              |
+  | :func:`os.pidfd_open` is available and functional, and the event loop now selects the best          |                           |
+  | available child watcher for each platform.                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a ``loop_factory`` parameter to :func:`asyncio.run` to allow specifying a custom event loop     | Not implemented           |
+  | factory.                                                                                            |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a C implementation of :func:`asyncio.current_task` for a 4x-6x speedup.                         | Not relevant [#aio]_      |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`asyncio.iscoroutine` now returns ``False`` for generators, as :mod:`asyncio` does not        | Not implemented           |
+  | support legacy generator-based coroutines.                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`asyncio.wait` and :func:`asyncio.as_completed` now accept generators yielding tasks.         | Not implemented           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `calendar <https://docs.python.org/3/whatsnew/3.12.html#calendar>`_                                                             |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add the enums :class:`calendar.Month` and :class:`calendar.Day` defining months of the year and     | Not implemented [#nomod]_ |
+  | days of the week.                                                                                   |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `csv <https://docs.python.org/3/whatsnew/3.12.html#csv>`_                                                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :const:`csv.QUOTE_NOTNULL` and :const:`csv.QUOTE_STRINGS` flags to provide finer grained        | Not implemented [#nomod]_ |
+  | control of ``None`` and empty strings by reader and writer objects.                                 |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `dis <https://docs.python.org/3/whatsnew/3.12.html#dis>`_                                                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Pseudo instruction opcodes are now exposed in the :mod:`dis` module, along with the new             | Not relevant [#nomod]_    |
+  | :data:`dis.hasarg` and :data:`dis.hasexc` collections.                                              |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `fractions <https://docs.python.org/3/whatsnew/3.12.html#fractions>`_                                                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Objects of type :class:`fractions.Fraction` now support float-style formatting.                     | Not implemented [#nomod]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `importlib.resources <https://docs.python.org/3/whatsnew/3.12.html#importlib-resources>`_                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`importlib.resources.as_file` now supports resource directories, and the first parameter of   | Not relevant [#nomod]_    |
+  | :func:`importlib.resources.files` is renamed to ``anchor``.                                         |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `inspect <https://docs.python.org/3/whatsnew/3.12.html#inspect>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`inspect.markcoroutinefunction` to mark sync functions that return a coroutine for use    | Not implemented [#mplib]_ |
+  | with :func:`inspect.iscoroutinefunction`.                                                           |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`inspect.getasyncgenstate` and :func:`inspect.getasyncgenlocals` for determining the      | Not implemented [#mplib]_ |
+  | current state of asynchronous generators.                                                           |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The performance of :func:`inspect.getattr_static` has been considerably improved.                   | Not relevant [#mplib]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `itertools <https://docs.python.org/3/whatsnew/3.12.html#itertools>`_                                                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`itertools.batched` for collecting into even-sized tuples where the last batch may be     | Not implemented [#mplib]_ |
+  | shorter than the rest.                                                                              |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.12.html#math>`_                                                                     |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`math.sumprod` for computing a sum of products.                                           | Not implemented           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Extend :func:`math.nextafter` to include a ``steps`` argument for moving up or down multiple steps  | Not implemented [#nfa]_   |
+  | at a time.                                                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `os <https://docs.python.org/3/whatsnew/3.12.html#os>`_                                                                         |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :data:`os.PIDFD_NONBLOCK` to open a file descriptor for a process with :func:`os.pidfd_open` in | Not relevant              |
+  | non-blocking mode.                                                                                  |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :class:`os.DirEntry` now includes an :meth:`os.DirEntry.is_junction` method to check if the entry   | Not relevant              |
+  | is a junction.                                                                                      |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`os.listdrives`, :func:`os.listvolumes` and :func:`os.listmounts` functions on Windows.   | Not relevant              |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`os.stat` and :func:`os.lstat` are now more accurate on Windows, filling ``st_birthtime`` and | Not relevant              |
+  | widening ``st_dev``/``st_ino``.                                                                     |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `os.path <https://docs.python.org/3/whatsnew/3.12.html#os-path>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`os.path.isjunction` to check if a given path is a junction.                              | Not relevant [#mplib]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`os.path.splitroot` to split a path into a triad (drive, root, tail).                     | Not implemented [#mplib]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `pathlib <https://docs.python.org/3/whatsnew/3.12.html#pathlib>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add support for subclassing :class:`pathlib.PurePath` and :class:`pathlib.Path`; subclasses may     | Not implemented [#mplib]_ |
+  | override the new :meth:`pathlib.PurePath.with_segments` method to pass information between path     |                           |
+  | instances.                                                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :meth:`pathlib.Path.walk` for walking directory trees and generating all file or directory      | Not implemented [#mplib]_ |
+  | names within them, similar to :func:`os.walk`.                                                      |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a ``walk_up`` optional parameter to :meth:`pathlib.PurePath.relative_to` to allow the insertion | Not implemented [#mplib]_ |
+  | of ``..`` entries in the result.                                                                    |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :meth:`pathlib.Path.is_junction` as a proxy to :func:`os.path.isjunction`.                      | Not relevant [#mplib]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a ``case_sensitive`` optional parameter to :meth:`pathlib.Path.glob`,                           | Not implemented [#mplib]_ |
+  | :meth:`pathlib.Path.rglob` and :meth:`pathlib.PurePath.match`.                                      |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `platform <https://docs.python.org/3/whatsnew/3.12.html#platform>`_                                                             |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add support for detecting Windows 11 and Windows Server releases past 2012.                         | Not relevant              |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `pdb <https://docs.python.org/3/whatsnew/3.12.html#pdb>`_                                                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add convenience variables to hold values temporarily for a debug session and provide quick access   | Not relevant [#nomod]_    |
+  | to values like the current frame or the return value.                                               |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `random <https://docs.python.org/3/whatsnew/3.12.html#random>`_                                                                 |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`random.binomialvariate`.                                                                 | Not implemented           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a default of ``lambd=1.0`` to :func:`random.expovariate`.                                       | Not implemented [#exv]_   |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `shutil <https://docs.python.org/3/whatsnew/3.12.html#shutil>`_                                                                 |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`shutil.make_archive` now passes the ``root_dir`` argument to custom archivers which support  | Not implemented [#mplib]_ |
+  | it, and no longer temporarily changes the current working directory.                                |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`shutil.rmtree` now accepts a new argument ``onexc`` which is an error handler like           | Not implemented [#mplib]_ |
+  | ``onerror`` but which expects an exception instance rather than a ``(typ, val, tb)`` triplet.       |                           |
+  | ``onerror`` is deprecated.                                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`shutil.which` now consults ``PATHEXT``, calls ``NeedCurrentDirectoryForExePathW`` and        | Not relevant [#mplib]_    |
+  | prefers a ``PATHEXT`` match over a direct match elsewhere in the search path, on Windows.           |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `sqlite3 <https://docs.python.org/3/whatsnew/3.12.html#sqlite3>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a command-line interface, the :attr:`sqlite3.Connection.autocommit` attribute and               | Not relevant [#sqlite]_   |
+  | ``autocommit`` parameter, an ``entrypoint`` parameter to :meth:`sqlite3.Connection.load_extension`, |                           |
+  | and :meth:`sqlite3.Connection.getconfig` and :meth:`sqlite3.Connection.setconfig`.                  |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `statistics <https://docs.python.org/3/whatsnew/3.12.html#statistics>`_                                                         |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Extend :func:`statistics.correlation` to include a ``ranked`` method for computing the Spearman     | Not implemented [#nomod]_ |
+  | correlation of ranked data.                                                                         |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.12.html#sys>`_                                                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add the :mod:`sys.monitoring` namespace to expose the new :pep:`669` monitoring API.                | Not implemented [#trace]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`sys.activate_stack_trampoline`, :func:`sys.deactivate_stack_trampoline` and              | Not relevant              |
+  | :func:`sys.is_stack_trampoline_active`.                                                             |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :data:`sys.last_exc`, which holds the last unhandled exception that was raised.  The legacy     | Not implemented           |
+  | :data:`sys.last_type`, :data:`sys.last_value` and :data:`sys.last_traceback` are deprecated.        |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`sys._current_exceptions` now returns a mapping from thread-id to an exception instance,      | Not implemented           |
+  | rather than to a ``(typ, exc, tb)`` tuple.                                                          |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The recursion limit set by :func:`sys.setrecursionlimit` now applies only to Python code; builtin   | Not implemented [#stk]_   |
+  | functions are protected by a different mechanism.                                                   |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `tempfile <https://docs.python.org/3/whatsnew/3.12.html#tempfile>`_                                                             |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The :func:`tempfile.NamedTemporaryFile` function has a new optional parameter ``delete_on_close``.  | Not implemented [#mplib]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`tempfile.mkdtemp` now always returns an absolute path, even if the argument provided to the  | Not implemented [#mplib]_ |
+  | ``dir`` parameter is a relative path.                                                               |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `threading <https://docs.python.org/3/whatsnew/3.12.html#threading>`_                                                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`threading.settrace_all_threads` and :func:`threading.setprofile_all_threads` that allow  | Not implemented [#trace]_ |
+  | setting tracing and profiling functions in all running threads in addition to the calling one.      |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `tkinter <https://docs.python.org/3/whatsnew/3.12.html#tkinter>`_                                                               |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :meth:`tkinter.Canvas.coords` now flattens its arguments.                                           | Not relevant [#nomod]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `tokenize <https://docs.python.org/3/whatsnew/3.12.html#tokenize>`_                                                             |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The :mod:`tokenize` module includes the changes introduced in :pep:`701`.                           | Not relevant [#nomod]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `types <https://docs.python.org/3/whatsnew/3.12.html#types>`_                                                                   |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add :func:`types.get_original_bases` to allow for further introspection of user-defined generic     | Not implemented [#mplib]_ |
+  | types when subclassed.                                                                              |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `typing <https://docs.python.org/3/whatsnew/3.12.html#typing>`_                                                                 |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | :func:`isinstance` checks against runtime-checkable protocols now use                               | Not implemented [#ann]_   |
+  | :func:`inspect.getattr_static` rather than :func:`hasattr`, the members of a runtime-checkable      |                           |
+  | protocol are now frozen when the class is created, and such checks are significantly faster.        |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | All :class:`typing.TypedDict` and :class:`typing.NamedTuple` classes now have the                   | Not implemented [#ann]_   |
+  | ``__orig_bases__`` attribute.                                                                       |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a ``frozen_default`` parameter to :func:`@typing.dataclass_transform                            | Not implemented [#ann]_   |
+  | <typing.dataclass_transform>`.                                                                      |                           |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `unicodedata <https://docs.python.org/3/whatsnew/3.12.html#unicodedata>`_                                                       |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | The Unicode database has been updated to version 15.0.0.                                            | Not relevant [#nomod]_    |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `unittest <https://docs.python.org/3/whatsnew/3.12.html#unittest>`_                                                             |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a ``--durations`` command line option, showing the N slowest test cases.                        | Not implemented [#mplib]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | `uuid <https://docs.python.org/3/whatsnew/3.12.html#uuid>`_                                                                     |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+  | Add a command-line interface.                                                                       | Not implemented [#nomod]_ |
+  +-----------------------------------------------------------------------------------------------------+---------------------------+
+
+.. rubric:: Notes
+
+.. [#p695] None of the type parameter syntax is recognised: ``type X = int``, ``def f[T]()`` and
+   ``class C[T]`` all raise :exc:`SyntaxError`, and there is no ``__type_params__`` attribute on
+   functions, classes or type aliases.  See also [#ann]_.
+
+.. [#f701] MicroPython's f-string support is implemented in the lexer, which rewrites the literal
+   into a ``str.format()`` call.  Most of what :pep:`701` allows already works: replacement fields
+   may reuse the enclosing quote character (including deeply nested f-strings), may contain
+   backslashes and escape sequences, may span multiple lines, and may contain ``#`` comments.  The
+   lexer is however not fully aware of Python syntax inside ``{...}``, so an expression containing a
+   ``}`` or ``:`` character inside a nested string literal -- for example ``f'{"}"}'`` or
+   ``f'{"a:b"}'`` -- is still rejected with a :exc:`SyntaxError`.  Adjacent-literal concatenation
+   where the non-f-string part contains braces is also unsupported.  See
+   ``tests/cpydiff/core_fstring_parser.py`` and ``tests/cpydiff/core_fstring_concat.py``.
+
+.. [#p709] MicroPython compiles comprehensions into a separate implicit function, so a comprehension
+   still appears as its own frame (``<listcomp>``, ``<dictcomp>``, ``<setcomp>``, ``<genexpr>``) in
+   tracebacks, and comprehension iteration variables are not visible in the enclosing scope.
+
+.. [#trace] MicroPython has no ``sys.monitoring`` namespace and no ``threading`` tracing hooks.  The
+   closest analogue is ``sys.settrace()``, which is gated behind ``MICROPY_PY_SYS_SETTRACE`` and is
+   disabled by default on all ports (it is enabled only in the unix ``coverage`` variant).
+
+.. [#buf] MicroPython has a full C-level buffer protocol, used by :class:`memoryview`,
+   :class:`bytearray`, :mod:`array` and many built-in modules, but it is not reachable from Python
+   code: defining ``__buffer__``/``__release_buffer__`` on a class has no effect and
+   ``memoryview(obj)`` raises :exc:`TypeError`.  There is also no ``collections.abc`` namespace and
+   therefore no ``collections.abc.Buffer``.
+
+.. [#stk] MicroPython protects against stack overflow with its own stack-limit check
+   (``MICROPY_STACK_CHECK``), raising ``RuntimeError: maximum recursion depth exceeded``.  The limit
+   is a byte budget configured by the port rather than a frame count, so there is no
+   ``sys.setrecursionlimit()`` or ``sys.getrecursionlimit()``.
+
+.. [#nul] MicroPython does not reject null bytes in source code.  A null byte inside a comment or a
+   string literal is accepted and passed through; only a null byte appearing where a token is
+   expected produces a :exc:`SyntaxError`, and then only incidentally.
+
+.. [#warn] MicroPython has no ``warnings`` module and issues no compile-time diagnostics, so neither
+   invalid escape sequences nor out-of-range octal escapes are reported.  The resulting values match
+   CPython: ``"\d"`` is a two-character string and ``"\777"`` is ``"\u01ff"``.  A bytes literal
+   such as ``b"\777"`` is a :exc:`SyntaxError`, as in CPython.
+
+.. [#note] MicroPython never wrapped :meth:`~object.__set_name__` exceptions in a
+   :exc:`RuntimeError`, so the exception already propagates unchanged.  However :pep:`678` exception
+   notes are not supported at all -- there is no ``add_note()`` method and no ``__notes__``
+   attribute -- so the added context information is missing.
+
+.. [#mv] MicroPython's :class:`memoryview` has no ``cast()`` method, so no format code can be
+   reinterpreted, half-float or otherwise.
+
+.. [#slice] :class:`slice` objects are not hashable in MicroPython.  In addition, ``slice`` cannot
+   be instantiated directly (``slice(1, 2)`` raises ``TypeError: can't create 'slice' instances``);
+   slice objects only ever arise from subscript syntax.
+
+.. [#aio] MicroPython's :mod:`asyncio` is already implemented partly in C (the scheduler, task queue
+   and ``current_task()``), so this particular CPython optimisation does not apply.
+
+.. [#exv] :func:`random.expovariate` is not provided by MicroPython's :mod:`random` module at all,
+   so the new default is moot.
+
+.. [#nfa] :func:`math.nextafter` is not provided by MicroPython's :mod:`math` module at all, so the
+   new ``steps`` argument is moot.
+
+.. [#sqlite] MicroPython has no :mod:`sqlite3` module.  A ``sqlite3`` FFI wrapper exists in the
+   ``unix-ffi`` section of `micropython-lib
+   <https://github.com/micropython/micropython-lib>`__, but it is a thin binding to the system
+   library and implements none of these APIs.
+
+.. [#nomod] MicroPython provides no equivalent module, neither built into the firmware nor as a
+   `micropython-lib <https://github.com/micropython/micropython-lib>`__ package, so there is nothing
+   for this change to apply to.
+
+.. [#mplib] This module is not built into MicroPython.  It is available only as a pure-Python
+   package in `micropython-lib <https://github.com/micropython/micropython-lib>`__, installable with
+   ``mip`` or ``mpremote mip install``.  These packages implement a deliberately reduced subset of
+   the CPython API, so features added to CPython are generally absent unless they are needed on a
+   microcontroller.
+
+.. [#ann] MicroPython parses type annotations but never evaluates them, so annotations produce no
+   runtime effects and no ``__annotations__`` attributes are created.  There is also no ``typing``
+   module and no ``__future__`` module, so these features cannot be used other than as inert
+   annotations.

--- a/docs/differences/python_313.rst
+++ b/docs/differences/python_313.rst
@@ -275,7 +275,7 @@ Changes to built-in and library modules:
   +-------------------------------------------------------------------------------------------------------------+--------------------------+
   | `re <https://docs.python.org/3.13/whatsnew/3.13.html#re>`_                                                                             |
   +-------------------------------------------------------------------------------------------------------------+--------------------------+
-  | Rename ``re.error`` to ``PatternError`` for improved clarity. ``re.error`` is kept for backward             | Not implemented [#re]_   |
+  | Rename ``re.error`` to ``PatternError`` for improved clarity. ``re.error`` is kept for backward             | Not implemented [#relib]_|
   | compatibility.                                                                                              |                          |
   +-------------------------------------------------------------------------------------------------------------+--------------------------+
   | `shutil <https://docs.python.org/3.13/whatsnew/3.13.html#shutil>`_                                                                     |
@@ -466,7 +466,7 @@ Changes to built-in and library modules:
 .. [#q] MicroPython has no ``queue`` module, in either the firmware or micropython-lib.
    :class:`collections.deque` and ``asyncio.ThreadSafeFlag`` are the usual substitutes.
 
-.. [#re] MicroPython's :mod:`re` module defines neither ``re.error`` nor
+.. [#relib] MicroPython's :mod:`re` module defines neither ``re.error`` nor
    ``PatternError``; a bad pattern raises a plain :exc:`ValueError`.  Code that needs to
    be portable should therefore catch :exc:`ValueError`, which both spellings of the
    CPython exception derive from.

--- a/docs/differences/python_313.rst
+++ b/docs/differences/python_313.rst
@@ -1,0 +1,495 @@
+.. _python_313:
+
+Python 3.13
+===========
+
+Python 3.13.0 (final) was released on the 7 October 2024.  Unlike earlier
+releases, Python 3.13 has no "features for 3.13" PEP; `PEP 719
+<https://www.python.org/dev/peps/pep-0719/>`_ defines the release schedule only.
+A detailed description of the changes can be found in
+`What's New in Python 3.13 <https://docs.python.org/3.13/whatsnew/3.13.html>`_.
+
+Python 3.13 added no new syntax to the language, so there is no "new syntax
+features" section below.  Its headline features -- the free-threaded build, the
+experimental JIT, the new interactive interpreter and mobile platform support --
+are almost entirely concerned with the internals of CPython or with host
+operating systems, and so have little bearing on MicroPython.
+
+Unlike the pages for earlier versions, this page also covers modules that
+MicroPython provides only through `micropython-lib
+<https://github.com/micropython/micropython-lib>`_ rather than compiling into
+the firmware; such rows are marked with a footnote.
+
+.. table::
+  :widths: 20 60 20
+
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | **Interpreter improvements**                                                                                      | **Status**               |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 703 <https://www.python.org/dev/peps/pep-0703/>`_       | Making the Global Interpreter Lock Optional in     | Not relevant [#gil]_     |
+  |                                                              | CPython                                            |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 744 <https://www.python.org/dev/peps/pep-0744/>`_       | An experimental just-in-time (JIT) compiler        | Not relevant [#nat]_     |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 667 <https://www.python.org/dev/peps/pep-0667/>`_       | Consistent views of namespaces                     | Not implemented [#loc]_  |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `gh-111201                                                   | A better interactive interpreter, based on code    | Partial [#repl]_         |
+  | <https://github.com/python/cpython/issues/111201>`_          | from the PyPy project                              |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `gh-112730                                                   | Improved error messages: colourised tracebacks and | Not implemented [#err]_  |
+  | <https://github.com/python/cpython/issues/112730>`_          | suggestions for mistyped names                     |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | **Platform support**                                                                                                                         |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 730 <https://www.python.org/dev/peps/pep-0730/>`_       | Support for mobile platforms: Apple iOS is now a   | Not relevant             |
+  |                                                              | tier 3 platform                                    |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 738 <https://www.python.org/dev/peps/pep-0738/>`_       | Support for mobile platforms: Android is now a     | Not relevant             |
+  |                                                              | tier 3 platform                                    |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 11 <https://www.python.org/dev/peps/pep-0011/>`_        | ``wasm32-wasi`` is promoted to a tier 2 platform   | Not relevant [#wasm]_    |
+  |                                                              | and ``wasm32-emscripten`` is demoted to tier 3     |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | **New typing features**                                                                                                                      |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 696 <https://www.python.org/dev/peps/pep-0696/>`_       | Type defaults for type parameters                  | Not implemented [#ann]_  |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 702 <https://www.python.org/dev/peps/pep-0702/>`_       | Marking deprecations using the type system         | Not implemented [#warn]_ |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 705 <https://www.python.org/dev/peps/pep-0705/>`_       | TypedDict: read-only items                         | Not implemented [#ann]_  |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 742 <https://www.python.org/dev/peps/pep-0742/>`_       | Narrowing types with ``TypeIs``                    | Not implemented [#ann]_  |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | **Important deprecations, removals or restrictions**                                                                                         |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `PEP 594 <https://www.python.org/dev/peps/pep-0594/>`_       | Remove 'dead batteries' from the standard library  | Not relevant [#lib]_     |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `gh-104780                                                   | The **2to3** program and the ``lib2to3`` module    | Not relevant             |
+  | <https://github.com/python/cpython/issues/104780>`_          | have been removed                                  |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `gh-89519                                                    | Support for chained :func:`classmethod`            | Complete [#cm]_          |
+  | <https://github.com/python/cpython/issues/89519>`_           | descriptors has been removed; they can no longer   |                          |
+  |                                                              | wrap other descriptors such as :func:`property`    |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `gh-79932                                                    | Calling ``frame.clear()`` on a suspended frame now | Not relevant [#loc]_     |
+  | <https://github.com/python/cpython/issues/79932>`_           | raises :exc:`RuntimeError`                         |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+  | `Removed modules and APIs                                    | A number of long-deprecated APIs in host-oriented  | Not relevant             |
+  | <https://docs.python.org/3.13/whatsnew/3.13.html#removed>`_  | modules such as ``configparser``, ``locale``,      |                          |
+  |                                                              | ``tkinter``, ``typing`` and ``importlib.metadata`` |                          |
+  |                                                              | have been removed                                  |                          |
+  +--------------------------------------------------------------+----------------------------------------------------+--------------------------+
+
+
+Other Language Changes:
+
+.. table::
+  :widths: 90 10
+
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The compiler now strips common leading whitespace from every line in a docstring, reducing the size of the  | Not relevant [#doc]_     |
+  | bytecode cache.                                                                                             |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Annotation scopes within class scopes can now contain lambdas and comprehensions. Comprehensions that are   | Not implemented [#ann]_  |
+  | located within class scopes are not inlined into their parent scope.                                        |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Future statements are no longer triggered by relative imports of the ``__future__`` module, meaning that    | Not relevant [#fut]_     |
+  | statements of the form ``from .__future__ import ...`` are now simply standard relative imports, with no    |                          |
+  | special features activated.                                                                                 |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``global`` declarations are now permitted in ``except`` blocks when that global is used in the ``else``     | Complete                 |
+  | block. Previously this raised an erroneous :exc:`SyntaxError`.                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``PYTHON_FROZEN_MODULES``, a new environment variable that determines whether frozen modules are        | Not relevant [#frz]_     |
+  | ignored by the import machinery, equivalent to the ``-X frozen_modules`` command-line option.               |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add support for the perf profiler working without frame pointers through the new environment variable       | Not relevant             |
+  | ``PYTHON_PERF_JIT_SUPPORT`` and command-line option ``-X perf_jit``.                                        |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The location of a ``.python_history`` file can be changed via the new ``PYTHON_HISTORY`` environment        | Not relevant [#repl]_    |
+  | variable.                                                                                                   |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Classes have a new ``__static_attributes__`` attribute, populated by the compiler with a tuple of the       | Not implemented          |
+  | class's attribute names which are assigned through ``self.<name>`` from any function in its body.           |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The compiler now creates a ``__firstlineno__`` attribute on classes with the line number of the first line  | Not implemented          |
+  | of the class definition.                                                                                    |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The :func:`exec` and :func:`eval` builtins now accept the *globals* and *locals* arguments as keywords.     | Not implemented          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The :func:`compile` builtin now accepts a new flag, ``ast.PyCF_OPTIMIZED_AST``, which is similar to         | Not relevant [#ast]_     |
+  | ``ast.PyCF_ONLY_AST`` except that the returned AST is optimized according to the value of the *optimize*    |                          |
+  | argument.                                                                                                   |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add a ``__name__`` attribute on :func:`property` objects.                                                   | Not implemented          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``PythonFinalizationError``, a new exception derived from :exc:`RuntimeError` and used to signal when   | Not implemented          |
+  | operations are blocked during finalization.                                                                 |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Allow the *count* argument of :meth:`str.replace` to be a keyword.                                          | Not implemented          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Many functions now emit a warning if a boolean value is passed as a file descriptor argument.               | Not relevant [#warn]_    |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Added ``name`` and ``mode`` attributes for compressed and archived file-like objects in the ``bz2``,        | Not relevant [#arch]_    |
+  | ``lzma``, ``tarfile`` and ``zipfile`` modules.                                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+
+Changes to built-in and library modules:
+
+.. table::
+  :widths: 90 10
+
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `argparse <https://docs.python.org/3.13/whatsnew/3.13.html#argparse>`_                                                                 |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the *deprecated* parameter to the :meth:`~argparse.ArgumentParser.add_argument` and ``add_parser()``    | Not implemented [#lib]_  |
+  | methods, to enable deprecating command-line options, positional arguments and subcommands.                  |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `array <https://docs.python.org/3.13/whatsnew/3.13.html#array>`_                                                                       |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``'w'`` type code (``Py_UCS4``) for Unicode characters. It should be used instead of the deprecated | Not implemented [#arr]_  |
+  | ``'u'`` type code.                                                                                          |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Register :class:`array.array` as a :class:`~collections.abc.MutableSequence` by implementing the            | Not implemented          |
+  | ``clear()`` method.                                                                                         |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `asyncio <https://docs.python.org/3.13/whatsnew/3.13.html#asyncio>`_                                                                   |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | :func:`asyncio.as_completed` now returns an object that is both an asynchronous iterator and a plain        | Not implemented          |
+  | iterator of awaitables.                                                                                     |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``asyncio.loop.create_unix_server()`` will now automatically remove the Unix socket when the server is      | Not relevant             |
+  | closed.                                                                                                     |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``DatagramTransport.sendto()`` will now send zero-length datagrams if called with an empty bytes object,    | Not relevant [#dgram]_   |
+  | and transport flow control now accounts for the datagram header.                                            |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``Queue.shutdown`` and ``QueueShutDown`` to manage queue termination.                                   | Not implemented [#aioq]_ |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``Server.close_clients()`` and ``Server.abort_clients()`` methods, which more forcefully close an   | Not implemented          |
+  | asyncio server.                                                                                             |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Accept a tuple of separators in ``StreamReader.readuntil()``, stopping when any one of them is encountered. | Not implemented [#ru]_   |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Several improvements to ``TaskGroup``: better behaviour when an external cancellation collides with an      | Not implemented [#tg]_   |
+  | internal one, preservation of the cancellation count, closing the coroutine when ``create_task()`` is       |                          |
+  | called on an inactive group, and a new ``**kwargs`` argument passed through to the task constructor.        |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `base64 <https://docs.python.org/3.13/whatsnew/3.13.html#base64>`_                                                                     |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``z85encode()`` and ``z85decode()`` functions for encoding :class:`bytes` as Z85 data and decoding      | Not implemented [#lib]_  |
+  | Z85-encoded data to ``bytes``.                                                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `copy <https://docs.python.org/3.13/whatsnew/3.13.html#copy>`_                                                                         |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The new ``copy.replace()`` function and the ``__replace__()`` protocol make creating modified copies of     | Not implemented [#lib]_  |
+  | objects much simpler.                                                                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `dbm <https://docs.python.org/3.13/whatsnew/3.13.html#dbm>`_                                                                           |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``dbm.sqlite3``, a new module which implements an SQLite backend, and make it the default ``dbm``       | Not relevant [#btree]_   |
+  | backend. Also allow removing all items through the new ``clear()`` methods of the GDBM and NDBM database    |                          |
+  | objects.                                                                                                    |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `glob <https://docs.python.org/3.13/whatsnew/3.13.html#glob>`_                                                                         |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``translate()``, a function to convert a path specification with shell-style wildcards to a regular     | Not implemented [#ffi]_  |
+  | expression.                                                                                                 |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `io <https://docs.python.org/3.13/whatsnew/3.13.html#io>`_                                                                             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The :class:`io.IOBase` finalizer now logs any errors raised by the ``close()`` method with                  | Not implemented          |
+  | ``sys.unraisablehook``. Previously, errors were ignored silently by default.                                |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `ipaddress <https://docs.python.org/3.13/whatsnew/3.13.html#ipaddress>`_                                                               |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``IPv4Address.ipv6_mapped`` property, which returns the IPv4-mapped IPv6 address.                   | Not implemented [#mod]_  |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Fix ``is_global`` and ``is_private`` behaviour in ``IPv4Address``, ``IPv6Address``, ``IPv4Network`` and     | Not implemented [#mod]_  |
+  | ``IPv6Network``.                                                                                            |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `itertools <https://docs.python.org/3.13/whatsnew/3.13.html#itertools>`_                                                               |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``batched()`` has a new *strict* parameter, which raises a :exc:`ValueError` if the final batch is shorter  | Not implemented [#bat]_  |
+  | than the specified batch size.                                                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `math <https://docs.python.org/3.13/whatsnew/3.13.html#math>`_                                                                         |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The new function :func:`math.fma` performs fused multiply-add operations, computing ``x * y + z`` with only | Not implemented          |
+  | a single round.                                                                                             |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `mimetypes <https://docs.python.org/3.13/whatsnew/3.13.html#mimetypes>`_                                                               |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``guess_file_type()`` function to guess a MIME type from a filesystem path. Using paths with        | Not implemented [#mod]_  |
+  | ``guess_type()`` is now soft deprecated.                                                                    |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `os <https://docs.python.org/3.13/whatsnew/3.13.html#os>`_                                                                             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``process_cpu_count()`` function to get the number of logical CPU cores usable by the calling       | Not implemented          |
+  | thread of the current process.                                                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``cpu_count()`` and ``process_cpu_count()`` can be overridden through the new environment variable          | Not relevant             |
+  | ``PYTHON_CPU_COUNT`` or the new command-line option ``-X cpu_count``.                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add a low level interface to Linux's *timer file descriptors* via ``timerfd_create()`` and related          | Not relevant             |
+  | functions and constants.                                                                                    |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``lchmod()``, ``fchmod()`` and the *follow_symlinks* argument of ``chmod()`` are now available on Windows,  | Not relevant             |
+  | and ``mkdir()`` and ``makedirs()`` now support passing a *mode* value of ``0o700``.                         |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``posix_spawn()`` now accepts ``None`` for the *env* argument, and can use the ``POSIX_SPAWN_CLOSEFROM``    | Not relevant             |
+  | attribute in the *file_actions* parameter.                                                                  |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `os.path <https://docs.python.org/3.13/whatsnew/3.13.html#os-path>`_                                                                   |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``isreserved()`` to check if a path is reserved on the current system. This function is only available  | Not relevant             |
+  | on Windows.                                                                                                 |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | On Windows, ``isabs()`` no longer considers paths starting with exactly one slash to be absolute, and       | Not relevant             |
+  | ``realpath()`` now resolves MS-DOS style file names even if the file is not accessible.                     |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `pathlib <https://docs.python.org/3.13/whatsnew/3.13.html#pathlib>`_                                                                   |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``UnsupportedOperation``, which is raised instead of :exc:`NotImplementedError` when a path operation   | Not implemented [#lib]_  |
+  | isn't supported.                                                                                            |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``Path.from_uri()``, a new constructor for creating ``Path`` objects from 'file' URIs, and              | Not implemented [#lib]_  |
+  | ``PurePath.full_match()`` for matching paths with shell-style wildcards.                                    |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``PurePath.parser`` class attribute to store the implementation of :mod:`os.path` used for          | Not implemented [#lib]_  |
+  | low-level path parsing and joining.                                                                         |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the *recurse_symlinks* keyword-only argument to ``Path.glob()`` and ``rglob()``, which now also return  | Not implemented [#lib]_  |
+  | files as well as directories when given a pattern ending with ``**``.                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the *follow_symlinks* keyword-only argument to ``Path.is_file()``, ``Path.is_dir()``, ``Path.owner()``  | Not implemented [#lib]_  |
+  | and ``Path.group()``.                                                                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `queue <https://docs.python.org/3.13/whatsnew/3.13.html#queue>`_                                                                       |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``Queue.shutdown`` and ``ShutDown`` to manage queue termination.                                        | Not implemented [#q]_    |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `random <https://docs.python.org/3.13/whatsnew/3.13.html#random>`_                                                                     |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add a command-line interface.                                                                               | Not relevant             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `re <https://docs.python.org/3.13/whatsnew/3.13.html#re>`_                                                                             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Rename ``re.error`` to ``PatternError`` for improved clarity. ``re.error`` is kept for backward             | Not implemented [#re]_   |
+  | compatibility.                                                                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `shutil <https://docs.python.org/3.13/whatsnew/3.13.html#shutil>`_                                                                     |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Support the *dir_fd* and *follow_symlinks* keyword arguments in ``chown()``.                                | Not relevant             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `site <https://docs.python.org/3.13/whatsnew/3.13.html#site>`_                                                                         |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``.pth`` files are now decoded using UTF-8 first, and then with the locale encoding if UTF-8 decoding       | Not relevant             |
+  | fails.                                                                                                      |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `sqlite3 <https://docs.python.org/3.13/whatsnew/3.13.html#sqlite3>`_                                                                   |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | A :exc:`ResourceWarning` is now emitted if a ``Connection`` object is not closed explicitly, and a *filter* | Not relevant [#ffi]_     |
+  | keyword-only parameter was added to ``Connection.iterdump()``.                                              |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `ssl <https://docs.python.org/3.13/whatsnew/3.13.html#ssl>`_                                                                           |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The ``create_default_context()`` API now includes ``VERIFY_X509_PARTIAL_CHAIN`` and ``VERIFY_X509_STRICT``  | Not relevant [#tls]_     |
+  | in its default flags.                                                                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `statistics <https://docs.python.org/3.13/whatsnew/3.13.html#statistics>`_                                                             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``kde()`` for kernel density estimation and ``kde_random()`` for sampling from an estimated probability | Not implemented [#mod]_  |
+  | density function.                                                                                           |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `subprocess <https://docs.python.org/3.13/whatsnew/3.13.html#subprocess>`_                                                             |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The ``subprocess`` module now uses the ``posix_spawn()`` function in more situations.                       | Not relevant [#mod]_     |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `sys <https://docs.python.org/3.13/whatsnew/3.13.html#sys>`_                                                                           |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``sys._is_interned()`` function to test if a string was interned. This function is not guaranteed   | Not implemented [#int]_  |
+  | to exist in all implementations of Python.                                                                  |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `tempfile <https://docs.python.org/3.13/whatsnew/3.13.html#tempfile>`_                                                                 |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | On Windows, the default mode ``0o700`` used by ``tempfile.mkdtemp()`` now limits access to the new          | Not relevant             |
+  | directory.                                                                                                  |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `time <https://docs.python.org/3.13/whatsnew/3.13.html#time>`_                                                                         |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | On Windows, :func:`time.monotonic` and :func:`time.time` now use higher resolution clocks, giving a         | Not relevant             |
+  | resolution of 1 microsecond instead of 15.6 milliseconds.                                                   |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `traceback <https://docs.python.org/3.13/whatsnew/3.13.html#traceback>`_                                                               |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add the ``exc_type_str`` attribute to ``TracebackException`` and deprecate the ``exc_type`` attribute. Add  | Not implemented [#tb]_   |
+  | the *save_exc_type* parameter to indicate whether ``exc_type`` should be saved.                             |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add a new *show_group* keyword-only parameter to ``TracebackException.format_exception_only()`` to          | Not implemented [#tb]_   |
+  | recursively format the nested exceptions of a ``BaseExceptionGroup``.                                       |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `types <https://docs.python.org/3.13/whatsnew/3.13.html#types>`_                                                                       |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``SimpleNamespace`` can now take a single positional argument to initialise the namespace's arguments. This | Not implemented [#ty]_   |
+  | argument must either be a mapping or an iterable of key-value pairs.                                        |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `typing <https://docs.python.org/3.13/whatsnew/3.13.html#typing>`_                                                                     |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add ``ReadOnly``, ``TypeIs``, ``NoDefault``, ``get_protocol_members()`` and ``is_protocol()``, and allow    | Not implemented [#ann]_  |
+  | ``ClassVar`` to be nested in ``Final`` and vice versa.                                                      |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `warnings <https://docs.python.org/3.13/whatsnew/3.13.html#warnings>`_                                                                 |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The new ``warnings.deprecated()`` decorator provides a way to communicate deprecations to a static type     | Not implemented [#warn]_ |
+  | checker and to warn on usage of deprecated classes and functions.                                           |                          |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `zipimport <https://docs.python.org/3.13/whatsnew/3.13.html#zipimport>`_                                                               |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Add support for ZIP64 format files.                                                                         | Not relevant [#arch]_    |
+  +-------------------------------------------------------------------------------------------------------------+--------------------------+
+
+.. rubric:: Notes
+
+.. [#gil] MicroPython has no CPython-style global interpreter lock to remove.  Ports
+   that support threading (``MICROPY_PY_THREAD``) either run threads on a single core
+   under a scheduler lock, or use a port-specific mutex around the interpreter and
+   garbage collector; the trade-offs are quite different to those of CPython.
+
+.. [#nat] MicroPython has no tracing JIT.  It does provide ahead-of-time native code
+   generation through the ``@micropython.native``, ``@micropython.viper`` and
+   ``@micropython.asm_thumb`` decorators, and ``.mpy`` files may contain
+   pre-compiled native code, but these are opt-in per function rather than an
+   automatic optimisation of hot loops.
+
+.. [#loc] MicroPython does not implement :pep:`667`, and its starting point differs
+   from CPython's in any case: :func:`locals` returns the *globals* dictionary when
+   called inside a function, because local variables live on the stack and are not
+   reified into a dictionary.  Frame objects are only available when
+   ``MICROPY_PY_SYS_SETTRACE`` is enabled, and those frames expose ``f_globals``,
+   ``f_code``, ``f_lasti`` and ``f_back`` but no ``f_locals`` and no ``clear()``
+   method, so neither the new write-through proxy nor the new :exc:`RuntimeError`
+   applies.
+
+.. [#repl] MicroPython has its own REPL implementation (``MICROPY_HELPER_REPL``) which
+   already provides several of the features listed here, including line editing with
+   Emacs-style key bindings, word-wise cursor movement, an in-memory command history
+   (``MICROPY_READLINE_HISTORY_SIZE``, eight entries by default), automatic
+   indentation of continuation lines, tab completion of names, and a paste mode
+   entered with ``Ctrl-E``.  What it does not provide is colour output, the ``F1``,
+   ``F2`` and ``F3`` bindings, a history file such as ``.python_history``, or bare
+   ``exit``, ``quit`` and ``help`` commands -- ``exit`` and ``quit`` are not builtins
+   in MicroPython, so they raise :exc:`NameError` unless imported from :mod:`sys`.
+
+.. [#err] MicroPython deliberately trades error message quality for code size.  The
+   ``MICROPY_ERROR_REPORTING`` option selects between ``NONE``, ``TERSE``, ``NORMAL``
+   and ``DETAILED``; even ``DETAILED``, the default on the unix port, does not attempt
+   the "did you mean" suggestions or the colourised output added in CPython 3.13, and
+   most microcontroller ports default to ``NORMAL`` or ``TERSE``.
+
+.. [#wasm] MicroPython has its own ``webassembly`` port, built with Emscripten and
+   published as the ``@micropython/micropython-webassembly-pyscript`` package.  It is
+   independent of CPython's WebAssembly work, so CPython's platform tier changes do not
+   affect it.
+
+.. [#ann] MicroPython parses type annotations but never evaluates them, so annotations
+   produce no runtime effects and no ``__annotations__`` attributes are created.  There
+   is also no ``typing`` module, so these features cannot be used other than as inert
+   annotations.
+
+.. [#warn] MicroPython core has no warnings machinery at all: there is no ``warnings``
+   module built into the firmware and no :exc:`DeprecationWarning`,
+   :exc:`SyntaxWarning` or :exc:`ResourceWarning` exception types.  The ``warnings``
+   module in micropython-lib [#lib]_ provides only a ``warn()`` function that prints its
+   argument.  Every CPython change described as "now emits a warning" therefore has no
+   MicroPython counterpart.
+
+.. [#lib] This module is not built into MicroPython firmware.  It is a pure-Python
+   package distributed through `micropython-lib
+   <https://github.com/micropython/micropython-lib>`_ and must be installed explicitly,
+   for example with ``mpremote mip install <name>``.
+
+.. [#ffi] This module is only available in the ``unix-ffi`` section of micropython-lib.
+   It depends on FFI access to the host C library and so cannot be used on
+   microcontroller ports.
+
+.. [#mod] MicroPython has no counterpart to this module, in either the firmware or
+   micropython-lib.
+
+.. [#cm] MicroPython never supported chaining a :func:`classmethod` around another
+   descriptor: applying ``@classmethod`` to a :func:`property` yields a bound method
+   wrapping the property object rather than invoking it.  CPython 3.13 removing the
+   feature therefore brings CPython into line with MicroPython's existing behaviour.
+
+.. [#doc] The point is moot for MicroPython, which goes further than the CPython
+   optimisation: ``MICROPY_ENABLE_DOC_STRING`` defaults to ``0``, so docstrings are
+   discarded by the compiler entirely and no ``__doc__`` attributes are created.
+
+.. [#fut] MicroPython's compiler has no notion of future statements at all, so neither
+   ``from __future__ import ...`` nor ``from .__future__ import ...`` activates any
+   special behaviour.  micropython-lib [#lib]_ ships a stub ``__future__`` module so
+   that such imports do not fail.
+
+.. [#frz] MicroPython freezes modules into the firmware at build time as a core part of
+   how ports are built, and there is no run-time option to ignore them.
+
+.. [#ast] MicroPython has no ``ast`` module and does not expose an abstract syntax tree;
+   :func:`compile` (where enabled) accepts only the standard modes and no flags
+   argument.
+
+.. [#arch] MicroPython's compression support is provided by the ``deflate`` module,
+   which offers a single ``DeflateIO`` stream wrapper, and by the ``tarfile`` and
+   ``zlib`` modules in micropython-lib [#lib]_.  There is no ``bz2``, ``lzma``,
+   ``zipfile`` or ``zipimport`` module.
+
+.. [#arr] MicroPython's :mod:`array` module supports the type codes ``b``, ``B``, ``h``,
+   ``H``, ``i``, ``I``, ``l``, ``L``, ``q``, ``Q``, ``f`` and ``d``.  It has never
+   supported ``u``, so the deprecation itself has no effect, but the replacement ``w``
+   type code is not implemented either.
+
+.. [#dgram] MicroPython's ``asyncio`` has no transport and protocol layer, so there is
+   no ``DatagramTransport``; datagrams are sent with the ``socket`` module directly.
+
+.. [#aioq] MicroPython's ``asyncio`` has no ``Queue`` class at all.  ``ThreadSafeFlag``
+   and ``Event`` are the usual means of signalling between tasks.
+
+.. [#ru] MicroPython's ``asyncio.StreamReader`` provides ``read()``, ``readline()`` and
+   ``readexactly()``, but no ``readuntil()``.
+
+.. [#tg] MicroPython's ``asyncio`` has no ``TaskGroup``; ``gather()`` is the closest
+   equivalent.
+
+.. [#bat] This is a refinement of ``itertools.batched()``, which was itself added in
+   CPython 3.12 and is not implemented by MicroPython, so the *strict* parameter has
+   nothing to apply to.
+
+.. [#q] MicroPython has no ``queue`` module, in either the firmware or micropython-lib.
+   :class:`collections.deque` and ``asyncio.ThreadSafeFlag`` are the usual substitutes.
+
+.. [#re] MicroPython's :mod:`re` module defines neither ``re.error`` nor
+   ``PatternError``; a bad pattern raises a plain :exc:`ValueError`.  Code that needs to
+   be portable should therefore catch :exc:`ValueError`, which both spellings of the
+   CPython exception derive from.
+
+.. [#tls] MicroPython's ``ssl`` module is implemented on top of Mbed TLS (axTLS on a few
+   ports), not OpenSSL, and does not provide ``create_default_context()`` or the
+   ``VERIFY_X509_*`` constants.  Certificate verification is configured through the
+   ``cert_reqs`` and ``cadata`` arguments to ``ssl.SSLContext`` instead.
+
+.. [#int] MicroPython interns every string that is used as an identifier, as a "qstr" in
+   a global pool, and :func:`sys.intern` is available when
+   ``MICROPY_PY_SYS_INTERN`` is enabled.  There is no way to query whether a given
+   string has been interned.
+
+.. [#tb] The ``traceback`` module in micropython-lib [#lib]_ provides only
+   ``format_tb()``, ``format_exception()``, ``format_exception_only()``,
+   ``print_exception()``, ``print_exc()`` and ``format_exc()``.  There is no
+   ``TracebackException`` class for these changes to apply to.
+
+.. [#ty] The ``types`` module in micropython-lib [#lib]_ defines ``SimpleNamespace`` as
+   ``None``, along with ``CodeType``, ``MappingProxyType``, ``TracebackType`` and
+   ``FrameType``, because MicroPython does not expose the corresponding objects.
+
+.. [#btree] MicroPython's nearest equivalent to ``dbm`` is the ``btree`` module, which
+   wraps the BerkeleyDB 1.xx library and provides a persistent key/value store with a
+   dict-like interface.

--- a/docs/differences/python_314.rst
+++ b/docs/differences/python_314.rst
@@ -162,7 +162,7 @@ Changes to built-in modules:
   +----------------------------------------------------------------------------------------------------------------+------------------------------+
   | `io <https://docs.python.org/3/whatsnew/3.14.html#io>`_                                                                                       |
   +----------------------------------------------------------------------------------------------------------------+------------------------------+
-  | Calling ``read()`` on a non-blocking text stream may now raise :exc:`BlockingIOError` rather than returning an | Not implemented [#io]_       |
+  | Calling ``read()`` on a non-blocking text stream may now raise :exc:`BlockingIOError` rather than returning an | Not implemented [#iolib]_    |
   | empty string.                                                                                                  |                              |
   +----------------------------------------------------------------------------------------------------------------+------------------------------+
   | Added the ``io.Reader`` and ``io.Writer`` protocols for static typing.                                         | Not relevant [#ann]_         |
@@ -310,7 +310,7 @@ Changes to built-in modules:
    ``mip``, and generally implements only a commonly used subset of the
    CPython API.
 
-.. [#io] MicroPython has no text-mode/binary-mode stream distinction of the
+.. [#iolib] MicroPython has no text-mode/binary-mode stream distinction of the
    kind this change describes.  Non-blocking streams conventionally return
    ``None`` from ``read()`` when no data is available rather than raising.
    :exc:`BlockingIOError` does exist as an :exc:`OSError` subclass.

--- a/docs/differences/python_314.rst
+++ b/docs/differences/python_314.rst
@@ -1,0 +1,321 @@
+.. _python_314:
+
+Python 3.14
+===========
+
+Python 3.14.0 (final) was released on the 7 October 2025.  Unlike earlier
+releases there is no "features for 3.14" PEP equivalent to :pep:`619`; the
+closest analogue is `PEP 745 <https://peps.python.org/pep-0745/>`_, which
+defines only the release schedule.  A detailed description of the changes can
+be found in `What's New in Python 3.14
+<https://docs.python.org/3/whatsnew/3.14.html>`_.
+
+The headline result for MicroPython is :pep:`750` template strings
+(t-strings), which are fully implemented -- an unusual case of MicroPython
+picking up a brand new CPython feature almost immediately.  MicroPython's
+version lag is not uniform across features: a specific contributor and use
+case drove early adoption of t-strings, while considerably older additions
+such as :pep:`634` structural pattern matching (3.10) and :pep:`654` exception
+groups (3.11) remain unimplemented.
+
+Unlike the pages for Python 3.5 to 3.10, this page also covers modules that
+MicroPython ships only in `micropython-lib
+<https://github.com/micropython/micropython-lib>`_ rather than compiling into
+the firmware.  Such rows are marked with a note; those modules are optional
+packages installed with ``mip`` or ``mpremote mip``, not built-in modules.
+
+.. table::
+  :widths: 20 60 20
+
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | **New syntax features**                                                                                                       | **Status**                 |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 750 <https://peps.python.org/pep-750/>`_            | Template string literals (t-strings)                               | Complete [#tstr]_          |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 758 <https://peps.python.org/pep-758/>`_            | Allow ``except`` and ``except*`` expressions without parentheses   | Not implemented [#exc]_    |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 765 <https://peps.python.org/pep-765/>`_            | Disallow ``return``, ``break`` and ``continue`` that exit a        | Not implemented [#warn]_   |
+  |                                                          | ``finally`` block                                                  |                            |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | **New features in the standard library**                                                                                                                   |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 784 <https://peps.python.org/pep-784/>`_            | Adding Zstandard to the standard library                           | Not implemented [#zstd]_   |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 749 <https://peps.python.org/pep-749/>`_            | Implementing PEP 649, including the new ``annotationlib`` module   | Not implemented [#ann]_    |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 734 <https://peps.python.org/pep-734/>`_            | Multiple interpreters in the standard library                      | Not implemented [#interp]_ |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | **Interpreter improvements**                                                                                                                               |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 649 <https://peps.python.org/pep-649/>`_            | Deferred evaluation of annotations, so that ``from __future__      | Not implemented [#ann]_    |
+  |                                                          | import annotations`` is no longer needed                           |                            |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 768 <https://peps.python.org/pep-768/>`_            | Safe external debugger interface for CPython                       | Not relevant               |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 741 <https://peps.python.org/pep-741/>`_            | Python configuration C API                                         | Not relevant               |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 779 <https://peps.python.org/pep-779/>`_            | Free-threaded Python is officially supported                       | Not relevant               |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 776 <https://peps.python.org/pep-776/>`_            | Emscripten support (tier 3)                                        | Not relevant [#wasm]_      |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `Tail-calling interpreter                                | A new type of interpreter that uses tail calls between small C     | Not relevant               |
+  | <https://docs.python.org/3/whatsnew/3.14.html>`_         | functions, 3-5% faster on average                                  |                            |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `REPL improvements                                       | The default interactive shell now highlights Python syntax as it   | Partial [#repl]_           |
+  | <https://docs.python.org/3/whatsnew/3.14.html>`_         | is typed, and ``import`` statements offer auto-completion of       |                            |
+  |                                                          | module names                                                       |                            |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `Error messages                                          | Further improvements to error messages, including suggestions for  | Not implemented [#errmsg]_ |
+  | <https://docs.python.org/3/whatsnew/3.14.html>`_         | misspelled keyword arguments and clearer reports of unbalanced     |                            |
+  |                                                          | brackets                                                           |                            |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | **Important deprecations, removals or restrictions**                                                                                                       |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+  | `PEP 761 <https://peps.python.org/pep-761/>`_            | Discontinuation of PGP signatures for CPython release artifacts    | Not relevant               |
+  +----------------------------------------------------------+--------------------------------------------------------------------+----------------------------+
+
+
+Other Language Changes:
+
+.. table::
+  :widths: 90 10
+
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | All Windows code pages are now supported as ``cpXXX`` codecs on Windows.                                       | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Mixed-mode arithmetic between a real number and a :class:`complex` number now follows the recommendations of   | Not implemented [#cplx]_     |
+  | C99 Annex G, so that infinities and NaNs propagate correctly.                                                  |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Incorrect usage of ``await`` and asynchronous comprehensions is now detected even when the enclosing code is   | Not implemented [#opt]_      |
+  | optimized away by the ``-O`` command line option.                                                              |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Slots of C types are no longer replaced with wrapped versions when a pure Python subclass is created.          | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :meth:`bytes.fromhex` and :meth:`bytearray.fromhex` now accept ASCII :class:`bytes` and bytes-like objects in  | Complete [#hex]_             |
+  | addition to :class:`str`.                                                                                      |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the :meth:`float.from_number` and :meth:`complex.from_number` constructors.                              | Not implemented              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The ``,`` and ``_`` thousands separators are now also supported in the fractional part when formatting a       | Not implemented [#sep]_      |
+  | :class:`float`.                                                                                                |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :func:`int` no longer delegates to the :meth:`~object.__trunc__` method.                                       | Complete [#trunc]_           |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :func:`map` has a new keyword-only ``strict`` flag, used to require that all the iterables have an equal       | Not implemented              |
+  | length.                                                                                                        |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :class:`memoryview` now supports subscription, making it a generic type (``memoryview[int]``).                 | Not implemented              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Using :const:`NotImplemented` in a boolean context now raises :exc:`TypeError`; previously this emitted a      | Not implemented              |
+  | :exc:`DeprecationWarning`.                                                                                     |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The three-argument form of :func:`pow` now tries :meth:`~object.__rpow__` if necessary.  MicroPython's         | Not implemented              |
+  | three-argument :func:`pow` accepts integers only and otherwise raises :exc:`TypeError`.                        |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :class:`super` objects are now copyable and pickleable.                                                        | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | ``-X importtime=2`` now also reports modules that were already present in :data:`sys.modules`.                 | Not implemented              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The ``-c`` command line option now automatically dedents its code argument.  The unix port accepts ``-c`` but  | Not implemented              |
+  | rejects indented code with an :exc:`IndentationError`.                                                         |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The ``-J`` command line option is no longer reserved for use by Jython.                                        | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The cyclic garbage collector became incremental in 3.14.0 and was reverted to a generational design in 3.14.5. | Not relevant [#gc]_          |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+
+Changes to built-in modules:
+
+.. table::
+  :widths: 90 10
+
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.14.html#asyncio>`_                                                                             |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :func:`asyncio.create_task`, :meth:`asyncio.TaskGroup.create_task` and :func:`asyncio.eager_task_factory` now  | Not implemented              |
+  | accept arbitrary keyword arguments, which are passed on to the :class:`asyncio.Task` constructor.              |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`asyncio.capture_call_graph` and :func:`asyncio.print_call_graph` for introspecting the call graph | Not implemented              |
+  | of a running task.                                                                                             |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | asyncio can now be used as a command line tool (``python -m asyncio ps PID`` and ``pstree PID``) to inspect a  | Not relevant                 |
+  | running process.                                                                                               |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `base64 <https://docs.python.org/3/whatsnew/3.14.html#base64>`_                                                                               |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`base64.z85encode` and :func:`base64.z85decode` for Z85 data encoding.                             | Not implemented [#mplib]_    |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `errno <https://docs.python.org/3/whatsnew/3.14.html#errno>`_                                                                                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the :data:`errno.EHWPOISON` error code.  MicroPython exposes only a small curated subset of the          | Not implemented              |
+  | ``errno`` values.                                                                                              |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `gzip and zlib <https://docs.python.org/3/whatsnew/3.14.html#gzip>`_                                                                          |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The :mod:`gzip` and :mod:`zlib` modules are now also available as ``compression.gzip`` and                     | Not implemented [#zstd]_     |
+  | ``compression.zlib``.                                                                                          |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `heapq <https://docs.python.org/3/whatsnew/3.14.html#heapq>`_                                                                                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the max-heap variants ``heapify_max``, ``heappush_max``, ``heappop_max``, ``heapreplace_max`` and        | Not implemented              |
+  | ``heappushpop_max``.                                                                                           |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `io <https://docs.python.org/3/whatsnew/3.14.html#io>`_                                                                                       |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Calling ``read()`` on a non-blocking text stream may now raise :exc:`BlockingIOError` rather than returning an | Not implemented [#io]_       |
+  | empty string.                                                                                                  |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the ``io.Reader`` and ``io.Writer`` protocols for static typing.                                         | Not relevant [#ann]_         |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `json <https://docs.python.org/3/whatsnew/3.14.html#json>`_                                                                                   |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Serialization errors now carry exception notes identifying the offending object.  MicroPython does not         | Not implemented              |
+  | implement the :pep:`678` ``add_note()`` mechanism that this relies on.                                         |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | The :mod:`json` module is now usable as a command line tool, with colourised output.                           | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.14.html#math>`_                                                                                   |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`math.isnormal` and :func:`math.issubnormal`.                                                      | Not implemented              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Domain errors raised by the :mod:`math` module now carry more detailed messages.                               | Not implemented [#errmsg]_   |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `operator <https://docs.python.org/3/whatsnew/3.14.html#operator>`_                                                                           |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`operator.is_none` and :func:`operator.is_not_none`.                                               | Not implemented [#mplib]_    |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `os <https://docs.python.org/3/whatsnew/3.14.html#os>`_                                                                                       |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`os.readinto` to read into a pre-allocated writable buffer from a file descriptor.                 | Not implemented [#readinto]_ |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`os.reload_environ` to refresh :data:`os.environ`.  MicroPython has no :data:`os.environ`, only    | Not relevant                 |
+  | :func:`os.getenv` and :func:`os.putenv` on ports that support them.                                            |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the ``SCHED_DEADLINE`` and ``SCHED_NORMAL`` constants.                                                   | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `os.path <https://docs.python.org/3/whatsnew/3.14.html#os-path>`_                                                                             |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | :func:`os.path.realpath` now accepts ``strict=ALLOW_MISSING`` to ignore missing final components.  The         | Not implemented [#mplib]_    |
+  | micropython-lib ``os-path`` package provides no ``realpath`` at all.                                           |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `pathlib <https://docs.python.org/3/whatsnew/3.14.html#pathlib>`_                                                                             |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :meth:`!Path.copy`, :meth:`!Path.copy_into`, :meth:`!Path.move` and :meth:`!Path.move_into`, together    | Not implemented [#mplib]_    |
+  | with the :attr:`!Path.info` attribute.                                                                         |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.14.html#sys>`_                                                                                     |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added :func:`sys.remote_exec` to execute code in a remote process (:pep:`768`).                                | Not relevant                 |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+  | Added the ``sys.flags.thread_inherit_context`` and ``sys.flags.context_aware_warnings`` flags.  MicroPython    | Not relevant                 |
+  | has no ``sys.flags`` at all.                                                                                   |                              |
+  +----------------------------------------------------------------------------------------------------------------+------------------------------+
+
+.. rubric:: Notes
+
+.. [#tstr] Template strings are implemented in full, including the ``t``
+   string prefix, the ``string.templatelib`` module with its ``Template`` and
+   ``Interpolation`` types, iteration, concatenation, nested quotes and the
+   ``{expr=}`` debug form.  They require ``MICROPY_PY_TSTRINGS``, which is
+   enabled by default at the full-features ROM level: the alif, mimxrt and
+   samd (SAMD51 only) ports, the unix coverage variant and the webassembly
+   pyscript variant.  The zephyr port enables them when explicitly configured
+   for the full-features (or higher) ROM level via Kconfig, which is not the
+   default.  ``mpy-cross`` always accepts t-string syntax, so a ``.mpy`` file
+   using t-strings can be cross-compiled even for a target port whose own
+   interpreter would reject the syntax.  Two deviations from CPython remain:
+   the ``!a`` conversion is not supported, and there is no :func:`format`
+   built-in, so processing code should use :meth:`str.format` instead.  See
+   :mod:`string.templatelib` for details.
+
+.. [#exc] MicroPython's grammar accepts only a single expression after
+   ``except``, so ``except A, B:`` is a :exc:`SyntaxError`; the parenthesized
+   form ``except (A, B):`` works as usual.  The ``except*`` syntax is a
+   :pep:`654` (Python 3.11) feature that MicroPython does not implement at
+   all, so the :pep:`758` relaxation is doubly inapplicable there.
+
+.. [#warn] MicroPython has a warning category hierarchy and an internal
+   ``mp_warning()`` mechanism, but the compiler emits no ``SyntaxWarning``
+   diagnostics.  ``return``, ``break`` and ``continue`` inside a ``finally``
+   block are accepted silently and swallow any in-flight exception, exactly as
+   in earlier CPython versions.
+
+.. [#zstd] MicroPython has no Zstandard support and no ``compression``
+   namespace package.  Its compression story is the built-in :mod:`deflate`
+   module, which offers ``DeflateIO`` with ``RAW``, ``ZLIB``, ``GZIP`` and
+   ``AUTO`` formats.  micropython-lib layers thin ``gzip`` and ``zlib``
+   compatibility shims on top of it.
+
+.. [#ann] MicroPython parses type annotations but never evaluates them, so
+   annotations produce no runtime effects and no ``__annotations__``
+   attributes are created.  The lazy-evaluation semantics of :pep:`649` are
+   therefore largely moot, but there is no ``annotationlib`` module, no real
+   ``__annotations__`` dictionary and no ``typing`` module, so none of this
+   can be used other than as inert annotations.
+
+.. [#interp] MicroPython supports multiple independent VM instances at the C
+   level (the interpreter state lives in a single ``mp_state_ctx`` structure,
+   which the embed port relies on), but there is no Python-level API to
+   create or communicate with them, so nothing equivalent to
+   ``concurrent.interpreters`` exists.
+
+.. [#wasm] :pep:`776` concerns the support tier CPython assigns to its own
+   Emscripten builds, so it is not something MicroPython can implement.
+   MicroPython has independently targeted Emscripten for some time through its
+   ``webassembly`` port.
+
+.. [#repl] MicroPython's REPL already offers tab completion, and completion
+   after ``import`` specifically suggests built-in module names.  There is no
+   syntax highlighting.  Both depend on ``MICROPY_HELPER_REPL``, which is
+   enabled from the extra-features ROM level upwards.
+
+.. [#errmsg] MicroPython's exception messages are deliberately terse to save
+   ROM.  ``MICROPY_ERROR_REPORTING`` selects between four levels (none, terse,
+   normal and detailed), with detailed used from the full-features ROM level
+   upwards, but even that level does not attempt CPython's suggestion-style
+   diagnostics.
+
+.. [#cplx] MicroPython promotes the real operand to a complex number and then
+   applies the textbook formula, with no special handling of infinities or
+   NaNs.  For example ``complex(float('inf'), 0) * 2`` evaluates to
+   ``(inf+nanj)`` rather than the ``(inf+0j)`` that C99 Annex G requires.
+
+.. [#opt] MicroPython's ``-O`` option sets the optimisation level used for
+   ``assert`` removal and ``__debug__``.  An ``assert`` whose expression
+   contains a misplaced ``await`` is reported as a :exc:`SyntaxError` at the
+   default level, but is discarded without complaint under ``-O``.
+
+.. [#hex] MicroPython accepts any object supporting the buffer protocol here,
+   which makes it broader than CPython 3.14: :class:`str`, :class:`bytes`,
+   :class:`bytearray` and :class:`memoryview` arguments all work.
+
+.. [#sep] MicroPython honours the ``,`` and ``_`` separators only when
+   formatting integers.  They are ignored entirely for :class:`float` values,
+   in the integer part as well as the fractional part, so ``'{:,.2f}'`` yields
+   an ungrouped result.
+
+.. [#trunc] MicroPython has never consulted ``__trunc__``, so its behaviour
+   already matches Python 3.14.  Note that MicroPython does not implement
+   ``__index__`` as a distinct protocol either: :func:`int` and sequence
+   subscripting both go through ``__int__``, and an object defining only
+   ``__index__`` raises :exc:`TypeError`.
+
+.. [#gc] MicroPython's collector is a non-generational mark-and-sweep
+   collector, so neither the incremental nor the generational design applies.
+   :func:`gc.collect` takes no generation argument.
+
+.. [#mplib] This module is not built into MicroPython firmware.  It is
+   provided as an optional pure-Python package in `micropython-lib
+   <https://github.com/micropython/micropython-lib>`_, installable with
+   ``mip``, and generally implements only a commonly used subset of the
+   CPython API.
+
+.. [#io] MicroPython has no text-mode/binary-mode stream distinction of the
+   kind this change describes.  Non-blocking streams conventionally return
+   ``None`` from ``read()`` when no data is available rather than raising.
+   :exc:`BlockingIOError` does exist as an :exc:`OSError` subclass.
+
+.. [#readinto] Buffer-oriented reads are idiomatic in MicroPython, and stream
+   objects such as files and :class:`io.BytesIO` do provide a ``readinto()``
+   method.  What is missing is the file-descriptor level :func:`os.readinto`.
+

--- a/docs/differences/python_35.rst
+++ b/docs/differences/python_35.rst
@@ -8,57 +8,59 @@ Below is a list of finalised/accepted PEPs for Python 3.5 grouped into their imp
 .. table::
   :widths: 30 50 20
 
-  +--------------------------------------------------------------------------------------------------------------+------------------------+
-  | **Extensions to the syntax**                                                                                 | **Status**             |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_ | Additional unpacking generalizations                | Partial [#f1]_         |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 465 <https://www.python.org/dev/peps/pep-0465/>`_ | A new matrix multiplication operator                | Complete               |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_ | Coroutines with ``async`` and ``await`` syntax      | Partial [#f2]_         |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | **Extensions and changes to runtime**                                                                                                 |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 461 <https://www.python.org/dev/peps/pep-0461/>`_ | % formatting for binary strings                     | Partial [#f3]_         |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 475 <https://www.python.org/dev/peps/pep-0475/>`_ | Retrying system calls that fail with ``EINTR``      | Complete               |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 479 <https://www.python.org/dev/peps/pep-0479/>`_ | Change ``StopIteration`` handling inside generators | Complete               |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | **Standard library changes**                                                                                                          |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 471 <https://www.python.org/dev/peps/pep-0471/>`_ | ``os.scandir()``                                    | Not implemented [#f4]_ |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 485 <https://www.python.org/dev/peps/pep-0485/>`_ | ``math.isclose()``, a function for testing          | Complete               |
-  |                                                        | approximate equality                                |                        |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | **Miscellaneous changes**                                                                                                             |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_ | Improved Python zip application support             | Not implemented        |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 486 <https://www.python.org/dev/peps/pep-0486/>`_ | Make the Python Launcher aware of virtual           | Not relevant           |
-  |                                                        | environments                                        |                        |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ | Type hints (advisory only)                          | Complete [#fth]_       |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 488 <https://www.python.org/dev/peps/pep-0488/>`_ | Elimination of PYO files                            | Not relevant           |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
-  | `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_ | Redesigning extension module loading                | Not relevant           |
-  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  +--------------------------------------------------------------------------------------------------------------+--------------------+
+  | **Extensions to the syntax**                                                                                 | **Status**         |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_ | Additional unpacking generalizations                | Partial [#f1]_     |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 465 <https://www.python.org/dev/peps/pep-0465/>`_ | A new matrix multiplication operator                | Complete           |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_ | Coroutines with ``async`` and ``await`` syntax      | Partial [#f2]_     |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | **Extensions and changes to runtime**                                                                                             |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 461 <https://www.python.org/dev/peps/pep-0461/>`_ | % formatting for binary strings                     | Partial [#f3]_     |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 475 <https://www.python.org/dev/peps/pep-0475/>`_ | Retrying system calls that fail with ``EINTR``      | Complete           |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 479 <https://www.python.org/dev/peps/pep-0479/>`_ | Change ``StopIteration`` handling inside generators | Complete           |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | **Standard library changes**                                                                                                      |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 471 <https://www.python.org/dev/peps/pep-0471/>`_ | ``os.scandir()``                                    | Not implemented    |
+  |                                                        |                                                     | [#f4]_             |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 485 <https://www.python.org/dev/peps/pep-0485/>`_ | ``math.isclose()``, a function for testing          | Complete           |
+  |                                                        | approximate equality                                |                    |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | **Miscellaneous changes**                                                                                                         |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_ | Improved Python zip application support             | Not implemented    |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 486 <https://www.python.org/dev/peps/pep-0486/>`_ | Make the Python Launcher aware of virtual           | Not relevant       |
+  |                                                        | environments                                        |                    |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ | Type hints (advisory only)                          | Complete [#fth]_   |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 488 <https://www.python.org/dev/peps/pep-0488/>`_ | Elimination of PYO files                            | Not relevant       |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  | `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_ | Redesigning extension module loading                | Not relevant       |
+  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
 
 Other Language Changes:
 
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Added the *namereplace* error handlers. The *backslashreplace* error handlers now work with decoding and  | Not implemented        |
-  | translating.                                                                                              |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Property docstrings are now writable. This is especially useful for collections.namedtuple() docstrings   | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Circular imports involving relative imports are now supported.                                            | Complete               |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Added the *namereplace* error handlers. The *backslashreplace* error handlers now work with decoding and  | Not           |
+  | translating.                                                                                              | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Property docstrings are now writable. This is especially useful for collections.namedtuple() docstrings   | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Circular imports involving relative imports are now supported.                                            | Complete      |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
 
 
 New Modules:
@@ -73,120 +75,134 @@ Changes to built-in modules:
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `collections <https://docs.python.org/3/whatsnew/3.5.html#collections>`_                                                           |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *OrderedDict* class is now implemented in C, which makes it 4 to 100 times faster.                    | Complete               |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | *OrderedDict.items()* , *OrderedDict.keys()* , *OrderedDict.values()* views now support reversed()        | Not implemented        |
-  | iteration.                                                                                                |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The deque class now defines *index()*, *insert()*, and *copy()*, and supports the + and * operators.      | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Docstrings produced by namedtuple() can now be updated.                                                   | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The UserString class now implements the *__getnewargs__()*, *__rmod__()*, *casefold()*, *format_map()*,   | Not implemented        |
-  | *isprintable()*, and *maketrans()* methods to match the corresponding methods of str.                     |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `heapq <https://docs.python.org/3/whatsnew/3.5.html#heapq>`_                                                                       |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Element comparison in *merge()* can now be customized by passing a key function in a new optional key     | Not implemented        |
-  | keyword argument, and a new optional *reverse* keyword argument can be used to reverse element comparison |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `io <https://docs.python.org/3/whatsnew/3.5.html#io>`_                                                                             |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new *BufferedIOBase.readinto1()* method, that uses at most one call to the underlying raw stream's      | Not implemented        |
-  | *RawIOBase.read()* or *RawIOBase.readinto()* methods                                                      |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `json <https://docs.python.org/3/whatsnew/3.5.html#json>`_                                                                         |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | JSON decoder now raises JSONDecodeError instead of ValueError to provide better context information about | Not implemented        |
-  | the error.                                                                                                |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `math <https://docs.python.org/3/whatsnew/3.5.html#math>`_                                                                         |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Two new constants have been added to the math module: *inf* and *nan*.                                    | Complete               |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new function *isclose()* provides a way to test for approximate equality.                               | Complete               |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `os <https://docs.python.org/3/whatsnew/3.5.html#os>`_                                                                             |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The new *scandir()* function returning an iterator of DirEntry objects has been added.                    | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *urandom()* function now uses the *getrandom()* syscall on Linux 3.17 or newer, and *getentropy()* on | Complete               |
-  | OpenBSD 5.6 and newer, removing the need to use /dev/urandom and avoiding failures due to potential file  |                        |
-  | descriptor exhaustion.                                                                                    |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | New *get_blocking()* and *set_blocking()* functions allow getting and setting a file descriptor's blocking| Not implemented        |
-  | mode (O_NONBLOCK.)                                                                                        |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | There is a new *os.path.commonpath()* function returning the longest common sub-path of each passed       | Not implemented        |
-  | pathname                                                                                                  |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `re <https://docs.python.org/3/whatsnew/3.5.html#re>`_                                                                             |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | References and conditional references to groups with fixed length are now allowed in lookbehind assertions| Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The number of capturing groups in regular expressions is no longer limited to 100.                        | Not implemented [#f5]_ |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *sub()* and *subn()* functions now replace unmatched groups with empty strings instead of raising an  | Partial [#f6]_         |
-  | exception.                                                                                                |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *re.error* exceptions have new attributes, msg, pattern, pos, lineno, and colno, that provide better  | Not implemented        |
-  | context information about the error                                                                       |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `socket <https://docs.python.org/3/whatsnew/3.5.html#socket>`_                                                                     |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Functions with timeouts now use a monotonic clock, instead of a system clock.                             | Complete               |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new *socket.sendfile()* method allows sending a file over a socket by using the high-performance        | Not implemented        |
-  | *os.sendfile()* function on UNIX, resulting in uploads being from 2 to 3 times faster than when using     |                        |
-  | plain *socket.send()*                                                                                     |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *socket.sendall()* method no longer resets the socket timeout every time bytes are received or sent.  | Partial [#f7]_         |
-  | The socket timeout is now the maximum total duration to send all data.                                    |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The backlog argument of the *socket.listen()* method is now optional. By default it is set to SOMAXCONN or| Partial [#f8]_         |
-  | to 128, whichever is less.                                                                                |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `ssl <https://docs.python.org/3/whatsnew/3.5.html#ssl>`_                                                                           |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Memory BIO Support                                                                                        | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | Application-Layer Protocol Negotiation Support                                                            | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | There is a new *SSLSocket.version()* method to query the actual protocol version in use.                  | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The SSLSocket class now implements a *SSLSocket.sendfile()* method.                                       | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *SSLSocket.send()* method now raises either the *ssl.SSLWantReadError* or *ssl.SSLWantWriteError*     | Partial [#f9]_         |
-  | exception on a non-blocking socket if the operation would block. Previously, it would return 0.           |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *cert_time_to_seconds()* function now interprets the input time as UTC and not as local time, per RFC | Not implemented        |
-  | 5280. Additionally, the return value is always an int.                                                    |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | New *SSLObject.shared_ciphers()* and *SSLSocket.shared_ciphers()* methods return the list of ciphers sent | Not implemented        |
-  | by the client during the handshake.                                                                       |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *SSLSocket.do_handshake()*, *SSLSocket.read()*, *SSLSocket.shutdown()*, and *SSLSocket.write()*       | Not implemented        |
-  | methods of the SSLSocket class no longer reset the socket timeout every time bytes are received or sent.  |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *match_hostname()* function now supports matching of IP addresses.                                    | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.5.html#sys>`_                                                                           |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new *set_coroutine_wrapper()* function allows setting a global hook that will be called whenever a      | Won't do [#f10]_       |
-  | coroutine object is created by an async def function. A corresponding *get_coroutine_wrapper()* can be    |                        |
-  | used to obtain a currently set wrapper.                                                                   |                        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | A new *is_finalizing()* function can be used to check if the Python interpreter is shutting down.         | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | `time <https://docs.python.org/3/whatsnew/3.5.html#time>`_                                                                         |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
-  | The *monotonic()* function is now always available                                                        | Not implemented        |
-  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `collections <https://docs.python.org/3/whatsnew/3.5.html#collections>`_                                                  |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *OrderedDict* class is now implemented in C, which makes it 4 to 100 times faster.                    | Complete      |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | *OrderedDict.items()* , *OrderedDict.keys()* , *OrderedDict.values()* views now support reversed()        | Not           |
+  | iteration.                                                                                                | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The deque class now defines *index()*, *insert()*, and *copy()*, and supports the + and * operators.      | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Docstrings produced by namedtuple() can now be updated.                                                   | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The UserString class now implements the *__getnewargs__()*, *__rmod__()*, *casefold()*, *format_map()*,   | Not           |
+  | *isprintable()*, and *maketrans()* methods to match the corresponding methods of str.                     | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `heapq <https://docs.python.org/3/whatsnew/3.5.html#heapq>`_                                                              |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Element comparison in *merge()* can now be customized by passing a key function in a new optional key     | Not           |
+  | keyword argument, and a new optional *reverse* keyword argument can be used to reverse element comparison | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `io <https://docs.python.org/3/whatsnew/3.5.html#io>`_                                                                    |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new *BufferedIOBase.readinto1()* method, that uses at most one call to the underlying raw stream's      | Not           |
+  | *RawIOBase.read()* or *RawIOBase.readinto()* methods                                                      | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `json <https://docs.python.org/3/whatsnew/3.5.html#json>`_                                                                |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | JSON decoder now raises JSONDecodeError instead of ValueError to provide better context information about | Not           |
+  | the error.                                                                                                | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `math <https://docs.python.org/3/whatsnew/3.5.html#math>`_                                                                |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Two new constants have been added to the math module: *inf* and *nan*.                                    | Complete      |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new function *isclose()* provides a way to test for approximate equality.                               | Complete      |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `os <https://docs.python.org/3/whatsnew/3.5.html#os>`_                                                                    |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The new *scandir()* function returning an iterator of DirEntry objects has been added.                    | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *urandom()* function now uses the *getrandom()* syscall on Linux 3.17 or newer, and *getentropy()* on | Complete      |
+  | OpenBSD 5.6 and newer, removing the need to use /dev/urandom and avoiding failures due to potential file  |               |
+  | descriptor exhaustion.                                                                                    |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | New *get_blocking()* and *set_blocking()* functions allow getting and setting a file descriptor's blocking| Not           |
+  | mode (O_NONBLOCK.)                                                                                        | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | There is a new *os.path.commonpath()* function returning the longest common sub-path of each passed       | Not           |
+  | pathname                                                                                                  | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `re <https://docs.python.org/3/whatsnew/3.5.html#re>`_                                                                    |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | References and conditional references to groups with fixed length are now allowed in lookbehind assertions| Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The number of capturing groups in regular expressions is no longer limited to 100.                        | Not           |
+  |                                                                                                           | implemented   |
+  |                                                                                                           | [#f5]_        |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *sub()* and *subn()* functions now replace unmatched groups with empty strings instead of raising an  | Partial [#f6]_|
+  | exception.                                                                                                |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *re.error* exceptions have new attributes, msg, pattern, pos, lineno, and colno, that provide better  | Not           |
+  | context information about the error                                                                       | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `socket <https://docs.python.org/3/whatsnew/3.5.html#socket>`_                                                            |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Functions with timeouts now use a monotonic clock, instead of a system clock.                             | Complete      |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new *socket.sendfile()* method allows sending a file over a socket by using the high-performance        | Not           |
+  | *os.sendfile()* function on UNIX, resulting in uploads being from 2 to 3 times faster than when using     | implemented   |
+  | plain *socket.send()*                                                                                     |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *socket.sendall()* method no longer resets the socket timeout every time bytes are received or sent.  | Partial [#f7]_|
+  | The socket timeout is now the maximum total duration to send all data.                                    |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The backlog argument of the *socket.listen()* method is now optional. By default it is set to SOMAXCONN or| Partial [#f8]_|
+  | to 128, whichever is less.                                                                                |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `ssl <https://docs.python.org/3/whatsnew/3.5.html#ssl>`_                                                                  |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Memory BIO Support                                                                                        | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | Application-Layer Protocol Negotiation Support                                                            | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | There is a new *SSLSocket.version()* method to query the actual protocol version in use.                  | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The SSLSocket class now implements a *SSLSocket.sendfile()* method.                                       | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *SSLSocket.send()* method now raises either the *ssl.SSLWantReadError* or *ssl.SSLWantWriteError*     | Partial [#f9]_|
+  | exception on a non-blocking socket if the operation would block. Previously, it would return 0.           |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *cert_time_to_seconds()* function now interprets the input time as UTC and not as local time, per RFC | Not           |
+  | 5280. Additionally, the return value is always an int.                                                    | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | New *SSLObject.shared_ciphers()* and *SSLSocket.shared_ciphers()* methods return the list of ciphers sent | Not           |
+  | by the client during the handshake.                                                                       | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *SSLSocket.do_handshake()*, *SSLSocket.read()*, *SSLSocket.shutdown()*, and *SSLSocket.write()*       | Not           |
+  | methods of the SSLSocket class no longer reset the socket timeout every time bytes are received or sent.  | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *match_hostname()* function now supports matching of IP addresses.                                    | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.5.html#sys>`_                                                                  |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new *set_coroutine_wrapper()* function allows setting a global hook that will be called whenever a      | Won't do      |
+  | coroutine object is created by an async def function. A corresponding *get_coroutine_wrapper()* can be    | [#f10]_       |
+  | used to obtain a currently set wrapper.                                                                   |               |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | A new *is_finalizing()* function can be used to check if the Python interpreter is shutting down.         | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | `time <https://docs.python.org/3/whatsnew/3.5.html#time>`_                                                                |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
+  | The *monotonic()* function is now always available                                                        | Not           |
+  |                                                                                                           | implemented   |
+  +-----------------------------------------------------------------------------------------------------------+---------------+
 
 .. rubric:: Notes
 

--- a/docs/differences/python_35.rst
+++ b/docs/differences/python_35.rst
@@ -8,57 +8,57 @@ Below is a list of finalised/accepted PEPs for Python 3.5 grouped into their imp
 .. table::
   :widths: 30 50 20
 
-  +--------------------------------------------------------------------------------------------------------------+--------------------+
-  | **Extensions to the syntax**                                                                                 | **Status**         |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_ | Additional unpacking generalizations                | Partial            |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 465 <https://www.python.org/dev/peps/pep-0465/>`_ | A new matrix multiplication operator                | Complete           |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_ | Coroutines with ``async`` and ``await`` syntax      | Complete           |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | **Extensions and changes to runtime**                                                                                             |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 461 <https://www.python.org/dev/peps/pep-0461/>`_ | % formatting for binary strings                     | Complete           |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 475 <https://www.python.org/dev/peps/pep-0475/>`_ | Retrying system calls that fail with ``EINTR``      | Complete           |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 479 <https://www.python.org/dev/peps/pep-0479/>`_ | Change ``StopIteration`` handling inside generators | Complete           |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | **Standard library changes**                                                                                                      |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 471 <https://www.python.org/dev/peps/pep-0471/>`_ | ``os.scandir()``                                    |                    |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 485 <https://www.python.org/dev/peps/pep-0485/>`_ | ``math.isclose()``, a function for testing          | Complete           |
-  |                                                        | approximate equality                                |                    |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | **Miscellaneous changes**                                                                                                         |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_ | Improved Python zip application support             |                    |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 486 <https://www.python.org/dev/peps/pep-0486/>`_ | Make the Python Launcher aware of virtual           | Not relevant       |
-  |                                                        | environments                                        |                    |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ | Type hints (advisory only)                          | Complete [#fth]_   |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 488 <https://www.python.org/dev/peps/pep-0488/>`_ | Elimination of PYO files                            | Not relevant       |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
-  | `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_ | Redesigning extension module loading                |                    |
-  +--------------------------------------------------------+-----------------------------------------------------+--------------------+
+  +--------------------------------------------------------------------------------------------------------------+------------------------+
+  | **Extensions to the syntax**                                                                                 | **Status**             |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 448 <https://www.python.org/dev/peps/pep-0448/>`_ | Additional unpacking generalizations                | Partial [#f1]_         |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 465 <https://www.python.org/dev/peps/pep-0465/>`_ | A new matrix multiplication operator                | Complete               |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 492 <https://www.python.org/dev/peps/pep-0492/>`_ | Coroutines with ``async`` and ``await`` syntax      | Partial [#f2]_         |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | **Extensions and changes to runtime**                                                                                                 |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 461 <https://www.python.org/dev/peps/pep-0461/>`_ | % formatting for binary strings                     | Partial [#f3]_         |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 475 <https://www.python.org/dev/peps/pep-0475/>`_ | Retrying system calls that fail with ``EINTR``      | Complete               |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 479 <https://www.python.org/dev/peps/pep-0479/>`_ | Change ``StopIteration`` handling inside generators | Complete               |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | **Standard library changes**                                                                                                          |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 471 <https://www.python.org/dev/peps/pep-0471/>`_ | ``os.scandir()``                                    | Not implemented [#f4]_ |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 485 <https://www.python.org/dev/peps/pep-0485/>`_ | ``math.isclose()``, a function for testing          | Complete               |
+  |                                                        | approximate equality                                |                        |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | **Miscellaneous changes**                                                                                                             |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 441 <https://www.python.org/dev/peps/pep-0441/>`_ | Improved Python zip application support             | Not implemented        |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 486 <https://www.python.org/dev/peps/pep-0486/>`_ | Make the Python Launcher aware of virtual           | Not relevant           |
+  |                                                        | environments                                        |                        |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_ | Type hints (advisory only)                          | Complete [#fth]_       |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 488 <https://www.python.org/dev/peps/pep-0488/>`_ | Elimination of PYO files                            | Not relevant           |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
+  | `PEP 489 <https://www.python.org/dev/peps/pep-0489/>`_ | Redesigning extension module loading                | Not relevant           |
+  +--------------------------------------------------------+-----------------------------------------------------+------------------------+
 
 Other Language Changes:
 
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Added the *namereplace* error handlers. The *backslashreplace* error handlers now work with decoding and  |               |
-  | translating.                                                                                              |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Property docstrings are now writable. This is especially useful for collections.namedtuple() docstrings   |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Circular imports involving relative imports are now supported.                                            |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Added the *namereplace* error handlers. The *backslashreplace* error handlers now work with decoding and  | Not implemented        |
+  | translating.                                                                                              |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Property docstrings are now writable. This is especially useful for collections.namedtuple() docstrings   | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Circular imports involving relative imports are now supported.                                            | Complete               |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
 
 
 New Modules:
@@ -73,121 +73,149 @@ Changes to built-in modules:
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `collections <https://docs.python.org/3/whatsnew/3.5.html#collections>`_                                                  |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *OrderedDict* class is now implemented in C, which makes it 4 to 100 times faster.                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | *OrderedDict.items()* , *OrderedDict.keys()* , *OrderedDict.values()* views now support reversed()        |               |
-  | iteration.                                                                                                |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The deque class now defines *index()*, *insert()*, and *copy()*, and supports the + and * operators.      |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Docstrings produced by namedtuple() can now be updated.                                                   |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The UserString class now implements the *__getnewargs__()*, *__rmod__()*, *casefold()*, *format_map()*,   |               |
-  | *isprintable()*, and *maketrans()* methods to match the corresponding methods of str.                     |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `heapq <https://docs.python.org/3/whatsnew/3.5.html#heapq>`_                                                              |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Element comparison in *merge()* can now be customized by passing a key function in a new optional key     |               |
-  | keyword argument, and a new optional *reverse* keyword argument can be used to reverse element comparison |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `io <https://docs.python.org/3/whatsnew/3.5.html#io>`_                                                                    |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new *BufferedIOBase.readinto1()* method, that uses at most one call to the underlying raw stream's      |               |
-  | *RawIOBase.read()* or *RawIOBase.readinto()* methods                                                      |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `json <https://docs.python.org/3/whatsnew/3.5.html#json>`_                                                |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | JSON decoder now raises JSONDecodeError instead of ValueError to provide better context information about |               |
-  | the error.                                                                                                |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `math <https://docs.python.org/3/whatsnew/3.5.html#math>`_                                                                |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Two new constants have been added to the math module: *inf* and *nan*.                                    | Complete      |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new function *isclose()* provides a way to test for approximate equality.                               |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `os <https://docs.python.org/3/whatsnew/3.5.html#os>`_                                                                    |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The new *scandir()* function returning an iterator of DirEntry objects has been added.                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *urandom()* function now uses the *getrandom()* syscall on Linux 3.17 or newer, and *getentropy()* on |               |
-  | OpenBSD 5.6 and newer, removing the need to use /dev/urandom and avoiding failures due to potential file  |               |
-  | descriptor exhaustion.                                                                                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | New *get_blocking()* and *set_blocking()* functions allow getting and setting a file descriptor's blocking|               |
-  | mode (O_NONBLOCK.)                                                                                        |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | There is a new *os.path.commonpath()* function returning the longest common sub-path of each passed       |               |
-  | pathname                                                                                                  |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `re <https://docs.python.org/3/whatsnew/3.5.html#re>`_                                                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | References and conditional references to groups with fixed length are now allowed in lookbehind assertions|               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The number of capturing groups in regular expressions is no longer limited to 100.                        |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *sub()* and *subn()* functions now replace unmatched groups with empty strings instead of raising an  |               |
-  | exception.                                                                                                |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *re.error* exceptions have new attributes, msg, pattern, pos, lineno, and colno, that provide better  |               |
-  | context information about the error                                                                       |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `socket <https://docs.python.org/3/whatsnew/3.5.html#socket>`_                                                            |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Functions with timeouts now use a monotonic clock, instead of a system clock.                             |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new *socket.sendfile()* method allows sending a file over a socket by using the high-performance        |               |
-  | *os.sendfile()* function on UNIX, resulting in uploads being from 2 to 3 times faster than when using     |               |
-  | plain *socket.send()*                                                                                     |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *socket.sendall()* method no longer resets the socket timeout every time bytes are received or sent.  |               |
-  | The socket timeout is now the maximum total duration to send all data.                                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The backlog argument of the *socket.listen()* method is now optional. By default it is set to SOMAXCONN or| Complete      |
-  | to 128, whichever is less.                                                                                |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `ssl <https://docs.python.org/3/whatsnew/3.5.html#ssl>`_                                                                  |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Memory BIO Support                                                                                        |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | Application-Layer Protocol Negotiation Support                                                            |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | There is a new *SSLSocket.version()* method to query the actual protocol version in use.                  |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The SSLSocket class now implements a *SSLSocket.sendfile()* method.                                       |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *SSLSocket.send()* method now raises either the *ssl.SSLWantReadError* or *ssl.SSLWantWriteError*     |               |
-  | exception on a non-blocking socket if the operation would block. Previously, it would return 0.           |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *cert_time_to_seconds()* function now interprets the input time as UTC and not as local time, per RFC |               |
-  | 5280. Additionally, the return value is always an int.                                                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | New *SSLObject.shared_ciphers()* and *SSLSocket.shared_ciphers()* methods return the list of ciphers sent |               |
-  | by the client during the handshake.                                                                       |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *SSLSocket.do_handshake()*, *SSLSocket.read()*, *SSLSocket.shutdown()*, and *SSLSocket.write()*       |               |
-  | methods of the SSLSocket class no longer reset the socket timeout every time bytes are received or sent.  |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *match_hostname()* function now supports matching of IP addresses.                                    |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.5.html#sys>`_                                                                  |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new *set_coroutine_wrapper()* function allows setting a global hook that will be called whenever a      |               |
-  | coroutine object is created by an async def function. A corresponding *get_coroutine_wrapper()* can be    |               |
-  | used to obtain a currently set wrapper.                                                                   |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | A new *is_finalizing()* function can be used to check if the Python interpreter is shutting down.         |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | `time <https://docs.python.org/3/whatsnew/3.5.html#time>`_                                                                |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
-  | The *monotonic()* function is now always available                                                        |               |
-  +-----------------------------------------------------------------------------------------------------------+---------------+
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `collections <https://docs.python.org/3/whatsnew/3.5.html#collections>`_                                                           |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *OrderedDict* class is now implemented in C, which makes it 4 to 100 times faster.                    | Complete               |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | *OrderedDict.items()* , *OrderedDict.keys()* , *OrderedDict.values()* views now support reversed()        | Not implemented        |
+  | iteration.                                                                                                |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The deque class now defines *index()*, *insert()*, and *copy()*, and supports the + and * operators.      | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Docstrings produced by namedtuple() can now be updated.                                                   | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The UserString class now implements the *__getnewargs__()*, *__rmod__()*, *casefold()*, *format_map()*,   | Not implemented        |
+  | *isprintable()*, and *maketrans()* methods to match the corresponding methods of str.                     |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `heapq <https://docs.python.org/3/whatsnew/3.5.html#heapq>`_                                                                       |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Element comparison in *merge()* can now be customized by passing a key function in a new optional key     | Not implemented        |
+  | keyword argument, and a new optional *reverse* keyword argument can be used to reverse element comparison |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `io <https://docs.python.org/3/whatsnew/3.5.html#io>`_                                                                             |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new *BufferedIOBase.readinto1()* method, that uses at most one call to the underlying raw stream's      | Not implemented        |
+  | *RawIOBase.read()* or *RawIOBase.readinto()* methods                                                      |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `json <https://docs.python.org/3/whatsnew/3.5.html#json>`_                                                                         |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | JSON decoder now raises JSONDecodeError instead of ValueError to provide better context information about | Not implemented        |
+  | the error.                                                                                                |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.5.html#math>`_                                                                         |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Two new constants have been added to the math module: *inf* and *nan*.                                    | Complete               |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new function *isclose()* provides a way to test for approximate equality.                               | Complete               |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new *gcd()* function has been added. The *fractions.gcd()* function is now deprecated.                  | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `os <https://docs.python.org/3/whatsnew/3.5.html#os>`_                                                                             |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The new *scandir()* function returning an iterator of DirEntry objects has been added.                    | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *urandom()* function now uses the *getrandom()* syscall on Linux 3.17 or newer, and *getentropy()* on | Complete               |
+  | OpenBSD 5.6 and newer, removing the need to use /dev/urandom and avoiding failures due to potential file  |                        |
+  | descriptor exhaustion.                                                                                    |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | New *get_blocking()* and *set_blocking()* functions allow getting and setting a file descriptor's blocking| Not implemented        |
+  | mode (O_NONBLOCK.)                                                                                        |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | There is a new *os.path.commonpath()* function returning the longest common sub-path of each passed       | Not implemented        |
+  | pathname                                                                                                  |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `re <https://docs.python.org/3/whatsnew/3.5.html#re>`_                                                                             |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | References and conditional references to groups with fixed length are now allowed in lookbehind assertions| Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The number of capturing groups in regular expressions is no longer limited to 100.                        | Not implemented [#f5]_ |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *sub()* and *subn()* functions now replace unmatched groups with empty strings instead of raising an  | Partial [#f6]_         |
+  | exception.                                                                                                |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *re.error* exceptions have new attributes, msg, pattern, pos, lineno, and colno, that provide better  | Not implemented        |
+  | context information about the error                                                                       |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `socket <https://docs.python.org/3/whatsnew/3.5.html#socket>`_                                                                     |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Functions with timeouts now use a monotonic clock, instead of a system clock.                             | Complete               |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new *socket.sendfile()* method allows sending a file over a socket by using the high-performance        | Not implemented        |
+  | *os.sendfile()* function on UNIX, resulting in uploads being from 2 to 3 times faster than when using     |                        |
+  | plain *socket.send()*                                                                                     |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *socket.sendall()* method no longer resets the socket timeout every time bytes are received or sent.  | Partial [#f7]_         |
+  | The socket timeout is now the maximum total duration to send all data.                                    |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The backlog argument of the *socket.listen()* method is now optional. By default it is set to SOMAXCONN or| Partial [#f8]_         |
+  | to 128, whichever is less.                                                                                |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `ssl <https://docs.python.org/3/whatsnew/3.5.html#ssl>`_                                                                           |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Memory BIO Support                                                                                        | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | Application-Layer Protocol Negotiation Support                                                            | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | There is a new *SSLSocket.version()* method to query the actual protocol version in use.                  | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The SSLSocket class now implements a *SSLSocket.sendfile()* method.                                       | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *SSLSocket.send()* method now raises either the *ssl.SSLWantReadError* or *ssl.SSLWantWriteError*     | Partial [#f9]_         |
+  | exception on a non-blocking socket if the operation would block. Previously, it would return 0.           |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *cert_time_to_seconds()* function now interprets the input time as UTC and not as local time, per RFC | Not implemented        |
+  | 5280. Additionally, the return value is always an int.                                                    |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | New *SSLObject.shared_ciphers()* and *SSLSocket.shared_ciphers()* methods return the list of ciphers sent | Not implemented        |
+  | by the client during the handshake.                                                                       |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *SSLSocket.do_handshake()*, *SSLSocket.read()*, *SSLSocket.shutdown()*, and *SSLSocket.write()*       | Not implemented        |
+  | methods of the SSLSocket class no longer reset the socket timeout every time bytes are received or sent.  |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *match_hostname()* function now supports matching of IP addresses.                                    | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.5.html#sys>`_                                                                           |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new *set_coroutine_wrapper()* function allows setting a global hook that will be called whenever a      | Won't do [#f10]_       |
+  | coroutine object is created by an async def function. A corresponding *get_coroutine_wrapper()* can be    |                        |
+  | used to obtain a currently set wrapper.                                                                   |                        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | A new *is_finalizing()* function can be used to check if the Python interpreter is shutting down.         | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | `time <https://docs.python.org/3/whatsnew/3.5.html#time>`_                                                                         |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
+  | The *monotonic()* function is now always available                                                        | Not implemented        |
+  +-----------------------------------------------------------------------------------------------------------+------------------------+
 
 .. rubric:: Notes
 
+.. [#f1] Unpacking generalizations are supported in function calls (several
+   ``*args`` and ``**kwargs`` may be given), but not in list, tuple, set or
+   dict displays: ``[*a, *b]`` and ``{**a, **b}`` raise ``SyntaxError``.
+.. [#f2] ``async def``, ``await``, ``async for`` and ``async with`` are all
+   supported, but the ``__await__`` special method is not, so only coroutines
+   and generators can be awaited.
+.. [#f3] ``bytes`` supports the pre-existing conversions (``%s``, ``%d``,
+   ``%x``, ``%c``, ...), but the new ``%b`` and ``%a`` conversions are missing
+   and ``bytearray`` does not implement ``%`` at all.
+.. [#f4] Neither ``os.scandir()`` nor ``os.DirEntry`` exist.  MicroPython
+   instead provides ``os.ilistdir()``, which serves the same purpose of
+   iterating a directory without extra ``stat()`` calls.
+.. [#f5] The bundled ``re1.5`` engine rejects patterns with more than 63
+   capturing groups with ``ValueError: regex too complex``.
+.. [#f6] ``re.sub()`` does replace unmatched groups with empty strings, but
+   ``re.subn()`` is not implemented.
+.. [#f7] On the unix port ``sendall()`` issues a single ``send()``, so the
+   timeout is never restarted.  On lwip-based ports ``sendall()`` writes in
+   chunks and restarts the timeout for each chunk, so it is not a maximum
+   total duration.
+.. [#f8] The *backlog* argument is optional on all ports, but only the unix
+   port defaults to ``min(SOMAXCONN, 128)``; other ports default to
+   ``MICROPY_PY_SOCKET_LISTEN_BACKLOG_DEFAULT``, which is 2.
+.. [#f9] A write that would block raises ``OSError(EAGAIN)`` rather than
+   returning 0, but ``ssl.SSLWantReadError`` and ``ssl.SSLWantWriteError`` do
+   not exist.
+.. [#f10] These functions were deprecated in CPython 3.7 and removed in
+   CPython 3.8.
 .. [#fth] The MicroPython parser correct ignores all type hints. However, the ``typing`` module is not built-in.

--- a/docs/differences/python_36.rst
+++ b/docs/differences/python_36.rst
@@ -61,147 +61,147 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | A *global* or *nonlocal* statement must now textually appear before the first use of the affected name in   | Complete        |
-  | the same scope. Previously this was a SyntaxWarning.                                                        |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | It is now possible to set a special method to None to indicate that the corresponding operation is not      | Partial         |
-  | available. For example, if a class sets *__iter__()* to *None* , the class is not iterable.                 | [#specialnone]_ |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Long sequences of repeated traceback lines are now abbreviated as *[Previous line repeated {count} more     | Not implemented |
-  | times]*                                                                                                     |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Import now raises the new exception *ModuleNotFoundError* when it cannot find a module. Code that currently | Not implemented |
-  | checks for ImportError (in try-except) will still work.                                                     |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
-  | Class methods relying on zero-argument *super()* will now work correctly when called from metaclass methods | Not implemented |
-  | during class creation.                                                                                      |                 |
-  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | A *global* or *nonlocal* statement must now textually appear before the first use of the affected name in   | Complete      |
+  | the same scope. Previously this was a SyntaxWarning.                                                        |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | It is now possible to set a special method to None to indicate that the corresponding operation is not      | Partial       |
+  | available. For example, if a class sets *__iter__()* to *None* , the class is not iterable.                 | [#specnone]_  |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Long sequences of repeated traceback lines are now abbreviated as *[Previous line repeated {count} more     | Not           |
+  | times]*                                                                                                     | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Import now raises the new exception *ModuleNotFoundError* when it cannot find a module. Code that currently | Not           |
+  | checks for ImportError (in try-except) will still work.                                                     | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Class methods relying on zero-argument *super()* will now work correctly when called from metaclass methods | Not           |
+  | during class creation.                                                                                      | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `array <https://docs.python.org/3.6/whatsnew/3.6.html#array>`_                                                                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Exhausted iterators of *array.array* will now stay exhausted even if the iterated array is extended.         | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `binascii <https://docs.python.org/3.6/whatsnew/3.6.html#binascii>`_                                                            |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The b2a_base64() function now accepts an optional newline keyword argument to control whether the newline    | Complete         |
-  | character is appended to the return value                                                                    |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `cmath <https://docs.python.org/3.6/whatsnew/3.6.html#cmath>`_                                                                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new cmath.tau (τ) constant has been added                                                                | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | New constants: *cmath.inf* and *cmath.nan* to match *math.inf* and *math.nan* , and also *cmath.infj* and    | Not implemented  |
-  | *cmath.nanj* to match the format used by complex repr                                                        |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `collections <https://docs.python.org/3.6/whatsnew/3.6.html#collections>`_                                                      |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new Collection abstract base class has been added to represent sized iterable container classes          | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new *Reversible* abstract base class represents iterable classes that also provide the *__reversed__()*  | Not implemented  |
-  | method.                                                                                                      |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new *AsyncGenerator* abstract base class represents asynchronous generators.                             | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The *namedtuple()* function now accepts an optional keyword argument module, which, when specified, is used  | Not implemented  |
-  | for the *__module__* attribute of the returned named tuple class.                                            |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The verbose and rename arguments for *namedtuple()* are now keyword-only.                                    | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Recursive *collections.deque* instances can now be pickled.                                                  | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `hashlib <https://docs.python.org/3.6/whatsnew/3.6.html#hashlib>`_                                                              |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | BLAKE2 hash functions were added to the module. *blake2b()* and *blake2s()* are always available and support | Not implemented  |
-  | the full feature set of BLAKE2.                                                                              |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The SHA-3 hash functions *sha3_224()*, *sha3_256()*, *sha3_384()*, *sha3_512()*, and *SHAKE* hash functions  | Not implemented  |
-  | *shake_128()* and *shake_256()* were added.                                                                  |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The password-based key derivation function *scrypt()* is now available with OpenSSL 1.1.0 and newer.         | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `json <https://docs.python.org/3.6/whatsnew/3.6.html#json>`_                                                                    |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | *json.load()* and *json.loads()* now support binary input. Encoded JSON should be represented using either   | Partial          |
-  | UTF-8, UTF-16, or UTF-32.                                                                                    | [#jsonbytes]_    |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `math <https://docs.python.org/3.6/whatsnew/3.6.html#math>`_                                                                    |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new math.tau (τ) constant has been added                                                                 | Complete         |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `os <https://docs.python.org/3.6/whatsnew/3.6.html#os>`_                                                                        |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | A new *close()* method allows explicitly closing a *scandir()* iterator. The *scandir()* iterator now        | Not implemented  |
-  | supports the context manager protocol.                                                                       |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | On Linux, *os.urandom()* now blocks until the system urandom entropy pool is initialized to increase the     | Complete         |
-  | security.                                                                                                    |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The Linux *getrandom()* syscall (get random bytes) is now exposed as the new *os.getrandom()* function.      | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `re <https://docs.python.org/3.6/whatsnew/3.6.html#re>`_                                                                        |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Added support of modifier spans in regular expressions. Examples: *'(?i:p)ython'* matches 'python' and       | Not implemented  |
-  | 'Python', but not 'PYTHON'; *'(?i)g(?-i:v)r'* matches *'GvR'* and *'gvr'*, but not *'GVR'*.                  |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Match object groups can be accessed by *__getitem__*, which is equivalent to *group()*. So *mo['name']* is   | Not implemented  |
-  | now equivalent to *mo.group('name')*.                                                                        |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Match objects now support index-like objects as group indices.                                               | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `socket <https://docs.python.org/3.6/whatsnew/3.6.html#socket>`_                                                                |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The *ioctl()* function now supports the *SIO_LOOPBACK_FAST_PATH* control code.                               | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The *getsockopt()* constants *SO_DOMAIN* , *SO_PROTOCOL*, *SO_PEERSEC* , and *SO_PASSSEC* are now supported. | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The *setsockopt()* now supports the *setsockopt(level, optname, None, optlen: int)* form.                    | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The socket module now supports the address family *AF_ALG* to interface with Linux Kernel crypto API.        | Not implemented  |
-  | *ALG_*, *SOL_ALG* and *sendmsg_afalg()* were added.                                                          |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | New Linux constants *TCP_USER_TIMEOUT* and *TCP_CONGESTION* were added.                                      | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `ssl <https://docs.python.org/3.6/whatsnew/3.6.html#ssl>`_                                                                      |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | ssl supports OpenSSL 1.1.0. The minimum recommend version is 1.0.2.                                          | Not relevant     |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | 3DES has been removed from the default cipher suites and ChaCha20 Poly1305 cipher suites have been added.    | Not relevant     |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | *SSLContext* has better default configuration for options and ciphers.                                       | Not relevant     |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | SSL session can be copied from one client-side connection to another with the new *SSLSession* class. TLS    | Not implemented  |
-  | session resumption can speed up the initial handshake, reduce latency and improve performance.               |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new *get_ciphers()* method can be used to get a list of enabled ciphers in order of cipher priority.     | Partial          |
-  |                                                                                                              | [#getciphers]_   |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | All constants and flags have been converted to *IntEnum* and *IntFlags*.                                     | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Server and client-side specific TLS protocols for *SSLContext* were added.                                   | Complete         |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | Added *SSLContext.post_handshake_auth* to enable and *ssl.SSLSocket.verify_client_post_handshake()* to       | Not implemented  |
-  | initiate TLS 1.3 post-handshake authentication.                                                              |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `struct <https://docs.python.org/3.6/whatsnew/3.6.html#struct>`_                                                                |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | now supports IEEE 754 half-precision floats via the 'e' format specifier.                                    | Complete         |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `sys <https://docs.python.org/3.6/whatsnew/3.6.html#sys>`_                                                                      |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The new *getfilesystemencodeerrors()* function returns the name of the error mode used to convert between    | Not relevant     |
-  | Unicode filenames and bytes filenames.                                                                       |                  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | `zlib <https://docs.python.org/3.6/whatsnew/3.6.html#zlib>`_                                                                    |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
-  | The *compress()* and *decompress()* functions now accept keyword arguments                                   | Not implemented  |
-  +--------------------------------------------------------------------------------------------------------------+------------------+
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `array <https://docs.python.org/3.6/whatsnew/3.6.html#array>`_                                                                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Exhausted iterators of *array.array* will now stay exhausted even if the iterated array is extended.         | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `binascii <https://docs.python.org/3.6/whatsnew/3.6.html#binascii>`_                                                          |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The b2a_base64() function now accepts an optional newline keyword argument to control whether the newline    | Complete       |
+  | character is appended to the return value                                                                    |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `cmath <https://docs.python.org/3.6/whatsnew/3.6.html#cmath>`_                                                                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new cmath.tau (τ) constant has been added                                                                | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | New constants: *cmath.inf* and *cmath.nan* to match *math.inf* and *math.nan* , and also *cmath.infj* and    | Not implemented|
+  | *cmath.nanj* to match the format used by complex repr                                                        |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `collections <https://docs.python.org/3.6/whatsnew/3.6.html#collections>`_                                                    |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new Collection abstract base class has been added to represent sized iterable container classes          | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new *Reversible* abstract base class represents iterable classes that also provide the *__reversed__()*  | Not implemented|
+  | method.                                                                                                      |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new *AsyncGenerator* abstract base class represents asynchronous generators.                             | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The *namedtuple()* function now accepts an optional keyword argument module, which, when specified, is used  | Not implemented|
+  | for the *__module__* attribute of the returned named tuple class.                                            |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The verbose and rename arguments for *namedtuple()* are now keyword-only.                                    | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Recursive *collections.deque* instances can now be pickled.                                                  | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `hashlib <https://docs.python.org/3.6/whatsnew/3.6.html#hashlib>`_                                                            |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | BLAKE2 hash functions were added to the module. *blake2b()* and *blake2s()* are always available and support | Not implemented|
+  | the full feature set of BLAKE2.                                                                              |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The SHA-3 hash functions *sha3_224()*, *sha3_256()*, *sha3_384()*, *sha3_512()*, and *SHAKE* hash functions  | Not implemented|
+  | *shake_128()* and *shake_256()* were added.                                                                  |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The password-based key derivation function *scrypt()* is now available with OpenSSL 1.1.0 and newer.         | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `json <https://docs.python.org/3.6/whatsnew/3.6.html#json>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | *json.load()* and *json.loads()* now support binary input. Encoded JSON should be represented using either   | Partial        |
+  | UTF-8, UTF-16, or UTF-32.                                                                                    | [#jsonbytes]_  |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `math <https://docs.python.org/3.6/whatsnew/3.6.html#math>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new math.tau (τ) constant has been added                                                                 | Complete       |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `os <https://docs.python.org/3.6/whatsnew/3.6.html#os>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | A new *close()* method allows explicitly closing a *scandir()* iterator. The *scandir()* iterator now        | Not implemented|
+  | supports the context manager protocol.                                                                       |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | On Linux, *os.urandom()* now blocks until the system urandom entropy pool is initialized to increase the     | Complete       |
+  | security.                                                                                                    |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The Linux *getrandom()* syscall (get random bytes) is now exposed as the new *os.getrandom()* function.      | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `re <https://docs.python.org/3.6/whatsnew/3.6.html#re>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Added support of modifier spans in regular expressions. Examples: *'(?i:p)ython'* matches 'python' and       | Not implemented|
+  | 'Python', but not 'PYTHON'; *'(?i)g(?-i:v)r'* matches *'GvR'* and *'gvr'*, but not *'GVR'*.                  |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Match object groups can be accessed by *__getitem__*, which is equivalent to *group()*. So *mo['name']* is   | Not implemented|
+  | now equivalent to *mo.group('name')*.                                                                        |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Match objects now support index-like objects as group indices.                                               | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `socket <https://docs.python.org/3.6/whatsnew/3.6.html#socket>`_                                                              |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The *ioctl()* function now supports the *SIO_LOOPBACK_FAST_PATH* control code.                               | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The *getsockopt()* constants *SO_DOMAIN* , *SO_PROTOCOL*, *SO_PEERSEC* , and *SO_PASSSEC* are now supported. | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The *setsockopt()* now supports the *setsockopt(level, optname, None, optlen: int)* form.                    | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The socket module now supports the address family *AF_ALG* to interface with Linux Kernel crypto API.        | Not implemented|
+  | *ALG_*, *SOL_ALG* and *sendmsg_afalg()* were added.                                                          |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | New Linux constants *TCP_USER_TIMEOUT* and *TCP_CONGESTION* were added.                                      | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `ssl <https://docs.python.org/3.6/whatsnew/3.6.html#ssl>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | ssl supports OpenSSL 1.1.0. The minimum recommend version is 1.0.2.                                          | Not relevant   |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | 3DES has been removed from the default cipher suites and ChaCha20 Poly1305 cipher suites have been added.    | Not relevant   |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | *SSLContext* has better default configuration for options and ciphers.                                       | Not relevant   |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | SSL session can be copied from one client-side connection to another with the new *SSLSession* class. TLS    | Not implemented|
+  | session resumption can speed up the initial handshake, reduce latency and improve performance.               |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new *get_ciphers()* method can be used to get a list of enabled ciphers in order of cipher priority.     | Partial        |
+  |                                                                                                              | [#getciphers]_ |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | All constants and flags have been converted to *IntEnum* and *IntFlags*.                                     | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Server and client-side specific TLS protocols for *SSLContext* were added.                                   | Complete       |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | Added *SSLContext.post_handshake_auth* to enable and *ssl.SSLSocket.verify_client_post_handshake()* to       | Not implemented|
+  | initiate TLS 1.3 post-handshake authentication.                                                              |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `struct <https://docs.python.org/3.6/whatsnew/3.6.html#struct>`_                                                              |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | now supports IEEE 754 half-precision floats via the 'e' format specifier.                                    | Complete       |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `sys <https://docs.python.org/3.6/whatsnew/3.6.html#sys>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The new *getfilesystemencodeerrors()* function returns the name of the error mode used to convert between    | Not relevant   |
+  | Unicode filenames and bytes filenames.                                                                       |                |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | `zlib <https://docs.python.org/3.6/whatsnew/3.6.html#zlib>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------------------+----------------+
+  | The *compress()* and *decompress()* functions now accept keyword arguments                                   | Not implemented|
+  +--------------------------------------------------------------------------------------------------------------+----------------+
 
 .. rubric:: Notes
 
@@ -214,7 +214,7 @@ Changes to built-in modules:
    attribute is created for modules, classes or functions.  MicroPython also
    accepts annotations on expressions that CPython rejects.
 .. [#setname] Currently, only :func:`__set_name__` is implemented.
-.. [#specialnone] MicroPython does not treat ``None`` as "operation not
+.. [#specnone] MicroPython does not treat ``None`` as "operation not
    available"; it simply attempts the call and raises ``TypeError: 'NoneType'
    object isn't callable``.  This gives the right outcome for ``__iter__`` and
    ``__hash__``, but differs where CPython falls back to another protocol, e.g.

--- a/docs/differences/python_36.rst
+++ b/docs/differences/python_36.rst
@@ -11,47 +11,49 @@ Python 3.6 beta 1 was released on 12 Sep 2016, and a summary of the new features
   +-----------------------------------------------------------------------------------------------------------+-----------------+
   | **New Syntax Features**                                                                                   | **Status**      |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 498 <https://www.python.org/dev/peps/pep-0498/>`_ | Literal String Formatting                        | Complete        |
+  | `PEP 498 <https://www.python.org/dev/peps/pep-0498/>`_ | Literal String Formatting                        | Partial         |
+  |                                                        |                                                  | [#fstring]_     |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | `PEP 515 <https://www.python.org/dev/peps/pep-0515/>`_ | Underscores in Numeric Literals                  | Complete        |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 525 <https://www.python.org/dev/peps/pep-0525/>`_ | Asynchronous Generators                          |                 |
+  | `PEP 525 <https://www.python.org/dev/peps/pep-0525/>`_ | Asynchronous Generators                          | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_ | Syntax for Variable Annotations (provisional)    | Complete        |
+  | `PEP 526 <https://www.python.org/dev/peps/pep-0526/>`_ | Syntax for Variable Annotations (provisional)    | Partial         |
+  |                                                        |                                                  | [#annotations]_ |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 530 <https://www.python.org/dev/peps/pep-0530/>`_ | Asynchronous Comprehensions                      |                 |
+  | `PEP 530 <https://www.python.org/dev/peps/pep-0530/>`_ | Asynchronous Comprehensions                      | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | **New Built-in Features**                                                                                                   |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 468 <https://www.python.org/dev/peps/pep-0468/>`_ | Preserving the order of *kwargs* in a function   |                 |
+  | `PEP 468 <https://www.python.org/dev/peps/pep-0468/>`_ | Preserving the order of *kwargs* in a function   | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | `PEP 487 <https://www.python.org/dev/peps/pep-0487/>`_ | Simpler customization of class creation          | Partial         |
   |                                                        |                                                  | [#setname]_     |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 520 <https://www.python.org/dev/peps/pep-0520/>`_ | Preserving Class Attribute Definition Order      |                 |
+  | `PEP 520 <https://www.python.org/dev/peps/pep-0520/>`_ | Preserving Class Attribute Definition Order      | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | **Standard Library Changes**                                                                                                |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 495 <https://www.python.org/dev/peps/pep-0495/>`_ | Local Time Disambiguation                        |                 |
+  | `PEP 495 <https://www.python.org/dev/peps/pep-0495/>`_ | Local Time Disambiguation                        | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 506 <https://www.python.org/dev/peps/pep-0506/>`_ | Adding A Secrets Module To The Standard Library  |                 |
+  | `PEP 506 <https://www.python.org/dev/peps/pep-0506/>`_ | Adding A Secrets Module To The Standard Library  | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 519 <https://www.python.org/dev/peps/pep-0519/>`_ | Adding a file system path protocol               |                 |
+  | `PEP 519 <https://www.python.org/dev/peps/pep-0519/>`_ | Adding a file system path protocol               | Not implemented |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | **CPython Internals**                                                                                                       |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | `PEP 509 <https://www.python.org/dev/peps/pep-0509/>`_ | Add a private version to dict                    | Won't do        |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 523 <https://www.python.org/dev/peps/pep-0523/>`_ | Adding a frame evaluation API to CPython         |                 |
+  | `PEP 523 <https://www.python.org/dev/peps/pep-0523/>`_ | Adding a frame evaluation API to CPython         | Not relevant    |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
   | **Linux/Window Changes**                                                                                                    |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 524 <https://www.python.org/dev/peps/pep-0524/>`_ | Make ``os.urandom()`` blocking on Linux          |                 |
+  | `PEP 524 <https://www.python.org/dev/peps/pep-0524/>`_ | Make ``os.urandom()`` blocking on Linux          | Complete        |
   |                                                        | (during system startup)                          |                 |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 528 <https://www.python.org/dev/peps/pep-0528/>`_ | Change Windows console encoding to UTF-8         |                 |
+  | `PEP 528 <https://www.python.org/dev/peps/pep-0528/>`_ | Change Windows console encoding to UTF-8         | Not relevant    |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
-  | `PEP 529 <https://www.python.org/dev/peps/pep-0529/>`_ | Change Windows filesystem encoding to UTF-8      |                 |
+  | `PEP 529 <https://www.python.org/dev/peps/pep-0529/>`_ | Change Windows filesystem encoding to UTF-8      | Not relevant    |
   +--------------------------------------------------------+--------------------------------------------------+-----------------+
 
 Other Language Changes:
@@ -59,147 +61,167 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | A *global* or *nonlocal* statement must now textually appear before the first use of the affected name in   |               |
-  | the same scope. Previously this was a SyntaxWarning.                                                        |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | It is now possible to set a special method to None to indicate that the corresponding operation is not      |               |
-  | available. For example, if a class sets *__iter__()* to *None* , the class is not iterable.                 |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Long sequences of repeated traceback lines are now abbreviated as *[Previous line repeated {count} more     |               |
-  | times]*                                                                                                     |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Import now raises the new exception *ModuleNotFoundError* when it cannot find a module. Code that currently |               |
-  | checks for ImportError (in try-except) will still work.                                                     |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Class methods relying on zero-argument *super()* will now work correctly when called from metaclass methods |               |
-  | during class creation.                                                                                      |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | A *global* or *nonlocal* statement must now textually appear before the first use of the affected name in   | Complete        |
+  | the same scope. Previously this was a SyntaxWarning.                                                        |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | It is now possible to set a special method to None to indicate that the corresponding operation is not      | Partial         |
+  | available. For example, if a class sets *__iter__()* to *None* , the class is not iterable.                 | [#specialnone]_ |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Long sequences of repeated traceback lines are now abbreviated as *[Previous line repeated {count} more     | Not implemented |
+  | times]*                                                                                                     |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Import now raises the new exception *ModuleNotFoundError* when it cannot find a module. Code that currently | Not implemented |
+  | checks for ImportError (in try-except) will still work.                                                     |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
+  | Class methods relying on zero-argument *super()* will now work correctly when called from metaclass methods | Not implemented |
+  | during class creation.                                                                                      |                 |
+  +-------------------------------------------------------------------------------------------------------------+-----------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `array <https://docs.python.org/3.6/whatsnew/3.6.html#array>`_                                               |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Exhausted iterators of *array.array* will now stay exhausted even if the iterated array is extended.         |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `binascii <https://docs.python.org/3.6/whatsnew/3.6.html#binascii>`_                                         |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The b2a_base64() function now accepts an optional newline keyword argument to control whether the newline    | Complete       |
-  | character is appended to the return value                                                                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `cmath <https://docs.python.org/3.6/whatsnew/3.6.html#cmath>`_                                               |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new cmath.tau (τ) constant has been added                                                                |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | New constants: *cmath.inf* and *cmath.nan* to match *math.inf* and *math.nan* , and also *cmath.infj* and    |                |
-  | *cmath.nanj* to match the format used by complex repr                                                        |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `collections <https://docs.python.org/3.6/whatsnew/3.6.html#collections>`_                                                    |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new Collection abstract base class has been added to represent sized iterable container classes          |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new *Reversible* abstract base class represents iterable classes that also provide the *__reversed__()*  |                |
-  | method.                                                                                                      |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new *AsyncGenerator* abstract base class represents asynchronous generators.                             |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The *namedtuple()* function now accepts an optional keyword argument module, which, when specified, is used  |                |
-  | for the *__module__* attribute of the returned named tuple class.                                            |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The verbose and rename arguments for *namedtuple()* are now keyword-only.                                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Recursive *collections.deque* instances can now be pickled.                                                  |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `hashlib <https://docs.python.org/3.6/whatsnew/3.6.html#hashlib>`_                                                            |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | BLAKE2 hash functions were added to the module. *blake2b()* and *blake2s()* are always available and support |                |
-  | the full feature set of BLAKE2.                                                                              |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The SHA-3 hash functions *sha3_224()*, *sha3_256()*, *sha3_384()*, *sha3_512()*, and *SHAKE* hash functions  |                |
-  | *shake_128()* and *shake_256()* were added.                                                                  |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The password-based key derivation function *scrypt()* is now available with OpenSSL 1.1.0 and newer.         |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `json <https://docs.python.org/3.6/whatsnew/3.6.html#json>`_                                                                  |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | *json.load()* and *json.loads()* now support binary input. Encoded JSON should be represented using either   |                |
-  | UTF-8, UTF-16, or UTF-32.                                                                                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `math <https://docs.python.org/3.6/whatsnew/3.6.html#math>`_                                                                  |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new math.tau (τ) constant has been added                                                                 | Complete       |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `os <https://docs.python.org/3.6/whatsnew/3.6.html#os>`_                                                                      |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | A new *close()* method allows explicitly closing a *scandir()* iterator. The *scandir()* iterator now        |                |
-  | supports the context manager protocol.                                                                       |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | On Linux, *os.urandom()* now blocks until the system urandom entropy pool is initialized to increase the     |                |
-  | security.                                                                                                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The Linux *getrandom()* syscall (get random bytes) is now exposed as the new *os.getrandom()* function.      |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `re <https://docs.python.org/3.6/whatsnew/3.6.html#re>`_                                                                      |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Added support of modifier spans in regular expressions. Examples: *'(?i:p)ython'* matches 'python' and       |                |
-  | 'Python', but not 'PYTHON'; *'(?i)g(?-i:v)r'* matches *'GvR'* and *'gvr'*, but not *'GVR'*.                  |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Match object groups can be accessed by *__getitem__*, which is equivalent to *group()*. So *mo['name']* is   |                |
-  | now equivalent to *mo.group('name')*.                                                                        |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Match objects now support index-like objects as group indices.                                               |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `socket <https://docs.python.org/3.6/whatsnew/3.6.html#socket>`_                                                              |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The *ioctl()* function now supports the *SIO_LOOPBACK_FAST_PATH* control code.                               |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The *getsockopt()* constants *SO_DOMAIN* , *SO_PROTOCOL*, *SO_PEERSEC* , and *SO_PASSSEC* are now supported. |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The *setsockopt()* now supports the *setsockopt(level, optname, None, optlen: int)* form.                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The socket module now supports the address family *AF_ALG* to interface with Linux Kernel crypto API.        |                |
-  | *ALG_*, *SOL_ALG* and *sendmsg_afalg()* were added.                                                          |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | New Linux constants *TCP_USER_TIMEOUT* and *TCP_CONGESTION* were added.                                      |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `ssl <https://docs.python.org/3.6/whatsnew/3.6.html#ssl>`_                                                                    |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | ssl supports OpenSSL 1.1.0. The minimum recommend version is 1.0.2.                                          |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | 3DES has been removed from the default cipher suites and ChaCha20 Poly1305 cipher suites have been added.    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | *SSLContext* has better default configuration for options and ciphers.                                       |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | SSL session can be copied from one client-side connection to another with the new *SSLSession* class. TLS    |                |
-  | session resumption can speed up the initial handshake, reduce latency and improve performance.               |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new *get_ciphers()* method can be used to get a list of enabled ciphers in order of cipher priority.     |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | All constants and flags have been converted to *IntEnum* and *IntFlags*.                                     |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Server and client-side specific TLS protocols for *SSLContext* were added.                                   |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | Added *SSLContext.post_handshake_auth* to enable and *ssl.SSLSocket.verify_client_post_handshake()* to       |                |
-  | initiate TLS 1.3 post-handshake authentication.                                                              |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `struct <https://docs.python.org/3.6/whatsnew/3.6.html#struct>`_                                             |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | now supports IEEE 754 half-precision floats via the 'e' format specifier.                                    |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `sys <https://docs.python.org/3.6/whatsnew/3.6.html#sys>`_                                                   |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The new *getfilesystemencodeerrors()* function returns the name of the error mode used to convert between    |                |
-  | Unicode filenames and bytes filenames.                                                                       |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | `zlib <https://docs.python.org/3.6/whatsnew/3.6.html#zlib>`_                                                 |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
-  | The *compress()* and *decompress()* functions now accept keyword arguments                                   |                |
-  +--------------------------------------------------------------------------------------------------------------+----------------+
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `array <https://docs.python.org/3.6/whatsnew/3.6.html#array>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Exhausted iterators of *array.array* will now stay exhausted even if the iterated array is extended.         | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `binascii <https://docs.python.org/3.6/whatsnew/3.6.html#binascii>`_                                                            |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The b2a_base64() function now accepts an optional newline keyword argument to control whether the newline    | Complete         |
+  | character is appended to the return value                                                                    |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `cmath <https://docs.python.org/3.6/whatsnew/3.6.html#cmath>`_                                                                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new cmath.tau (τ) constant has been added                                                                | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | New constants: *cmath.inf* and *cmath.nan* to match *math.inf* and *math.nan* , and also *cmath.infj* and    | Not implemented  |
+  | *cmath.nanj* to match the format used by complex repr                                                        |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `collections <https://docs.python.org/3.6/whatsnew/3.6.html#collections>`_                                                      |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new Collection abstract base class has been added to represent sized iterable container classes          | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new *Reversible* abstract base class represents iterable classes that also provide the *__reversed__()*  | Not implemented  |
+  | method.                                                                                                      |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new *AsyncGenerator* abstract base class represents asynchronous generators.                             | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The *namedtuple()* function now accepts an optional keyword argument module, which, when specified, is used  | Not implemented  |
+  | for the *__module__* attribute of the returned named tuple class.                                            |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The verbose and rename arguments for *namedtuple()* are now keyword-only.                                    | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Recursive *collections.deque* instances can now be pickled.                                                  | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `hashlib <https://docs.python.org/3.6/whatsnew/3.6.html#hashlib>`_                                                              |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | BLAKE2 hash functions were added to the module. *blake2b()* and *blake2s()* are always available and support | Not implemented  |
+  | the full feature set of BLAKE2.                                                                              |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The SHA-3 hash functions *sha3_224()*, *sha3_256()*, *sha3_384()*, *sha3_512()*, and *SHAKE* hash functions  | Not implemented  |
+  | *shake_128()* and *shake_256()* were added.                                                                  |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The password-based key derivation function *scrypt()* is now available with OpenSSL 1.1.0 and newer.         | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `json <https://docs.python.org/3.6/whatsnew/3.6.html#json>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | *json.load()* and *json.loads()* now support binary input. Encoded JSON should be represented using either   | Partial          |
+  | UTF-8, UTF-16, or UTF-32.                                                                                    | [#jsonbytes]_    |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `math <https://docs.python.org/3.6/whatsnew/3.6.html#math>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new math.tau (τ) constant has been added                                                                 | Complete         |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `os <https://docs.python.org/3.6/whatsnew/3.6.html#os>`_                                                                        |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | A new *close()* method allows explicitly closing a *scandir()* iterator. The *scandir()* iterator now        | Not implemented  |
+  | supports the context manager protocol.                                                                       |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | On Linux, *os.urandom()* now blocks until the system urandom entropy pool is initialized to increase the     | Complete         |
+  | security.                                                                                                    |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The Linux *getrandom()* syscall (get random bytes) is now exposed as the new *os.getrandom()* function.      | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `re <https://docs.python.org/3.6/whatsnew/3.6.html#re>`_                                                                        |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Added support of modifier spans in regular expressions. Examples: *'(?i:p)ython'* matches 'python' and       | Not implemented  |
+  | 'Python', but not 'PYTHON'; *'(?i)g(?-i:v)r'* matches *'GvR'* and *'gvr'*, but not *'GVR'*.                  |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Match object groups can be accessed by *__getitem__*, which is equivalent to *group()*. So *mo['name']* is   | Not implemented  |
+  | now equivalent to *mo.group('name')*.                                                                        |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Match objects now support index-like objects as group indices.                                               | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `socket <https://docs.python.org/3.6/whatsnew/3.6.html#socket>`_                                                                |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The *ioctl()* function now supports the *SIO_LOOPBACK_FAST_PATH* control code.                               | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The *getsockopt()* constants *SO_DOMAIN* , *SO_PROTOCOL*, *SO_PEERSEC* , and *SO_PASSSEC* are now supported. | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The *setsockopt()* now supports the *setsockopt(level, optname, None, optlen: int)* form.                    | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The socket module now supports the address family *AF_ALG* to interface with Linux Kernel crypto API.        | Not implemented  |
+  | *ALG_*, *SOL_ALG* and *sendmsg_afalg()* were added.                                                          |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | New Linux constants *TCP_USER_TIMEOUT* and *TCP_CONGESTION* were added.                                      | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `ssl <https://docs.python.org/3.6/whatsnew/3.6.html#ssl>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | ssl supports OpenSSL 1.1.0. The minimum recommend version is 1.0.2.                                          | Not relevant     |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | 3DES has been removed from the default cipher suites and ChaCha20 Poly1305 cipher suites have been added.    | Not relevant     |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | *SSLContext* has better default configuration for options and ciphers.                                       | Not relevant     |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | SSL session can be copied from one client-side connection to another with the new *SSLSession* class. TLS    | Not implemented  |
+  | session resumption can speed up the initial handshake, reduce latency and improve performance.               |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new *get_ciphers()* method can be used to get a list of enabled ciphers in order of cipher priority.     | Partial          |
+  |                                                                                                              | [#getciphers]_   |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | All constants and flags have been converted to *IntEnum* and *IntFlags*.                                     | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Server and client-side specific TLS protocols for *SSLContext* were added.                                   | Complete         |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | Added *SSLContext.post_handshake_auth* to enable and *ssl.SSLSocket.verify_client_post_handshake()* to       | Not implemented  |
+  | initiate TLS 1.3 post-handshake authentication.                                                              |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `struct <https://docs.python.org/3.6/whatsnew/3.6.html#struct>`_                                                                |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | now supports IEEE 754 half-precision floats via the 'e' format specifier.                                    | Complete         |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `sys <https://docs.python.org/3.6/whatsnew/3.6.html#sys>`_                                                                      |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The new *getfilesystemencodeerrors()* function returns the name of the error mode used to convert between    | Not relevant     |
+  | Unicode filenames and bytes filenames.                                                                       |                  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | `zlib <https://docs.python.org/3.6/whatsnew/3.6.html#zlib>`_                                                                    |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
+  | The *compress()* and *decompress()* functions now accept keyword arguments                                   | Not implemented  |
+  +--------------------------------------------------------------------------------------------------------------+------------------+
 
 .. rubric:: Notes
 
+.. [#fstring] f-strings are parsed by a simplified pre-processor rather than a
+   full parser.  Concatenation with an adjacent literal containing braces is not
+   supported, expressions containing unbalanced braces or brackets are not
+   supported, and the ``!a`` conversion is not implemented because
+   :func:`ascii` is not available.
+.. [#annotations] Annotations are parsed but discarded: no ``__annotations__``
+   attribute is created for modules, classes or functions.  MicroPython also
+   accepts annotations on expressions that CPython rejects.
 .. [#setname] Currently, only :func:`__set_name__` is implemented.
+.. [#specialnone] MicroPython does not treat ``None`` as "operation not
+   available"; it simply attempts the call and raises ``TypeError: 'NoneType'
+   object isn't callable``.  This gives the right outcome for ``__iter__`` and
+   ``__hash__``, but differs where CPython falls back to another protocol, e.g.
+   with ``__len__ = None`` CPython's ``bool(obj)`` returns ``True`` whereas
+   MicroPython raises ``TypeError``.
+.. [#jsonbytes] Binary input is accepted, but only UTF-8 encoded data;
+   UTF-16 and UTF-32 are not supported.
+.. [#getciphers] ``SSLContext.get_ciphers()`` returns a list of cipher-suite
+   name strings rather than CPython's list of dictionaries describing each
+   cipher.

--- a/docs/differences/python_37.rst
+++ b/docs/differences/python_37.rst
@@ -11,30 +11,30 @@ New Features:
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
   | **Feature**                                                                                               | **Status**                           |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 538 <https://www.python.org/dev/peps/pep-0538/>`_ | Coercing the legacy C locale to a UTF-8 based    |                                      |
+  | `PEP 538 <https://www.python.org/dev/peps/pep-0538/>`_ | Coercing the legacy C locale to a UTF-8 based    | Not relevant                         |
   |                                                        | locale                                           |                                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 539 <https://www.python.org/dev/peps/pep-0539/>`_ | A New C-API for Thread-Local Storage in CPython  |                                      |
+  | `PEP 539 <https://www.python.org/dev/peps/pep-0539/>`_ | A New C-API for Thread-Local Storage in CPython  | Not relevant                         |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 540 <https://www.python.org/dev/peps/pep-0540/>`_ | UTF-8 mode                                       |                                      |
+  | `PEP 540 <https://www.python.org/dev/peps/pep-0540/>`_ | UTF-8 mode                                       | Not relevant                         |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 552 <https://www.python.org/dev/peps/pep-0552/>`_ | Deterministic pyc                                |                                      |
+  | `PEP 552 <https://www.python.org/dev/peps/pep-0552/>`_ | Deterministic pyc                                | Not relevant                         |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 553 <https://www.python.org/dev/peps/pep-0553/>`_ | Built-in ``breakpoint()``                        |                                      |
+  | `PEP 553 <https://www.python.org/dev/peps/pep-0553/>`_ | Built-in ``breakpoint()``                        | Not implemented                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_ | Data Classes                                     |                                      |
+  | `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_ | Data Classes                                     | Not implemented                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 560 <https://www.python.org/dev/peps/pep-0560/>`_ | Core support for typing module and generic types |                                      |
+  | `PEP 560 <https://www.python.org/dev/peps/pep-0560/>`_ | Core support for typing module and generic types | Not implemented                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_ | Module ``__getattr__`` and ``__dir__``           | Partial                              |
+  | `PEP 562 <https://www.python.org/dev/peps/pep-0562/>`_ | Module ``__getattr__`` and ``__dir__``           | Partial [#fmodattr]_                 |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_ | Postponed Evaluation of Annotations              |                                      |
+  | `PEP 563 <https://www.python.org/dev/peps/pep-0563/>`_ | Postponed Evaluation of Annotations              | Partial [#fannot]_                   |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
   | `PEP 564 <https://www.python.org/dev/peps/pep-0564/>`_ | Time functions with nanosecond resolution        | Partial [#ftimenanosec]_             |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 565 <https://www.python.org/dev/peps/pep-0565/>`_ | Show DeprecationWarning in ``__main__``          |                                      |
+  | `PEP 565 <https://www.python.org/dev/peps/pep-0565/>`_ | Show DeprecationWarning in ``__main__``          | Not implemented                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
-  | `PEP 567 <https://www.python.org/dev/peps/pep-0567/>`_ | Context Variables                                |                                      |
+  | `PEP 567 <https://www.python.org/dev/peps/pep-0567/>`_ | Context Variables                                | Not implemented                      |
   +--------------------------------------------------------+--------------------------------------------------+--------------------------------------+
 
 Other Language Changes:
@@ -42,67 +42,101 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``async`` and ``await`` are now reserved keywords                                                               | Complete       |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``dict`` objects must preserve insertion-order                                                                  |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | More than 255 arguments can now be passed to a function; a function can now have more than 255 parameters       |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``bytes.fromhex()`` and ``bytearray.fromhex()`` now ignore all ASCII whitespace, not only spaces                |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``str``, ``bytes``, and ``bytearray`` gained support for the new ``isascii()`` method, which can be used to     |                |
-  | test if a string or bytes contain only the ASCII characters                                                     |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``ImportError`` now displays module name and module ``__file__`` path when ``from ... import ...`` fails        |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | Circular imports involving absolute imports with binding a submodule to a name are now supported                |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | ``object.__format__(x, '')`` is now equivalent to ``str(x)`` rather than ``format(str(self), '')``              |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | In order to better support dynamic creation of stack traces, ``types.TracebackType`` can now be                 |                |
-  | instantiated from Python code, and the ``tb_next`` attribute on tracebacks is now writable                      |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | When using the ``-m`` switch, ``sys.path[0]`` is now eagerly expanded to the full starting directory path,      |                |
-  | rather than being left as the empty directory (which allows imports from the current working directory          |                |
-  | at the time when an import occurs)                                                                              |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
-  | The new ``-X importtime`` option or the ``PYTHONPROFILEIMPORTTIME`` environment variable can be used to         |                |
-  | show the timing of each module import                                                                           |                |
-  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``async`` and ``await`` are now reserved keywords                                                               | Complete                 |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``dict`` objects must preserve insertion-order                                                                  | Not implemented          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | More than 255 arguments can now be passed to a function; a function can now have more than 255 parameters       | Not implemented          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``bytes.fromhex()`` and ``bytearray.fromhex()`` now ignore all ASCII whitespace, not only spaces                | Complete                 |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``str``, ``bytes``, and ``bytearray`` gained support for the new ``isascii()`` method, which can be used to     | Not implemented          |
+  | test if a string or bytes contain only the ASCII characters                                                     |                          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``ImportError`` now displays module name and module ``__file__`` path when ``from ... import ...`` fails        | Not implemented          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Circular imports involving absolute imports with binding a submodule to a name are now supported                | Complete                 |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | ``object.__format__(x, '')`` is now equivalent to ``str(x)`` rather than ``format(str(self), '')``              | Partial [#fformat]_      |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | In order to better support dynamic creation of stack traces, ``types.TracebackType`` can now be                 | Not implemented          |
+  | instantiated from Python code, and the ``tb_next`` attribute on tracebacks is now writable                      |                          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | When using the ``-m`` switch, ``sys.path[0]`` is now eagerly expanded to the full starting directory path,      | Not implemented          |
+  | rather than being left as the empty directory (which allows imports from the current working directory          |                          |
+  | at the time when an import occurs)                                                                              |                          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  | The new ``-X importtime`` option or the ``PYTHONPROFILEIMPORTTIME`` environment variable can be used to         | Not relevant             |
+  | show the timing of each module import                                                                           |                          |
+  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.7.html#asyncio>`_                                           |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | Too many to list                                                                                           |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.7.html#gc>`_                                                     |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | New features include *gc.freeze()*, *gc.unfreeze()*, *gc-get_freeze_count*                                 |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `math <https://docs.python.org/3/whatsnew/3.7.html#math>`_                                                 |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | math.remainder() added to implement IEEE 754-style remainder                                               |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `re <https://docs.python.org/3/whatsnew/3.7.html#re>`_                                                     |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | A number of tidy up features including better support for splitting on empty strings and copy support for  |                |
-  | compiled expressions and match objects                                                                     |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.7.html#sys>`_                                                   |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | sys.breakpointhook() added. sys.get(/set)_coroutine_origin_tracking_depth() added                          |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | `time <https://docs.python.org/3/whatsnew/3.7.html#time>`_                                                 |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
-  | Mostly updates to support nanosecond resolution in PEP564, see above                                       |                |
-  +------------------------------------------------------------------------------------------------------------+----------------+
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.7.html#asyncio>`_                                                                      |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Too many to list                                                                                           | Partial [#fasyncio]_     |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.7.html#gc>`_                                                                                |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | New features include *gc.freeze()*, *gc.unfreeze()*, *gc-get_freeze_count*                                 | Not implemented          |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.7.html#math>`_                                                                            |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | math.remainder() added to implement IEEE 754-style remainder                                               | Not implemented          |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `re <https://docs.python.org/3/whatsnew/3.7.html#re>`_                                                                                |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | A number of tidy up features including better support for splitting on empty strings and copy support for  | Not implemented [#fre]_  |
+  | compiled expressions and match objects                                                                     |                          |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.7.html#sys>`_                                                                              |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | sys.breakpointhook() added. sys.get(/set)_coroutine_origin_tracking_depth() added                          | Not implemented          |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | `time <https://docs.python.org/3/whatsnew/3.7.html#time>`_                                                                            |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  | Mostly updates to support nanosecond resolution in PEP564, see above                                       | Partial [#ftime]_        |
+  +------------------------------------------------------------------------------------------------------------+--------------------------+
 
 .. rubric:: Notes
 
+.. [#fmodattr] Module-level ``__getattr__`` is supported on builds with
+   ``MICROPY_MODULE_GETATTR`` enabled (the default from the "core features"
+   ROM level upwards).  Module-level ``__dir__`` is ignored: ``dir()`` on a
+   module does not dispatch to it.
+
+.. [#fannot] MicroPython's parser discards annotations, so they are never
+   evaluated -- which gives the same practical result as PEP 563.  They are not
+   stored either: there is no ``__annotations__`` attribute on modules, classes
+   or functions, and ``__future__`` is not a built-in module.
+
 .. [#ftimenanosec] Only :func:`time.time_ns` is implemented.
+
+.. [#fformat] MicroPython has no ``format()`` built-in and does not implement
+   the ``__format__`` special method.  ``str.format()`` with an empty format
+   specification already uses ``str(x)``, which matches the Python 3.7
+   behaviour, but a non-empty specification raises ``TypeError`` for objects
+   that define only ``__str__``.
+
+.. [#fasyncio] Of the Python 3.7 :mod:`asyncio` additions, MicroPython
+   implements ``asyncio.run()``, ``asyncio.create_task()``,
+   ``asyncio.current_task()`` and ``StreamWriter.wait_closed()``.  It does not
+   implement ``asyncio.all_tasks()``, ``asyncio.get_running_loop()``,
+   ``asyncio.BufferedProtocol``, ``contextvars`` support,
+   ``Server.serve_forever()``, ``Server.start_serving()``,
+   ``Server.is_serving()``, ``loop.sock_sendfile()`` or ``loop.start_tls()``.
+
+.. [#fre] Neither of these changes applies: MicroPython has no module-level
+   ``re.split()`` (only the ``regex.split()`` method), splitting on a pattern
+   that can match an empty string returns the subject unsplit, and there is no
+   ``copy`` module with which to copy compiled patterns or match objects.
+
+.. [#ftime] Only :func:`time.time_ns` is implemented.
+   :func:`time.clock_gettime_ns`, :func:`time.monotonic_ns`,
+   :func:`time.perf_counter_ns`, :func:`time.process_time_ns` and
+   :func:`time.thread_time_ns` are not.

--- a/docs/differences/python_37.rst
+++ b/docs/differences/python_37.rst
@@ -42,66 +42,69 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``async`` and ``await`` are now reserved keywords                                                               | Complete                 |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``dict`` objects must preserve insertion-order                                                                  | Not implemented          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | More than 255 arguments can now be passed to a function; a function can now have more than 255 parameters       | Not implemented          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``bytes.fromhex()`` and ``bytearray.fromhex()`` now ignore all ASCII whitespace, not only spaces                | Complete                 |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``str``, ``bytes``, and ``bytearray`` gained support for the new ``isascii()`` method, which can be used to     | Not implemented          |
-  | test if a string or bytes contain only the ASCII characters                                                     |                          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``ImportError`` now displays module name and module ``__file__`` path when ``from ... import ...`` fails        | Not implemented          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | Circular imports involving absolute imports with binding a submodule to a name are now supported                | Complete                 |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | ``object.__format__(x, '')`` is now equivalent to ``str(x)`` rather than ``format(str(self), '')``              | Partial [#fformat]_      |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | In order to better support dynamic creation of stack traces, ``types.TracebackType`` can now be                 | Not implemented          |
-  | instantiated from Python code, and the ``tb_next`` attribute on tracebacks is now writable                      |                          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | When using the ``-m`` switch, ``sys.path[0]`` is now eagerly expanded to the full starting directory path,      | Not implemented          |
-  | rather than being left as the empty directory (which allows imports from the current working directory          |                          |
-  | at the time when an import occurs)                                                                              |                          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
-  | The new ``-X importtime`` option or the ``PYTHONPROFILEIMPORTTIME`` environment variable can be used to         | Not relevant             |
-  | show the timing of each module import                                                                           |                          |
-  +-----------------------------------------------------------------------------------------------------------------+--------------------------+
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``async`` and ``await`` are now reserved keywords                                                               | Complete       |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``dict`` objects must preserve insertion-order                                                                  | Not implemented|
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | More than 255 arguments can now be passed to a function; a function can now have more than 255 parameters       | Not implemented|
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``bytes.fromhex()`` and ``bytearray.fromhex()`` now ignore all ASCII whitespace, not only spaces                | Complete       |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``str``, ``bytes``, and ``bytearray`` gained support for the new ``isascii()`` method, which can be used to     | Not implemented|
+  | test if a string or bytes contain only the ASCII characters                                                     |                |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``ImportError`` now displays module name and module ``__file__`` path when ``from ... import ...`` fails        | Not implemented|
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | Circular imports involving absolute imports with binding a submodule to a name are now supported                | Complete       |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | ``object.__format__(x, '')`` is now equivalent to ``str(x)`` rather than ``format(str(self), '')``              | Partial        |
+  |                                                                                                                 | [#fformat]_    |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | In order to better support dynamic creation of stack traces, ``types.TracebackType`` can now be                 | Not implemented|
+  | instantiated from Python code, and the ``tb_next`` attribute on tracebacks is now writable                      |                |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | When using the ``-m`` switch, ``sys.path[0]`` is now eagerly expanded to the full starting directory path,      | Not implemented|
+  | rather than being left as the empty directory (which allows imports from the current working directory          |                |
+  | at the time when an import occurs)                                                                              |                |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
+  | The new ``-X importtime`` option or the ``PYTHONPROFILEIMPORTTIME`` environment variable can be used to         | Not relevant   |
+  | show the timing of each module import                                                                           |                |
+  +-----------------------------------------------------------------------------------------------------------------+----------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.7.html#asyncio>`_                                                                      |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | Too many to list                                                                                           | Partial [#fasyncio]_     |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.7.html#gc>`_                                                                                |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | New features include *gc.freeze()*, *gc.unfreeze()*, *gc-get_freeze_count*                                 | Not implemented          |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `math <https://docs.python.org/3/whatsnew/3.7.html#math>`_                                                                            |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | math.remainder() added to implement IEEE 754-style remainder                                               | Not implemented          |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `re <https://docs.python.org/3/whatsnew/3.7.html#re>`_                                                                                |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | A number of tidy up features including better support for splitting on empty strings and copy support for  | Not implemented [#fre]_  |
-  | compiled expressions and match objects                                                                     |                          |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.7.html#sys>`_                                                                              |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | sys.breakpointhook() added. sys.get(/set)_coroutine_origin_tracking_depth() added                          | Not implemented          |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | `time <https://docs.python.org/3/whatsnew/3.7.html#time>`_                                                                            |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
-  | Mostly updates to support nanosecond resolution in PEP564, see above                                       | Partial [#ftime]_        |
-  +------------------------------------------------------------------------------------------------------------+--------------------------+
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.7.html#asyncio>`_                                                            |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | Too many to list                                                                                           | Partial        |
+  |                                                                                                            | [#fasyncio]_   |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.7.html#gc>`_                                                                      |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | New features include *gc.freeze()*, *gc.unfreeze()*, *gc-get_freeze_count*                                 | Not implemented|
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `math <https://docs.python.org/3/whatsnew/3.7.html#math>`_                                                                  |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | math.remainder() added to implement IEEE 754-style remainder                                               | Not implemented|
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `re <https://docs.python.org/3/whatsnew/3.7.html#re>`_                                                                      |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | A number of tidy up features including better support for splitting on empty strings and copy support for  | Not implemented|
+  | compiled expressions and match objects                                                                     | [#fre]_        |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.7.html#sys>`_                                                                    |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | sys.breakpointhook() added. sys.get(/set)_coroutine_origin_tracking_depth() added                          | Not implemented|
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | `time <https://docs.python.org/3/whatsnew/3.7.html#time>`_                                                                  |
+  +------------------------------------------------------------------------------------------------------------+----------------+
+  | Mostly updates to support nanosecond resolution in PEP564, see above                                       | Partial        |
+  |                                                                                                            | [#ftime]_      |
+  +------------------------------------------------------------------------------------------------------------+----------------+
 
 .. rubric:: Notes
 

--- a/docs/differences/python_38.rst
+++ b/docs/differences/python_38.rst
@@ -11,117 +11,127 @@ a detailed description of the changes can be found in `What's New in Python
 .. table::
   :widths: 20 60 20
 
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | **Features**                                                                                               | **Status**    |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 570 <https://www.python.org/dev/peps/pep-0570/>`_ | Positional-only arguments                         |               |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 572 <https://www.python.org/dev/peps/pep-0572/>`_ | Assignment Expressions                            | Complete      |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ | Pickle protocol 5 with out-of-band data           |               |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 578 <https://www.python.org/dev/peps/pep-0578/>`_ | Runtime audit hooks                               |               |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 587 <https://www.python.org/dev/peps/pep-0587/>`_ | Python Initialization Configuration               |               |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | `PEP 590 <https://www.python.org/dev/peps/pep-0590/>`_ | Vectorcall: a fast calling protocol for CPython   |               |
-  +--------------------------------------------------------+---------------------------------------------------+---------------+
-  | **Miscellaneous**                                                                                                          |
-  +------------------------------------------------------------------------------------------------------------+---------------+
-  |  f-strings support = for self-documenting expressions and debugging                                        | Complete      |
-  +------------------------------------------------------------------------------------------------------------+---------------+
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | **Features**                                                                                               | **Status**         |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 570 <https://www.python.org/dev/peps/pep-0570/>`_ | Positional-only arguments                         | Not implemented    |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 572 <https://www.python.org/dev/peps/pep-0572/>`_ | Assignment Expressions                            | Complete           |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ | Pickle protocol 5 with out-of-band data           | Not implemented    |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 578 <https://www.python.org/dev/peps/pep-0578/>`_ | Runtime audit hooks                               | Not relevant       |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 587 <https://www.python.org/dev/peps/pep-0587/>`_ | Python Initialization Configuration               | Not relevant       |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | `PEP 590 <https://www.python.org/dev/peps/pep-0590/>`_ | Vectorcall: a fast calling protocol for CPython   | Not relevant       |
+  +--------------------------------------------------------+---------------------------------------------------+--------------------+
+  | **Miscellaneous**                                                                                                               |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  |  f-strings support = for self-documenting expressions and debugging                                        | Partial [#fstr38]_ |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
 
 Other Language Changes:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | A *continue* statement was illegal in the *finally* clause due to a problem with the implementation. In    | Complete    |
-  | Python 3.8 this restriction was lifted                                                                     |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | The *bool*, *int* , and *fractions.Fraction* types now have an *as_integer_ratio()* method like that found |             |
-  | in *float* and *decimal.Decimal*                                                                           |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Constructors of *int*, *float* and *complex* will now use the *__index__()* special method, if available   |             |
-  | and the corresponding method *__int__()*, *__float__()* or *__complex__()* is not available                |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added support of *\N{name}* escapes in regular expressions                                                 |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Dict and dictviews are now iterable in reversed insertion order using *reversed()*                         |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | The syntax allowed for keyword names in function calls was further restricted. In particular,              |             |
-  | f((keyword)=arg) is no longer allowed                                                                      |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Generalized iterable unpacking in yield and return statements no longer requires enclosing parentheses     |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | When a comma is missed in code such as [(10, 20) (30, 40)], the compiler displays a SyntaxWarning with a   |             |
-  | helpful suggestion                                                                                         |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Arithmetic operations between subclasses of *datetime.date* or *datetime.datetime* and *datetime.timedelta*|             |
-  | objects now return an instance of the subclass, rather than the base class                                 |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | When the Python interpreter is interrupted by *Ctrl-C (SIGINT)* and the resulting *KeyboardInterrupt*      |             |
-  | exception is not caught, the Python process now exits via a SIGINT signal or with the correct exit code    |             |
-  | such that the calling process can detect that it died due to  a *Ctrl-C*                                   |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Some advanced styles of programming require updating the *types.CodeType* object for an existing function  |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | For integers, the three-argument form of the pow() function now permits the exponent to be negative in the |             |
-  | case where the base is relatively prime to the modulus                                                     |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Dict comprehensions have been synced-up with dict literals so that the key is computed first and the value |             |
-  | second                                                                                                     |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | The *object.__reduce__()* method can now return a tuple from two to six elements long                      |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | A *continue* statement was illegal in the *finally* clause due to a problem with the implementation. In    | Complete           |
+  | Python 3.8 this restriction was lifted                                                                     |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | The *bool*, *int* , and *fractions.Fraction* types now have an *as_integer_ratio()* method like that found | Not implemented    |
+  | in *float* and *decimal.Decimal*                                                                           |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Constructors of *int*, *float* and *complex* will now use the *__index__()* special method, if available   | Not implemented    |
+  | and the corresponding method *__int__()*, *__float__()* or *__complex__()* is not available                |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added support of *\N{name}* escapes in regular expressions                                                 | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Dict and dictviews are now iterable in reversed insertion order using *reversed()*                         | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | The syntax allowed for keyword names in function calls was further restricted. In particular,              | Not implemented    |
+  | f((keyword)=arg) is no longer allowed                                                                      |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Generalized iterable unpacking in yield and return statements no longer requires enclosing parentheses     | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | When a comma is missed in code such as [(10, 20) (30, 40)], the compiler displays a SyntaxWarning with a   | Not implemented    |
+  | helpful suggestion                                                                                         |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Arithmetic operations between subclasses of *datetime.date* or *datetime.datetime* and *datetime.timedelta*| Not implemented    |
+  | objects now return an instance of the subclass, rather than the base class                                 |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | When the Python interpreter is interrupted by *Ctrl-C (SIGINT)* and the resulting *KeyboardInterrupt*      | Complete           |
+  | exception is not caught, the Python process now exits via a SIGINT signal or with the correct exit code    |                    |
+  | such that the calling process can detect that it died due to  a *Ctrl-C*                                   |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Some advanced styles of programming require updating the *types.CodeType* object for an existing function  | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | For integers, the three-argument form of the pow() function now permits the exponent to be negative in the | Not implemented    |
+  | case where the base is relatively prime to the modulus                                                     |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Dict comprehensions have been synced-up with dict literals so that the key is computed first and the value | Not implemented    |
+  | second                                                                                                     |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | The *object.__reduce__()* method can now return a tuple from two to six elements long                      | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.8.html#asyncio>`_                                                         |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | *asyncio.run()* has graduated from the provisional to stable API                                           | Complete    |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Running *python -m asyncio* launches a natively async REPL                                                 |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | The exception *asyncio.CancelledError* now inherits from *BaseException* rather than *Exception* and no    | Complete    |
-  | longer inherits from *concurrent.futures.CancelledError*                                                   |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added *asyncio.Task.get_coro()* for getting the wrapped coroutine within an *asyncio.Task*                 |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Asyncio tasks can now be named, either by passing the name keyword argument to *asyncio.create_task()* or  |             |
-  | the *create_task()* event loop method, or by calling the *set_name()* method on the task object            |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added support for Happy Eyeballs to *asyncio.loop.create_connection()*. To specify the behavior, two new   |             |
-  | parameters have been added: *happy_eyeballs_delay* and interleave.                                         |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.8.html#gc>`_                                                                   |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | *get_objects()* can now receive an optional generation parameter indicating a generation to get objects    |             |
-  | from. (Note, though, that while *gc* is a built-in, *get_objects()* is not implemented for MicroPython)    |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | `math <https://docs.python.org/3/whatsnew/3.8.html#math>`_                                                               |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added new function *math.dist()* for computing Euclidean distance between two points                       |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Expanded the *math.hypot()* function to handle multiple dimensions                                         |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added new function, *math.prod()*, as analogous function to *sum()* that returns the product of a "start"  |             |
-  | value (default: 1) times an iterable of numbers                                                            |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added two new combinatoric functions *math.perm()* and *math.comb()*                                       |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Added a new function *math.isqrt()* for computing accurate integer square roots without conversion to      |             |
-  | floating point                                                                                             |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | The function *math.factorial()* no longer accepts arguments that are not int-like                          | Complete    |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.8.html#sys>`_                                                                 |
-  +------------------------------------------------------------------------------------------------------------+-------------+
-  | Add new *sys.unraisablehook()* function which can be overridden to control how "unraisable exceptions"     |             |
-  | are handled                                                                                                |             |
-  +------------------------------------------------------------------------------------------------------------+-------------+
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.8.html#asyncio>`_                                                                |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | *asyncio.run()* has graduated from the provisional to stable API                                           | Complete           |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Running *python -m asyncio* launches a natively async REPL                                                 | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | The exception *asyncio.CancelledError* now inherits from *BaseException* rather than *Exception* and no    | Complete           |
+  | longer inherits from *concurrent.futures.CancelledError*                                                   |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added *asyncio.Task.get_coro()* for getting the wrapped coroutine within an *asyncio.Task*                 | Partial [#coro38]_ |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Asyncio tasks can now be named, either by passing the name keyword argument to *asyncio.create_task()* or  | Not implemented    |
+  | the *create_task()* event loop method, or by calling the *set_name()* method on the task object            |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added support for Happy Eyeballs to *asyncio.loop.create_connection()*. To specify the behavior, two new   | Not implemented    |
+  | parameters have been added: *happy_eyeballs_delay* and interleave.                                         |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.8.html#gc>`_                                                                          |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | *get_objects()* can now receive an optional generation parameter indicating a generation to get objects    | Not implemented    |
+  | from. (Note, though, that while *gc* is a built-in, *get_objects()* is not implemented for MicroPython)    |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.8.html#math>`_                                                                      |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added new function *math.dist()* for computing Euclidean distance between two points                       | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Expanded the *math.hypot()* function to handle multiple dimensions                                         | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added new function, *math.prod()*, as analogous function to *sum()* that returns the product of a "start"  | Not implemented    |
+  | value (default: 1) times an iterable of numbers                                                            |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added two new combinatoric functions *math.perm()* and *math.comb()*                                       | Not implemented    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Added a new function *math.isqrt()* for computing accurate integer square roots without conversion to      | Not implemented    |
+  | floating point                                                                                             |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | The function *math.factorial()* no longer accepts arguments that are not int-like                          | Complete           |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.8.html#sys>`_                                                                        |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+  | Add new *sys.unraisablehook()* function which can be overridden to control how "unraisable exceptions"     | Not implemented    |
+  | are handled                                                                                                |                    |
+  +------------------------------------------------------------------------------------------------------------+--------------------+
+
+.. rubric:: Notes
+
+.. [#fstr38] The ``=`` specifier is supported, but the interpolated value is
+   formatted with ``str()`` rather than with the implicit ``repr()`` that
+   CPython uses, and whitespace around the ``=`` (eg ``f'{x = }'``) is not
+   supported.
+
+.. [#coro38] There is no ``get_coro()`` method.  The wrapped coroutine is
+   instead reachable via the undocumented ``Task.coro`` attribute.

--- a/docs/differences/python_38.rst
+++ b/docs/differences/python_38.rst
@@ -11,120 +11,133 @@ a detailed description of the changes can be found in `What's New in Python
 .. table::
   :widths: 20 60 20
 
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | **Features**                                                                                               | **Status**         |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 570 <https://www.python.org/dev/peps/pep-0570/>`_ | Positional-only arguments                         | Not implemented    |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 572 <https://www.python.org/dev/peps/pep-0572/>`_ | Assignment Expressions                            | Complete           |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ | Pickle protocol 5 with out-of-band data           | Not implemented    |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 578 <https://www.python.org/dev/peps/pep-0578/>`_ | Runtime audit hooks                               | Not relevant       |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 587 <https://www.python.org/dev/peps/pep-0587/>`_ | Python Initialization Configuration               | Not relevant       |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | `PEP 590 <https://www.python.org/dev/peps/pep-0590/>`_ | Vectorcall: a fast calling protocol for CPython   | Not relevant       |
-  +--------------------------------------------------------+---------------------------------------------------+--------------------+
-  | **Miscellaneous**                                                                                                               |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  |  f-strings support = for self-documenting expressions and debugging                                        | Partial [#fstr38]_ |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | **Features**                                                                                               | **Status**    |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 570 <https://www.python.org/dev/peps/pep-0570/>`_ | Positional-only arguments                         | Not           |
+  |                                                        |                                                   | implemented   |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 572 <https://www.python.org/dev/peps/pep-0572/>`_ | Assignment Expressions                            | Complete      |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 574 <https://www.python.org/dev/peps/pep-0574/>`_ | Pickle protocol 5 with out-of-band data           | Not           |
+  |                                                        |                                                   | implemented   |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 578 <https://www.python.org/dev/peps/pep-0578/>`_ | Runtime audit hooks                               | Not relevant  |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 587 <https://www.python.org/dev/peps/pep-0587/>`_ | Python Initialization Configuration               | Not relevant  |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | `PEP 590 <https://www.python.org/dev/peps/pep-0590/>`_ | Vectorcall: a fast calling protocol for CPython   | Not relevant  |
+  +--------------------------------------------------------+---------------------------------------------------+---------------+
+  | **Miscellaneous**                                                                                                          |
+  +------------------------------------------------------------------------------------------------------------+---------------+
+  |  f-strings support = for self-documenting expressions and debugging                                        | Partial       |
+  |                                                                                                            | [#fstr38]_    |
+  +------------------------------------------------------------------------------------------------------------+---------------+
 
 Other Language Changes:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | A *continue* statement was illegal in the *finally* clause due to a problem with the implementation. In    | Complete           |
-  | Python 3.8 this restriction was lifted                                                                     |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | The *bool*, *int* , and *fractions.Fraction* types now have an *as_integer_ratio()* method like that found | Not implemented    |
-  | in *float* and *decimal.Decimal*                                                                           |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Constructors of *int*, *float* and *complex* will now use the *__index__()* special method, if available   | Not implemented    |
-  | and the corresponding method *__int__()*, *__float__()* or *__complex__()* is not available                |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added support of *\N{name}* escapes in regular expressions                                                 | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Dict and dictviews are now iterable in reversed insertion order using *reversed()*                         | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | The syntax allowed for keyword names in function calls was further restricted. In particular,              | Not implemented    |
-  | f((keyword)=arg) is no longer allowed                                                                      |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Generalized iterable unpacking in yield and return statements no longer requires enclosing parentheses     | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | When a comma is missed in code such as [(10, 20) (30, 40)], the compiler displays a SyntaxWarning with a   | Not implemented    |
-  | helpful suggestion                                                                                         |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Arithmetic operations between subclasses of *datetime.date* or *datetime.datetime* and *datetime.timedelta*| Not implemented    |
-  | objects now return an instance of the subclass, rather than the base class                                 |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | When the Python interpreter is interrupted by *Ctrl-C (SIGINT)* and the resulting *KeyboardInterrupt*      | Complete           |
-  | exception is not caught, the Python process now exits via a SIGINT signal or with the correct exit code    |                    |
-  | such that the calling process can detect that it died due to  a *Ctrl-C*                                   |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Some advanced styles of programming require updating the *types.CodeType* object for an existing function  | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | For integers, the three-argument form of the pow() function now permits the exponent to be negative in the | Not implemented    |
-  | case where the base is relatively prime to the modulus                                                     |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Dict comprehensions have been synced-up with dict literals so that the key is computed first and the value | Not implemented    |
-  | second                                                                                                     |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | The *object.__reduce__()* method can now return a tuple from two to six elements long                      | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | A *continue* statement was illegal in the *finally* clause due to a problem with the implementation. In    | Complete    |
+  | Python 3.8 this restriction was lifted                                                                     |             |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | The *bool*, *int* , and *fractions.Fraction* types now have an *as_integer_ratio()* method like that found | Not         |
+  | in *float* and *decimal.Decimal*                                                                           | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Constructors of *int*, *float* and *complex* will now use the *__index__()* special method, if available   | Not         |
+  | and the corresponding method *__int__()*, *__float__()* or *__complex__()* is not available                | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added support of *\N{name}* escapes in regular expressions                                                 | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Dict and dictviews are now iterable in reversed insertion order using *reversed()*                         | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | The syntax allowed for keyword names in function calls was further restricted. In particular,              | Not         |
+  | f((keyword)=arg) is no longer allowed                                                                      | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Generalized iterable unpacking in yield and return statements no longer requires enclosing parentheses     | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | When a comma is missed in code such as [(10, 20) (30, 40)], the compiler displays a SyntaxWarning with a   | Not         |
+  | helpful suggestion                                                                                         | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Arithmetic operations between subclasses of *datetime.date* or *datetime.datetime* and *datetime.timedelta*| Not         |
+  | objects now return an instance of the subclass, rather than the base class                                 | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | When the Python interpreter is interrupted by *Ctrl-C (SIGINT)* and the resulting *KeyboardInterrupt*      | Complete    |
+  | exception is not caught, the Python process now exits via a SIGINT signal or with the correct exit code    |             |
+  | such that the calling process can detect that it died due to  a *Ctrl-C*                                   |             |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Some advanced styles of programming require updating the *types.CodeType* object for an existing function  | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | For integers, the three-argument form of the pow() function now permits the exponent to be negative in the | Not         |
+  | case where the base is relatively prime to the modulus                                                     | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Dict comprehensions have been synced-up with dict literals so that the key is computed first and the value | Not         |
+  | second                                                                                                     | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | The *object.__reduce__()* method can now return a tuple from two to six elements long                      | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.8.html#asyncio>`_                                                                |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | *asyncio.run()* has graduated from the provisional to stable API                                           | Complete           |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Running *python -m asyncio* launches a natively async REPL                                                 | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | The exception *asyncio.CancelledError* now inherits from *BaseException* rather than *Exception* and no    | Complete           |
-  | longer inherits from *concurrent.futures.CancelledError*                                                   |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added *asyncio.Task.get_coro()* for getting the wrapped coroutine within an *asyncio.Task*                 | Partial [#coro38]_ |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Asyncio tasks can now be named, either by passing the name keyword argument to *asyncio.create_task()* or  | Not implemented    |
-  | the *create_task()* event loop method, or by calling the *set_name()* method on the task object            |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added support for Happy Eyeballs to *asyncio.loop.create_connection()*. To specify the behavior, two new   | Not implemented    |
-  | parameters have been added: *happy_eyeballs_delay* and interleave.                                         |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.8.html#gc>`_                                                                          |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | *get_objects()* can now receive an optional generation parameter indicating a generation to get objects    | Not implemented    |
-  | from. (Note, though, that while *gc* is a built-in, *get_objects()* is not implemented for MicroPython)    |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | `math <https://docs.python.org/3/whatsnew/3.8.html#math>`_                                                                      |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added new function *math.dist()* for computing Euclidean distance between two points                       | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Expanded the *math.hypot()* function to handle multiple dimensions                                         | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added new function, *math.prod()*, as analogous function to *sum()* that returns the product of a "start"  | Not implemented    |
-  | value (default: 1) times an iterable of numbers                                                            |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added two new combinatoric functions *math.perm()* and *math.comb()*                                       | Not implemented    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Added a new function *math.isqrt()* for computing accurate integer square roots without conversion to      | Not implemented    |
-  | floating point                                                                                             |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | The function *math.factorial()* no longer accepts arguments that are not int-like                          | Complete           |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.8.html#sys>`_                                                                        |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
-  | Add new *sys.unraisablehook()* function which can be overridden to control how "unraisable exceptions"     | Not implemented    |
-  | are handled                                                                                                |                    |
-  +------------------------------------------------------------------------------------------------------------+--------------------+
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.8.html#asyncio>`_                                                         |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | *asyncio.run()* has graduated from the provisional to stable API                                           | Complete    |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Running *python -m asyncio* launches a natively async REPL                                                 | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | The exception *asyncio.CancelledError* now inherits from *BaseException* rather than *Exception* and no    | Complete    |
+  | longer inherits from *concurrent.futures.CancelledError*                                                   |             |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added *asyncio.Task.get_coro()* for getting the wrapped coroutine within an *asyncio.Task*                 | Partial     |
+  |                                                                                                            | [#coro38]_  |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Asyncio tasks can now be named, either by passing the name keyword argument to *asyncio.create_task()* or  | Not         |
+  | the *create_task()* event loop method, or by calling the *set_name()* method on the task object            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added support for Happy Eyeballs to *asyncio.loop.create_connection()*. To specify the behavior, two new   | Not         |
+  | parameters have been added: *happy_eyeballs_delay* and interleave.                                         | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.8.html#gc>`_                                                                   |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | *get_objects()* can now receive an optional generation parameter indicating a generation to get objects    | Not         |
+  | from. (Note, though, that while *gc* is a built-in, *get_objects()* is not implemented for MicroPython)    | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | `math <https://docs.python.org/3/whatsnew/3.8.html#math>`_                                                               |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added new function *math.dist()* for computing Euclidean distance between two points                       | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Expanded the *math.hypot()* function to handle multiple dimensions                                         | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added new function, *math.prod()*, as analogous function to *sum()* that returns the product of a "start"  | Not         |
+  | value (default: 1) times an iterable of numbers                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added two new combinatoric functions *math.perm()* and *math.comb()*                                       | Not         |
+  |                                                                                                            | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Added a new function *math.isqrt()* for computing accurate integer square roots without conversion to      | Not         |
+  | floating point                                                                                             | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | The function *math.factorial()* no longer accepts arguments that are not int-like                          | Complete    |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.8.html#sys>`_                                                                 |
+  +------------------------------------------------------------------------------------------------------------+-------------+
+  | Add new *sys.unraisablehook()* function which can be overridden to control how "unraisable exceptions"     | Not         |
+  | are handled                                                                                                | implemented |
+  +------------------------------------------------------------------------------------------------------------+-------------+
 
 .. rubric:: Notes
 

--- a/docs/differences/python_39.rst
+++ b/docs/differences/python_39.rst
@@ -41,93 +41,104 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | *__import__()* now raises *ImportError* instead of *ValueError*                                             | Complete             |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | Python now gets the absolute path of the script filename specified on the command line (ex: *python3*       | Not implemented      |
-  | *script.py*): the *__file__* attribute of the *__main__* module became an absolute path, rather than a      |                      |
-  | relative path                                                                                               |                      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | By default, for best performance, the errors argument is only checked at the first encoding/decoding error  | Partial [#encargs]_  |
-  | and the encoding argument is sometimes ignored for empty strings                                            |                      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | *"".replace("", s, n)* now returns *s* instead of an empty string for all non-zero n. It is now consistent  | Complete             |
-  | with *"".replace("", s)*                                                                                    |                      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | Any valid expression can now be used as a decorator. Previously, the grammar was much more restrictive      | Not implemented      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | Parallel running of *aclose()* / *asend()* / *athrow()* is now prohibited, and *ag_running* now reflects    | Not implemented      |
-  | the actual running status of the async generator                                                            | [#asyncgen]_         |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | Unexpected errors in calling the *__iter__* method are no longer masked by TypeError in the in operator and | Partial [#itermask]_ |
-  | functions contains(), indexOf() and countOf() of the operator module                                        |                      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
-  | Unparenthesized lambda expressions can no longer be the expression part in an if clause in comprehensions   | Not implemented      |
-  | and generator expressions                                                                                   |                      |
-  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | *__import__()* now raises *ImportError* instead of *ValueError*                                             | Complete      |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Python now gets the absolute path of the script filename specified on the command line (ex: *python3*       | Not           |
+  | *script.py*): the *__file__* attribute of the *__main__* module became an absolute path, rather than a      | implemented   |
+  | relative path                                                                                               |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | By default, for best performance, the errors argument is only checked at the first encoding/decoding error  | Partial       |
+  | and the encoding argument is sometimes ignored for empty strings                                            | [#encargs]_   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | *"".replace("", s, n)* now returns *s* instead of an empty string for all non-zero n. It is now consistent  | Complete      |
+  | with *"".replace("", s)*                                                                                    |               |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Any valid expression can now be used as a decorator. Previously, the grammar was much more restrictive      | Not           |
+  |                                                                                                             | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Parallel running of *aclose()* / *asend()* / *athrow()* is now prohibited, and *ag_running* now reflects    | Not           |
+  | the actual running status of the async generator                                                            | implemented   |
+  |                                                                                                             | [#asyncgen]_  |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Unexpected errors in calling the *__iter__* method are no longer masked by TypeError in the in operator and | Partial       |
+  | functions contains(), indexOf() and countOf() of the operator module                                        | [#itermask]_  |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
+  | Unparenthesized lambda expressions can no longer be the expression part in an if clause in comprehensions   | Not           |
+  | and generator expressions                                                                                   | implemented   |
+  +-------------------------------------------------------------------------------------------------------------+---------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.9.html#asyncio>`_                                                                     |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Due to significant security concerns, the reuse_address parameter of *asyncio.loop.create_datagram_endpoint()*| Not relevant         |
-  | is no longer supported                                                                                        |                      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added a new coroutine *shutdown_default_executor()* that schedules a shutdown for the default executor that   | Not relevant         |
-  | waits on the *ThreadPoolExecutor* to finish closing. Also, *asyncio.run()* has been updated to use the new    |                      |
-  | coroutine.                                                                                                    |                      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added *asyncio.PidfdChildWatcher*, a Linux-specific child watcher implementation that polls process file      | Not relevant         |
-  | descriptors                                                                                                   |                      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | added a new *coroutine asyncio.to_thread()*                                                                   | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | When cancelling the task due to a timeout, *asyncio.wait_for()* will now wait until the cancellation is       | Complete             |
-  | complete also in the case when timeout is <= 0, like it does with positive timeouts                           |                      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | *asyncio* now raises *TyperError* when calling incompatible methods with an *ssl.SSLSocket* socket            | Not relevant         |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.9.html#gc>`_                                                                               |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Garbage collection does not block on resurrected objects                                                      | Not relevant         |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added a new function *gc.is_finalized()* to check if an object has been finalized by the garbage collector    | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `math <https://docs.python.org/3/whatsnew/3.9.html#math>`_                                                                           |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added *math.lcm()*: return the least common multiple of specified arguments                                   | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added *math.nextafter()*: return the next floating-point value after x towards y                              | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added *math.ulp()*: return the value of the least significant bit of a float                                  | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `os <https://docs.python.org/3/whatsnew/3.9.html#os>`_                                                                               |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Exposed the Linux-specific *os.pidfd_open()* and *os.P_PIDFD*                                                 | Not relevant         |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | The *os.unsetenv()* function is now also available on Windows                                                 | Complete             |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | The *os.putenv()* and *os.unsetenv()* functions are now always available                                      | Partial [#osenv]_    |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  |  Added *os.waitstatus_to_exitcode()* function: convert a wait status to an exit code                          | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `random <https://docs.python.org/3/whatsnew/3.9.html#random>`_                                                                       |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added a new *random.Random.randbytes* method: generate random bytes                                           | Not implemented      |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.9.html#sys>`_                                                                             |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Added a new *sys.platlibdir* attribute: name of the platform-specific library directory                       | Not relevant         |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
-  | Previously, *sys.stderr* was block-buffered when non-interactive. Now stderr defaults to always being         | Not relevant         |
-  | line-buffered                                                                                                 | [#stderr]_           |
-  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.9.html#asyncio>`_                                                              |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Due to significant security concerns, the reuse_address parameter of *asyncio.loop.create_datagram_endpoint()*| Not relevant  |
+  | is no longer supported                                                                                        |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added a new coroutine *shutdown_default_executor()* that schedules a shutdown for the default executor that   | Not relevant  |
+  | waits on the *ThreadPoolExecutor* to finish closing. Also, *asyncio.run()* has been updated to use the new    |               |
+  | coroutine.                                                                                                    |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added *asyncio.PidfdChildWatcher*, a Linux-specific child watcher implementation that polls process file      | Not relevant  |
+  | descriptors                                                                                                   |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | added a new *coroutine asyncio.to_thread()*                                                                   | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | When cancelling the task due to a timeout, *asyncio.wait_for()* will now wait until the cancellation is       | Complete      |
+  | complete also in the case when timeout is <= 0, like it does with positive timeouts                           |               |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | *asyncio* now raises *TyperError* when calling incompatible methods with an *ssl.SSLSocket* socket            | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.9.html#gc>`_                                                                        |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Garbage collection does not block on resurrected objects                                                      | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added a new function *gc.is_finalized()* to check if an object has been finalized by the garbage collector    | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `math <https://docs.python.org/3/whatsnew/3.9.html#math>`_                                                                    |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added *math.lcm()*: return the least common multiple of specified arguments                                   | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added *math.nextafter()*: return the next floating-point value after x towards y                              | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added *math.ulp()*: return the value of the least significant bit of a float                                  | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `os <https://docs.python.org/3/whatsnew/3.9.html#os>`_                                                                        |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Exposed the Linux-specific *os.pidfd_open()* and *os.P_PIDFD*                                                 | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The *os.unsetenv()* function is now also available on Windows                                                 | Complete      |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | The *os.putenv()* and *os.unsetenv()* functions are now always available                                      | Partial       |
+  |                                                                                                               | [#osenv]_     |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  |  Added *os.waitstatus_to_exitcode()* function: convert a wait status to an exit code                          | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `random <https://docs.python.org/3/whatsnew/3.9.html#random>`_                                                                |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added a new *random.Random.randbytes* method: generate random bytes                                           | Not           |
+  |                                                                                                               | implemented   |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.9.html#sys>`_                                                                      |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Added a new *sys.platlibdir* attribute: name of the platform-specific library directory                       | Not relevant  |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
+  | Previously, *sys.stderr* was block-buffered when non-interactive. Now stderr defaults to always being         | Not relevant  |
+  | line-buffered                                                                                                 | [#stderr]_    |
+  +---------------------------------------------------------------------------------------------------------------+---------------+
 
 .. rubric:: Notes
 

--- a/docs/differences/python_39.rst
+++ b/docs/differences/python_39.rst
@@ -19,19 +19,19 @@ and a detailed description of the changes can be found in
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
   | `PEP 584 <https://www.python.org/dev/peps/pep-0584/>`_ | Union operators added to dict                      | Complete [#pep584]_  |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
-  | `PEP 585 <https://www.python.org/dev/peps/pep-0584/>`_ | Type hinting generics in standard collections      |                      |
+  | `PEP 585 <https://www.python.org/dev/peps/pep-0584/>`_ | Type hinting generics in standard collections      | Not implemented      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
-  | `PEP 593 <https://www.python.org/dev/peps/pep-0593/>`_ | Flexible function and variable annotations         |                      |
+  | `PEP 593 <https://www.python.org/dev/peps/pep-0593/>`_ | Flexible function and variable annotations         | Not implemented      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
   | `PEP 602 <https://www.python.org/dev/peps/pep-0602/>`_ | CPython adopts an annual release cycle. Instead of | Not relevant         |
   |                                                        | annual, aiming for two month release cycle         |                      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
-  | `PEP 614 <https://www.python.org/dev/peps/pep-0614/>`_ | Relaxed grammar restrictions on decorators         |                      |
+  | `PEP 614 <https://www.python.org/dev/peps/pep-0614/>`_ | Relaxed grammar restrictions on decorators         | Not implemented      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
-  | `PEP 615 <https://www.python.org/dev/peps/pep-0615/>`_ | The IANA Time Zone Database is now present in the  |                      |
+  | `PEP 615 <https://www.python.org/dev/peps/pep-0615/>`_ | The IANA Time Zone Database is now present in the  | Not implemented      |
   |                                                        | standard library in the zoneinfo module            |                      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
-  | `PEP 616 <https://www.python.org/dev/peps/pep-0616/>`_ | String methods to remove prefixes and suffixes     |                      |
+  | `PEP 616 <https://www.python.org/dev/peps/pep-0616/>`_ | String methods to remove prefixes and suffixes     | Not implemented      |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
   | `PEP 617 <https://www.python.org/dev/peps/pep-0617/>`_ | CPython now uses a new parser based on PEG         | Not relevant         |
   +--------------------------------------------------------+----------------------------------------------------+----------------------+
@@ -41,94 +41,114 @@ Other Language Changes:
 .. table::
   :widths: 90 10
 
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | *__import__()* now raises *ImportError* instead of *ValueError*                                             | Complete      |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Python now gets the absolute path of the script filename specified on the command line (ex: *python3*       |               |
-  | *script.py*): the *__file__* attribute of the *__main__* module became an absolute path, rather than a      |               |
-  | relative path                                                                                               |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | By default, for best performance, the errors argument is only checked at the first encoding/decoding error  |               |
-  | and the encoding argument is sometimes ignored for empty strings                                            |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | *"".replace("", s, n)* now returns *s* instead of an empty string for all non-zero n. It is now consistent  |               |
-  | with *"".replace("", s)*                                                                                    |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Any valid expression can now be used as a decorator. Previously, the grammar was much more restrictive      |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Parallel running of *aclose()* / *asend()* / *athrow()* is now prohibited, and *ag_running* now reflects    |               |
-  | the actual running status of the async generator                                                            |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Unexpected errors in calling the *__iter__* method are no longer masked by TypeError in the in operator and |               |
-  | functions contains(), indexOf() and countOf() of the operator module                                        |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
-  | Unparenthesized lambda expressions can no longer be the expression part in an if clause in comprehensions   |               |
-  | and generator expressions                                                                                   |               |
-  +-------------------------------------------------------------------------------------------------------------+---------------+
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | *__import__()* now raises *ImportError* instead of *ValueError*                                             | Complete             |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | Python now gets the absolute path of the script filename specified on the command line (ex: *python3*       | Not implemented      |
+  | *script.py*): the *__file__* attribute of the *__main__* module became an absolute path, rather than a      |                      |
+  | relative path                                                                                               |                      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | By default, for best performance, the errors argument is only checked at the first encoding/decoding error  | Partial [#encargs]_  |
+  | and the encoding argument is sometimes ignored for empty strings                                            |                      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | *"".replace("", s, n)* now returns *s* instead of an empty string for all non-zero n. It is now consistent  | Complete             |
+  | with *"".replace("", s)*                                                                                    |                      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | Any valid expression can now be used as a decorator. Previously, the grammar was much more restrictive      | Not implemented      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | Parallel running of *aclose()* / *asend()* / *athrow()* is now prohibited, and *ag_running* now reflects    | Not implemented      |
+  | the actual running status of the async generator                                                            | [#asyncgen]_         |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | Unexpected errors in calling the *__iter__* method are no longer masked by TypeError in the in operator and | Partial [#itermask]_ |
+  | functions contains(), indexOf() and countOf() of the operator module                                        |                      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
+  | Unparenthesized lambda expressions can no longer be the expression part in an if clause in comprehensions   | Not implemented      |
+  | and generator expressions                                                                                   |                      |
+  +-------------------------------------------------------------------------------------------------------------+----------------------+
 
 Changes to built-in modules:
 
 .. table::
   :widths: 90 10
 
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `asyncio <https://docs.python.org/3/whatsnew/3.9.html#asyncio>`_                                                              |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Due to significant security concerns, the reuse_address parameter of *asyncio.loop.create_datagram_endpoint()*|               |
-  | is no longer supported                                                                                        |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added a new coroutine *shutdown_default_executor()* that schedules a shutdown for the default executor that   |               |
-  | waits on the *ThreadPoolExecutor* to finish closing. Also, *asyncio.run()* has been updated to use the new    |               |
-  | coroutine.                                                                                                    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added *asyncio.PidfdChildWatcher*, a Linux-specific child watcher implementation that polls process file      |               |
-  | descriptors                                                                                                   |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | added a new *coroutine asyncio.to_thread()*                                                                   |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | When cancelling the task due to a timeout, *asyncio.wait_for()* will now wait until the cancellation is       |               |
-  | complete also in the case when timeout is <= 0, like it does with positive timeouts                           |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | *asyncio* now raises *TyperError* when calling incompatible methods with an *ssl.SSLSocket* socket            |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `gc <https://docs.python.org/3/whatsnew/3.9.html#gc>`_                                                                        |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Garbage collection does not block on resurrected objects                                                      |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added a new function *gc.is_finalized()* to check if an object has been finalized by the garbage collector    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `math <https://docs.python.org/3/whatsnew/3.9.html#math>`_                                                                    |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added *math.lcm()*: return the least common multiple of specified arguments                                   |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added *math.nextafter()*: return the next floating-point value after x towards y                              |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added *math.ulp()*: return the value of the least significant bit of a float                                  |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `os <https://docs.python.org/3/whatsnew/3.9.html#os>`_                                                                        |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Exposed the Linux-specific *os.pidfd_open()* and *os.P_PIDFD*                                                 |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The *os.unsetenv()* function is now also available on Windows                                                 | Complete      |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | The *os.putenv()* and *os.unsetenv()* functions are now always available                                      | Complete      |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  |  Added *os.waitstatus_to_exitcode()* function: convert a wait status to an exit code                          |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `random <https://docs.python.org/3/whatsnew/3.9.html#random>`_                                                                |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added a new *random.Random.randbytes* method: generate random bytes                                           |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | `sys <https://docs.python.org/3/whatsnew/3.9.html#sys>`_                                                                      |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Added a new *sys.platlibdir* attribute: name of the platform-specific library directory                       |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
-  | Previously, *sys.stderr* was block-buffered when non-interactive. Now stderr defaults to always being         |               |
-  | line-buffered                                                                                                 |               |
-  +---------------------------------------------------------------------------------------------------------------+---------------+
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `asyncio <https://docs.python.org/3/whatsnew/3.9.html#asyncio>`_                                                                     |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Due to significant security concerns, the reuse_address parameter of *asyncio.loop.create_datagram_endpoint()*| Not relevant         |
+  | is no longer supported                                                                                        |                      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added a new coroutine *shutdown_default_executor()* that schedules a shutdown for the default executor that   | Not relevant         |
+  | waits on the *ThreadPoolExecutor* to finish closing. Also, *asyncio.run()* has been updated to use the new    |                      |
+  | coroutine.                                                                                                    |                      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added *asyncio.PidfdChildWatcher*, a Linux-specific child watcher implementation that polls process file      | Not relevant         |
+  | descriptors                                                                                                   |                      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | added a new *coroutine asyncio.to_thread()*                                                                   | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | When cancelling the task due to a timeout, *asyncio.wait_for()* will now wait until the cancellation is       | Complete             |
+  | complete also in the case when timeout is <= 0, like it does with positive timeouts                           |                      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | *asyncio* now raises *TyperError* when calling incompatible methods with an *ssl.SSLSocket* socket            | Not relevant         |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `gc <https://docs.python.org/3/whatsnew/3.9.html#gc>`_                                                                               |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Garbage collection does not block on resurrected objects                                                      | Not relevant         |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added a new function *gc.is_finalized()* to check if an object has been finalized by the garbage collector    | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `math <https://docs.python.org/3/whatsnew/3.9.html#math>`_                                                                           |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Expanded the *math.gcd()* function to handle multiple arguments. Formerly, it only supported two arguments    | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added *math.lcm()*: return the least common multiple of specified arguments                                   | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added *math.nextafter()*: return the next floating-point value after x towards y                              | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added *math.ulp()*: return the value of the least significant bit of a float                                  | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `os <https://docs.python.org/3/whatsnew/3.9.html#os>`_                                                                               |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Exposed the Linux-specific *os.pidfd_open()* and *os.P_PIDFD*                                                 | Not relevant         |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | The *os.unsetenv()* function is now also available on Windows                                                 | Complete             |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | The *os.putenv()* and *os.unsetenv()* functions are now always available                                      | Partial [#osenv]_    |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  |  Added *os.waitstatus_to_exitcode()* function: convert a wait status to an exit code                          | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `random <https://docs.python.org/3/whatsnew/3.9.html#random>`_                                                                       |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added a new *random.Random.randbytes* method: generate random bytes                                           | Not implemented      |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | `sys <https://docs.python.org/3/whatsnew/3.9.html#sys>`_                                                                             |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Added a new *sys.platlibdir* attribute: name of the platform-specific library directory                       | Not relevant         |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
+  | Previously, *sys.stderr* was block-buffered when non-interactive. Now stderr defaults to always being         | Not relevant         |
+  | line-buffered                                                                                                 | [#stderr]_           |
+  +---------------------------------------------------------------------------------------------------------------+----------------------+
 
 .. rubric:: Notes
 
 .. [#pep584] PEP 584 ``dict`` union operator is only available on MicroPython builds with ``MICROPY_CPYTHON_COMPAT`` enabled.
+
+.. [#encargs] MicroPython also only inspects the ``errors`` argument after a decoding error has been detected, but unlike
+   CPython the ``encoding`` argument is always validated and raises ``LookupError`` for an unknown encoding, including for
+   empty strings. Support for the ``errors`` argument requires ``MICROPY_PY_BUILTINS_BYTES_DECODE_ERRORS``, which is only
+   enabled at the "extra features" ROM level and above.
+
+.. [#asyncgen] MicroPython does not support asynchronous generators at all, not just the restriction added in Python 3.9. An
+   ``async def`` function containing ``yield`` produces an ordinary generator with no ``__aiter__`` method, so it cannot be
+   used with ``async for``, and there are no ``aclose()``, ``asend()``, ``athrow()`` or ``ag_running`` attributes.
+
+.. [#itermask] The ``in`` operator propagates exceptions raised by ``__iter__`` rather than masking them as ``TypeError``.
+   However MicroPython has no built-in ``operator`` module, and the ``operator`` module provided by micropython-lib does not
+   implement ``contains()``, ``indexOf()`` or ``countOf()``.
+
+.. [#osenv] ``os.putenv()`` and ``os.unsetenv()`` are only available on ports that enable
+   ``MICROPY_PY_OS_GETENV_PUTENV_UNSETENV`` (currently the ``unix`` and ``windows`` ports). Bare-metal ports have no process
+   environment, so these functions are not provided there.
+
+.. [#stderr] MicroPython's ``sys.stderr`` is unbuffered and writes to the same underlying stream as ``sys.stdout``, so the
+   distinction between block-buffered and line-buffered output does not apply.

--- a/docs/library/builtins.rst
+++ b/docs/library/builtins.rst
@@ -103,15 +103,18 @@ Functions and types
 
 .. class:: int()
 
-   .. classmethod:: from_bytes(bytes, byteorder)
+   .. classmethod:: from_bytes(bytes, byteorder='big')
 
-      In MicroPython, `byteorder` parameter must be positional (this is
-      compatible with CPython).
+      In MicroPython, `byteorder` is optional (defaulting to ``'big'``) but,
+      unlike CPython, both arguments must be passed positionally and the
+      *signed* keyword argument is not supported (the bytes are always
+      interpreted as unsigned).
 
-   .. method:: to_bytes(size, byteorder, /, *, signed=False)
+   .. method:: to_bytes(length=1, byteorder='big', *, signed=False)
 
-      In MicroPython, `byteorder` parameter must be positional (this is
-      compatible with CPython).
+      In MicroPython, *length* and *byteorder* are both optional. Unlike
+      CPython, they may be passed either positionally or as keyword
+      arguments.
 
 .. function:: isinstance()
 

--- a/docs/library/string.templatelib.rst
+++ b/docs/library/string.templatelib.rst
@@ -12,7 +12,10 @@ interpolated values before they are combined.
 **Availability:** template strings require ``MICROPY_PY_TSTRINGS`` to be enabled
 at compile time. They are enabled by default at the full feature level, which
 includes the alif, mimxrt and samd (SAMD51 only) ports, the unix coverage variant
-and the webassembly pyscript variant.
+and the webassembly pyscript variant. The zephyr port also enables them when
+configured for the full-features (or higher) ROM level via Kconfig. ``mpy-cross``
+always accepts t-string syntax when cross-compiling ``.mpy`` files, regardless of
+the target port's ROM level.
 
 Classes
 -------


### PR DESCRIPTION
### Summary

Update the CPython Differences docs. 

There were some updates required in the existing 3.5-3.10 pages and this also adds new pages for 3.11-3.14.

### Trade-offs and Alternatives

These are becoming increasingly challenging to maintain but I'm not sure of a better alternative! 

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.