### PR TITLE
extmod/machine_i2c: Add I2C.scl() and I2C.sda() methods.

### DIFF
--- a/docs/library/machine.I2C.rst
+++ b/docs/library/machine.I2C.rst
@@ -107,6 +107,20 @@ General Methods
    those that respond.  A device responds if it pulls the SDA line low after
    its address (including a write bit) is sent on the bus.
 
+.. method:: I2C.scl()
+
+   Return the pin object used for the SCL line, or ``None`` if the port does
+   not report it.
+
+.. method:: I2C.sda()
+
+   Return the pin object used for the SDA line, or ``None`` if the port does
+   not report it.
+
+   `machine.SoftI2C` reports both pins on all ports.  For hardware I2C the
+   pins are reported on the esp32, renesas-ra, rp2, samd and stm32 ports; the
+   remaining ports return ``None``.
+
 Primitive I2C operations
 ------------------------
 

--- a/extmod/machine_i2c.c
+++ b/extmod/machine_i2c.c
@@ -650,6 +650,26 @@ static mp_obj_t machine_i2c_writeto_mem(size_t n_args, const mp_obj_t *pos_args,
 }
 static MP_DEFINE_CONST_FUN_OBJ_KW(machine_i2c_writeto_mem_obj, 1, machine_i2c_writeto_mem);
 
+static mp_obj_t machine_i2c_scl(mp_obj_t self_in) {
+    mp_obj_base_t *self = (mp_obj_base_t *)MP_OBJ_TO_PTR(self_in);
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)MP_OBJ_TYPE_GET_SLOT(self->type, protocol);
+    if (i2c_p->scl != NULL) {
+        return i2c_p->scl(self);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_i2c_scl_obj, machine_i2c_scl);
+
+static mp_obj_t machine_i2c_sda(mp_obj_t self_in) {
+    mp_obj_base_t *self = (mp_obj_base_t *)MP_OBJ_TO_PTR(self_in);
+    mp_machine_i2c_p_t *i2c_p = (mp_machine_i2c_p_t *)MP_OBJ_TYPE_GET_SLOT(self->type, protocol);
+    if (i2c_p->sda != NULL) {
+        return i2c_p->sda(self);
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_i2c_sda_obj, machine_i2c_sda);
+
 static const mp_rom_map_elem_t machine_i2c_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&machine_i2c_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_deinit), MP_ROM_PTR(&machine_i2c_deinit_obj) },
@@ -671,6 +691,8 @@ static const mp_rom_map_elem_t machine_i2c_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_readfrom_mem), MP_ROM_PTR(&machine_i2c_readfrom_mem_obj) },
     { MP_ROM_QSTR(MP_QSTR_readfrom_mem_into), MP_ROM_PTR(&machine_i2c_readfrom_mem_into_obj) },
     { MP_ROM_QSTR(MP_QSTR_writeto_mem), MP_ROM_PTR(&machine_i2c_writeto_mem_obj) },
+    { MP_ROM_QSTR(MP_QSTR_scl), MP_ROM_PTR(&machine_i2c_scl_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sda), MP_ROM_PTR(&machine_i2c_sda_obj) },
 };
 MP_DEFINE_CONST_DICT(mp_machine_i2c_locals_dict, machine_i2c_locals_dict_table);
 
@@ -680,6 +702,16 @@ MP_DEFINE_CONST_DICT(mp_machine_i2c_locals_dict, machine_i2c_locals_dict_table);
 // Implementation of soft I2C
 
 #if MICROPY_PY_MACHINE_SOFTI2C
