### PR TITLE
tools/mpremote: Add tell() support for remote mounted files.

### DIFF
--- a/tools/mpremote/mpremote/transport_serial.py
+++ b/tools/mpremote/mpremote/transport_serial.py
@@ -457,6 +457,7 @@ fs_hook_code = f"""\
 import os, io, struct, micropython
 
 SEEK_SET = 0
+SEEK_CUR = 1
 
 class RemoteCommand:
     def __init__(self):
@@ -682,6 +683,9 @@ class RemoteFile(io.IOBase):
         if n < 0:
             raise OSError(n)
         return n
+
+    def tell(self):
+        return self.seek(0, SEEK_CUR)
 
 
 class RemoteFS:

--- a/tools/mpremote/tests/test_mount.sh
+++ b/tools/mpremote/tests/test_mount.sh
@@ -48,3 +48,7 @@ $MPREMOTE mount ${TMP} run "${TEST_DIR}/_test_mount_write_array.py"
 # Test readinto() with array returns byte count and fills correctly.
 echo -----
 $MPREMOTE mount ${TMP} run "${TEST_DIR}/_test_mount_readinto_array.py"
+
+# Test seek() and tell() on a remote file.
+echo -----
+$MPREMOTE mount ${TMP} exec "f = open('test.txt'); print(f.tell(), f.seek(4), f.tell(), f.seek(0, 2), f.tell(), f.seek(8), f.tell())"

--- a/tools/mpremote/tests/test_mount.sh.exp
+++ b/tools/mpremote/tests/test_mount.sh.exp
@@ -15,3 +15,6 @@ Local directory ${TMP} is mounted at /remote
 Local directory ${TMP} is mounted at /remote
 4
 [25185, 25699]
+-----
+Local directory ${TMP} is mounted at /remote
+0 4 4 12 12 8 8


### PR DESCRIPTION
### Summary

This allows `.tell()` to be executed on remote mounted files, reusing the existing `.seek()` for simple implementation.

This is intended to replace #18298.

### Testing

Added a test, it passes on PYBV10.

### Trade-offs and Alternatives

#18298 implements this in a different, more complex way.

### Generative AI

I did not use generative AI tools when creating this PR.