### PR TITLE
stm32/sdcard: Add support for UHS-I SD cards.

### DIFF
--- a/ports/stm32/boards/OPENMV_N6/board.c
+++ b/ports/stm32/boards/OPENMV_N6/board.c
@@ -28,9 +28,10 @@
 #include "boardctrl.h"
 #include "xspi.h"
 
-// Values for OTP fuses for VDDIO2/3, to select low voltage mode (<2.5V).
+// Values for OTP fuses for VDDIO2/3/4, to select low voltage mode (<2.5V).
 // See RM0486, Section 5, Table 18.
 #define BSEC_HW_CONFIG_ID       (124U)
+#define BSEC_HWS_HSLV_VDDIO4    (1U << 14)
 #define BSEC_HWS_HSLV_VDDIO3    (1U << 15)
 #define BSEC_HWS_HSLV_VDDIO2    (1U << 16)
 
@@ -48,7 +49,7 @@ void mboot_board_early_init(void) {
     // Program high speed IO optimization fuses if they aren't already set.
     uint32_t fuse;
     BSEC_HandleTypeDef hbsec = { .Instance = BSEC };
-    const uint32_t mask = BSEC_HWS_HSLV_VDDIO2 | BSEC_HWS_HSLV_VDDIO3;
+    const uint32_t mask = BSEC_HWS_HSLV_VDDIO2 | BSEC_HWS_HSLV_VDDIO3 | BSEC_HWS_HSLV_VDDIO4;
     if (HAL_BSEC_OTP_Read(&hbsec, BSEC_HW_CONFIG_ID, &fuse) != HAL_OK) {
         fuse = 0;
     } else if ((fuse & mask) != mask) {

--- a/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
+++ b/ports/stm32/boards/OPENMV_N6/mpconfigboard.h
@@ -101,9 +101,15 @@
 
 // SD Card SDMMC
 // SD_VSELECT: low(default)=3.3V IO, high=1.8V IO
-// SD_RESET: drive low to turn off SD VCC (pulled high by default)
+// SD_RESET: drive low to turn off SD VCC (pulled high by default on UHS-I capable
+//   hardware, in which case it reads high at startup; reads low otherwise)
 // SD_DETECT: pulled high in hardware, goes low when SD inserted
 #define MICROPY_HW_SDCARD_SDMMC             (1)
+#define MICROPY_HW_SDCARD_VSELECT_PIN       (pyb_pin_SD_VSELECT)
+#define MICROPY_HW_SDCARD_RESET_PIN         (pyb_pin_SD_RESET)
+// UHS-I SDR104 at 200MHz (the SDMMC kernel clock is HCLK at 200MHz).
+#define MICROPY_HW_SDCARD_UHS_SWITCH_PATTERN (SDMMC_SDR104_SWITCH_PATTERN)
+#define MICROPY_HW_SDCARD_UHS_CLK_DIV       (0)
 #define MICROPY_HW_SDCARD_CK                (pyb_pin_SD_SDIO_CK)
 #define MICROPY_HW_SDCARD_CMD               (pyb_pin_SD_SDIO_CMD)
 #define MICROPY_HW_SDCARD_D0                (pyb_pin_SD_SDIO_D0)

--- a/ports/stm32/boards/OPENMV_N6/stm32n6xx_hal_conf.h
+++ b/ports/stm32/boards/OPENMV_N6/stm32n6xx_hal_conf.h
@@ -13,6 +13,9 @@
 #define HSE_STARTUP_TIMEOUT (100)
 #define LSE_STARTUP_TIMEOUT (5000)
 
+// Enable the HAL's SD card 1.8V switch support, for UHS-I mode.
+#define USE_SD_TRANSCEIVER (1)
+
 #include "boards/stm32n6xx_hal_conf_base.h"
 
 #endif // MICROPY_INCLUDED_STM32N6XX_HAL_CONF_H

--- a/ports/stm32/boards/stm32n6xx_hal_conf_base.h
+++ b/ports/stm32/boards/stm32n6xx_hal_conf_base.h
@@ -97,7 +97,9 @@
 // Miscellaneous HAL settings
 #define VDD_VALUE           3300UL
 #define USE_RTOS            0
+#ifndef USE_SD_TRANSCEIVER
 #define USE_SD_TRANSCEIVER  0
+#endif
 #define USE_SPI_CRC         1
 
 // Disable dynamic callback registration

--- a/ports/stm32/sdcard.c
+++ b/ports/stm32/sdcard.c
@@ -162,11 +162,72 @@ inline static bool usbd_msc_lu_includes_sdcard(void) {
 #define SDIO_BUS_WIDE_VALUE SDIO_BUS_WIDE_8B
 #endif
 
+// A board can support UHS-I mode (1.8V signalling) on UHS-I capable SD cards by defining:
+//   MICROPY_HW_SDCARD_VSELECT_PIN - output pin that switches the SD bus I/O rail (and the
+//     corresponding MCU I/O voltage domain) between 3.3V (low) and 1.8V (high)
+//   MICROPY_HW_SDCARD_RESET_PIN - active-low output pin controlling SD card VDD; it is also
+//     sampled at startup to detect whether the hardware supports UHS-I (it reads high if so)
+// and optionally:
+//   MICROPY_HW_SDCARD_UHS_SWITCH_PATTERN - CMD6 pattern selecting the UHS-I speed mode
+//   MICROPY_HW_SDCARD_UHS_CLK_DIV - SDMMC clock divider to use after the speed switch
+#if defined(MICROPY_HW_SDCARD_VSELECT_PIN) && defined(MICROPY_HW_SDCARD_RESET_PIN)
+#define SDCARD_ENABLE_UHS1 (1)
+#if !defined(USE_SD_TRANSCEIVER) || USE_SD_TRANSCEIVER == 0
+#error "UHS-I support requires USE_SD_TRANSCEIVER=1 in the HAL configuration"
+#endif
+#ifndef MICROPY_HW_SDCARD_UHS_SWITCH_PATTERN
+#define MICROPY_HW_SDCARD_UHS_SWITCH_PATTERN SDMMC_SDR50_SWITCH_PATTERN
+#endif
+#ifndef MICROPY_HW_SDCARD_UHS_CLK_DIV
+#define MICROPY_HW_SDCARD_UHS_CLK_DIV (1)
+#endif
+#if MICROPY_HW_SDCARD_SDMMC == 2
+#define SDCARD_DLYB DLYB_SDMMC2
+#else
+#define SDCARD_DLYB DLYB_SDMMC1
+#endif
+#if defined(STM32N6)
+// The SD bus pins sit in a switchable VDDIO power domain; a board can select which
+// one with MICROPY_HW_SDCARD_VDDIO (2-5), defaulting to the domain that the used
+// SDMMC's default pins are in.  The matching HSLV_VDDIOx OTP fuse must be set for
+// the 1.8V pad voltage range to be selectable.
+#ifndef MICROPY_HW_SDCARD_VDDIO
+#if MICROPY_HW_SDCARD_SDMMC == 2
+#define MICROPY_HW_SDCARD_VDDIO (5)
+#else
+#define MICROPY_HW_SDCARD_VDDIO (4)
+#endif
+#endif
+#if MICROPY_HW_SDCARD_VDDIO == 2
+#define SDCARD_VDDIO_SET_RANGE LL_PWR_SetVddIO2VoltageRange
+#define SDCARD_VDDIO_GET_RANGE LL_PWR_GetVddIO2VoltageRange
+#elif MICROPY_HW_SDCARD_VDDIO == 3
+#define SDCARD_VDDIO_SET_RANGE LL_PWR_SetVddIO3VoltageRange
+#define SDCARD_VDDIO_GET_RANGE LL_PWR_GetVddIO3VoltageRange
+#elif MICROPY_HW_SDCARD_VDDIO == 4
+#define SDCARD_VDDIO_SET_RANGE LL_PWR_SetVddIO4VoltageRange
+#define SDCARD_VDDIO_GET_RANGE LL_PWR_GetVddIO4VoltageRange
+#elif MICROPY_HW_SDCARD_VDDIO == 5
+#define SDCARD_VDDIO_SET_RANGE LL_PWR_SetVddIO5VoltageRange
+#define SDCARD_VDDIO_GET_RANGE LL_PWR_GetVddIO5VoltageRange
+#else
+#error "Invalid MICROPY_HW_SDCARD_VDDIO"
+#endif
+#endif
+#else
+#define SDCARD_ENABLE_UHS1 (0)
+#endif
+
 #define PYB_SDMMC_FLAG_SD       (0x01)
 #define PYB_SDMMC_FLAG_MMC      (0x02)
 #define PYB_SDMMC_FLAG_ACTIVE   (0x04)
 
 static uint8_t pyb_sdmmc_flags;
+
+#if SDCARD_ENABLE_UHS1
+// Set if the hardware supports UHS-I, detected at startup via MICROPY_HW_SDCARD_RESET_PIN.
+static bool sdcard_uhs_capable;
+#endif
 
 #define TIMEOUT_MS 30000
 
@@ -180,10 +241,7 @@ static union {
     #endif
 } sdmmc_handle;
 
-void sdcard_init(void) {
-    // Set SD/MMC to no mode and inactive
-    pyb_sdmmc_flags = 0;
-
+static void sdcard_pin_config(void) {
     // configure SD GPIO
     // we do this here an not in HAL_SD_MspInit because it apparently
     // makes it more robust to have the pins always pulled high
@@ -204,6 +262,41 @@ void sdcard_init(void) {
     mp_hal_pin_config_alt_static(MICROPY_HW_SDCARD_D7, MP_HAL_PIN_MODE_ALT, MP_HAL_PIN_PULL_UP, STATIC_AF_SDCARD_D7);
     #endif
     #endif
+
+    #if SDCARD_ENABLE_UHS1
+    if (sdcard_uhs_capable) {
+        // UHS-I bus rates need the fastest GPIO drive setting.
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_CK, MP_HAL_PIN_SPEED_VERY_HIGH);
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_CMD, MP_HAL_PIN_SPEED_VERY_HIGH);
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_D0, MP_HAL_PIN_SPEED_VERY_HIGH);
+        #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_D1, MP_HAL_PIN_SPEED_VERY_HIGH);
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_D2, MP_HAL_PIN_SPEED_VERY_HIGH);
+        mp_hal_pin_config_speed(MICROPY_HW_SDCARD_D3, MP_HAL_PIN_SPEED_VERY_HIGH);
+        #endif
+    }
+    #endif
+}
+
+void sdcard_init(void) {
+    // Set SD/MMC to no mode and inactive
+    pyb_sdmmc_flags = 0;
+
+    #if SDCARD_ENABLE_UHS1
+    // Sample the SD reset pin to detect UHS-I capable hardware: it reads high when
+    // the UHS-I power switch circuitry is present.
+    mp_hal_pin_config(MICROPY_HW_SDCARD_RESET_PIN, MP_HAL_PIN_MODE_INPUT, MP_HAL_PIN_PULL_NONE, 0);
+    sdcard_uhs_capable = mp_hal_pin_read(MICROPY_HW_SDCARD_RESET_PIN);
+    if (sdcard_uhs_capable) {
+        // Take over the card's power enable (keeping it powered) and select 3.3V signalling.
+        mp_hal_pin_high(MICROPY_HW_SDCARD_RESET_PIN);
+        mp_hal_pin_config(MICROPY_HW_SDCARD_RESET_PIN, MP_HAL_PIN_MODE_OUTPUT, MP_HAL_PIN_PULL_NONE, 0);
+        mp_hal_pin_low(MICROPY_HW_SDCARD_VSELECT_PIN);
+        mp_hal_pin_config(MICROPY_HW_SDCARD_VSELECT_PIN, MP_HAL_PIN_MODE_OUTPUT, MP_HAL_PIN_PULL_NONE, 0);
+    }
+    #endif
+
+    sdcard_pin_config();
 
     // configure the SD card detect pin
     // we do this here so we can detect if the SD card is inserted before powering it on
@@ -276,7 +369,127 @@ bool sdcard_is_present(void) {
 }
 
 #if MICROPY_HW_ENABLE_SDCARD
-static HAL_StatusTypeDef sdmmc_init_sd(void) {
+
+#if SDCARD_ENABLE_UHS1
+
+// Switch the SD bus I/O voltage.  Called by the HAL during the CMD11 voltage switch
+// sequence (with the bus clock stopped), and by this driver to restore 3.3V signalling.
+void HAL_SD_DriveTransceiver_1_8V_Callback(FlagStatus status) {
+    if (status == SET) {
+        // The card acknowledged the switch: change the bus I/O rail to 1.8V and then
+        // update the MCU pad voltage range to match the new rail voltage.
+        mp_hal_pin_high(MICROPY_HW_SDCARD_VSELECT_PIN);
+        mp_hal_delay_ms(1);
+        #if defined(STM32N6)
+        SDCARD_VDDIO_SET_RANGE(LL_PWR_VDDIO_VOLTAGE_RANGE_1V8);
+        #endif
+    } else {
+        // Restore the pad voltage range first (a 1.8V pad range on a 3.3V rail can
+        // damage the device), then switch the bus I/O rail back to 3.3V.
+        #if defined(STM32N6)
+        SDCARD_VDDIO_SET_RANGE(LL_PWR_VDDIO_VOLTAGE_RANGE_3V3);
+        #endif
+        mp_hal_pin_low(MICROPY_HW_SDCARD_VSELECT_PIN);
+    }
+}
+
+static void sdcard_power_cycle(void) {
+    // Return the bus to 3.3V signalling.
+    HAL_SD_DriveTransceiver_1_8V_Callback(RESET);
+
+    // Drive the SD bus pins low so the card is not back-powered via its I/O pins
+    // while its supply is off.
+    static const mp_hal_pin_obj_t bus_pins[] = {
+        MICROPY_HW_SDCARD_CK, MICROPY_HW_SDCARD_CMD, MICROPY_HW_SDCARD_D0,
+        #if MICROPY_HW_SDCARD_BUS_WIDTH >= 4
+        MICROPY_HW_SDCARD_D1, MICROPY_HW_SDCARD_D2, MICROPY_HW_SDCARD_D3,
+        #endif
+    };
+    for (size_t i = 0; i < MP_ARRAY_SIZE(bus_pins); ++i) {
+        mp_hal_pin_low(bus_pins[i]);
+        mp_hal_pin_config(bus_pins[i], MP_HAL_PIN_MODE_OUTPUT, MP_HAL_PIN_PULL_NONE, 0);
+    }
+
+    // Power cycle the SD card: its supply must fall below 0.5V for at least 1ms.
+    mp_hal_pin_low(MICROPY_HW_SDCARD_RESET_PIN);
+    mp_hal_delay_ms(20);
+    mp_hal_pin_high(MICROPY_HW_SDCARD_RESET_PIN);
+    mp_hal_delay_ms(10);
+
+    // Restore the SD bus pins.
+    sdcard_pin_config();
+}
+
+// Perform a CMD6 SWITCH_FUNC transaction, reading back the 64-byte switch status.
+// The HAL's own CMD6 helpers arm the data path via DCTRL.DTEN without linking it to
+// the command (CMDTRANS), which hangs on this SDMMC peripheral, so the transfer is
+// done here using the same command-transfer mechanism as regular block reads.
+static uint32_t sdcard_cmd6_switch(uint32_t arg, uint32_t *status) {
+    SDMMC_TypeDef *sdmmc = sdmmc_handle.sd.Instance;
+
+    uint32_t errorstate = SDMMC_CmdBlockLength(sdmmc, 64);
+    if (errorstate != HAL_SD_ERROR_NONE) {
+        return errorstate;
+    }
+
+    SDMMC_DataInitTypeDef config = {
+        .DataTimeOut = 6250000, // 250ms at the 25MHz switching clock
+        .DataLength = 64,
+        .DataBlockSize = SDMMC_DATABLOCK_SIZE_64B,
+        .TransferDir = SDMMC_TRANSFER_DIR_TO_SDMMC,
+        .TransferMode = SDMMC_TRANSFER_MODE_BLOCK,
+        .DPSM = SDMMC_DPSM_DISABLE,
+    };
+    (void)SDMMC_ConfigData(sdmmc, &config);
+    __SDMMC_CMDTRANS_ENABLE(sdmmc);
+
+    errorstate = SDMMC_CmdSwitch(sdmmc, arg);
+
+    if (errorstate == HAL_SD_ERROR_NONE) {
+        // The 64-byte status block fits entirely in the SDMMC FIFO, and takes well
+        // under a millisecond to arrive at the 25MHz switching clock, so wait out
+        // the transfer and then drain the FIFO unconditionally.  The status flags
+        // cannot be used to pace the drain: after the 1.8V switch the data path
+        // status reads stale until the FIFO is accessed, so the flag-driven receive
+        // loops that the HAL uses deadlock here.
+        mp_hal_delay_ms(2);
+        for (int i = 0; i < 16; ++i) {
+            status[i] = SDMMC_ReadFIFO(sdmmc);
+        }
+        // The status refreshes some time after the FIFO accesses above, so give it
+        // a grace period before believing what it says.
+        uint32_t sta;
+        for (int i = 0; ; ++i) {
+            sta = sdmmc->STA;
+            if (sta & (SDMMC_FLAG_DATAEND | SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DCRCFAIL |
+                       SDMMC_FLAG_RXOVERR)) {
+                break;
+            }
+            if (i >= 100) {
+                break;
+            }
+            mp_hal_delay_us(100);
+        }
+        if (sta & (SDMMC_FLAG_DTIMEOUT | SDMMC_FLAG_DCRCFAIL | SDMMC_FLAG_RXOVERR)) {
+            errorstate = SDMMC_ERROR_GENERAL_UNKNOWN_ERR;
+        } else if (!(sta & SDMMC_FLAG_DATAEND)) {
+            // The card did not send the status block.
+            sdmmc->DCTRL = 0;
+            errorstate = SDMMC_ERROR_TIMEOUT;
+        }
+    }
+
+    __SDMMC_CMDTRANS_DISABLE(sdmmc);
+    __SDMMC_CLEAR_FLAG(sdmmc, SDMMC_STATIC_DATA_FLAGS);
+
+    return errorstate;
+}
+
+#endif // SDCARD_ENABLE_UHS1
+
+static HAL_StatusTypeDef sdmmc_init_sd_bus(bool uhs) {
+    (void)uhs;
+
     // SD device interface configuration
     sdmmc_handle.sd.Instance = SDIO;
     sdmmc_handle.sd.Init.ClockEdge = SDIO_CLOCK_EDGE_RISING;
@@ -287,10 +500,30 @@ static HAL_StatusTypeDef sdmmc_init_sd(void) {
     sdmmc_handle.sd.Init.BusWide = SDIO_BUS_WIDE_1B;
     sdmmc_handle.sd.Init.HardwareFlowControl = SDIO_HARDWARE_FLOW_CONTROL_DISABLE;
     sdmmc_handle.sd.Init.ClockDiv = SDIO_TRANSFER_CLK_DIV;
+    #if SDCARD_ENABLE_UHS1
+    if (uhs) {
+        // Run card identification and the 1.8V voltage switch at 25MHz; the clock is
+        // raised to the UHS-I rate after the speed switch below.
+        sdmmc_handle.sd.Init.TranceiverPresent = SDMMC_TRANSCEIVER_PRESENT;
+        sdmmc_handle.sd.Init.ClockDiv = SDMMC_NSPEED_CLK_DIV;
+        // Keep the bus clock free-running in UHS-I mode (matching the ST BSPs); with
+        // clock power saving enabled the voltage switch and CMD6 sequences stall.
+        sdmmc_handle.sd.Init.ClockPowerSave = SDIO_CLOCK_POWER_SAVE_DISABLE;
+    } else {
+        sdmmc_handle.sd.Init.TranceiverPresent = SDMMC_TRANSCEIVER_NOT_PRESENT;
+    }
+    #endif
 
     // init the SD interface, with retry if it's not ready yet
     HAL_StatusTypeDef status;
     for (int retry = 10; (status = HAL_SD_Init(&sdmmc_handle.sd)) != HAL_OK; retry--) {
+        #if SDCARD_ENABLE_UHS1
+        if (uhs) {
+            // Don't retry a failed UHS-I init here: the card may be stuck mid voltage
+            // switch and needs a power cycle, which the caller takes care of.
+            return status;
+        }
+        #endif
         if (retry == 0) {
             return status;
         }
@@ -306,7 +539,79 @@ static HAL_StatusTypeDef sdmmc_init_sd(void) {
     }
     #endif
 
+    #if SDCARD_ENABLE_UHS1
+    if (uhs) {
+        bool uhs_active = sdmmc_handle.sd.SdCard.CardSpeed == CARD_ULTRA_HIGH_SPEED;
+        #if defined(STM32N6)
+        if (uhs_active) {
+            // Verify that the pad voltage range switch took effect: without the
+            // matching HSLV_VDDIOx OTP fuse the VRSEL write is silently ignored and
+            // the pads remain in 3.3V mode, which passes the (slow) initialisation
+            // but fails at UHS-I bus rates.  Fail the attempt here so the caller
+            // power cycles the card and falls back to 3.3V operation.
+            if (SDCARD_VDDIO_GET_RANGE() != LL_PWR_VDDIO_VOLTAGE_RANGE_1V8) {
+                HAL_SD_DeInit(&sdmmc_handle.sd);
+                return HAL_ERROR;
+            }
+        }
+        #endif
+        uint32_t pattern;
+        uint32_t clk_div;
+        if (uhs_active) {
+            // The card accepted the 1.8V voltage switch during init: select the UHS-I
+            // speed mode.
+            pattern = MICROPY_HW_SDCARD_UHS_SWITCH_PATTERN;
+            clk_div = MICROPY_HW_SDCARD_UHS_CLK_DIV;
+        } else {
+            // The card remained at 3.3V signalling: select high speed mode (SDR25).
+            pattern = SDMMC_SDR25_SWITCH_PATTERN;
+            clk_div = SDIO_TRANSFER_CLK_DIV;
+        }
+        uint32_t switch_status[16];
+        uint32_t errorstate = sdcard_cmd6_switch(pattern, switch_status);
+        if (errorstate == HAL_SD_ERROR_NONE
+            && (((uint8_t *)switch_status)[16] & 0xf) != (pattern & 0xf)) {
+            // The card did not switch to the requested speed mode.
+            errorstate = SDMMC_ERROR_UNSUPPORTED_FEATURE;
+        }
+        if (errorstate != HAL_SD_ERROR_NONE) {
+            HAL_SD_DeInit(&sdmmc_handle.sd);
+            return HAL_ERROR;
+        }
+        if (uhs_active) {
+            // Sample the incoming data on the feedback clock, via the delay block.
+            MODIFY_REG(SDIO->CLKCR, SDMMC_CLKCR_SELCLKRX, SDMMC_CLKCR_SELCLKRX_1);
+            LL_DLYB_Enable(SDCARD_DLYB);
+            SDIO->CLKCR |= SDMMC_CLKCR_BUSSPEED;
+        }
+        // Raise the bus clock to its final rate.
+        sdmmc_handle.sd.Init.ClockDiv = clk_div;
+        MODIFY_REG(SDIO->CLKCR, SDMMC_CLKCR_CLKDIV, clk_div);
+    }
+    #endif
+
     return HAL_OK;
+}
+
+static HAL_StatusTypeDef sdmmc_init_sd(void) {
+    #if SDCARD_ENABLE_UHS1
+    if (sdcard_uhs_capable) {
+        // Try to bring the card up in UHS-I mode.  Power cycle the card before each
+        // attempt so it is in a known 3.3V state: a warm reset can leave the card in
+        // 1.8V mode (in which case it will not advertise 1.8V support), and a failed
+        // attempt can leave it stuck mid voltage switch.
+        for (int attempt = 0; attempt < 2; ++attempt) {
+            sdcard_power_cycle();
+            HAL_StatusTypeDef status = sdmmc_init_sd_bus(true);
+            if (status == HAL_OK) {
+                return HAL_OK;
+            }
+        }
+        // Fall back to a plain 3.3V init.
+        sdcard_power_cycle();
+    }
+    #endif
+    return sdmmc_init_sd_bus(false);
 }
 #endif
 
@@ -390,6 +695,13 @@ void sdcard_power_off(void) {
         #if MICROPY_HW_ENABLE_SDCARD
         case PYB_SDMMC_FLAG_ACTIVE | PYB_SDMMC_FLAG_SD:
             HAL_SD_DeInit(&sdmmc_handle.sd);
+            #if SDCARD_ENABLE_UHS1
+            if (sdcard_uhs_capable) {
+                // The card may be in 1.8V signalling mode; power cycle it so the next
+                // init starts from a known 3.3V state.
+                sdcard_power_cycle();
+            }
+            #endif
             break;
         #endif
         #if MICROPY_HW_ENABLE_MMCARD


### PR DESCRIPTION
### Summary

This adds UHS-I support (1.8V signalling, SDR50/SDR104) to the stm32 port's SD card driver, for boards whose hardware can switch the SD bus I/O rail between 3.3V and 1.8V, and enables it on the OPENMV_N6 board at SDR104/200MHz.

On the OpenMV N6, same board/card/workload (16MB file, 512KB chunks), unpatched vs patched firmware:

| | 3.3V 50MHz (current) | SDR104 200MHz (this PR) |
|---|---|---|
| file read | 21.8 MB/s | **70.8 MB/s** |
| file write | 19.7 MB/s | **56.1 MB/s** |
| raw block read | 22.4 MB/s | **83.3 MB/s** |

SDR50 at 100MHz (43.5 MB/s raw reads) is available as a conservative alternative via one board macro.

A board opts in by defining `MICROPY_HW_SDCARD_VSELECT_PIN` (drives the SD rail voltage select) and `MICROPY_HW_SDCARD_RESET_PIN` (active-low SD card power). The reset pin doubles as a hardware-revision detect: it is sampled at startup and reads high only on UHS-I capable hardware, so one firmware supports old and new board revisions. The voltage switch itself (ACMD41 S18R / CMD11) is the HAL's `USE_SD_TRANSCEIVER` flow; the transceiver callback drives the select pin and, on STM32N6, moves the configured VDDIO domain (`MICROPY_HW_SDCARD_VDDIO`, defaulting from the SDMMC instance) to the 1.8V pad range. Cards that don't support 1.8V get a proper CMD6 high-speed switch at 3.3V; any UHS failure power-cycles the card via the reset pin and falls back to the existing 3.3V behaviour.

Two STM32N6 hardware findings shaped the implementation:

1. **The SDMMC data-path status flags read stale after the 1.8V switch until the FIFO is accessed.** Command-path flags are fine and IDMA/IRQ transfers are unaffected, but any CPU-polled receive loop that gates FIFO reads on RXFIFOHF/DATAEND deadlocks — which is exactly what the HAL's own `SD_UltraHighSpeed()`/`SD_SwitchSpeed()` do (against a 0xFFFFFFFF ms software timeout), so `HAL_SD_ConfigSpeedBusOperation()` hangs forever on this part. The driver therefore performs the CMD6 switch itself using the CMDTRANS mechanism, drains the 64-byte status from the FIFO after the transfer time has elapsed, and only then consults the (by then refreshed) status flags. This was proven at register level: the FIFO contained the complete, correct switch status while STA/DCOUNT still claimed no data had arrived.

2. **`VDDIOxVRSEL` writes are silently ignored unless the matching `HSLV_VDDIOx` OTP fuse is programmed.** Without the fuse the pads stay in 3.3V mode: the (slow) initialisation still passes, then every transfer at UHS rates fails. Verified by A/B on two boards (fused vs unfused). The driver reads the range back after switching and treats a non-stick as a failed attempt, so unfused boards cleanly fall back to 3.3V — and once a bootloader update programs the fuse, the same firmware starts running SDR104 automatically. The OPENMV_N6 board commit programs the fuse (RM0486 Table 18, OTP word 124 bit 14) alongside the existing VDDIO2/3 fuses.

### Testing

- **OpenMV N6 (STM32N657, fused)**: SDR104 at 200MHz — numbers above, data CRC-verified against 3.3V-mode reads of the same blocks, 10/10 power-cycle/init soak loops at both SDR104 and SDR50, plus 16MB file write/read-back CRC verification.
- **OpenMV N6 (second board, OTP fuse unprogrammed)**: VRSEL non-stick detected, clean automatic fallback to 3.3V/50MHz — 10/10 init soaks, 22.35 MB/s (identical to unpatched firmware), OTP verified untouched before/after.
- **Regression on non-UHS boards**: builds without the new config macros compile to **byte-identical binaries** (verified by hash for four board targets — the feature preprocesses away entirely). On-hardware SD regression runs (raw reads, file write/read, CRC verification) passed on STM32F427, STM32F765 and STM32H743 (x2 boards) hardware with speeds unchanged.
- **Build-tested**: PYBV11, NUCLEO_F767ZI, NUCLEO_H743ZI, NUCLEO_N657X0 (the latter verifying the `USE_SD_TRANSCEIVER=0` default path on N6).
- Non-UHS boards keep `ClockPowerSave` enabled and the exact current init sequence; UHS-I init disables clock power saving (as the ST BSPs do) because the voltage-switch and CMD6 sequences stall with it enabled.

### Trade-offs and Alternatives

- **Code size**: +992 bytes text on OPENMV_N6 (the board that enables it). Zero impact on all other boards — without the config macros the binaries are byte-identical.
- **Using the HAL's `HAL_SD_ConfigSpeedBusOperation()` instead of a driver-side CMD6**: attempted first, but it hard-hangs on the N6 (finding 1 above), so the CMD6 transaction is implemented in sdcard.c with the same command-transfer mechanism regular block reads use.
- **Unfused/older hardware cost**: on UHS-capable board revisions whose OTP fuse isn't programmed yet, each SD init spends two failed UHS attempts (two card power cycles, ~300-400ms) before falling back to 3.3V. This is once per mount and buys automatic activation when the fuse is later programmed; caching the result to skip retries was considered but rejected as unnecessary complexity for a once-per-boot cost.
- **SDR104 vs SDR50 default**: the generic driver defaults to the conservative SDR50; OPENMV_N6 explicitly selects SDR104, which soaked cleanly. The receive path uses the feedback clock via the delay block with its default configuration, matching what the ST HAL does for UHS modes; per-unit DLYB tuning was not needed at 200MHz but could be added later if a marginal card/board combination shows CRC errors.
