### PR TITLE
alif/Makefile: Allow build to work with spaces in the path.

### DIFF
--- a/ports/alif/Makefile
+++ b/ports/alif/Makefile
@@ -93,7 +93,7 @@ $(BUILD)/$(ALIF_TOC_CONFIG): mcu/$(ALIF_TOC_CONFIG).in | $(BUILD)
 
 $(ALIF_TOC_BIN): $(ALIF_TOC_APPS)
 	$(Q)$(PYTHON) $(ALIF_TOOLS)/app-gen-toc.py \
-		--filename $(abspath $(BUILD)/$(ALIF_TOC_CONFIG)) \
+		--filename "$(abspath $(BUILD)/$(ALIF_TOC_CONFIG))" \
 		--output-dir $(BUILD) \
 		--firmware-dir $(BUILD) \
 		--output $@


### PR DESCRIPTION
### Summary

This minor fix allows alif boards to be built when there is a space in the absolute path for the repository.

### Testing

Tested building ALIF_ENSEMBLE in a clone of the repo called `micropython clean`.  It now works.

### Generative AI

I did not use generative AI tools when creating this PR.
