### PR TITLE
mimxrt/Makefile: Use float-abi=hard when FP is single precision.

### DIFF
--- a/ports/mimxrt/Makefile
+++ b/ports/mimxrt/Makefile
@@ -462,7 +462,7 @@ ifeq ($(MICROPY_FLOAT_IMPL),single)
     CFLAGS += \
         -DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT \
         -fsingle-precision-constant \
-        -mfloat-abi=softfp \
+        -mfloat-abi=hard \
         -mfpu=fpv5-sp-d16
 else ifeq ($(MICROPY_FLOAT_IMPL),double)
     CFLAGS += \


### PR DESCRIPTION
### Summary

Using hard ABI passes floats in floating point registers, which is what MicroPython's native .mpy format expects.

All other bare-metal ports use this ABI setting (alif, nrf, psoc-edge, renesas-ra, samd stm32).

### Testing

Tested by @robert-hh in https://github.com/micropython/micropython/pull/19661#issuecomment-5450436776

On affected boards, `extmod/random_extra_float.py` would fail when run using `run-natmodtests.py` but now passes with this change.


### Generative AI

I did not use generative AI tools when creating this PR.
