### PR TITLE
tests/multi_exmod/machine_can_05: Fix test setup race.

### DIFF
--- a/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
+++ b/tests/multi_extmod/machine_can_05_tx_prio_cancel.py
@@ -43,6 +43,8 @@ def instance0():
     # requirement)
     multitest.wait("instance1 ready")
 
+    bcast_countdown = 5
+
     # "Babble" medium priority messages onto the bus to prevent
     # instance1() from sending anything lower priority than this
     while len(recv) < ITERS:
@@ -50,6 +52,12 @@ def instance0():
             can.send(id, b"BABBLE", CAN.FLAG_EXT_ID)
             if len(recv) >= ITERS:
                 break
+            if bcast_countdown > 0:
+                # queue some "babble" messages onto the bus before signalling to
+                # instance1 that it can start trying to send
+                bcast_countdown -= 1
+                if not bcast_countdown:
+                    multitest.broadcast("instance0 babbling")
 
     print("received", ITERS, "messages")
     for can_id in recv:
@@ -92,7 +100,7 @@ def instance1():
     # make sure instance0 can queue outgoing medium-priority
     # babble before we start trying to send, so we're trying to
     # send onto an already busy bus
-    time.sleep_ms(100)
+    multitest.wait("instance0 babbling")
 
     for i in range(ITERS):
         # Fill the transmit queue with low priority messages (all extended IDs)


### PR DESCRIPTION
### Summary

This is an attempt to fix the problem described by Damien [in this PR comment](https://github.com/micropython/micropython/pull/19484#issuecomment-5138652908). It is a follow-up to b35383b which fixed one test setup race, but seemed to introduce failures - at least on some stm32 test configs.

Guessing at a root cause: the 100ms sleep may not have been enough for the host to always coordinate instances, in which case instance1 might start sending onto the bus before instance0. Fix is to add an explicit synchronisation point so instance1 doesn't try to send until after instance0 has definitely started "babbling".

*This work was funded through GitHub Sponsors.*

### Testing

* Testing current master between stm32 boards PYBDV11 and NUCLEO-F413ZH, on my system approx 1 in 100 runs of test `machine_can_05_tx_prio_cancel.py` would fail with similar output to @dpgeorge's report in the linked comment. Suspect host timing may be the reason why Damien sees this every time and I only see it occasionally.
* With this fix, was able to complete 1000 test runs in both directions (`-p2`) with no failures.

### Trade-offs and Alternatives

* With this kind of fix it's sometimes unclear if you've solved the problem or merely changed some timing characteristics to move it, but using an explicit synchronisation point rather than sleeping 100ms and assuming this is long enough is unlikely to make things worse and may be fixing the root cause of the reported failures.

### Generative AI

I did not use generative AI tools when creating this PR.