### PR TITLE
github/workflows: Report coverage for the unix port's own sources.

### DIFF
--- a/.github/workflows/ports_unix.yml
+++ b/.github/workflows/ports_unix.yml
@@ -115,7 +115,12 @@ jobs:
     - name: Run gcov coverage analysis
       run: |
         (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
+        (cd ports/unix && gcov -o build-coverage *.c || true)
         (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
+        # The port compiles its own sources by bare filename, so gcov records
+        # them with no path to match against the tree.  Make them relative to
+        # ports/unix like the reports above already are.
+        (cd ports/unix && sed -i '1s|^\(.*Source:\)\([^/]*\)$|\1../../ports/unix/\2|' *.gcov)
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:
@@ -154,7 +159,12 @@ jobs:
     - name: Run gcov coverage analysis
       run: |
         (cd ports/unix && gcov -o build-coverage/py ../../py/*.c || true)
+        (cd ports/unix && gcov -o build-coverage *.c || true)
         (cd ports/unix && gcov -o build-coverage/extmod ../../extmod/*.c || true)
+        # The port compiles its own sources by bare filename, so gcov records
+        # them with no path to match against the tree.  Make them relative to
+        # ports/unix like the reports above already are.
+        (cd ports/unix && sed -i '1s|^\(.*Source:\)\([^/]*\)$|\1../../ports/unix/\2|' *.gcov)
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v7
       with:


### PR DESCRIPTION
### Summary

Codecov reported 95.65% patch coverage on a unix port PR of mine while a local gcov run over the same build said 91%, and the reason is that the coverage jobs only gcov `py/` and `extmod/`. Everything under `ports/unix` is built and exercised by the test run but never measured. `ports/unix/modtime.c` is the one exception, and only by accident: `extmod/modtime.c` textually includes it, so its data lands in the extmod object dir and gets picked up.

That leaves a fair chunk of the port invisible - `unix_mphal.c`, `main.c`, `mpthreadport.c`, `modsocket.c` at 34%, `modtermios.c` at 0%.

The broader question is whether we really only want to capture coverage of the common / shared code as part of this job, or if it really is valuable to show coverage of more of the port?

I guess there's a larger change possible that would report all the per-port coverage data, with the common stuff reported separately, though this would probably only now "just" be almost possible to do properly with the help of octoprobe that can run test suites on hardware, but would require a way to capture that coverage data from those test runs and aggregate is.

A complication in this PR as it stands is path names. The port compiles its sources by bare filename, so gcov records them as `unix_mphal.c` with no path, and nothing on the gcov side puts one back (`-p` and `-s` don't help, nor does invoking it from elsewhere). Codecov is then left with nothing to match against the tree, and `main.c` matches 24 files in this repo. The sed rewrites only Source lines containing no `/`, so the bare port names get fixed while the existing `../../py/...` and `/usr/include/...` entries are left alone.

The new pass sits between the existing two deliberately: the passes overwrite each other's shared header reports, and putting it last would cut `py/runtime.h` from 4 reported lines to 2.

### Testing

Ran the step verbatim out of the workflow YAML under `bash -e` against a local coverage build: 183 -> 198 `.gcov` files, every new one repo-relative, and `py/runtime.h` and `mphalport.h` come out identical to before. Same change applied to the 64-bit and 32-bit jobs.

I can't confirm locally that codecov accepts the rewritten paths since it does its path fixing server-side. It already accepts `../../ports/unix/modtime.c` today via the extmod pass, so the form is known good, but the codecov report on this PR is the real proof.

### Trade-offs and Alternatives

The sed is blunt. The tidier alternative is changing how the port hands source paths to the compiler so gcov records them with a path, but that's a much wider change to the build for a CI-only benefit.

Leaving the paths bare and relying on codecov's own path fixing would be simpler, but I couldn't establish whether an ambiguous basename gets dropped or mismapped, and mismapping `main.c` onto another port would corrupt that port's report.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the code and is responsible for the description above.
