### PR TITLE
docs/library/machine.RTC: Show memory() as instance method.

### DIFF
--- a/docs/library/machine.RTC.rst
+++ b/docs/library/machine.RTC.rst
@@ -95,6 +95,12 @@ Methods
    `memoryview` and `array.array`). ``RTC.memory()`` reads RTC memory and returns
    a `bytes` object.
 
+   Call this as an instance method (create an ``RTC`` object first)::
+
+      rtc = machine.RTC()
+      rtc.memory(b'data')
+      print(rtc.memory())
+
    Data written to RTC user memory is persistent across restarts, including
    :ref:`soft_reset` and `machine.deepsleep()`.
 


### PR DESCRIPTION
## Summary
- Clarify that `RTC.memory` must be called on an instance.
- Add a short example using `machine.RTC()` then `rtc.memory(...)`.

## Test plan
- [x] Diff reviewed against upstream `docs/library/machine.RTC.rst`
- [ ] Docs render check by maintainer if needed

Fixes #18176
