### PR TITLE
mimxrt/modmachine: Fix reset_cause and add HARD/DEEPSLEEP constants.

### DIFF
--- a/ports/mimxrt/main.c
+++ b/ports/mimxrt/main.c
@@ -72,6 +72,7 @@ int main(void) {
     board_init();
     ticks_init();
     pendsv_init();
+    machine_init();
 
     #if MICROPY_HW_ENABLE_PSRAM
     size_t psram_size = configure_external_ram();
@@ -206,6 +207,7 @@ int main(void) {
         #if MICROPY_PY_MACHINE_QECNT
         machine_encoder_deinit_all();
         #endif
+        machine_set_soft_reset();
         gc_sweep_all();
         mp_deinit();
     }

--- a/ports/mimxrt/modmachine.c
+++ b/ports/mimxrt/modmachine.c
@@ -68,7 +68,9 @@
     \
     /* Reset reasons */ \
     { MP_ROM_QSTR(MP_QSTR_PWRON_RESET),         MP_ROM_INT(MP_PWRON_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_HARD_RESET),          MP_ROM_INT(MP_HARD_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_WDT_RESET),           MP_ROM_INT(MP_WDT_RESET) }, \
+    { MP_ROM_QSTR(MP_QSTR_DEEPSLEEP_RESET),     MP_ROM_INT(MP_DEEPSLEEP_RESET) }, \
     { MP_ROM_QSTR(MP_QSTR_SOFT_RESET),          MP_ROM_INT(MP_SOFT_RESET) }, \
 
 typedef enum {
@@ -84,6 +86,38 @@ typedef enum {
 #define DBL_TAP_MAGIC 0xf01669ef // Randomly selected, adjusted to have first and last bit set
 #define DBL_TAP_MAGIC_QUICK_BOOT 0xf02669ef
 
+static uint8_t reset_cause;
+
+void machine_init(void) {
+    // Determine the current reset cause.
+    #ifdef MIMXRT117x_SERIES
+    uint32_t user_reset_flag = kSRC_M7CoreIppUserResetFlag;
+    #else
+    uint32_t user_reset_flag = kSRC_IppUserResetFlag;
+    #endif
+    if (SRC->SRSR & user_reset_flag) {
+        reset_cause = MP_DEEPSLEEP_RESET;
+    } else if (SNVS->LPSR & SNVS_LPSR_LPTA_MASK) {
+        // Device was reset due to low-power timer alarm.
+        machine_rtc_alarm_off(true);
+        reset_cause = MP_DEEPSLEEP_RESET;
+    } else {
+        uint16_t wdog =
+            WDOG_GetStatusFlags(WDOG1) & (kWDOG_PowerOnResetFlag | kWDOG_TimeoutResetFlag | kWDOG_SoftwareResetFlag);
+        if (wdog == kWDOG_PowerOnResetFlag) {
+            reset_cause = MP_PWRON_RESET;
+        } else if (wdog == kWDOG_TimeoutResetFlag) {
+            reset_cause = MP_WDT_RESET;
+        } else {
+            reset_cause = MP_HARD_RESET;
+        }
+    }
+}
+
+void machine_set_soft_reset(void) {
+    reset_cause = MP_SOFT_RESET;
+}
+
 static mp_obj_t mp_machine_unique_id(void) {
     unsigned char id[8];
     mp_hal_get_unique_id(id);
@@ -98,23 +132,6 @@ MP_NORETURN static void mp_machine_reset(void) {
 }
 
 static mp_int_t mp_machine_reset_cause(void) {
-    #ifdef MIMXRT117x_SERIES
-    uint32_t user_reset_flag = kSRC_M7CoreIppUserResetFlag;
-    #else
-    uint32_t user_reset_flag = kSRC_IppUserResetFlag;
-    #endif
-    if (SRC->SRSR & user_reset_flag) {
-        return MP_DEEPSLEEP_RESET;
-    }
-    uint16_t reset_cause =
-        WDOG_GetStatusFlags(WDOG1) & (kWDOG_PowerOnResetFlag | kWDOG_TimeoutResetFlag | kWDOG_SoftwareResetFlag);
-    if (reset_cause == kWDOG_PowerOnResetFlag) {
-        reset_cause = MP_PWRON_RESET;
-    } else if (reset_cause == kWDOG_TimeoutResetFlag) {
-        reset_cause = MP_WDT_RESET;
-    } else {
-        reset_cause = MP_SOFT_RESET;
-    }
     return reset_cause;
 }
 

--- a/ports/mimxrt/modmachine.h
+++ b/ports/mimxrt/modmachine.h
@@ -31,6 +31,9 @@
 
 extern const mp_obj_type_t machine_can_type;
 
+void machine_init(void);
+void machine_set_soft_reset(void);
+
 void machine_adc_init(void);
 void machine_can_irq_deinit(void);
 void machine_pin_irq_deinit(void);
@@ -42,6 +45,7 @@ void machine_sdcard_init0(void);
 void mimxrt_sdram_init(void);
 void machine_i2s_init0();
 void machine_i2s_deinit_all(void);
+void machine_rtc_alarm_off(bool clear);
 void machine_rtc_start(void);
 uint64_t machine_rtc_get_ticks(void);
 uint64_t machine_rtc_get_seconds(void);


### PR DESCRIPTION
### Summary

The `machine.reset_cause()` function was only partially working on mimxrt. This commit fixes it so that all five reset causes now work correctly:
- SOFT_RESET is now set only after a soft reset at the REPL.
- HARD_RESET is now set correctly (previously it used SOFT_RESET), and this constant is exposed to Python.
- DEEPSLEEP_RESET is now set when the timer alarm wakes the device, and this constant is exposed to Python.

### Testing

Tested on TEENSY40, using this helper script:
```py
# cause.py
import machine

reason = {}
for g in machine.__dict__:
    if g.endswith("_RESET"):
        reason[getattr(machine, g)] = g
print("cause =", machine.reset_cause(), reason[machine.reset_cause()])
```
Run that via `mpremote resume run cause.py` to check the reset cause.

Tested all 5 cases, using `machine.reset()`, `machine.deepsleep(1000)` and `machine.WDT(timeout=1000)` to trigger the cases.

### Generative AI

I did not use generative AI tools when creating this PR.
