### PR TITLE
tools/mpy-tool.py: Improve qstr printing in disassembly.

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -679,9 +679,9 @@ class CompiledModule:
         print("arch:", arch_name)
         if self.header[2] & MP_NATIVE_ARCH_FLAGS_PRESENT != 0:
             print("arch_flags:", hex(self.arch_flags))
-        print("qstr_table[%u]:" % len(self.qstr_table))
+        print("qstr_table[%u] (* for static qstrs):" % len(self.qstr_table))
         for q in self.qstr_table:
-            print("    %s" % q.str)
+            print("    {!r} {}".format(q.str, "*" if q.str in qstrutil.static_qstr_list else ""))
         print("obj_table:", self.obj_table)
         self.raw_code.disassemble()
 


### PR DESCRIPTION
### Summary

This PR tweaks `mpy-tool.py`'s printout of qstr strings when disassemblying a MPY file.

Now strings will be printed with non-printable and control codes being quoted (using Python's `repr()`), and containing a special marker in case a qstr is encoded as an index in the static qstr table.

The changes here are limited to the disassembly output (ie. when called with `-d`), so it shouldn't affect regular operation of the tool in other scenarios.

This obviously changes the output of the disassembly output, but the original would still be harder to parse in case control codes were part of the QSTR being printed.  These changes, if anything, would simplify handling of those cases (it did simplify my tooling for sure! :)).

### Testing

Manual testing was done to check the output of `mpy-tool` when invoked with the `-d` flag on MPY files containing control codes in QSTRs.  CI also runs `mpy-tool` with `-d` in `ci_mpy_format_test`, so in theory that should also check I didn't mess up somewhere else.

### Generative AI

I did not use generative AI tools when creating this PR.