### PR TITLE
py/objtype: Validate that __len__ returns an int.

### DIFF
--- a/py/objtype.c
+++ b/py/objtype.c
@@ -443,6 +443,7 @@ static mp_obj_t instance_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                 val = MP_OBJ_NEW_SMALL_INT(mp_obj_get_int_truncated(val));
                 break;
             case MP_UNARY_OP_INT_MAYBE:
+            case MP_UNARY_OP_LEN:
                 // Must return int
                 if (!mp_obj_is_int(val)) {
                     mp_raise_TypeError(NULL);

--- a/tests/basics/builtin_len_user.py
+++ b/tests/basics/builtin_len_user.py
@@ -1,0 +1,41 @@
+# test builtin len with user-defined __len__
+
+class A:
+    def __len__(self):
+        return 3
+
+
+print(len(A()))
+
+
+class B:
+    def __len__(self):
+        return None
+
+
+try:
+    len(B())
+except TypeError:
+    print("TypeError")
+
+
+class C:
+    def __len__(self):
+        return ""
+
+
+try:
+    len(C())
+except TypeError:
+    print("TypeError")
+
+
+class D:
+    def __len__(self):
+        return ()
+
+
+try:
+    len(D())
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
### Summary

Fixes #19512. `instance_unary_op` already validates that `__hash__` / `__int__` return an int, but `MP_UNARY_OP_LEN` fell through unchecked, so `len(obj)` could return `None` / `str` / `float`.

Fold `MP_UNARY_OP_LEN` into the existing `MP_UNARY_OP_INT_MAYBE` arm (approach from @jseop-lim on the issue). Non-int `__len__` results raise `TypeError`. This also covers callers that go through instance `unary_op`.

### Testing

- `tests/basics/builtin_len_user.py` (int OK; `None` / `str` / `tuple` -> `TypeError`)
- `tests/run-tests.py basics/builtin_len_user.py` on unix `standard` and `minimal`

### Trade-offs and Alternatives

Code size (unix `standard`, clean rebuild, `size` text section):

| Version | bytes | vs master |
|---|---:|---:|
| master | 796150 | - |
| this commit | 796150 | 0 |

`instance_unary_op` in `objtype.o` grows by 8 bytes; the linked binary text is unchanged (section padding).

Does not reject a negative `__len__` (not free; left for a separate discussion as on the issue).

Deliberate divergence vs CPython: `__len__` returning `bool` raises `TypeError` here (`mp_obj_is_int` excludes `bool`), same as `__int__` / #19203. Not covered in the test so the harness can compare against CPython.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.