+
+static mp_obj_t mp_machine_soft_i2c_scl(mp_obj_base_t *self_in) {
+    mp_machine_soft_i2c_obj_t *self = (mp_machine_soft_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t mp_machine_soft_i2c_sda(mp_obj_base_t *self_in) {
+    mp_machine_soft_i2c_obj_t *self = (mp_machine_soft_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
 
 static void mp_machine_soft_i2c_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     mp_machine_soft_i2c_obj_t *self = MP_OBJ_TO_PTR(self_in);
@@ -750,6 +782,8 @@ static const mp_machine_i2c_p_t mp_machine_soft_i2c_p = {
     .read = mp_machine_soft_i2c_read,
     .write = mp_machine_soft_i2c_write,
     .transfer = mp_machine_soft_i2c_transfer,
+    .scl = mp_machine_soft_i2c_scl,
+    .sda = mp_machine_soft_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/extmod/modmachine.h
+++ b/extmod/modmachine.h
@@ -168,6 +168,8 @@ typedef struct _mp_machine_i2c_p_t {
     int (*write)(mp_obj_base_t *obj, const uint8_t *src, size_t len);
     int (*transfer)(mp_obj_base_t *obj, uint16_t addr, size_t n, mp_machine_i2c_buf_t *bufs, unsigned int flags);
     int (*transfer_single)(mp_obj_base_t *obj, uint16_t addr, size_t len, uint8_t *buf, unsigned int flags);
+    mp_obj_t (*scl)(mp_obj_base_t *obj);
+    mp_obj_t (*sda)(mp_obj_base_t *obj);
 } mp_machine_i2c_p_t;
 
 // SoftI2C object.

--- a/ports/alif/mphalport.h
+++ b/ports/alif/mphalport.h
@@ -289,6 +289,7 @@ typedef struct _machine_pin_obj_t {
 } machine_pin_obj_t;
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
+#define mp_hal_pin_to_obj(p) MP_OBJ_FROM_PTR(p)
 
 static inline qstr mp_hal_pin_name(mp_hal_pin_obj_t pin) {
     return pin->name;

--- a/ports/esp32/machine_i2c.c
+++ b/ports/esp32/machine_i2c.c
@@ -355,9 +355,21 @@ mp_obj_t machine_hw_i2c_make_new(const mp_obj_type_t *type, size_t n_args, size_
     return MP_OBJ_FROM_PTR(self);
 }
 
+static mp_obj_t machine_hw_i2c_scl(mp_obj_base_t *self_in) {
+    machine_hw_i2c_obj_t *self = (machine_hw_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t machine_hw_i2c_sda(mp_obj_base_t *self_in) {
+    machine_hw_i2c_obj_t *self = (machine_hw_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
+
 static const mp_machine_i2c_p_t machine_hw_i2c_p = {
     .transfer_supports_write1 = true,
     .transfer = machine_hw_i2c_transfer,
+    .scl = machine_hw_i2c_scl,
+    .sda = machine_hw_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/ports/esp32/machine_pin.c
+++ b/ports/esp32/machine_pin.c
@@ -127,6 +127,16 @@ gpio_num_t machine_pin_get_id(mp_obj_t pin_in) {
     return PIN_OBJ_PTR_INDEX(self);
 }
 
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin) {
+    if (0 <= pin && pin < MP_ARRAY_SIZE(machine_pin_obj_table)) {
+        const machine_pin_obj_t *self = &machine_pin_obj_table[pin];
+        if (self->base.type != NULL) {
+            return MP_OBJ_FROM_PTR(self);
+        }
+    }
+    mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
+}
+
 static void machine_pin_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     machine_pin_obj_t *self = self_in;
     gpio_num_t gpio_num = PIN_OBJ_PTR_INDEX(self);

--- a/ports/esp32/mphalport.h
+++ b/ports/esp32/mphalport.h
@@ -115,6 +115,7 @@ void mp_hal_wake_main_task_from_isr(void);
 #define MP_HAL_PIN_FMT "%u"
 #define mp_hal_pin_obj_t gpio_num_t
 mp_hal_pin_obj_t machine_pin_get_id(mp_obj_t pin_in);
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin);
 #define mp_hal_get_pin_obj(o) machine_pin_get_id(o)
 #define mp_hal_pin_name(p) (p)
 static inline void mp_hal_pin_input(mp_hal_pin_obj_t pin) {

--- a/ports/esp8266/esp_mphal.h
+++ b/ports/esp8266/esp_mphal.h
@@ -91,6 +91,7 @@ void esp_enable_irq(uint32_t state);
 #define MP_HAL_PIN_FMT "%u"
 #define mp_hal_pin_obj_t uint32_t
 #define mp_hal_get_pin_obj(o) mp_obj_get_pin(o)
+#define mp_hal_pin_to_obj(p) MP_OBJ_FROM_PTR(&pyb_pin_obj[p])
 #define mp_hal_pin_name(p) (p)
 void mp_hal_pin_input(mp_hal_pin_obj_t pin);
 void mp_hal_pin_output(mp_hal_pin_obj_t pin);

--- a/ports/mimxrt/mphalport.h
+++ b/ports/mimxrt/mphalport.h
@@ -82,6 +82,7 @@ extern ringbuf_t stdin_ringbuf;
 
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
 #define mp_hal_get_pin_obj(o)   pin_find(o)
+#define mp_hal_pin_to_obj(p)    MP_OBJ_FROM_PTR(p)
 #define mp_hal_pin_name(p)      ((p)->name)
 #define mp_hal_pin_input(p) machine_pin_set_mode(p, PIN_MODE_IN);
 #define mp_hal_pin_output(p) machine_pin_set_mode(p, PIN_MODE_OUT);

--- a/ports/nrf/mphalport.h
+++ b/ports/nrf/mphalport.h
@@ -85,6 +85,7 @@ void mp_hal_get_random(size_t n, uint8_t *buf);
 #define MP_HAL_PIN_FMT           "%q"
 #define mp_hal_pin_obj_t const pin_obj_t *
 #define mp_hal_get_pin_obj(o)    pin_find(o)
+#define mp_hal_pin_to_obj(p)     MP_OBJ_FROM_PTR(p)
 #define mp_hal_pin_name(p)       ((p)->name)
 #define mp_hal_pin_high(p)       nrf_gpio_pin_set(p->pin)
 #define mp_hal_pin_low(p)        nrf_gpio_pin_clear(p->pin)

--- a/ports/renesas-ra/machine_i2c.c
+++ b/ports/renesas-ra/machine_i2c.c
@@ -149,10 +149,22 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     return ret;
 }
 
+static mp_obj_t machine_i2c_scl(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t machine_i2c_sda(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
+
 static const mp_machine_i2c_p_t machine_i2c_p = {
     .init = machine_i2c_init,
     .transfer = mp_machine_i2c_transfer_adaptor,
     .transfer_single = machine_i2c_transfer_single,
+    .scl = machine_i2c_scl,
+    .sda = machine_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/ports/renesas-ra/mphalport.h
+++ b/ports/renesas-ra/mphalport.h
@@ -107,6 +107,7 @@ static inline mp_uint_t mp_hal_ticks_cpu(void) {
 
 #define mp_hal_pin_obj_t        const machine_pin_obj_t *
 #define mp_hal_get_pin_obj(o)   machine_pin_find(o)
+#define mp_hal_pin_to_obj(p)    MP_OBJ_FROM_PTR(p)
 #define mp_hal_pin_name(p)      ((p)->name)
 #define mp_hal_pin_input(p)     ra_gpio_mode_input((p)->pin)
 #define mp_hal_pin_output(p)    ra_gpio_mode_output((p)->pin)

--- a/ports/rp2/machine_i2c.c
+++ b/ports/rp2/machine_i2c.c
@@ -158,9 +158,21 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     }
 }
 
+static mp_obj_t machine_i2c_scl(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t machine_i2c_sda(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
+
 static const mp_machine_i2c_p_t machine_i2c_p = {
     .transfer = mp_machine_i2c_transfer_adaptor,
     .transfer_single = machine_i2c_transfer_single,
+    .scl = machine_i2c_scl,
+    .sda = machine_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/ports/rp2/machine_pin.c
+++ b/ports/rp2/machine_pin.c
@@ -606,4 +606,11 @@ mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj) {
     return pin->id;
 }
 
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin) {
+    if (pin < MP_ARRAY_SIZE(machine_pin_obj_table)) {
+        return MP_OBJ_FROM_PTR(&machine_pin_obj_table[pin]);
+    }
+    mp_raise_ValueError(MP_ERROR_TEXT("invalid pin"));
+}
+
 MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_obj[NUM_BANK0_GPIOS]);

--- a/ports/rp2/mphalport.h
+++ b/ports/rp2/mphalport.h
@@ -138,6 +138,7 @@ extern uint32_t machine_pin_open_drain_mask;
 #endif
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin);
 
 static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
     return pin;

--- a/ports/samd/machine_i2c.c
+++ b/ports/samd/machine_i2c.c
@@ -263,9 +263,21 @@ static int machine_i2c_transfer_single(mp_obj_base_t *self_in, uint16_t addr, si
     return len;
 }
 
+static mp_obj_t machine_i2c_scl(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t machine_i2c_sda(mp_obj_base_t *self_in) {
+    machine_i2c_obj_t *self = (machine_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
+
 static const mp_machine_i2c_p_t machine_i2c_p = {
     .transfer = mp_machine_i2c_transfer_adaptor,
     .transfer_single = machine_i2c_transfer_single,
+    .scl = machine_i2c_scl,
+    .sda = machine_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/ports/samd/machine_pin.c
+++ b/ports/samd/machine_pin.c
@@ -521,4 +521,8 @@ mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t obj) {
     return pin->pin_id;
 }
 
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin) {
+    return MP_OBJ_FROM_PTR(pin_find_by_id(pin));
+}
+
 MP_REGISTER_ROOT_POINTER(void *machine_pin_irq_objects[16]);

--- a/ports/samd/mphalport.h
+++ b/ports/samd/mphalport.h
@@ -116,6 +116,7 @@ static inline mp_uint_t mp_hal_ticks_cpu(void) {
 extern uint32_t machine_pin_open_drain_mask[];
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
+mp_obj_t mp_hal_pin_to_obj(mp_hal_pin_obj_t pin);
 void mp_hal_set_pin_mux(mp_hal_pin_obj_t pin, uint8_t mux);
 void mp_hal_clr_pin_mux(mp_hal_pin_obj_t pin);
 

--- a/ports/stm32/machine_i2c.c
+++ b/ports/stm32/machine_i2c.c
@@ -228,8 +228,20 @@ mp_obj_t machine_hard_i2c_make_new(const mp_obj_type_t *type, size_t n_args, siz
     return MP_OBJ_FROM_PTR(self);
 }
 
+static mp_obj_t machine_hard_i2c_scl(mp_obj_base_t *self_in) {
+    machine_hard_i2c_obj_t *self = (machine_hard_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->scl);
+}
+
+static mp_obj_t machine_hard_i2c_sda(mp_obj_base_t *self_in) {
+    machine_hard_i2c_obj_t *self = (machine_hard_i2c_obj_t *)self_in;
+    return mp_hal_pin_to_obj(self->sda);
+}
+
 static const mp_machine_i2c_p_t machine_hard_i2c_p = {
     .transfer = machine_hard_i2c_transfer,
+    .scl = machine_hard_i2c_scl,
+    .sda = machine_hard_i2c_sda,
 };
 
 MP_DEFINE_CONST_OBJ_TYPE(

--- a/ports/stm32/mphalport.h
+++ b/ports/stm32/mphalport.h
@@ -137,6 +137,7 @@ static inline mp_uint_t mp_hal_ticks_cpu(void) {
 
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
 #define mp_hal_get_pin_obj(o)   pin_find(o)
+#define mp_hal_pin_to_obj(p)    MP_OBJ_FROM_PTR(p)
 #define mp_hal_pin_name(p)      ((p)->name)
 #define mp_hal_pin_input(p)     mp_hal_pin_config((p), MP_HAL_PIN_MODE_INPUT, MP_HAL_PIN_PULL_NONE, 0)
 #define mp_hal_pin_output(p)    mp_hal_pin_config((p), MP_HAL_PIN_MODE_OUTPUT, MP_HAL_PIN_PULL_NONE, 0)

--- a/ports/zephyr/mphalport.h
+++ b/ports/zephyr/mphalport.h
@@ -59,6 +59,7 @@ static inline uint64_t mp_hal_time_ns(void) {
 #define mp_hal_pin_obj_t const machine_pin_obj_t *
 
 mp_hal_pin_obj_t mp_hal_get_pin_obj(mp_obj_t pin_in);
+#define mp_hal_pin_to_obj(p) MP_OBJ_FROM_PTR(p)
 
 static inline unsigned int mp_hal_pin_name(mp_hal_pin_obj_t pin) {
     // TODO make it include the port

--- a/tests/extmod_hardware/machine_i2c_pins.py
+++ b/tests/extmod_hardware/machine_i2c_pins.py
@@ -1,0 +1,128 @@
+# Test retrieving the SCL/SDA pins of an I2C bus.
+#
+# IMPORTANT: This test does not need any external wiring, but it does
+# reconfigure the pins listed below, so they must be free to use.  The pins
+# mirror those used by extmod_hardware/machine_i2c_target.py.
+
+import sys
+
+try:
+    from machine import Pin, SoftI2C
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import unittest
+
+try:
+    from machine import I2C
+except ImportError:
+    I2C = None
+
+# Arguments for the hardware I2C constructor, or None if this platform has no
+# hardware I2C that can be constructed without further wiring information.
+args_hard = None
+kwargs_hard = {}
+
+# Configure pins based on the target.
+if sys.platform == "alif" and sys.implementation._build == "ALIF_ENSEMBLE":
+    args_soft = {"scl": "P1_1", "sda": "P1_0"}
+    args_hard = (0,)  # on pins P0_3/P0_2
+elif sys.platform == "esp32":
+    args_soft = {"scl": 5, "sda": 6}
+    args_hard = (0,)
+    kwargs_hard = {"scl": 9, "sda": 8}
+elif sys.platform == "rp2":
+    args_soft = {"scl": 5, "sda": 4}
+    args_hard = (1,)  # on gpio7/gpio6
+# Note: the stm32 port reports sys.platform as "pyboard" on all of its boards.
+elif sys.platform == "pyboard":
+    if sys.implementation._build == "NUCLEO_WB55":
+        args_soft = {"scl": "B8", "sda": "B9"}
+        args_hard = (3,)
+    elif sys.implementation._build == "ARDUINO_NICLA_VISION":
+        # SCL/SDA are the I2C1 pads; the hardware bus tested is I2C3 (PA8/PC9).
+        args_soft = {"scl": "SCL", "sda": "SDA"}
+        args_hard = (3,)
+    elif sys.implementation._build.startswith("PYB"):
+        args_soft = {"scl": "X1", "sda": "X2"}
+        args_hard = ("X",)
+    else:
+        print("Please add support for this test on this platform.")
+        raise SystemExit
+elif "zephyr-nucleo_wb55rg" in sys.implementation._machine:
+    # PB8=I2C1_SCL, PB9=I2C1_SDA (on Arduino header D15/D14)
+    args_soft = {"scl": Pin(("gpiob", 8)), "sda": Pin(("gpiob", 9))}
+    args_hard = ("i2c3",)
+elif "zephyr-rpi_pico" in sys.implementation._machine:
+    args_soft = {"scl": Pin(("gpio0", 5)), "sda": Pin(("gpio0", 4))}
+    args_hard = ("i2c1",)  # on gpio7/gpio6
+elif sys.platform == "renesas-ra":
+    if sys.implementation._build == "ARDUINO_PORTENTA_C33":
+        # I2C0 is on P408/P407, and this port does not accept explicit pins
+        # for the hardware bus, so the soft bus uses the same pins.
+        args_soft = {"scl": "P408", "sda": "P407"}
+        args_hard = (0,)
+    else:
+        print("Please add support for this test on this platform.")
+        raise SystemExit
+elif sys.platform == "mimxrt":
+    if "Teensy" in sys.implementation._machine:
+        args_soft = {"scl": "A6", "sda": "A3"}  # D20/D17
+    else:
+        args_soft = {"scl": "D0", "sda": "D1"}
+    args_hard = (0,)  # pins 19/18 on Teensy 4.x
+elif sys.platform == "samd":
+    args_soft = {"scl": "D5", "sda": "D1"}
+    args_hard = ()  # board default I2C on its default pins
+else:
+    print("Please add support for this test on this platform.")
+    raise SystemExit
+
+
+# Pin objects are not guaranteed to be singletons on every port, so compare
+# pins by their representation rather than by identity.
+def assert_is_pin(test, pin, expected=None):
+    test.assertIsInstance(pin, Pin)
+    if expected is not None:
+        test.assertEqual(repr(pin), repr(Pin(expected)))
+
+
+class TestSoftI2C(unittest.TestCase):
+    def setUp(self):
+        self.i2c = SoftI2C(**args_soft)
+
+    def test_pins(self):
+        assert_is_pin(self, self.i2c.scl(), args_soft["scl"])
+        assert_is_pin(self, self.i2c.sda(), args_soft["sda"])
+
+    def test_pins_after_init(self):
+        # Swapping the pins over must be reflected by the accessors.
+        self.i2c.init(scl=args_soft["sda"], sda=args_soft["scl"])
+        assert_is_pin(self, self.i2c.scl(), args_soft["sda"])
+        assert_is_pin(self, self.i2c.sda(), args_soft["scl"])
+
+
+class TestHardI2C(unittest.TestCase):
+    # Note: the bus is created inside the test rather than in setUp() because
+    # setUp() also runs for skipped tests.
+    @unittest.skipIf(I2C is None or args_hard is None, "no hardware I2C")
+    def test_pins(self):
+        i2c = I2C(*args_hard, **kwargs_hard)
+        try:
+            scl = i2c.scl()
+            sda = i2c.sda()
+            if scl is None:
+                # This port does not report the pins of a hardware I2C bus.
+                self.assertIsNone(sda)
+                return
+            assert_is_pin(self, scl, kwargs_hard.get("scl", None))
+            assert_is_pin(self, sda, kwargs_hard.get("sda", None))
+        finally:
+            # I2C.deinit() is not available on all firmware versions.
+            if hasattr(i2c, "deinit"):
+                i2c.deinit()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This adds `I2C.scl()` and `I2C.sda()`, which return the `machine.Pin` objects a bus is using.

The motivating use case is I2C bus recovery. In the Arduino Modulino package, Modulino nodes have their own MCU, so resetting the host board or hot-swapping a node mid-transaction can leave the bus stuck with a peripheral holding SDA low. Recovering from that means driving SCL for up to nine cycles while SDA is held high, then re-initialising the bus object. To do this the code has to know which pins the bus is on, and there is currently no API that answers that question. The library just receives an `I2C` object. This way we don't have to ask the library users to explicitly provide (and know) the pins used for the I2C bus. (The target audience is beginners).

The workaround in use today is to take `repr()` of the I2C object and pull the pin names out with a regular expression. That is expensive (it formats and allocates a string on a code path that runs at startup), and it depends on the exact layout of a debug representation that is port-specific and not an API contract.

The methods are backed by two new optional entries in the `mp_machine_i2c_p_t`
protocol struct:

- `machine.SoftI2C` implements them on **all** ports.
- Hardware I2C implements them on **esp32, renesas-ra, rp2, samd and stm32**.
- Hardware I2C on the remaining ports returns `None`, which is documented.

To keep the shared code portable this also adds `mp_hal_pin_to_obj()` to the C-level
pin HAL of every port that builds `extmod/machine_i2c.c` with SoftI2C enabled. See
*Trade-offs and Alternatives* for why that is needed.

`docs/library/machine.I2C.rst` documents both methods, including the `None` case and
which ports report hardware pins.

### Testing

A new hardware test, `tests/extmod_hardware/machine_i2c_pins.py`, checks that both
SoftI2C and hardware I2C report their pins, that the reported pins follow a subsequent
`init()`, and that a port which does not report hardware pins returns `None`
consistently for both. It needs no external wiring, and selects pins per target the
same way `extmod_hardware/machine_i2c_target.py` does.

Tested on hardware, 3/3 tests passing on each, covering all three ways a port can
represent a pin:

| Board | Port | `mp_hal_pin_obj_t` |
| --- | --- | --- |
| Arduino Nano RP2040 Connect | rp2 | `uint` (GPIO number) |
| Arduino Nano ESP32 | esp32 (S3) | `gpio_num_t` |
| Arduino Nicla Vision | stm32 (H747) | `const machine_pin_obj_t *` |
| Arduino Portenta C33 | renesas-ra (RA6M5) | `const machine_pin_obj_t *` |

Beyond the test, the returned objects were checked to be the same canonical `Pin`
objects reachable by name on each board - e.g. on the Nano RP2040 Connect,
`I2C(1).scl() is Pin('A1')`, and on the Nicla Vision the hardware buses report
`Pin(Pin.cpu.B8, mode=ALT_OPEN_DRAIN, pull=PULL_UP, alt=AF4_I2C1)` and friends for
I2C1/2/3, matching the board definition.

Build-tested only: **samd** (ADAFRUIT_ITSYBITSY_M4_EXPRESS) and unix.

Not tested at all, and where I would appreciate CI or another contributor's boards:
**esp8266, nrf, mimxrt, alif, zephyr, psoc-edge**. These receive only the one-line
`mp_hal_pin_to_obj` addition. For five of them it is the same pointer cast that stm32
and renesas-ra use, both of which are hardware-tested. **esp8266 is the one that
differs materially** - it indexes the port's pin table rather than casting a pointer -
and I have no toolchain for it here, so it is unverified. nrf could not be built
locally either (its build needs SoftDevice headers that `make submodules` does not
fetch).

### Trade-offs and Alternatives

**Code size.** Measured on PYBV11, the whole series costs **+104 bytes** of text, with
no change to data or bss (376360 -> 376464). Per-symbol on that build: the two shared
dispatchers in extmod are 20 bytes each, the two stm32 accessors are **4 bytes each**
(the HAL conversion is a cast, so the compiler emits almost nothing), the two function
objects are 8 bytes each, plus two locals-dict entries and two protocol-struct slots.
Ports with integer pin types pay ~32 bytes more for the `mp_hal_pin_to_obj` lookup
function. Every port pays for the two dict entries even if its hardware I2C returns
`None`; that could be avoided with a config option, but a two-entry gate did not seem
worth the `mpconfig` surface.

**Alternative considered and rejected: standardising `repr()` instead.** Since the
existing workaround parses `repr()`, one option is to make that output complete and
uniform across ports rather than add an API. Rejected for three reasons. First,
`repr()` is a debug representation, not an API contract - code that parses it relies on
something no port promises to keep stable, and changing the output to standardise it
would itself break anyone already parsing it. Second, it is not merely inconsistent, it
is *absent*: mimxrt prints `I2C(%u, freq=%u, timeout=%u)` and zephyr prints
`<I2C %s>`, neither of which contains the pins - and neither port stores the pins in
its I2C object, so completing their `repr()` needs exactly the same underlying change
as implementing the accessors. Third, where pins are printed the formats differ
(integers on esp32/rp2, quoted names on stm32/renesas-ra/alif/samd), so a parser still
needs per-port handling, and it pays string formatting, allocation and regex matching
at runtime for information the object already holds.

**API shape: two methods, rather than one `config()`/dict getter or attributes.**
Per-parameter accessor methods are what `machine` peripheral classes already use -
`PWM.freq()`, `PWM.duty_u16()`, `PWM.duty_ns()` - whereas the `config('param')` form
belongs to the network and Bluetooth classes (`WLAN.config()`, `BLE.config()`). Two
methods therefore follow the convention for this class, reuse the existing `scl`/`sda`
QSTRs so they add no new strings, and return the pin objects without allocating; a dict
would build and allocate one on every call, on a path that may run precisely when a bus
is already wedged.

The counter-argument is real, though: constructors take more than these two parameters
(`id`, `freq`, `timeout`), and a general getter would scale to all of them where adding
one method per parameter does not. I think that is worth doing as its own discussion
rather than here, because it is a cross-class decision - `SPI`, `UART` and `PWM` would
all want the same shape - and because `scl`/`sda` are the parameters with a concrete
use case today. If maintainers would rather have `config()` on `machine` classes, I am
happy to rework this on top of that decision. Either way the API shape set here is a
precedent for the other bus classes, so it is worth settling explicitly.

**Why not store `mp_obj_t` in the SoftI2C object and avoid the conversion entirely?**
`mp_machine_soft_i2c_obj_t` stores `mp_hal_pin_obj_t` because the bit-banging code
calls `mp_hal_pin_od_low()`, `mp_hal_pin_read()` and friends on it once per *bit*.
Storing the Python object would move a conversion into that hot path, change a struct that is public to every
port's soft-I2C code, and add GC-visible references to a struct that has none today.

**Why is `mp_hal_pin_to_obj` a macro on some ports and a function on others?** It
follows what `mp_hal_pin_obj_t` actually is, and matches how each port already defines
`mp_hal_get_pin_obj` in the same header:

- Where a pin is already a pointer to the pin object (stm32, renesas-ra, nrf, mimxrt,
  alif, zephyr), the conversion is a pure cast - `MP_OBJ_FROM_PTR` - so a macro emits
  no code at all.
- Where a pin is an integer (esp32, rp2, samd), it needs a bounds-checked table lookup
  that raises on failure. That cannot go in the header: the tables and helpers are
  declared in `machine_pin.h` / `pin_af.h`, which `mphalport.h` does not include, and
  `mphalport.h` is pulled in extremely early by nearly every file - adding those
  includes invites include cycles. The body also raises, which would drag
  `py/runtime.h` into every consumer.
- esp8266 is integer-typed but stays a macro: its pin table is already visible in
  `esp_mphal.h`, the table index equals `phys_port` for every valid entry, pin ids only
  ever arrive from the validating `mp_obj_get_pin()`, and that port is the most
  ROM-constrained in the tree.

Each port's helper therefore raises that port's own existing message for a bad pin
("invalid pin" on esp32/rp2, "not a Pin" on samd, via `pin_find_by_id()`) rather than a
new uniform one. In practice these paths are unreachable through this feature, since
stored pins always came from `mp_hal_get_pin_obj()` or a board's compile-time defaults;
the checks are for future callers of the HAL helper.

The cost of the mixed macro/function form is that macros get no type checking, and a
new port that omits the definition finds out only when something compiles
`machine_i2c.c` with SoftI2C enabled - a loud build error rather than silent breakage.
Making all ten real functions would be more uniform, at the price of adding a `.c`
definition to six ports that currently need no code; happy to change it if preferred.

**Hardware I2C returning `None` on some ports.** Filling the gap
is not uniform work: alif already stores its pins and would be the same two-liner, but
mimxrt and zephyr do not keep the pins in their I2C object (so it means adding fields or
recovering them from the peripheral/devicetree config), and nrf and psoc-edge have no
`ports/*/machine_i2c.c` at all. Since I cannot test any of those boards, I would rather
leave them to people who can than add unverified code. The alternative - raising
`NotImplementedError` instead of returning `None` - would make the gap louder but costs
an error message on every affected port; happy to switch if that is preferred.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.