### PR TITLE
alif: Run the CYW43 SPI bus at 32MHz. 

### DIFF
--- a/ports/alif/cyw43_configport.h
+++ b/ports/alif/cyw43_configport.h
@@ -79,8 +79,20 @@ static inline void cyw43_hal_pin_config(mp_hal_pin_obj_t pin, uint32_t mode, uin
     }
 }
 static inline void cyw43_hal_pin_config_irq_falling(mp_hal_pin_obj_t pin, bool enable) {
-    mp_hal_pin_config_irq_falling(pin, enable);
+    // Only used for WL_IRQ which is low-level triggered: the cyw43 holds the line low while it has pending frames.
+    if (enable) {
+        gpio_interrupt_set_level_trigger(pin->gpio, pin->pin);
+        gpio_interrupt_set_polarity_low(pin->gpio, pin->pin);
+        gpio_enable_interrupt(pin->gpio, pin->pin);
+        gpio_unmask_interrupt(pin->gpio, pin->pin);
+    } else {
+        gpio_mask_interrupt(pin->gpio, pin->pin);
+        gpio_disable_interrupt(pin->gpio, pin->pin);
+    }
 }
+
+extern void cyw43_post_poll_hook(void);
+#define CYW43_POST_POLL_HOOK cyw43_post_poll_hook();
 
 #define cyw43_bluetooth_controller_init mp_bluetooth_hci_controller_init
 #define cyw43_bluetooth_controller_deinit mp_bluetooth_hci_controller_deinit

--- a/ports/alif/cyw43_port_spi.c
+++ b/ports/alif/cyw43_port_spi.c
@@ -44,12 +44,20 @@
 #define WL_IRQ_HANDLER GPIO9_IRQ6Handler
 
 // Must run at IRQ priority above PendSV so it can wake cyw43-driver when PendSV is disabled.
