### PR TITLE
Fixes a warning when building btree with cmake

### DIFF
--- a/extmod/extmod.cmake
+++ b/extmod/extmod.cmake
@@ -146,6 +146,12 @@ if(MICROPY_PY_BTREE)
         BERKELEY_DB_CONFIG_FILE="${BERKELEY_DB_CONFIG_FILE}"
     )
 
+    # We need to suppress certain warnings to get berkeley-db to compile cleanly.
+    # Should be kept in sync with extmod.mk.
+    target_compile_options(micropy_extmod_btree PRIVATE
+        -Wno-old-style-definition -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-non-prototype -Wno-unknown-warning-option
+    )
+
     # The include directories and compile definitions below are needed to build
     # modbtree.c and should be added to the main MicroPython target.
 


### PR DESCRIPTION
The extmod.mk suppresses some more warnings. Those ones are not applied since they do not pop up with gcc 16.2.0.

<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->

Fixes https://github.com/micropython/micropython/issues/19643

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

Building RP_PICO_W with this fix does no longer yield warnings about old-style function definitions.


### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I did not use generative AI tools when creating this PR.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
