### PR TITLE
esp32: Fix ESP32-P4 LDO soft reset behaviour, make into static instances.

### DIFF
--- a/docs/library/esp32.rst
+++ b/docs/library/esp32.rst
@@ -639,4 +639,4 @@ For more details see Espressif's `ESP-IDF LDO documentation.
 
 .. method:: LDO.release()
 
-    Release the LDO channel.
+    Release the LDO channel, disabling its voltage output. Create a new LDO object to re-enable the output.

--- a/ports/esp32/esp32_ldo.c
+++ b/ports/esp32/esp32_ldo.c
@@ -34,17 +34,35 @@
 
 #include "esp_ldo_regulator.h"
 
+// ESP-IDF doesn't yet contain a macro for the number of LDO channels available
+#if CONFIG_IDF_TARGET_ESP32P4
+#define LDO_CHANNELS 4
+#else
+#error "Please add this chip's LDO driver support"
+#endif
+
 // LDO (Low-Dropout Regulator) Driver
 //
 // This module provides access to the internal LDO voltage regulators,
 // which can supply adjustable voltages to internal peripherals or external components.
 
-typedef struct _esp32_ldo_obj_t {
+static mp_obj_t esp32_ldo_release(mp_obj_t self_in);
+
+typedef struct {
     mp_obj_base_t base;
-    esp_ldo_channel_handle_t ldo_channel_handle;
-    int chan_id; // Cached for display
-    int voltage_mv; // Cached for display
+    esp_ldo_channel_handle_t ldo_channel_handle;  // Non-NULL if channel is acquired
+    uint16_t voltage_mv;
+    bool adjustable;
 } esp32_ldo_obj_t;
+
+static esp32_ldo_obj_t ldos[LDO_CHANNELS];
+
+// As the only esp32_ldo_obj_t instances are part of ldo array, don't need to store channel id
+static mp_uint_t get_chan_id(const esp32_ldo_obj_t *ldo) {
+    mp_uint_t result = ldo - ldos;
+    assert(result < LDO_CHANNELS);
+    return result + 1;  // 1-based channel ID numbering scheme
+}
 
 static mp_obj_t esp32_ldo_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *all_args) {
     static const mp_arg_t allowed_args[] = {
@@ -55,28 +73,60 @@ static mp_obj_t esp32_ldo_make_new(const mp_obj_type_t *type, size_t n_args, siz
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all_kw_array(n_args, n_kw, all_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    esp_ldo_channel_config_t channel_config = {
-        .chan_id = args[0].u_int,
-        .voltage_mv = args[1].u_int,
-        .flags.adjustable = args[2].u_bool,
-    };
+    mp_uint_t chan_id = args[0].u_int;
+    mp_uint_t voltage_mv = args[1].u_int;
+    mp_uint_t adjustable = args[2].u_bool;
 
-    esp32_ldo_obj_t *self = mp_obj_malloc(esp32_ldo_obj_t, &esp32_ldo_type);
-    self->ldo_channel_handle = NULL;
-    self->chan_id = args[0].u_int;
-    self->voltage_mv = args[1].u_int;
+    if (chan_id < 1 || chan_id > LDO_CHANNELS) {
+        mp_raise_ValueError(MP_ERROR_TEXT("channel_id"));
+    }
 
-    check_esp_err(esp_ldo_acquire_channel(&channel_config, &self->ldo_channel_handle));
-    return MP_OBJ_FROM_PTR(self);
+    mp_uint_t chan_idx = chan_id - 1;  // Hardware & IDF API uses 1-based indexing for channel IDs, array is 0-indexed
+
+    esp32_ldo_obj_t *result = &ldos[chan_idx];
+    result->base.type = &esp32_ldo_type;
+
+    // If the channel is acquired already then settings have to match
+    if (result->ldo_channel_handle != NULL &&
+        (result->voltage_mv != voltage_mv ||
+         result->adjustable != adjustable)) {
+        mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("LDO channel conflict"));
+    }
+
+    if (result->ldo_channel_handle == NULL) {
+        // Acquire the channel, unless we're returning an active LDO channel without changing it
+        esp_ldo_channel_config_t config = {
+            .chan_id = chan_id,
+            .voltage_mv = voltage_mv,
+            .flags.adjustable = adjustable,
+        };
+        check_esp_err(esp_ldo_acquire_channel(&config, &result->ldo_channel_handle));
+    }
+
+    result->voltage_mv = voltage_mv;
+    result->adjustable = adjustable;
+
+    return MP_OBJ_FROM_PTR(result);
+}
+
+void esp32_ldo_deinit_all(void) {
+    for (int i = 0; i < LDO_CHANNELS; i++) {
+        if (ldos[i].ldo_channel_handle != NULL) {
+            esp32_ldo_release(MP_OBJ_FROM_PTR(&ldos[i]));
+            ldos[i].ldo_channel_handle = NULL;
+        }
+    }
 }
 
 static void esp32_ldo_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
     const esp32_ldo_obj_t *self = self_in;
+    mp_uint_t chan_id = get_chan_id(self);
     if (self->ldo_channel_handle != NULL) {
-        mp_printf(print, "LDO(channel=%d, voltage=%dmV)", self->chan_id, self->voltage_mv);
+        mp_printf(print, "LDO(channel=%d, voltage=%dmV, adjustable=%d)", chan_id, self->voltage_mv,
+            self->adjustable);
     } else {
-        mp_printf(print, "LDO(released)");
+        mp_printf(print, "LDO(channel=%d, released)", chan_id);
     }
 }
 

--- a/ports/esp32/esp32_ldo.c
+++ b/ports/esp32/esp32_ldo.c
@@ -102,17 +102,6 @@ static mp_obj_t esp32_ldo_release(mp_obj_t self_in) {
 
 MP_DEFINE_CONST_FUN_OBJ_1(esp32_ldo_release_obj, esp32_ldo_release);
 
-static mp_obj_t esp32_ldo_del(mp_obj_t self_in) {
-    esp32_ldo_obj_t *self = self_in;
-    if (self->ldo_channel_handle != NULL) {
-        esp_ldo_release_channel(self->ldo_channel_handle);
-        self->ldo_channel_handle = NULL;
-    }
-    return mp_const_none;
-}
-
-static MP_DEFINE_CONST_FUN_OBJ_1(esp32_ldo_del_obj, esp32_ldo_del);
-
 static mp_obj_t esp32_ldo_enter(mp_obj_t self_in) {
     return self_in;
 }
@@ -129,7 +118,6 @@ static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp32_ldo_exit_obj, 4, 4, esp32_ldo_e
 static const mp_rom_map_elem_t esp32_ldo_locals_dict_table[] = {
     {MP_ROM_QSTR(MP_QSTR_adjust_voltage), MP_ROM_PTR(&esp32_ldo_adjust_voltage_obj)},
     {MP_ROM_QSTR(MP_QSTR_release), MP_ROM_PTR(&esp32_ldo_release_obj)},
-    {MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&esp32_ldo_del_obj)},
     {MP_ROM_QSTR(MP_QSTR___enter__), MP_ROM_PTR(&esp32_ldo_enter_obj)},
     {MP_ROM_QSTR(MP_QSTR___exit__), MP_ROM_PTR(&esp32_ldo_exit_obj)},
 };

--- a/ports/esp32/main.c
+++ b/ports/esp32/main.c
@@ -232,6 +232,9 @@ soft_reset_exit:
     #if MICROPY_PY_MACHINE_I2C_TARGET
     mp_machine_i2c_target_deinit_all();
     #endif
+    #if SOC_GP_LDO_SUPPORTED
+    esp32_ldo_deinit_all();
+    #endif
     machine_deinit();
 
     #if MICROPY_PY_SOCKET_EVENTS

--- a/ports/esp32/modesp32.h
+++ b/ports/esp32/modesp32.h
@@ -87,6 +87,7 @@ extern const mp_obj_type_t esp32_ldo_type;
 #if MICROPY_PY_ESP32_PCNT
 extern const mp_obj_type_t esp32_pcnt_type;
 
+void esp32_ldo_deinit_all(void);
 void esp32_pcnt_deinit_all(void);
 #endif
 


### PR DESCRIPTION
### Summary

@itdogwowo reported an issue recreating an adjustable LDO channel after soft reset in [this comment](https://github.com/micropython/micropython/issues/19027#issuecomment-5277288078).

While investigating I found that the finaliser (`__del__` method) on the LDO object was never called, because it wasn't allocated via `mp_obj_malloc_with_finaliser()`. This means that garbage collecting an LDO object, or `del ldo`, would not release the channel as intended.

Rather than enable the finaliser I've chosen to instead make the LDO objects static and clean them up deterministically towards the end of soft reset. I think this is useful because the LDO may be powering pins which are being used by other peripherals, and this lets us remove power after other peripherals have been deactivated.

This PR keeps the current behaviour where you don't need to keep the LDO object in scope for the LDO channel to stay active. This is similar to most other hardware-backed objects in MicroPython.

Also it's now possible to create multiple LDO objects pointing to the same channel and get back the same object, provided that the channel settings are the same each time.

### Testing

Tested manually using REPL, GPIO 48, LDO channel 4 and a multimeter on a DFRobot Firebeetle 2 ESP32-P4 board. GPIO 48 is powered by LDO channel 4 on this board.

### Trade-offs and Alternatives

* Finalisers would be simpler in code, but makes releasing of the LDO channel non-deterministic and possibly means de-powering a pin during soft reset before another peripheral is de-inited.

### Generative AI

I did not use generative AI tools when creating this PR.
