### PR TITLE
extmod/modtls_mbedtls: Close transport on handshake failure

### DIFF
--- a/extmod/modtls_mbedtls.c
+++ b/extmod/modtls_mbedtls.c
@@ -217,6 +217,25 @@ static inline void store_active_context(mp_obj_ssl_context_t *ssl_context) {
     #endif
 }
 
+static mp_uint_t ssl_socket_close_transport(mp_obj_ssl_socket_t *ssl_socket, int *error_code) {
+    mp_obj_t transport = ssl_socket->sock;
+
+    // Clear the active SSL context.
+    store_active_context(NULL);
+
+    // Already closed socket, do nothing.
+    if (transport == MP_OBJ_NULL) {
+        return 0;
+    }
+
+    // Detach the transport before cleanup so repeated closes are harmless.
+    ssl_socket->sock = MP_OBJ_NULL;
+
+    // Release TLS state before forwarding close to the owned transport.
+    mbedtls_ssl_free(&ssl_socket->ssl);
+    return mp_get_stream(transport)->ioctl(transport, MP_STREAM_CLOSE, 0, error_code);
+}
+
 static void ssl_check_async_handshake_failure(mp_obj_ssl_socket_t *sslsock, int *errcode) {
     if (
         #if MBEDTLS_VERSION_NUMBER >= 0x03000000
@@ -245,14 +264,16 @@ static void ssl_check_async_handshake_failure(mp_obj_ssl_socket_t *sslsock, int 
             // The length of the string written (not including the terminated nul byte),
             // or a negative err code.
             if (ret > 0) {
-                sslsock->sock = MP_OBJ_NULL;
-                mbedtls_ssl_free(&sslsock->ssl);
+                // Close the transport while preserving the certificate error.
+                int close_error_code = 0;
+                ssl_socket_close_transport(sslsock, &close_error_code);
                 mp_raise_msg_varg(&mp_type_ValueError, MP_ERROR_TEXT("%s"), xcbuf);
             }
         }
 
-        sslsock->sock = MP_OBJ_NULL;
-        mbedtls_ssl_free(&sslsock->ssl);
+        // Close the transport while preserving the TLS error.
+        int close_error_code = 0;
+        ssl_socket_close_transport(sslsock, &close_error_code);
         mbedtls_raise_error(*errcode);
     }
 }
