### PR TITLE
py/objdict: Make OrderedDict.fromkeys return an OrderedDict.

### DIFF
--- a/py/objdict.c
+++ b/py/objdict.c
@@ -296,6 +296,12 @@ static mp_obj_t dict_fromkeys(size_t n_args, const mp_obj_t *args) {
     }
 
     mp_obj_dict_t *self = MP_OBJ_TO_PTR(self_out);
+    #if MICROPY_PY_COLLECTIONS_ORDEREDDICT
+    if (args[0] == MP_OBJ_FROM_PTR(&mp_type_ordereddict)) {
+        self->base.type = &mp_type_ordereddict;
+        self->map.is_ordered = 1;
+    }
+    #endif
     while ((next = mp_iternext(iter)) != MP_OBJ_STOP_ITERATION) {
         mp_map_lookup(&self->map, next, MP_MAP_LOOKUP_ADD_IF_NOT_FOUND)->value = value;
     }

--- a/tests/basics/ordereddict_fromkeys.py
+++ b/tests/basics/ordereddict_fromkeys.py
@@ -1,0 +1,16 @@
+try:
+    from collections import OrderedDict
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+d = OrderedDict.fromkeys("abcdefg")
+print(type(d).__name__)
+print("".join(d))
+print(list(d.keys()))
+
+d2 = OrderedDict.fromkeys([1, 2, 3], 42)
+print(list(d2.values()))
+
+plain = dict.fromkeys([3, 1, 2])
+print(type(plain).__name__)


### PR DESCRIPTION
### Summary

Fixes #12011. `dict_fromkeys` is a classmethod shared by `dict` and `OrderedDict`; it always allocated a plain `dict`. When called as `OrderedDict.fromkeys`, set `base.type` and `map.is_ordered` on the result (same as `mp_obj_dict_make_new`).

### Testing

- `tests/basics/ordereddict_fromkeys.py` (type, insertion order, default value, `dict.fromkeys` regression)
- `tests/run-tests.py basics/ordereddict_fromkeys.py basics/dict_fromkeys.py basics/dict_fromkeys2.py` on unix port

### Code size

Unix `standard` port, `size` text section (clean rebuild):

| Version | bytes | vs master |
|---|---:|---:|
| master | 796206 | - |
| this commit | 796206 | 0 |

Only handles `OrderedDict` itself (not subclasses), consistent with existing OrderedDict support in MicroPython.

### Generative AI

I did not use generative AI tools when creating this PR.