### PR TITLE
py/runtime: Ignore AttributeError when looking up __all__.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1602,8 +1602,7 @@ void mp_import_all(mp_obj_t module) {
     mp_obj_t dest[2];
 
     #if MICROPY_MODULE___ALL__
-
-    mp_load_method_maybe(module, MP_QSTR___all__, dest);
+    mp_load_method_protected(module, MP_QSTR___all__, dest, false);
     if (dest[0] != MP_OBJ_NULL) {
         // When __all__ is defined, we must explicitly load all specified
         // symbols, possibly invoking the module __getattr__ function

--- a/tests/import/import_star.py
+++ b/tests/import/import_star.py
@@ -57,3 +57,15 @@ try:
     print("missed detection of incorrect __all__ definition")
 except TypeError as er:
     print("TypeError triggered for bad __all__ definition")
+
+# 6. test when package uses __getattr__ and raises AttributeError for __getattr__("__all__")
+from pkgstar_getattr_attr_er import *
+
+print("publicFun3" in globals())
+print(publicFun3())
+
+# 7. test when package uses __getattr__ and raises ValueError for __getattr__("__all__")
+try:
+    from pkgstar_getattr_value_er import *
+except ValueError as er:
+    print("ValueError triggered with args", er.args)

--- a/tests/import/pkgstar_getattr_attr_er/__init__.py
+++ b/tests/import/pkgstar_getattr_attr_er/__init__.py
@@ -1,0 +1,15 @@
+_print_msg = True
+
+
+def publicFun3():
+    return 3
+
+
+def __getattr__(attr):
+    global _print_msg
+    if _print_msg:
+        # CPython calls __getattr__("__all__") twice, but MicroPython only once.
+        # To make the output match, only print the message once.
+        print("__getattr__", attr)
+        _print_msg = False
+    raise AttributeError(attr)

--- a/tests/import/pkgstar_getattr_value_er/__init__.py
+++ b/tests/import/pkgstar_getattr_value_er/__init__.py
@@ -1,0 +1,3 @@
+def __getattr__(attr):
+    print("__getattr__", attr)
+    raise ValueError(attr)


### PR DESCRIPTION
### Summary

Commit 570744d06c5ba9dba59b4c3f432ca4f0abd396b6 introduced a regression when using `from foo import *`: if the module used `__getattr__` and raised an `AttributeError` when doing `__getattr__("__all__")` then that exception would be raised up to the caller of the import, rather than being ignored.

This commit fixes that by protecting the lookup of "__all__".  Tests are added which makes sure the behaviour matches CPython.

Fixes issue #19265.

### Testing

Tests are added that run under CI.

### Trade-offs and Alternatives

There is minor NLR overhead for the `mp_load_method_protected()` call, but import-star is already a slow path so shouldn't have much of an impact.

### Generative AI

I did not use generative AI tools when creating this PR.
