### PR TITLE
esp32/modmachine: Use popcount to count wake pins.

### DIFF
--- a/ports/esp32/modmachine.c
+++ b/ports/esp32/modmachine.c
@@ -326,9 +326,7 @@ static mp_obj_t machine_wake_pins(void) {
 
     // Only a few (~8) pins might cause wakeup.
     // Therefore, we calculate the required space in a first pass.
-    for (index = 0, len = 0; index < 64; index++) {
-        len += (status & (1ULL << index)) ? 1 : 0;
-    }
+    len = mp_popcount(status >> 32) + mp_popcount(status & 0xFFFFFFFF);
     if (len) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(mp_obj_new_tuple(len, NULL));
 


### PR DESCRIPTION
### Summary

This PR introduces a minor optimisation in `machine.wake_pins` when computing how much space to allocate to hold all the indices of the pins that triggered a wake event.

Rather than looping through 64 bits to figure out how many bits are set (and therefore if there's anything to be done), do one popcount each on the two 32-bits halves of the source value and sum the results up.

Saves 32 bytes on Xtensa and 16 bytes on RV32, not to mention being probably faster due to the fewer instructions being executed to compute the final value.

### Testing

Both ESP32 and ESP32C3 boards were put into deep sleep and woken up with different methods, checking whether the output of `machine.wake_pins()` without these changes applied matched the output after these changes were applied.

### Generative AI

I did not use generative AI tools when creating this PR.