### PR TITLE
shared/netutils: Factor mp_hal_get_mac_ascii out of ports.

### DIFF
--- a/ports/alif/alif.mk
+++ b/ports/alif/alif.mk
@@ -157,6 +157,7 @@ endif
 SHARED_SRC_C += $(addprefix shared/,\
 	libc/string0.c \
 	netutils/dhcpserver.c \
+	netutils/get_mac_ascii.c \
 	netutils/trace.c \
 	readline/readline.c \
 	runtime/gchelper_native.c \

--- a/ports/alif/mphalport.c
+++ b/ports/alif/mphalport.c
@@ -273,15 +273,6 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     mp_hal_generate_laa_mac(idx, buf);
 }
 
-void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
-    static const char hexchr[16] = "0123456789ABCDEF";
-    uint8_t mac[6];
-    mp_hal_get_mac(idx, mac);
-    for (; chr_len; ++chr_off, --chr_len) {
-        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
-    }
-}
-
 void mp_hal_get_random(size_t n, uint8_t *buf) {
     uint64_t rnd = 0;
     size_t rnd_bits = 0;

--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -285,6 +285,7 @@ SHARED_SRC_C += \
 	shared/libc/printf.c \
 	shared/libc/string0.c \
 	shared/netutils/dhcpserver.c \
+	shared/netutils/get_mac_ascii.c \
 	shared/netutils/netutils.c \
 	shared/netutils/trace.c \
 	shared/readline/readline.c \

--- a/ports/mimxrt/mphalport.c
+++ b/ports/mimxrt/mphalport.c
@@ -136,12 +136,3 @@ void mp_hal_generate_laa_mac(int idx, uint8_t buf[6]) {
 MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     mp_hal_generate_laa_mac(idx, buf);
 }
-
-void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
-    static const char hexchr[16] = "0123456789ABCDEF";
-    uint8_t mac[6];
-    mp_hal_get_mac(idx, mac);
-    for (; chr_len; ++chr_off, --chr_len) {
-        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
-    }
-}

--- a/ports/renesas-ra/Makefile
+++ b/ports/renesas-ra/Makefile
@@ -154,6 +154,7 @@ MPY_CROSS_FLAGS += -march=armv7m
 SHARED_SRC_C += $(addprefix shared/,\
 	libc/string0.c \
 	netutils/dhcpserver.c \
+	netutils/get_mac_ascii.c \
 	netutils/netutils.c \
 	netutils/trace.c \
 	readline/readline.c \

--- a/ports/renesas-ra/mphalport.c
+++ b/ports/renesas-ra/mphalport.c
@@ -165,15 +165,6 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     mp_hal_generate_laa_mac(idx, buf);
 }
 
-void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
-    static const char hexchr[16] = "0123456789ABCDEF";
-    uint8_t mac[6];
-    mp_hal_get_mac(idx, mac);
-    for (; chr_len; ++chr_off, --chr_len) {
-        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
-    }
-}
-
 #if MICROPY_HW_ENABLE_RNG
 void mp_hal_get_random(size_t n, uint8_t *buf) {
     for (int i = 0; i < n; i++) {

--- a/ports/rp2/CMakeLists.txt
+++ b/ports/rp2/CMakeLists.txt
@@ -129,6 +129,7 @@ set(MICROPY_SOURCE_LIB
     ${MICROPY_DIR}/lib/oofatfs/ff.c
     ${MICROPY_DIR}/lib/oofatfs/ffunicode.c
     ${MICROPY_DIR}/shared/netutils/dhcpserver.c
+    ${MICROPY_DIR}/shared/netutils/get_mac_ascii.c
     ${MICROPY_DIR}/shared/netutils/netutils.c
     ${MICROPY_DIR}/shared/netutils/trace.c
     ${MICROPY_DIR}/shared/readline/readline.c

--- a/ports/rp2/mphalport.c
+++ b/ports/rp2/mphalport.c
@@ -219,15 +219,6 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     mp_hal_generate_laa_mac(idx, buf);
 }
 
-void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
-    static const char hexchr[16] = "0123456789ABCDEF";
-    uint8_t mac[6];
-    mp_hal_get_mac(idx, mac);
-    for (; chr_len; ++chr_off, --chr_len) {
-        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
-    }
-}
-
 // Shouldn't be used, needed by cyw43-driver in debug build.
 uint32_t storage_read_blocks(uint8_t *dest, uint32_t block_num, uint32_t num_blocks) {
     panic_unsupported();

--- a/ports/stm32/Makefile
+++ b/ports/stm32/Makefile
@@ -195,6 +195,7 @@ MPY_CROSS_FLAGS += -march=$(MPY_CROSS_MCU_ARCH)
 SHARED_SRC_C += $(addprefix shared/,\
 	libc/string0.c \
 	netutils/dhcpserver.c \
+	netutils/get_mac_ascii.c \
 	netutils/netutils.c \
 	netutils/trace.c \
 	readline/readline.c \

--- a/ports/stm32/mphalport.c
+++ b/ports/stm32/mphalport.c
@@ -213,15 +213,6 @@ MP_WEAK void mp_hal_get_mac(int idx, uint8_t buf[6]) {
     mp_hal_generate_laa_mac(idx, buf);
 }
 
-void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
-    static const char hexchr[16] = "0123456789ABCDEF";
-    uint8_t mac[6];
-    mp_hal_get_mac(idx, mac);
-    for (; chr_len; ++chr_off, --chr_len) {
-        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
-    }
-}
-
 #if MICROPY_HW_ENABLE_RNG
 void mp_hal_get_random(size_t n, uint8_t *buf) {
     uint32_t val = 0;

--- a/shared/netutils/get_mac_ascii.c
+++ b/shared/netutils/get_mac_ascii.c
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <assert.h>
+#include "py/mphal.h"
+
+void mp_hal_get_mac_ascii(int idx, size_t chr_off, size_t chr_len, char *dest) {
+    static const char hexchr[16] = "0123456789ABCDEF";
+    uint8_t mac[6];
+    mp_hal_get_mac(idx, mac);
+    assert(chr_off <= 12 && chr_len <= 12 - chr_off);
+    for (; chr_len; ++chr_off, --chr_len) {
+        *dest++ = hexchr[mac[chr_off >> 1] >> (4 * (1 - (chr_off & 1))) & 0xf];
+    }
+}


### PR DESCRIPTION
### Summary

Fixes #19668.

`mp_hal_get_mac_ascii` indexed `mac[chr_off >> 1]` without checking that the requested hex slice stays within the 12-character MAC representation, so `chr_off == 12` read `mac[6]`.

The same helper was duplicated in stm32, rp2, mimxrt, renesas-ra, and alif. Move it to `shared/netutils/get_mac_ascii.c` and add `assert(chr_off <= 12 && chr_len <= 12 - chr_off)` in that single copy. In-tree callers use `(8, 4)` and are unchanged.

### Testing

- Relies on port CI builds (C HAL; no Python test)
- Diff removes the five port copies and wires `get_mac_ascii.c` into each port's shared/netutils sources

### Trade-offs and Alternatives

`assert` (not a runtime clamp): zero cost in typical release builds with `NDEBUG`, matches other HAL programmer-error checks. Invalid callers still trap in assert-enabled builds.

`shared/netutils` rather than a new `extmod/` file: this is a portable C HAL helper (no Python module), and these ports already build `shared/netutils`.

No unix `.text` delta (port HAL / shared helper only).

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.