### PR TITLE
rp2: Fix permanent "core1 in use" error if OOM.

### DIFF
--- a/ports/rp2/mpthreadport.c
+++ b/ports/rp2/mpthreadport.c
@@ -129,9 +129,6 @@ mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size
         mp_raise_msg(&mp_type_OSError, MP_ERROR_TEXT("core1 in use"));
     }
 
-    core1_entry = entry;
-    core1_arg = arg;
-
     if (*stack_size == 0) {
         *stack_size = 4096; // default stack size
     } else if (*stack_size < 2048) {
@@ -142,8 +139,11 @@ mp_uint_t mp_thread_create(void *(*entry)(void *), void *arg, size_t *stack_size
     core1_stack_num_words = *stack_size / sizeof(uint32_t);
     *stack_size = core1_stack_num_words * sizeof(uint32_t);
 
-    // Allocate stack.
+    // Ensure MemoryError in stack allocation does not leave core1_entry
+    // dangling.
     core1_stack = m_new(uint32_t, core1_stack_num_words);
+    core1_entry = entry;
+    core1_arg = arg;
 
     // Create thread on core1.
     multicore_reset_core1();


### PR DESCRIPTION


<!-- Thanks for submitting a Pull Request! We appreciate you spending the
     time to improve MicroPython. Please provide enough information so that
     others can review your Pull Request.

     Before submitting, please read:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines

     Please check any CI failures that appear after your Pull Request is opened.
-->

### Summary

<!-- Explain the reason for making this change. What problem does the pull request
     solve, or what improvement does it add? Add links if relevant,
     especially links to open issues. -->
If `_thread.start_new_thread` fails to allocate stack space because of MemoryError, it leaves the environment stuck in a way that appears to have a thread running on core1. Later, when memory is available, `start_new_thread` will continue to fail because it will appear that core1 is in use.

To remedy this, the `core1_entry` pointer is not setup until after the stack space is successfully allocated.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

This has been tested on the Wiznet W5100S-EVB-Pico board.

### Trade-offs and Alternatives

<!-- If the Pull Request has some negative impact (i.e. increased code size)
     then please explain why you think the trade-off improvement is worth it.
     If you can think of alternative ways to do this, please explain that here too.

     Delete this heading if not relevant (i.e. small fixes) -->

There are no real trade offs. Everything will work the same as without the patch, except that the system can continue to launch new thread tasks with this patch if it previously failed with MemoryError.

### Generative AI

<!-- Please delete the answer below which doesn't apply, or write your own
     answer with more details. -->

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.

<!-- We require everyone to answer this question. If you delete this section or
     ignore it then your PR may be closed.

     For more information, consult the MicroPython Generative AI Policy:
     https://github.com/micropython/micropython/wiki/ContributorGuidelines#generative-ai-policy
     -->
