### PR TITLE
docs: clarify ESP32 GPIO deep-sleep hold availability.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -57,6 +57,8 @@ Functions
     Configure whether non-RTC GPIO pin configuration is retained during
     deep-sleep mode for held pads. *enable* should be a boolean value.
 
+    .. note:: This is only available on ESP32, ESP32-C2, ESP32-C3, ESP32-S2, and ESP32-S3.
+
 .. function:: raw_temperature()
 
     Read the raw value of the internal temperature sensor, returning an integer.


### PR DESCRIPTION
### Summary

`esp32.gpio_deep_sleep_hold()` is absent on ESP32-C6 and several other ESP32 hardware variant because the underlying GPIO hold capability is not supported. 
This PR document its supported targets: ESP32, ESP32-C3, ESP32-S2, and ESP32-S3.

### Testing

Reviewed the existing ESP32 capability guard and validated the RST change.
Documentation built locally.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

- Fixes #19208