### PR TITLE
ports: Increase the STM32N6/MIMXRT TCP receive window.

### DIFF
--- a/ports/mimxrt/lwip_inc/lwipopts.h
+++ b/ports/mimxrt/lwip_inc/lwipopts.h
@@ -7,6 +7,16 @@
 
 #define LWIP_RAND() trng_random_u32()
 
+// All boards using lwIP have ample OCRAM so use full-size TCP segments and windows.
+#ifndef MEM_SIZE
+#define MEM_SIZE                        (13 * 1024)
+#define TCP_MSS                         (1460)
+#define TCP_WND                         (7 * TCP_MSS)
+#define TCP_SND_BUF                     (6 * TCP_MSS)
+#define MEMP_NUM_TCP_SEG                (24)
+#define PBUF_POOL_SIZE                  (7)
+#endif
+
 // Include common lwIP configuration.
 #include "extmod/lwip-include/lwipopts_common.h"
 

--- a/ports/stm32/lwip_inc/lwipopts.h
+++ b/ports/stm32/lwip_inc/lwipopts.h
@@ -15,7 +15,7 @@
 #define MEM_SIZE                        (64 * 1024)
 #define PBUF_POOL_SIZE                  (32)
 #define TCP_MSS                         (1460)
-#define TCP_WND                         (16 * TCP_MSS)
+#define TCP_WND                         (32 * TCP_MSS)
 #define TCP_SND_BUF                     (16 * TCP_MSS)
 #define MEMP_NUM_TCP_SEG                (64)
 #endif


### PR DESCRIPTION
### Summary

Two per-port lwIP sizing fixes found while benchmarking TCP/UDP on WiFi
hardware:

1. **stm32 (STM32N6): double the TCP receive window to 32*MSS.** TCP
   receive is bounded by window/RTT. At the ~5-6ms round-trip time of the
   OPENMV_N6's CYW43439 WiFi link, the existing 16*MSS window works out to
   ~31Mbit/s — exactly what the board measures, well below what the link
   carries (~43Mbit/s UDP on the same air). The larger window is covered
   by the existing PBUF_POOL, so there is no additional static memory
   cost. The send buffer is unchanged.
2. **mimxrt: use full-size TCP segments and windows.** The port used the
   smallest `lwipopts_common.h` tier: MSS=800, a 6400-byte window and an
   8000-byte heap. That caps TCP at single-digit Mbit/s on WiFi RTTs and
   costs per-packet efficiency everywhere. Switch to MSS=1460 with a 7*MSS
   receive window, 6*MSS send buffer and a 13K heap — sized so the heap
   comfortably exceeds the send buffer, keeping lwIP's ERR_MEM retry path
   cold. All values are `#ifndef`-guarded so boards can override them, and
   only boards with a network interface build lwIP on this port (all of
   which have ample OCRAM).

Measured (Python socket benchmarks, 2.4GHz WiFi, same board/AP/position
per pair, multiple runs):

| Board | Test | before | after |
|---|---|---|---|
| OPENMV_N6 (CYW43439) | TCP RX | ~31 Mbit/s | 35–39 Mbit/s |
| OPENMV_N6 | TCP TX / UDP | — | unchanged |
| OpenMV RT1060 (CYW4343W) | TCP TX | 6.4 Mbit/s | 22.2 Mbit/s (**3.5x**) |
| OpenMV RT1060 | TCP RX | 15.9 Mbit/s | 24 Mbit/s (**1.5x**) |
| OpenMV RT1060 | UDP | — | unchanged |

100M ethernet on the RT10xx still runs at line rate (91/91 Mbit/s TCP),
and the N6's gigabit ethernet is unaffected (its sub-millisecond RTT was
never window-limited).

### Testing

Runtime tested with TCP/UDP benchmarks in both directions on an OpenMV N6
(CYW43439 WiFi + RGMII ethernet) and an OpenMV RT1060 (CYW4343W WiFi +
100M ethernet), numbers above.

Build-tested: OPENMV_N6, TEENSY41, MIMXRT1060_EVK.

### Trade-offs and Alternatives

The mimxrt change grows lwIP's static footprint by roughly 20K on
network-enabled boards (heap + full-size pbuf pool). Boards that want the
old sizes can override any value before the guarded block. The stm32
change is N6-scoped and costs nothing beyond window accounting.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked
the code and is responsible for the code and the description above.