+// WL_IRQ is low-level triggered.  Mask the handler here while the event is processed, and unmask it in cyw43_post_poll_hook().
 void WL_IRQ_HANDLER(void) {
     if (gpio_read_int_rawstatus(pin_WL_IRQ->gpio, pin_WL_IRQ->pin)) {
+        gpio_mask_interrupt(pin_WL_IRQ->gpio, pin_WL_IRQ->pin);
         gpio_interrupt_eoi(pin_WL_IRQ->gpio, pin_WL_IRQ->pin);
         pendsv_schedule_dispatch(PENDSV_DISPATCH_CYW43, cyw43_poll);
         __SEV();
     }
+}
+
+// Called by cyw43-driver at the end of every cyw43_poll (CYW43_POST_POLL_HOOK).
+void cyw43_post_poll_hook(void) {
+    gpio_interrupt_eoi(pin_WL_IRQ->gpio, pin_WL_IRQ->pin);
+    gpio_unmask_interrupt(pin_WL_IRQ->gpio, pin_WL_IRQ->pin);
 }
 
 static void spi_bus_init(void) {

--- a/ports/alif/cyw43_port_spi.c
+++ b/ports/alif/cyw43_port_spi.c
@@ -36,7 +36,7 @@
 // CYW43 is connected to SPI3.
 #define HW_SPI_UNIT (3)
 #define HW_SPI ((SPI_Type *)SPI3_BASE)
-#define SPI_BAUDRATE (16000000)
+#define SPI_BAUDRATE (32000000)
 #define SPI_RX_FIFO_SIZE (16)
 
 // WL_IRQ is on P9_6.
@@ -75,6 +75,9 @@ static void spi_bus_init(void) {
     // Starts out clock_polarity=1, clock_phase=0.
     spi_mode_master(HW_SPI);
     spi_set_bus_speed(HW_SPI, SPI_BAUDRATE, GetSystemAHBClock());
+    // Above 16MHz the MISO round-trip (chip output delay plus trace) exceeds
+    // the default sample point; delay RX sampling to compensate.
+    spi_set_rx_sample_delay(HW_SPI, 2);
     spi_set_mode(HW_SPI, SPI_MODE_2);
     spi_set_protocol(HW_SPI, SPI_PROTO_SPI);
     spi_set_dfs(HW_SPI, 8);

--- a/ports/alif/lwip_inc/lwipopts.h
+++ b/ports/alif/lwip_inc/lwipopts.h
@@ -10,11 +10,11 @@
 
 #define LWIP_RAND() se_services_rand64()
 
-#define MEM_SIZE                        (16 * 1024)
+#define MEM_SIZE                        (48 * 1024)
 #define TCP_MSS                         (1460)
 #define TCP_OVERSIZE                    (TCP_MSS)
-#define TCP_WND                         (8 * TCP_MSS)
-#define TCP_SND_BUF                     (8 * TCP_MSS)
+#define TCP_WND                         (16 * TCP_MSS)
+#define TCP_SND_BUF                     (16 * TCP_MSS)
 #define TCP_SND_QUEUELEN                (2 * (TCP_SND_BUF / TCP_MSS))
 #define TCP_QUEUE_OOSEQ                 (1)
 #define MEMP_NUM_TCP_SEG                (2 * TCP_SND_QUEUELEN)


### PR DESCRIPTION
### Summary

Three improvements to CYW43 WiFi on the alif port, found while
benchmarking an OpenMV AE3 (CYW43439 on SPI):

1. **Make WL_IRQ level sensitive.** The chip holds the IRQ line asserted
   for as long as it has pending frames, so a falling-edge trigger stops
   firing whenever a poll doesn't fully drain the chip — the wakeup is
   lost. The pin is now level-low sensitive, masked in the handler, and
   unmasked after every poll via `CYW43_POST_POLL_HOOK` (the same pattern
   the rp2 port uses): a still-asserted line immediately re-raises the
   IRQ, so no wakeup can be lost.
2. **Run the SPI bus at 32MHz** (was 16MHz; the gSPI interface is rated to
   50MHz). Raising the clock alone fails — the chip's firmware download
   breaks at 24MHz and above — because the MISO round-trip exceeds the
   controller's default sample point. Setting the SPI RX sample delay to
   2 cycles makes 32MHz reliable.
3. **Increase lwIP TCP buffers** (8→16 MSS window/send buffer, 16K→48K
   heap): TCP was window/RTT-limited below what the link carries, and the
   heap now comfortably covers the send buffer so lwIP's ERR_MEM retry
   path stays cold. The Ensemble parts have ample SRAM.

Measured on an OpenMV AE3 (2.4GHz, same board/AP/position, Python socket
benchmarks, 3+ runs per configuration):

|  | before | this PR | change |
|---|---|---|---|
| TCP TX | 11.3–11.5 Mbit/s | 12.2–12.6 Mbit/s | +10% |
| TCP RX | 10.0–10.2 Mbit/s | 10.2–11.8 Mbit/s | +10–15% |
| UDP TX | 13.4 Mbit/s | 13.8–14.2 Mbit/s, 0% loss | +3–5% |
| UDP RX, paced ≤10 Mbit/s | @5 clean, @10 ~35% loss | unchanged | — |

The TCP gains come almost entirely from the lwIP buffer commit
(window/RTT-limited before). The 32MHz commit contributes the UDP TX bump —
small, because per-frame CPU cost rather than wire time dominates this SPI
path. The IRQ commit is throughput-neutral in these tests but closes a
real lost-wakeup class.

### Testing

Tested on an OpenMV AE3 (CYW43439, SPI): repeated WLAN bring-up cycles and
Python socket TCP/UDP benchmarks in both directions (numbers above).
Interrupt servicing of every received frame was verified with the driver's
stats counters; 32MHz bring-up is stable across repeated
boot/scan/connect/traffic cycles, and reproducibly fails without the
sample-delay change (which is why both are in one commit).

Known pre-existing issue, unchanged by this PR: sustained UDP receive
above ~15Mbit/s collapses to 100% loss on this board. Instrumentation
shows the chip itself stops asserting the IRQ and holds an empty queue
during such floods — a chip-side power-save interaction (with power save
disabled via `cyw43_wifi_pm()` it degrades gracefully instead). Addressing
it properly needs DMA/service-rate work on the SPI path and is left for a
future change.

Build-tested: OPENMV_AE3.

### Trade-offs and Alternatives

The lwIP heap increase costs 32K of SRAM on a part with megabytes of it.
The IRQ change adds a mask/unmask per poll cycle, which is noise compared
to the SPI transfers it brackets.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.
