### PR TITLE
tinyusb: change submodule to a MicroPython fork and fix CDC TX persistence issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
 	branch = circuitpython
 [submodule "lib/tinyusb"]
 	path = lib/tinyusb
-	url = https://github.com/hathach/tinyusb
+	url = https://github.com/micropython/tinyusb.git
 [submodule "lib/mynewt-nimble"]
 	path = lib/mynewt-nimble
 	url = https://github.com/micropython/mynewt-nimble.git

--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -64,14 +64,6 @@
 // Initialise TinyUSB device.
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
-    #if MICROPY_HW_USB_CDC
-    tud_cdc_configure_t cfg = {
-        .rx_persistent = 0,
-        .tx_persistent = 1,
-        .tx_overwritabe_if_not_connected = 1,
-    };
-    tud_cdc_configure(&cfg);
-    #endif
 }
 
 // Run the TinyUSB device task

--- a/shared/tinyusb/tusb_config.h
+++ b/shared/tinyusb/tusb_config.h
@@ -83,6 +83,7 @@
 #ifndef CFG_TUD_CDC_TX_BUFSIZE
 #define CFG_TUD_CDC_TX_BUFSIZE  ((CFG_TUD_MAX_SPEED == OPT_MODE_HIGH_SPEED) ? 512 : 256)
 #endif
+#define CFG_TUD_CDC_TX_PERSISTENT (1)
 #endif // CFG_TUD_CDC
 
 // MSC Configuration


### PR DESCRIPTION
### Summary

We recently updated to TinyUSB 0.21.0. At the time of updating we didn't realise that they changed how CDC TX persistence is configured -- from runtime configuration to a static macro configuration.

But in the process of changing that, and their updating to a new streams FIFO, the CDC TX persistence got broken.

This PR aims to fix that by forking TinyUSB and applying a patch, then updating the submodule here to point to that fork.

If this is accepted, I'll tag the fork commit as `0.21.0-micropython1`.

### Testing

Tested on RPI_PICO, the REPL banner now appears after a hard reset.

### Trade-offs and Alternatives

This is an alternative to #19606.

We already have forks of many repos (eg our own fork of `tinyusb-espressif`)... so having a fork of TinyUSB isn't too bad and allows us to fix other bugs in the future if they arise.

We have changed submodule links before, eg 2b5feb9121a2fd6679c1ec0c6f4f2cb00b6e3616 and 305707b281bc64aacb154e0165bd0a9ca3fedfe8 so this change to tinyusb submodule shouldn't introduce any additional problems with git.

### Generative AI

I did not use generative AI tools when creating this PR.
