### PR TITLE
Patch TinyUSB CDC TX persistence bug

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -180,6 +180,7 @@ DRIVERS_SRC_C += $(addprefix drivers/,\
 	)
 
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, $(TINYUSB_SRC_C)))
 TINYUSB_SRC_C += tinyusb_port/tusb_alif_dcd.c
 

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -94,6 +94,7 @@ endif
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/chipidea/ci_hs/dcd_ci_hs.c \

--- a/ports/nrf/Makefile
+++ b/ports/nrf/Makefile
@@ -268,6 +268,7 @@ SRC_C += drivers/usb/usb_cdc.c
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/nordic/nrf5x/dcd_nrf5x.c \

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -172,6 +172,7 @@ SHARED_SRC_C += $(addprefix shared/,\
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/renesas/rusb2/dcd_rusb2.c \

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -771,3 +771,36 @@ add_custom_command(
     VERBATIM
     COMMAND_EXPAND_LISTS
 )
+
+########################################################################################
+# Patch tinyusb to fix known issues.
+
+if(NOT UPDATE_SUBMODULES)
+    find_program(PATCH_EXECUTABLE patch REQUIRED)
+
+    # Need to patch cdc_device.c.
+    set(TINYUSB_CDC_DEVICE_ORIGINAL "${PICO_TINYUSB_PATH}/src/class/cdc/cdc_device.c")
+    set(TINYUSB_CDC_DEVICE_PATCH_FILE "${MICROPY_DIR}/shared/tinyusb/cdc_device.c.patch")
+    set(TINYUSB_CDC_DEVICE_PATCHED "${CMAKE_BINARY_DIR}/cdc_device.c")
+
+    # Command to patch the original file.
+    add_custom_command(
+        OUTPUT "${TINYUSB_CDC_DEVICE_PATCHED}"
+        COMMAND ${CMAKE_COMMAND} -E copy "${TINYUSB_CDC_DEVICE_ORIGINAL}" "${TINYUSB_CDC_DEVICE_PATCHED}"
+        COMMAND ${PATCH_EXECUTABLE} "${TINYUSB_CDC_DEVICE_PATCHED}" "${TINYUSB_CDC_DEVICE_PATCH_FILE}"
+        DEPENDS "${TINYUSB_CDC_DEVICE_ORIGINAL}" "${TINYUSB_CDC_DEVICE_PATCH_FILE}"
+        VERBATIM
+    )
+
+    # Set include directories for the patched file.
+    set_source_files_properties("${TINYUSB_CDC_DEVICE_PATCHED}"
+        PROPERTIES
+        INCLUDE_DIRECTORIES "${PICO_TINYUSB_PATH}/src/class/cdc"
+    )
+
+    # Modify list of tinyusb sources to replace original file with patched file.
+    get_target_property(TINYUSB_SOURCES tinyusb_device_base INTERFACE_SOURCES)
+    list(REMOVE_ITEM TINYUSB_SOURCES "${TINYUSB_CDC_DEVICE_ORIGINAL}")
+    list(APPEND TINYUSB_SOURCES "${TINYUSB_CDC_DEVICE_PATCHED}")
+    set_target_properties(tinyusb_device_base PROPERTIES INTERFACE_SOURCES "${TINYUSB_SOURCES}")
+endif()

--- a/ports/samd/Makefile
+++ b/ports/samd/Makefile
@@ -162,6 +162,7 @@ LIBM_SRC_C += $(SRC_LIB_LIBM_SQRT_SW_C)
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/microchip/samd/dcd_samd.c \

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -465,6 +465,7 @@ USBDEV_SRC_C += $(addprefix $(USBDEV_DIR)/,\
 
 # TinyUSB Stack source
 -include $(TOP)/lib/tinyusb/src/tinyusb.mk
+include $(TOP)/shared/tinyusb/tinyusb_patch.mk
 TINYUSB_SRC_C := $(sort $(addprefix lib/tinyusb/, \
 	$(TINYUSB_SRC_C) \
 	src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c \

--- a/shared/tinyusb/cdc_device.c.patch
+++ b/shared/tinyusb/cdc_device.c.patch
@@ -1,0 +1,10 @@
+--- a/cdc_device.c
++++ b/cdc_device.c
+@@ -343,7 +343,6 @@ uint16_t cdcd_open(uint8_t rhport, const tusb_desc_interface_t* itf_desc, uint16
+           tu_edpt_stream_open(stream_tx, rhport, desc_ep, CFG_TUD_CDC_TX_EPSIZE);
+
+   #if CFG_TUD_CDC_TX_PERSISTENT
+-          tu_edpt_stream_write_xfer(stream_tx); // flush pending data
+   #else
+           tu_edpt_stream_clear(stream_tx);
+   #endif

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -64,14 +64,6 @@
 // Initialise TinyUSB device.
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
-    #if MICROPY_HW_USB_CDC
-    tud_cdc_configure_t cfg = {
-        .rx_persistent = 0,
-        .tx_persistent = 1,
-        .tx_overwritabe_if_not_connected = 1,
-    };
-    tud_cdc_configure(&cfg);
-    #endif
 }
 
 // Run the TinyUSB device task

--- a/shared/tinyusb/tinyusb_patch.mk
+++ b/shared/tinyusb/tinyusb_patch.mk
@@ -1,0 +1,18 @@
+# Patch tinyusb for known issues.
+#
+# This file should be included immediately after including `$(TOP)/lib/tinyusb/src/tinyusb.mk`.
+
+TINYUSB_CDC_DEVICE_ORIGINAL = $(TOP)/lib/tinyusb/src/class/cdc/cdc_device.c
+TINYUSB_CDC_DEVICE_PATCH_FILE = $(TOP)/shared/tinyusb/cdc_device.c.patch
+TINYUSB_CDC_DEVICE_PATCHED = $(BUILD)/cdc_device.c
+
+TINYUSB_SRC_C := $(filter-out src/class/cdc/cdc_device.c, $(TINYUSB_SRC_C))
+
+$(TINYUSB_CDC_DEVICE_PATCHED): $(TINYUSB_CDC_DEVICE_ORIGINAL) $(TINYUSB_CDC_DEVICE_PATCH_FILE) | $(HEADER_BUILD)
+	$(ECHO) "Create $@"
+	$(Q)$(CP) $< $@
+	$(Q)patch --quiet $@ $(TINYUSB_CDC_DEVICE_PATCH_FILE)
+
+$(TINYUSB_CDC_DEVICE_PATCHED:.c=.o): CFLAGS += -I$(TOP)/lib/tinyusb/src/class/cdc
+
+OBJ += $(TINYUSB_CDC_DEVICE_PATCHED:.c=.o)

--- a/shared/tinyusb/tusb_config.h
+++ b/shared/tinyusb/tusb_config.h
@@ -83,6 +83,7 @@
 #ifndef CFG_TUD_CDC_TX_BUFSIZE
 #define CFG_TUD_CDC_TX_BUFSIZE  ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 256)
 #endif
+#define CFG_TUD_CDC_TX_PERSISTENT (1)
 #endif // CFG_TUD_CDC
 
 // MSC Configuration


### PR DESCRIPTION
### Summary

We recently updated to TinyUSB 0.21.0.  At the time of updating we didn't realise that they changed how CDC TX persistence is configured -- from runtime configuration to a static macro configuration.

But in the process of changing that, and their updating to a new streams FIFO, the CDC TX persistence got broken.

This PR aims to patch that bug in tinyusb by applying a small `.patch` file as part of the build process:
- exclude original `cdc_device.c` from the build
- copy original `cdc_device.c` to `build-BOARD/cdc_device.c`
- patch that file
- add the patched file back to the build
- build as usual

Both CMake (rp2 port) and make (everything else) are covered.

### Testing

Tested on RPI_PICO and TEENSY40: the REPL banner now appears correctly after a hard reset (prior to this patch it was corrupted).

### Trade-offs and Alternatives

This slightly complicates the build by patching during the build process.

Alternatives:
- fork TinyUSB to fix it
- wait for TinyUSB to fix it and release a new (patch) version
- not fix it and accept that after a hard reset the REPL output is corrupt (and some chars are copied to the input stream)

### Generative AI

I used Gemini to give me hints on how to wrangle CMake into getting this to work, but wrote everything myself.