### PR TITLE
tests: Fix comparing performance with run-perfbench.

### DIFF
--- a/tests/run-perfbench.py
+++ b/tests/run-perfbench.py
@@ -216,7 +216,7 @@ def parse_output(filename):
                 ": " in l
                 and ": SKIP" not in l
                 and "CRASH: " not in l
-                and "skipped: " not in l
+                and re.search("skipped.*: ", l) is None
                 and "failed: " not in l
             ):
                 name, values = l.strip().split(": ")


### PR DESCRIPTION
### Summary

The option `-s` (--diff-score) or `-m` (--diff-time) fails when the specified result contains tests
that was that are skipped with `too large`.

The following benchmark result:
```
N=84 M=96 n_average=8
perf_bench/bm_chaos.py: 222636.00 0.0202 224.58 0.0202
  :
perf_bench/bm_float.py: 38311.38 0.0013 3915.29 0.0013
perf_bench/bm_hexiom.py: SKIP: too large
perf_bench/bm_nqueens.py: 382078.88 0.0029 2617.26 0.0029
  :
perf_bench/viper_call2b.py: 148569.00 0.0766 201.93 0.0765
21 tests performed
21 tests passed
3 tests skipped because they are too large: perf_bench/bm_hexiom.py perf_bench/misc_mandel.py perf_bench/misc_raytrace.py
```
occures the following error:
```
ValueError: could not convert string to float: 'perf_bench/bm_hexiom.py'
```
The last line
```
3 tests skipped because they are too large: perf_bench/bm_hexiom.py perf_bench/misc_mandel.py 
```
should be skipped.

The line that contains `skipped: ` is ignored by following line in run-perfbench.py,
but `skipped because they are too large: ` is not.
https://github.com/micropython/micropython/blob/14e9793c917960a5a3ea9146c949c4223a38c00d/tests/run-perfbench.py#L219

This patch skips line that contains `skipped: ` and `skipped because they are too large: ` using regular expression.

### Testing

By applying this patch, run-perfbench.py compare result even benchmark result contains skipped result with `too large`

### Generative AI
I did not use generative AI tools when creating this PR.