### PR TITLE
lib/micropython-lib: Update submodule to latest.

### DIFF
--- a/tests/extmod/vfs_basic.py
+++ b/tests/extmod/vfs_basic.py
@@ -45,7 +45,7 @@ class Filesystem:
 
     def stat(self, path):
         print(self.id, "stat", repr(path))
-        return (self.id,)
+        return (self.id, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
     def statvfs(self, path):
         print(self.id, "statvfs", repr(path))
@@ -64,7 +64,7 @@ for path in os.listdir("/"):
     vfs.umount("/" + path)
 
 # stat root dir
-print(os.stat("/"))
+print(tuple(os.stat("/")))
 
 # statvfs root dir; verify that f_namemax has a sensible size
 print(os.statvfs("/")[9] >= 32)
@@ -131,7 +131,7 @@ os.mkdir("test_dir")
 os.remove("test_file")
 os.rename("test_file", "test_file2")
 os.rmdir("test_dir")
-print(os.stat("test_file"))
+print(tuple(os.stat("test_file")))
 print(os.statvfs("/test_mnt"))
 open("test_file")
 open("test_file", "wb")
@@ -148,7 +148,7 @@ except OSError:
 
 # root dir
 vfs.mount(Filesystem(3), "/")
-print(os.stat("/"))
+print(tuple(os.stat("/")))
 print(os.statvfs("/"))
 print(os.listdir())
 open("test")

--- a/tests/extmod/vfs_basic.py.exp
+++ b/tests/extmod/vfs_basic.py.exp
@@ -40,7 +40,7 @@ OSError
 1 rename 'test_file' 'test_file2'
 1 rmdir 'test_dir'
 1 stat 'test_file'
-(1,)
+(1, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 1 statvfs '/'
 (1,)
 1 open test_file r


### PR DESCRIPTION
### Summary

This update to micropython-lib brings in the following changes.

pathlib:
- fix glob/rglob to return Path objects rather than strings
- add Path.expanduser()

pprint:
- add simple and partial implementation for depth of 1
- refactor implementation and add PrettyPrint class
- implement depth recursion
- add test_pprint.py
- fix use of micropython.const
- bump version to 0.1.0

requests:
- add context manager for response object
- switch to HTTP/1.1 with Content-Length and raw streaming
- add support for relative redirect URLs
- support unicode in json and data payloads
- add support for query and anchor chars directly after domain
- add tests for query and anchor in URL
- add chunked response body support
- test chunked response decoding
- document chunked response support
- match response header names case-insensitively
- reuse lowerl for Content-Length matching

uaiohttpclient:
- use "utf8" encoding instead of "latin-1"
- add basic test for uaiohttpclient.request

umqtt.robust:
- let reconnect() call the connect() method of parent class
- document and add examples overriding the connect() method
- ease document readability

umqtt.simple:
- add example for mqtt tls
- close any old socket on connect
- add call to main() at end of example scripts
- encode subscribe Remaining Length as VBI
- share subscribe/unsubscribe packet encoding
- share Remaining Length VBI encoding
- avoid None comparisons in _send_subunsub

unittest:
- remove f-strings
- optimise by reusing AssertRaisesContext for assertWarns
- optimise by removing support for CPython
- optimise calling of _handle_test_exception
- optimise by only formatting msg if needed
- optimise skipUnless in terms of skipIf
- optimise to only create a single nop lambda
- bump minor version due to recent optimisations

unix-ffi:
- json: fix json.loads() of a bytes object
- ffilib: extend libc versions range
- signal: add alarm() and pause() functions
- signal: add SIGALRM constant

usb:
- examples: put timeout=0 in CDCInterface constructor
- usb-device-cdc: fix default timeout in CDCInterface.init()
- usb-device-cdc: optimise CDCInterface constructor
- usb-device-core: fix comment describing the signature of done_cb
- usb-device-hid: enable configuring the bInterval on hid devices
- usb-device-keyboard: add a simpler keyboard example, document releasing

uuid:
- provide UUID class and uuid4() implementation using os.urandom()
- convert test to use unittest
- use bytes.hex instead of binascii.hexlify
- add UUID.bytes attribute
- make UUID.__repr__ match CPython

various:
- aioble/security: only schedule save when needed
- aiohttp: match response header names case-insensitively
- aiorepl: fix Enter key handling in raw terminal mode
- collections-defaultdict: add items() function
- colorsys: add colorsys and test_colorsys from CPython
- copy: provide top-level documentation
- lora: fix CRC error IRQ bit mask for sx126x
- mip: add an alias for codeberg repos
- ntptime: use NTPv4
- operator: add mul and some other operators
- os: provide namedtuple response for os.stat()
- ssd1306: add I2C protocol example for SSD1306 display

### Testing

These changes were tested when they were made in micropython-lib.

They will also be tested by CI and Octoprobe.

### Generative AI

I did not use generative AI tools when creating this PR.
