### PR TITLE
rp2: Bump pico-sdk to v2.3.1

### DIFF
--- a/ports/rp2/memmap_rp2/default_rodata_excludes.incl
+++ b/ports/rp2/memmap_rp2/default_rodata_excludes.incl
@@ -1,0 +1,2 @@
+/* Change for MicroPython: keep libc.a and the newlib mem* in SRAM */
+*(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib*_a-mem*.o *libm.a:) .rodata*)

--- a/ports/rp2/memmap_rp2/default_text_excludes.incl
+++ b/ports/rp2/memmap_rp2/default_text_excludes.incl
@@ -1,4 +1,3 @@
-/* Change for MicroPython: additionally exclude gc.c, vm.c and parse.c from
-   flash, so their .text is placed in RAM (via the default .data section) for
-   faster execution. Keeps the SDK's default exclusions for libgcc/libc/libm. */
+/* Change for MicroPython: exclude gc.c, vm.c, parse.c, libgcc, libc and libm from
+   flash so their .text is placed in SRAM (via the default .data section). */
 *(EXCLUDE_FILE(*libgcc.a: *libc.a: *lib*_a-mem*.o *libm.a: *py/gc.c.o *py/vm.c.o *py/parse.c.o) .text*)


### PR DESCRIPTION
### Summary

Bump Pico SDK to v2.3.1 - https://github.com/raspberrypi/pico-sdk/releases/tag/2.3.1

### Testing

TBC

### Trade-offs and Alternatives

Pico SDK's "bugfix" to linker scripts was walked back in https://github.com/raspberrypi/pico-sdk/pull/3075 and our downstream divergences still preserve the SDK 2.3.0 behaviour. May require some consideration around deferring to upstream.

This bump also sets `-mstrict-align` on RISCV builds, so there may be a size difference.

Bugfixes may plausibly affect the following issues, but this is as of yet untested:

- [#17594](https://github.com/micropython/micropython/issues/17594) `time.sleep` waking early, Pico 2 W
- [#18811](https://github.com/micropython/micropython/issues/18811) asyncio stream IO hangs
- [#16008](https://github.com/micropython/micropython/issues/16008) `ntptime.settime()` breaks sleep timing under `_thread`
- [#17968](https://github.com/micropython/micropython/issues/17968) / [#15982](https://github.com/micropython/micropython/issues/15982) / [#16554](https://github.com/micropython/micropython/issues/16554) core1 hangs 

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.