### PR TITLE
py: Isolate mpy-cross sub-make from inherited BUILD.

### DIFF
--- a/py/mkrules.cmake
+++ b/py/mkrules.cmake
@@ -281,13 +281,13 @@ if(MICROPY_FROZEN_MANIFEST)
         if(NOT MICROPY_MAKE_EXECUTABLE)
             set(MICROPY_MAKE_EXECUTABLE make)
         endif()
-        # Clear FROZEN_MANIFEST/USER_C_MODULES in the mpy-cross sub-make so a
-        # shell-env FROZEN_MANIFEST=... doesn't leak in and trigger
-        # manifest.mk against the wrong cwd. mkrules.mk does the same for the
-        # make-based port path.
+        # Pin BUILD and clear FROZEN_MANIFEST/USER_C_MODULES in the mpy-cross
+        # sub-make so a command-line BUILD=... or shell-env FROZEN_MANIFEST=...
+        # doesn't leak in (BUILD ?= build won't override a defined empty
+        # BUILD=). mkrules.mk does the same for the make-based port path.
         add_custom_command(
             OUTPUT ${MICROPY_MPYCROSS_DEPENDENCY}
-            COMMAND ${MICROPY_MAKE_EXECUTABLE} -C ${MICROPY_DIR}/mpy-cross USER_C_MODULES= FROZEN_MANIFEST=
+            COMMAND ${MICROPY_MAKE_EXECUTABLE} -C ${MICROPY_DIR}/mpy-cross BUILD=${MICROPY_DIR}/mpy-cross/build USER_C_MODULES= FROZEN_MANIFEST=
         )
     endif()
 

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -201,12 +201,13 @@ $(HEADER_BUILD):
 	$(MKDIR) -p $@
 
 ifneq ($(MICROPY_MPYCROSS_DEPENDENCY),)
-# Build mpy-cross automatically if needed. Clear USER_C_MODULES and
-# FROZEN_MANIFEST so a port build with either set doesn't leak them into the
-# mpy-cross sub-make and cause manifest.mk there to parse the port's manifest
-# from the wrong cwd.
+# Build mpy-cross automatically if needed. Pin BUILD and clear USER_C_MODULES
+# and FROZEN_MANIFEST so a port build with BUILD=... / either of those set
+# doesn't leak them into the mpy-cross sub-make (BUILD ?= build won't override
+# a defined empty BUILD=; FROZEN_MANIFEST would parse the port manifest from
+# the wrong cwd).
 $(MICROPY_MPYCROSS_DEPENDENCY):
-	$(MAKE) -C "$(abspath $(dir $@)..)" USER_C_MODULES= FROZEN_MANIFEST=
+	$(MAKE) -C "$(abspath $(dir $@)..)" BUILD="$(abspath $(dir $@))" USER_C_MODULES= FROZEN_MANIFEST=
 endif
 
 ifneq ($(FROZEN_DIR),)


### PR DESCRIPTION
### Summary

Fixes #19667.

When a port build passes `BUILD=` on the make command line (common for out-of-tree builds), GNU make forwards that variable into the mpy-cross bootstrap sub-make. mpy-cross then writes `genhdr` into the port's build directory, qstr fragments can mix with the port's, and the firmware link fails (e.g. `undefined reference to mp_module_string`).

`USER_C_MODULES` / `FROZEN_MANIFEST` were already cleared in both bootstraps. Empty `BUILD=` is not enough because `BUILD ?= build` in `mkenv.mk` does not override a defined-but-empty value. Pin `BUILD` to the canonical `mpy-cross/build` path in:

- `py/mkrules.cmake` (cmake ports, including esp32)
- `py/mkrules.mk` (make-based ports)

### Testing

Reproduced the leak with a parent make that sets `BUILD=/tmp/...` and invokes the mpy-cross sub-make without pinning `BUILD` (binary lands in the leak dir). With the pinned `BUILD=.../mpy-cross/build` recipe, the binary stays under `mpy-cross/build/` and the parent `BUILD` dir is untouched.

Did not run a full esp32 firmware build for this change (build-system only). Existing cmake CI on the PR covers the bootstrap path.

### Trade-offs and Alternatives

No unix `.text` / `.mpy` delta (build system only).

Alternative of only clearing `BUILD=` was rejected: `BUILD ?= build` leaves an empty override in place.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.