### PR TITLE
esp32: Fix USB Serial/JTAG TX stall due to full EP buffer

### DIFF
--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -115,7 +115,7 @@ void usb_serial_jtag_tx_strn(const char *str, size_t len) {
         TickType_t start_tick = xTaskGetTickCount();
         while (!usb_serial_jtag_ll_txfifo_writable()) {
             TickType_t now_tick = xTaskGetTickCount();
-            if (!terminal_connected || now_tick > (start_tick + pdMS_TO_TICKS(200))) {
+            if (!terminal_connected || (now_tick - start_tick) > pdMS_TO_TICKS(200)) {
                 terminal_connected = false;
                 return;
             }

--- a/ports/esp32/usb_serial_jtag.c
+++ b/ports/esp32/usb_serial_jtag.c
@@ -77,12 +77,14 @@ static void usb_serial_jtag_isr_handler(void *arg) {
     }
 
     if (flags & USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY) {
-        // As per the ESP-IDF driver, allow for the possibility the USJ just sent a full
-        // 64-bit endpoint to the host and now it's waiting for another ZLP to flush the result
-        // to the OS
+        // This interrupt is only enabled after we've sent a full IN EP buffer to the host.
+
+        // As per the ESP-IDF driver, this is necessary if the USJ has just
+        // sent a full 64-byte EP to the host and now the host is waiting
+        // for another ZLP to signal that the transfer is actually done.
         usb_serial_jtag_ll_txfifo_flush();
 
-        // Disable this interrupt until next time we write into the FIFO
+        // Disable this interrupt until the next time we write a full EP buffer
         usb_serial_jtag_ll_disable_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
     }
 }
@@ -122,9 +124,22 @@ void usb_serial_jtag_tx_strn(const char *str, size_t len) {
         l = usb_serial_jtag_ll_write_txfifo((const uint8_t *)str, l);
         str += l;
         len -= l;
+    }
+
+    // Clear any old "serial in empty" interrupt, as we're about to either
+    // manually flush or enable the interrupt if the TXFIFO is full (no risk of
+    // a lost flush as we check if the TXFIFO is full after we do this.)
+    usb_serial_jtag_ll_clr_intsts_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
+
+    if (usb_serial_jtag_ll_txfifo_writable()) {
+        // If we haven't written a full EP buffer, manually flush it to send to the host
+        usb_serial_jtag_ll_txfifo_flush();
+    } else {
+        // If we have written a full EP buffer to send to the host then the hardware will flush
+        // automatically, but enable the "serial in empty" interrupt so we will send a ZLP once
+        // the full buffer has been sent.
         usb_serial_jtag_ll_ena_intr_mask(USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY);
     }
-    usb_serial_jtag_ll_txfifo_flush();
 }
 
 #endif // MICROPY_HW_ESP_USB_SERIAL_JTAG

--- a/tests/serial_test.py
+++ b/tests/serial_test.py
@@ -15,6 +15,13 @@ import time
 
 from test_utils import test_instance_epilog, convert_device_shortcut_to_real_device
 
+TEST_READ_TIMEOUT = 1
+
+# For ESP32 boards with both native/USJ USB and a UART serial port, soft
+# reset may flush the UART buffer before it completes - this can be quite large
+# if it's backed up a lot of data during the previous test.
+SOFT_RESET_TIMEOUT = 5
+
 echo_test_script = """
 import sys
 bytes_min=%u
@@ -98,9 +105,25 @@ def drain_input(ser):
         time.sleep(0.1)
 
 
+def reset_into_raw_repl(ser):
+    try:
+        ser.timeout = SOFT_RESET_TIMEOUT
+        ser.flushInput()
+        ser.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
+        EXPECTED1 = b"MPY: soft reboot\r\n"
+        EXPECTED2 = b"raw REPL; CTRL-B to exit\r\n>"
+        r1 = ser.read_until(EXPECTED1)
+        r2 = b""
+        if r1.endswith(EXPECTED1):
+            r2 = ser.read_until(EXPECTED2)
+        if not r2.endswith(EXPECTED2):
+            raise TestError("could not reset to raw REPL", r1 + r2)
+    finally:
+        ser.timeout = TEST_READ_TIMEOUT
+
+
 def send_script(ser, script):
-    ser.write(b"\x03\x01\x04")  # break, raw-repl, soft-reboot
-    drain_input(ser)
+    reset_into_raw_repl(ser)
     chunk_size = 32
     for i in range(0, len(script), chunk_size):
         ser.write(script[i : i + chunk_size])
@@ -270,13 +293,13 @@ def write_test(ser_repl, ser_data, bufsize, nbuf, verified):
 def do_test(dev_repl, dev_data=None, time_per_subtest=1):
     if dev_data is None:
         print("REPL and data on", dev_repl)
-        ser_repl = serial.Serial(dev_repl, baudrate=115200, timeout=1)
+        ser_repl = serial.Serial(dev_repl, baudrate=115200, timeout=TEST_READ_TIMEOUT)
         ser_data = ser_repl
     else:
         print("REPL on", dev_repl)
         print("data on", dev_data)
-        ser_repl = serial.Serial(dev_repl, baudrate=115200, timeout=1)
-        ser_data = serial.Serial(dev_data, baudrate=115200, timeout=1)
+        ser_repl = serial.Serial(dev_repl, baudrate=115200, timeout=TEST_READ_TIMEOUT)
+        ser_data = serial.Serial(dev_data, baudrate=115200, timeout=TEST_READ_TIMEOUT)
 
     # Do echo test first, and abort if it doesn't pass.
     echo_test(ser_repl, ser_data)


### PR DESCRIPTION
### Summary

Closes #19651.

I wasn't able to reproduce using standalone reproducer from this issue, but I was able to reproduce by installing `micropython-stubber==1.28.3` and running `stubber mcu --format py -s /dev/ttyACM0` as per issue description.

This failure is also visible by running `./tests/serial_test.py` on the Espressif USB serial/jtag port. The echo test fails when the length is 64 bytes (a clue!) and is out of sync from then on:

```
❯ ./serial_test.py -t /dev/ttyACM0
REPL and data on /dev/ttyACM0
DATA ECHO: FAIL     
  sent 1 b'z'
  echo match
<snip matching iterations>
  sent 62 b'tgytyJXgyyXJHtHygJXHXyXyayMttgXJtyaXtagMtJXtatyygaggJygMJJMJyt'
  echo match
  sent 63 b'LeLcFFdL9dcFdeKed9K9FFddLFceeFK9KFcF9LeFeKF9dcccF9cdFFcecKLdeeL'
  echo match
  sent 64 b'yEuEbEyBb8byw8ubEBEywbyw8bbuw8ybu8uyEyB8uE8EyE8Bb8BBbub8EybBEu88'
  echo 64 b''
  sent 65 b'lMMWtklrkrl33l3kMWrrr3ll3rrrk3r3MrlltkWOOrWrkrrWMrkk3ttlOt33kO3rM'
  echo 65 b'yEuEbEyBb8byw8ubEBEywbyw8bbuw8ybu8uyEyB8uE8EyE8Bb8BBbub8EybBEu88l'
  sent 66 b'u1uw11w1FFsVVVQuIwsuFI1uuVsFwuuIVuQsIw1wwIFQQwIssVuFwuIFQFuuuuwwsw'
  echo 66 b'MMWtklrkrl33l3kMWrrr3ll3rrrk3r3MrlltkWOOrWrkrrWMrkk3ttlOt33kO3rMu1'
<snip failing iterations>
```

---

The Espressif USB Serial/JTAG peripheral (USJ) manages a 64 byte TX FIFO of bytes to send to the host (via the IN endpoint of the USB device). This TXFIFO automatically flushes whenever it is full, but if exactly 64 bytes (the endpoint length) is queued then it expects a manually triggered txfifo flush after it empties, in order to send a ZLP (zero length packet) to the host to signal that the transfer is done. Otherwise the host will assume there is more data coming and wait.

The bug is caused by this sequence of evens:
    
1. USJ has no data to send to host (TXFIFO/IN EP), so the SERIAL_IN_EMPTY interrupt bit is set.
2. MicroPython sends exactly 64 bytes to host, queued into the TXFIFO. The hardware will start flushing to the host.
4. The SERIAL_IN_EMPTY interrupt is enabled, but because the bit was already set it triggers.
5. ISR calls txfifo_flush() but this is a no-op as the TXFIFO is already being flushed.
6. ISR is now disabled until the next time MicroPython tries to send data.
7. The hardware sends the 64 bytes to the USB host.
    
Because there is exactly 64 bytes in the buffer (i.e. EP size), the USB host will assume there is more data to come and will wait for either a ZLP or more data. Because the interrupt is disabled this won't happen, and that data won't be received on the host until the next time MicroPython tries to TX serial data to the host.
    
Fix is to clear the SERIAL_IN_EMPTY interrupt status to avoid stale interrupts, and to be explicit about when we flush immediately on send versus when we need to wait for the TXFIFO to empty.
    
(Debugging tools used to figure this out were the Linux `usbmon` kernel module with Wireshark, and the "grabserial" tool to compare timings on the traditional UART - via `grabserial -d /dev/ttyUSB0 -b 115200 --hex-ascii -T`.)

As per the issue report, this is not a v1.29 regression (double checked by reproducing on ESP32_GENERIC_C3, MicroPython v1.28, and IDF v5.5.1.)

### Test fix included

Second commit is a fix for the `serial_test.py` program when testing the USB Serial/JTAG Peripheral, as the DATA IN test would time out waiting for a soft reset when starting the next test in the sequence. This is because MicroPython flushes the plain UART peripheral on soft reset, and this could take more than the 0.1 seconds that was allowed for (for the 16384 byte test it could take a couple of seconds).

### Testing

* Ran the serial_test.py program, the "stubber mcu" test on ESP32_GENERIC_C3, ESP32_GENERIC_C5 and ESP32_GENERIC_P4 boards via the USB Serial/JTAG port. All three boards failed both tests without this fix, pass with this fix.
* Also ran `tools/mpremote/tests/run-mpremote-tests.py` on all three boards. Pass before and after this fix.

### Trade-offs and Alternatives

* It'd probably be more convenient to use the ESP-IDF driver for the USB Serial/JTAG peripheral, however this driver is synchronous only (there's no way to get a callback when data is received from the host). Also it has its own buffer layer, so we'd end up with double buffering on stdin (the ESP-IDF driver buffer and then MicroPython's stdin ringbuffer).

### Generative AI

I did not use generative AI tools when creating this PR.