### PR TITLE
rp2/rp2_pio: Add support for the origin directive in PIO programs.

### DIFF
--- a/docs/library/rp2.rst
+++ b/docs/library/rp2.rst
@@ -23,7 +23,7 @@ The ``rp2`` module includes functions for assembling PIO programs.
 
 For running PIO programs, see :class:`rp2.StateMachine`.
 
-.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, side_pindir=False, in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE)
+.. function:: asm_pio(*, out_init=None, set_init=None, sideset_init=None, side_pindir=False, in_shiftdir=PIO.SHIFT_LEFT, out_shiftdir=PIO.SHIFT_LEFT, autopush=False, autopull=False, push_thresh=32, pull_thresh=32, fifo_join=PIO.JOIN_NONE, origin=-1)
 
     Assemble a PIO program.
 
@@ -59,6 +59,8 @@ For running PIO programs, see :class:`rp2.StateMachine`.
     - *fifo_join* configures whether the 4-word TX and RX FIFOs should be
       combined into a single 8-word FIFO for one direction only. The options
       are `PIO.JOIN_NONE`, `PIO.JOIN_RX` and `PIO.JOIN_TX`.
+    - *origin* provides an optional offset for this program into the PIO memory
+      block
 
 .. function:: asm_pio_encode(instr, sideset_count, sideset_opt=False)
 

--- a/examples/rp2/pio_quadencoder.py
+++ b/examples/rp2/pio_quadencoder.py
@@ -1,0 +1,80 @@
+# Example using PIO to read a quadrature encoded signal.
+
+# ruff: noqa: F821 - @asm_pio decorator adds names to function scope
+
+from machine import Pin
+import rp2
+
+# This is a direct port of `quadrature_encoder.pio` from
+# https://github.com/raspberrypi/pico-examples/
+
+# This uses pins 16 and 17 for the quadrature encoding input signals.
+
+
+@rp2.asm_pio(
+    origin=0, out_shiftdir=rp2.PIO.SHIFT_LEFT, fifo_join=rp2.PIO.JOIN_NONE, autopull=False
+)
+def encoder():
+    # State 00
+    jmp("update")
+    jmp("decrement")
+    jmp("increment")
+    jmp("update")
+
+    # State 01
+    jmp("increment")
+    jmp("update")
+    jmp("update")
+    jmp("decrement")
+
+    # State 10
+    jmp("decrement")
+    jmp("update")
+    jmp("update")
+    jmp("increment")
+
+    # State 11
+    jmp("update")
+    jmp("increment")
+
+    # Pin2,Pin1 sequence
+    label("decrement")
+    jmp(y_dec, "update")
+
+    # Main loop
+    wrap_target()
+
+    label("update")
+    mov(isr, y)
+    push(noblock)
+
+    # Read the 2 input pins
+    label("sample_pins")
+    out(isr, 2)
+    in_(pins, 2)
+
+    # Save state and jump to state
+    mov(osr, isr)
+    mov(pc, isr)
+
+    # Pin1,Pin2 sequence
+    label("increment")
+    mov(y, invert(y))
+    jmp(y_dec, "increment_cont")
+    label("increment_cont")
+    mov(y, invert(y))
+
+    # Next iteration
+    wrap()
+
+
+pin16 = Pin(16, Pin.IN, Pin.PULL_UP)
+pin17 = Pin(17, Pin.IN, Pin.PULL_UP)
+sm = rp2.StateMachine(0, encoder, in_base=pin16, jmp_pin=pin16)
+sm.active(1)
+while True:
+    items = sm.rx_fifo()
+    while items > 0:
+        val = str(sm.get())
+        print(val + (" " * (len(val) - 10)) + "\r", end="")
+        items -= 1

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -13,7 +13,8 @@ _PROG_SHIFTCTRL = const(5)
 _PROG_OUT_PINS = const(6)
 _PROG_SET_PINS = const(7)
 _PROG_SIDESET_PINS = const(8)
-_PROG_MAX_FIELDS = const(9)
+_PROG_ORIGIN = const(9)
+_PROG_MAX_FIELDS = const(10)
 
 
 class PIOASMError(Exception):
@@ -35,6 +36,7 @@ class PIOASMEmit:
         push_thresh=32,
         pull_thresh=32,
         fifo_join=PIO.JOIN_NONE,
+        origin=-1,
     ):
         # array is a built-in module so importing it here won't require
         # scanning the filesystem.
@@ -51,7 +53,18 @@ class PIOASMEmit:
             | autopull << 17
             | autopush << 16
         )
-        self.prog = [array("H"), -1, -1, -1, execctrl, shiftctrl, out_init, set_init, sideset_init]
+        self.prog = [
+            array("H"),
+            -1,
+            -1,
+            -1,
+            execctrl,
+            shiftctrl,
+            out_init,
+            set_init,
+            sideset_init,
+            origin,
+        ]
 
         self.wrap_used = False
 

--- a/ports/rp2/rp2_pio.c
+++ b/ports/rp2/rp2_pio.c
@@ -218,6 +218,7 @@ enum {
     PROG_OUT_PINS,
     PROG_SET_PINS,
     PROG_SIDESET_PINS,
+    PROG_ORIGIN,
     PROG_MAX_FIELDS,
 };
 
@@ -342,9 +343,10 @@ static mp_obj_t rp2_pio_add_program(mp_obj_t self_in, mp_obj_t prog_in) {
     mp_obj_get_array_fixed_n(prog_in, PROG_MAX_FIELDS, &prog);
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(prog[PROG_DATA], &bufinfo, MP_BUFFER_READ);
+    mp_int_t origin = mp_obj_get_int(prog[PROG_ORIGIN]);
 
     // Add the program data to the PIO instruction memory.
-    struct pio_program pio_program = { bufinfo.buf, bufinfo.len / 2, -1 };
+    struct pio_program pio_program = { bufinfo.buf, bufinfo.len / 2, origin };
     if (!pio_can_add_program(self->pio, &pio_program)) {
         mp_raise_OSError(MP_ENOMEM);
     }


### PR DESCRIPTION
### Summary

This PR adds a new parameter to the PIO program decorator, to indicate an explicit program origin in the PIO memory area.

There was no possibility to pass an origin position in the PIO constructor, and that would create some problems for PIO programs that use computed jump offsets.  By default the state machine program loader does not guarantee a specific start position inside the PIO memory block, which makes things unpredictable for jump tables.

Now the decorator allows for an `origin` parameter that takes an integer containing the required offset in PIO memory.  Without that parameter behaviour is unchanged.

An example showing the usage of this parameter is supplied, `examples/rp2/pio_quadencoder.py`.  That is a direct port from `quadrature_encoder.pio` in the Raspberry Pi Pico samples repository into MicroPython's own PIO assembler.

Relevant documentation was also updated to keep track of the new decorator signature.

This closes #11531.

### Testing

Although I don't have an encoder available (who knows where the rotary switches went...), the clock frequency is high enough that when running the example code on a RP2040 shorting either pin 16 or pin 17 to ground triggers an increment/decrement response, demonstrating that the PIO program origin was actually picked up correctly (plus you can debug your own way through and see the value coming out :)).

### Trade-offs and Alternatives

Size increase is minimal, but this might probably be the least amount of code needed to pull this off.

There are a few PRs that are supposed to improve the state of things w.r.t. PIO, but none of those actually implement origin support.  If somebody else with a more complete PR wants to take these changes in to merge with theirs, that's fine by me.

### Generative AI

I did not use generative AI tools when creating this PR.