### PR TITLE
py/runtime: Check that __dict__ is a dict in import *.

### DIFF
--- a/py/runtime.c
+++ b/py/runtime.c
@@ -1619,14 +1619,17 @@ void mp_import_all(mp_obj_t module) {
     #endif
 
     #if MICROPY_CPYTHON_COMPAT
-    // Load the dict from the module.  In MicroPython, if __dict__ is
-    // available then it always returns a native mp_obj_dict_t instance.
+    // Load the dict from the module.  Normally this is a native dict, but a
+    // user object in sys.modules may expose a non-dict __dict__.
     mp_load_method(module, MP_QSTR___dict__, dest);
     #else
     // Without MICROPY_CPYTHON_COMPAT __dict__ is not available, so just
     // assume the given module is actually an mp_obj_module_t instance.
     dest[0] = MP_OBJ_FROM_PTR(mp_obj_module_get_globals(module));
     #endif
+    if (!mp_obj_is_dict_or_ordereddict(dest[0])) {
+        mp_raise_TypeError(NULL);
+    }
 
     // By default, the set of public names includes all names found in the module's
     // namespace which do not begin with an underscore character ('_')

--- a/tests/import/import_star_non_dict.py
+++ b/tests/import/import_star_non_dict.py
@@ -1,0 +1,21 @@
+# test from ... import * when module __dict__ is not a dict
+
+import sys
+
+if not hasattr(object, "__init__"):
+    # target doesn't have MICROPY_CPYTHON_COMPAT enabled
+    print("SKIP")
+    raise SystemExit
+
+
+class M:
+    pass
+
+
+m = M()
+try:
+    m.__dict__ = 42
+    sys.modules["m"] = m
+    from m import *
+except TypeError:
+    print("TypeError")


### PR DESCRIPTION
### Summary

Fixes #19621. `mp_import_all` loaded `__dict__` and passed it to `mp_obj_dict_get_map` without checking the type. A user object in `sys.modules` with a non-dict `__dict__` (e.g. an instance attribute shadowing the special getter) caused a segfault.

Check with `mp_obj_is_dict_or_ordereddict` and raise `TypeError` (same approach as validating other special-method return types).

### Testing

- `tests/import/import_star_non_dict.py` (PoC from the issue; CPython raises on assign, MicroPython on `import *`; both print `TypeError`)
- `tests/run-tests.py import/import_star_non_dict.py import/import_star.py import/import_star_error.py` on unix port

### Trade-offs and Alternatives

Code size (unix `standard`, `size` text section, clean rebuild):

| Version | bytes | vs master |
|---|---:|---:|
| master | 796390 | - |
| this commit | 796390 | 0 |

Does not change instance `__dict__` store semantics (still possible to assign a non-dict attribute named `__dict__`); only `import *` is hardened.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.