### PR TITLE
esp32/machine_sdcard: Move SDMMC slot/width defaults to per-board config

### DIFF
--- a/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
+++ b/ports/esp32/boards/ESP32_GENERIC_P4/mpconfigboard.h
@@ -13,6 +13,9 @@
 
 #define MICROPY_PY_MACHINE_SDCARD           (1)
 #define MICROPY_HW_SDMMC_LDO_CHAN_ID        (4)
+// This board wires the SD/MMC card to SDMMC slot 0 with a full 4-bit bus.
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
 
 #ifndef USB_SERIAL_JTAG_PACKET_SZ_BYTES
 #define USB_SERIAL_JTAG_PACKET_SZ_BYTES (64)

--- a/ports/esp32/machine_sdcard.h
+++ b/ports/esp32/machine_sdcard.h
@@ -26,6 +26,17 @@
 #ifndef MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 #define MICROPY_INCLUDED_ESP32_MACHINE_SDCARD_H
 
+// Default slot and bus width for a native SD/MMC machine.SDCard(). These are
+// conservative defaults (the historically usable slot 1, 1-bit); which slot is
+// wired and how many data lines are routed is board specific, so a board should
+// override these in its mpconfigboard.h to match its layout.
+#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
+#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
+#endif
+#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
+#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
+#endif
+
 // Default pins for the primary SPI-mode SD card bus (slot 2). SPI mode is
 // available on every ESP32 variant, so a board may override these in its
 // mpconfigboard.h to make machine.SDCard(slot=2) work without explicit pins.

--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -224,20 +224,6 @@
 #ifndef MICROPY_HW_ENABLE_SDCARD
 #define MICROPY_HW_ENABLE_SDCARD            (1)
 #endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_SLOT
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (0)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_SLOT       (1)
-#endif
-#endif
-#ifndef MICROPY_HW_SDMMC_DEFAULT_WIDTH
-#if CONFIG_IDF_TARGET_ESP32P4
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (4)
-#else
-#define MICROPY_HW_SDMMC_DEFAULT_WIDTH      (1)
-#endif
-#endif
 #define MICROPY_HW_SOFTSPI_MIN_DELAY        (0)
 #define MICROPY_HW_SOFTSPI_MAX_BAUDRATE     (esp_rom_get_cpu_ticks_per_us() * 1000000 / 200) // roughly
 #define MICROPY_PY_SSL                      (MICROPY_PY_NETWORK)


### PR DESCRIPTION
Follow-up to #19533. In that PR @dpgeorge suggested moving the
`MICROPY_HW_SDMMC_DEFAULT_SLOT` and `MICROPY_HW_SDMMC_DEFAULT_WIDTH`
defaults out of `mpconfigport.h`:

> maybe it makes sense now to move the MICROPY_HW_SDMMC_DEFAULT_SLOT and
> MICROPY_HW_SDMMC_DEFAULT_WIDTH default defines out of `mpconfigport.h`
> and into `machine_sdcard.h`?

(https://github.com/micropython/micropython/pull/19533#issuecomment-5267629411)

This does that, and goes one step further. These defines are only used by
`machine_sdcard.c`, so the first commit moves them next to the SD card SPI
pin defaults in `machine_sdcard.h`.

While moving them I checked the SoC capabilities: the ESP32-P4 exposes two
equally-capable SDMMC slots (`SOC_SDMMC_NUM_SLOTS == 2`, both up to 8-bit),
so the previous `slot 0 / 4-bit` value for P4 was not a silicon property
but a description of how the reference board is wired. The old
`#if CONFIG_IDF_TARGET_ESP32P4` special-case in the shared header was
therefore misleading.

So the second commit keeps only a conservative generic default in the
header (`slot 1`, `1-bit`) and moves the P4-specific `slot 0 / 4-bit`
wiring into `boards/ESP32_GENERIC_P4/mpconfigboard.h`, next to the existing
SDMMC LDO config. Any board can still override both defines via the
existing `#ifndef` guards.

No functional change: `ESP32_GENERIC_P4` keeps `slot 0 / 4-bit` and all
other targets keep `slot 1 / 1-bit`; the values are just defined in more
appropriate places.

Tested on hardware:
- `ESP32_GENERIC_P4`: default `machine.SDCard()` reads at ~6.8 MiB/s vs
  ~2.3 MiB/s when forced to `width=1`, confirming the 4-bit default is
  applied from the board config.
- `ESP32_GENERIC_S3` (XIAO ESP32-S3): SPI-mode `machine.SDCard(slot=2)`
  with the default pins still mounts and reads correctly (~1.5 MiB/s),
  confirming the refactor didn't regress the other targets.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.