@@ -966,15 +987,8 @@ static mp_uint_t socket_ioctl(mp_obj_t o_in, mp_uint_t request, uintptr_t arg, i
     mp_obj_t sock = self->sock;
 
     if (request == MP_STREAM_CLOSE) {
-        // Clear the SSL context.
-        store_active_context(NULL);
-
-        if (sock == MP_OBJ_NULL) {
-            // Already closed socket, do nothing.
-            return 0;
-        }
-        self->sock = MP_OBJ_NULL;
-        mbedtls_ssl_free(&self->ssl);
+        // Release TLS state and close the owned transport exactly once.
+        return ssl_socket_close_transport(self, errcode);
     } else if (request == MP_STREAM_POLL) {
         if (sock == MP_OBJ_NULL || self->last_error != 0) {
             // Closed or error socket, return NVAL flag.

--- a/tests/extmod/ssl_poll.py
+++ b/tests/extmod/ssl_poll.py
@@ -69,6 +69,7 @@ class _Pipe(io.IOBase):
 
         self.write_buffers = []
         self.last_poll_arg = None
+        self.close_call_count = 0
 
     def readinto(self, buf):
         if self.block_reads or len(self._other.write_buffers) == 0:
@@ -103,6 +104,7 @@ class _Pipe(io.IOBase):
             return ret
 
         elif request == _MP_STREAM_CLOSE:
+            self.close_call_count += 1
             return 0
 
         raise NotImplementedError()
@@ -126,9 +128,9 @@ def assert_poll(s, i, arg, expected_arg, expected_ret):
 def assert_raises(cb, *args, **kwargs):
     try:
         cb(*args, **kwargs)
-        raise AssertionError("should have raised")
-    except Exception as exc:
-        pass
+    except Exception:
+        return
+    raise AssertionError("should have raised")
 
 
 client_io, server_io = _Pipe.new_pair()
@@ -194,6 +196,11 @@ client_sock.close()
 assert_poll(
     client_sock, client_io, _MP_STREAM_POLL_RD, None, _MP_STREAM_POLL_NVAL
 )  # Did not go to the socket
+assert client_io.close_call_count == 1
+
+# Closing the TLS socket again does not close the transport twice.
+client_sock.close()
+assert client_io.close_call_count == 1
 
 
 # Errors propagates to poll:
@@ -208,3 +215,8 @@ assert_raises(client_sock.read, 128)
 assert_poll(
     client_sock, client_io, _MP_STREAM_POLL_RD, None, _MP_STREAM_POLL_NVAL
 )  # Did not go to the socket
+assert client_io.close_call_count == 1
+
+# Closing after a fatal handshake error does not close the transport twice.
+client_sock.close()
+assert client_io.close_call_count == 1


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

The existing MicroPython mbedtls implementation doesn't correctly close the underlying transport sockets on fatal SSL handshake errors that occur during read/write operations. It only deletes the reference to them, making future cleanup attempts no-ops.

This bug affects web server projects (Such as those leveraging Microdot) which target chromium-based browsers.

Unlike Firefox - when chromium encounters a self-signed certificate during the TLS handshake - It closes the connection before re-opening a new one even if the browser user explicitly accepted the warning prompt. This sub-optimal behavior is admitted in chromium sources as well (see the spoiler below).

Chrome's behavior combined with MicroPython's clean-up bug resulted in the device running out of free sockets to use, because all got stuck waiting for their time-outs, causing all requests to be dropped with ERR_CONNECTION_RESET errors. The server would become responsive once more after the underlying transports timed out and cleaned-up on their own.

Chromium isn't to blame for this bug - it merely triggers aggressively and makes it apparent.

This bug presumably affects all ports relying on mbedtls.

<details>
  <summary>Chromium sources</summary>
  
https://chromium.googlesource.com/chromium/src/+/refs/heads/main/net/http/http_network_transaction.cc#943
<img width="665" height="457" alt="screen2" src="https://github.com/user-attachments/assets/e4734c3d-f161-4aaa-b191-239dd95186c5" />

Chrome's behavior was confirmed by NetLog in my debugging session, and also by further observations of the code in the source file shared above.

Since I believe this to be a self-contained bug even without my Microdot reproduction scripts, I have decided to omit them from this PR. I can send them should they be important.
  
</details>

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

I was able to replicate this bug on ESP32 S2 and ESP32 C3 boards using MicroPython version 1.28.0 through actual socket exhaustion. And on the Unix port as well using the updated ssl_poll.py coverage test.

The Microdot-utilizing project in which I discovered this bug no longer experiences the ERR_CONNECTION_RESET errors anymore after the fix either, but it did before the code changes included in this PR.

I have included an additional check in the ssl_poll.py that ensures the socket was closed exactly once. In the bug-affected builds, this test caught the problem. After testing the code in this PR the test passes cleanly.

NOTE:

I suspect the original ssl_poll.py had an unrelated bug:

```python
def assert_raises(cb, *args, **kwargs):
    try:
        cb(*args, **kwargs)
        raise AssertionError("should have raised")
    except Exception as exc:
        pass
```

The `AssertionError("should have raised")` is raised in a way where it immediately gets caught and discarded. I assume the intent was to raise an `AssertionError()` only when `cb()` doesn't raise anything. So I changed this function to look like this:

```python
def assert_raises(cb, *args, **kwargs):
    try:
        cb(*args, **kwargs)
    except Exception:
        return
    raise AssertionError("should have raised")
```

Returning plainly if the `cb()` function raises as expected, raising an `AssertionError()` if not. Please let me know if the intent behind the code was different than what I took it to be.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

I am not aware of any worthwhile alternative approach that wouldn't only be mitigating the symptoms of this bug - or moving the burden of cleaning up to the Python code (which feels like inappropriately making Python code responsible for C-level lifecycles).

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

This PR was created after a long ai-assisted debugging session examining why self-signed certificates caused odd ERR_CONNECTION_RESET failures in chromium-based browsers and not others (like Firefox).

The code included in it was manually adjusted by me and manually reviewed by me and my colleagues.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
