### PR TITLE
docs/library: Add notes about minimum operating speed on ESP32 for BLE and WLAN.

### DIFF
--- a/docs/library/bluetooth.rst
+++ b/docs/library/bluetooth.rst
@@ -39,6 +39,13 @@ Configuration
 
     The radio must be made active before using any other methods on this class.
 
+.. note:: On ESP32 the BLE interface will not operate correctly and will
+    probably lock up the board if the system clock frequency has been changed to
+    a value below 80MHz.  Whilst this limitation may have been lifted from more
+    recent members of the ESP32 product line, for compatibility reasons across
+    hardware variants it is suggested to keep the system clock frequency above
+    80MHz if you use the BLE interface.
+
 .. method:: BLE.config('param', /)
             BLE.config(*, param=value, ...)
 

--- a/docs/library/network.WLAN.rst
+++ b/docs/library/network.WLAN.rst
@@ -30,7 +30,14 @@ Methods
 
     Activate ("up") or deactivate ("down") network interface, if boolean
     argument is passed. Otherwise, query current state if no argument is
-    provided. Most other methods require active interface.
+    provided. Most other methods require the interface being active.
+
+.. note:: On ESP32 the WLAN interface will not operate correctly and will
+    probably lock up the board if the system clock frequency has been changed to
+    a value below 80MHz.  Whilst this limitation may have been lifted from more
+    recent members of the ESP32 product line, for compatibility reasons across
+    hardware variants it is suggested to keep the system clock frequency above
+    80MHz if you use the WLAN interface.
 
 .. method:: WLAN.connect(ssid=None, key=None, *, bssid=None)
 


### PR DESCRIPTION
### Summary

This PR adds some information to both the `bluetooth.BLE` and `network.WLAN` classes' documentation indicating a potential issue that may arise with the ESP32 port if the
system clock frequency is set below the minimum operating system clock frequency of 80MHz.

This closes #18427.

### Testing

Besides locking up a few boards by setting the frequency to either 20MHz or 40MHz before or after activating the WiFi/BLE interface, the documentation was built with `make html` to make sure the note block appeared correctly.

### Generative AI

I did not use generative AI tools when creating this PR.