### PR TITLE
shared/tinyusb: Add back runtime CDC config for older TinyUSB.

### DIFF
--- a/shared/tinyusb/mp_usbd.h
+++ b/shared/tinyusb/mp_usbd.h
@@ -64,6 +64,15 @@
 // Initialise TinyUSB device.
 static inline void mp_usbd_init_tud(void) {
     tusb_init();
+    #if TUSB_VERSION_NUMBER < 2100 && MICROPY_HW_USB_CDC
+    // TinyUSB prior to 0.21.0 had TX persistence configurable at runtime.
+    tud_cdc_configure_t cfg = {
+        .rx_persistent = 0,
+        .tx_persistent = 1,
+        .tx_overwritabe_if_not_connected = 1,
+    };
+    tud_cdc_configure(&cfg);
+    #endif
 }
 
 // Run the TinyUSB device task


### PR DESCRIPTION
### Summary

Commit 6bde1b58a722ebf0aec33042029286ae11f4e18f removed this configuration because TinyUSB 0.21.0 no longer uses it.  But the esp32 port still uses an older TinyUSB version/fork (based on TinyUSB 0.18.0) and therefore still needs this runtime CDC configuration.

Without this setting, ESP32-S2 and -S3 boards do not display the initial REPL banner (that's mostly a cosmetic issue, but nevertheless nice to have).

### Testing

Tested on ESP32_GENERIC_S3, the REPL banner is now there after a hard reset (prior to this fix it was not).

Tested RPI_PICO is not affected by this change.

### Trade-offs and Alternatives

This is arguably a regression in MicroPython 1.29.0, but I don't think it's worth a patch release.

### Generative AI

I did not use generative AI tools when creating this PR.