### PR TITLE
zephyr/boards: Update RP2 boards for Zephyr 4.5

### DIFF
--- a/ports/zephyr/boards/rpi_pico.overlay
+++ b/ports/zephyr/boards/rpi_pico.overlay
@@ -29,12 +29,13 @@
 /delete-node/ &code_partition;
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
 		/* Code slot: 640 KiB - 0x100 placed after second-stage bootloader. */
 		code_partition: partition@100 {
+			compatible = "zephyr,mapped-partition";
 			label = "code-partition";
 			reg = <0x00000100 (DT_SIZE_K(640) - 0x100)>;
 			read-only;
@@ -42,6 +43,7 @@
 
 		/* Storage slot: 1408 KiB placed after code_partition. */
 		storage_partition: partition@a0000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x000a0000 DT_SIZE_K(1408)>;
 		};

--- a/ports/zephyr/boards/rpi_pico2_rp2350a_m33.overlay
+++ b/ports/zephyr/boards/rpi_pico2_rp2350a_m33.overlay
@@ -11,25 +11,22 @@
 	};
 };
 
+/delete-node/ &code_partition;
 &flash0 {
 	partitions {
-		compatible = "fixed-partitions";
+		ranges;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		second_stage_bootloader: partition@0 {
-			label = "second_stage_bootloader";
-			reg = <0x00000000 0x100>;
-			read-only;
-		};
-
-		code_partition: partition@100 {
-			label = "code-partition";
-			reg = <0x0000100 (DT_SIZE_M(1) - 0x100)>;
+		code_partition: partition@0 {
+			compatible = "zephyr,mapped-partition";
+			label = "code";
+			reg = <0x0000000 (DT_SIZE_M(1))>;
 			read-only;
 		};
 
 		storage_partition: partition@100000 {
+			compatible = "zephyr,mapped-partition";
 			label = "storage";
 			reg = <0x00100000 DT_SIZE_M(3)>;
 		};


### PR DESCRIPTION
Moving to mapped-partitions For Zephyr 4.5 see https://github.com/zephyrproject-rtos/zephyr/issues/107737

### Summary
Mapped-partitions

### Testing

Yes

### Trade-offs and Alternatives

No


### Generative AI

I did not use generative AI tools when creating this PR.

