### PR TITLE
rp2: Keep machine.RTC ticking while in lightsleep().

### DIFF
--- a/ports/rp2/modmachine.c
+++ b/ports/rp2/modmachine.c
@@ -257,16 +257,17 @@ static void mp_machine_lightsleep(size_t n_args, const mp_obj_t *args) {
         uint32_t save_sleep_en1 = clocks_hw->sleep_en1;
         if (use_timer_alarm) {
             // Use timer alarm to wake.
-            clocks_hw->sleep_en0 = 0x0;
             #if PICO_RP2040
+            clocks_hw->sleep_en0 = CLOCKS_SLEEP_EN0_CLK_RTC_RTC_BITS;
             clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_SYS_TIMER_BITS;
             #elif PICO_RP2350
+            clocks_hw->sleep_en0 = CLOCKS_SLEEP_EN0_CLK_REF_POWMAN_BITS | CLOCKS_SLEEP_EN0_CLK_SYS_POWMAN_BITS;
+            uint32_t sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
             if (watchdog_active) {
                 // clk_sys watchdog and clk_ref ticks must be enabled for the watchdog counter to decrement on RP2350.
-                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS;
-            } else {
-                clocks_hw->sleep_en1 = CLOCKS_SLEEP_EN1_CLK_REF_TICKS_BITS | CLOCKS_SLEEP_EN1_CLK_SYS_TIMER0_BITS;
+                sleep_en1 |= CLOCKS_SLEEP_EN1_CLK_SYS_WATCHDOG_BITS;
             }
+            clocks_hw->sleep_en1 = sleep_en1;
             #else
             #error Unknown processor
             #endif

--- a/tests/extmod_hardware/machine_rtc_sleep.py
+++ b/tests/extmod_hardware/machine_rtc_sleep.py
@@ -1,0 +1,74 @@
+# Test for RTC ticks during normal sleep and lightsleep.
+
+try:
+    from machine import RTC, lightsleep
+except ImportError:
+    print("SKIP")
+    raise SystemExit
+
+import sys, time
+
+if "rp2" in sys.platform:
+    pass
+else:
+    # At time of writing most other ports with machine.RTC and
+    # machine.lightsleep() aren't capable of passing this test due to
+    # inconsistent or broken lightsleep behaviour... If you find another port
+    # which can pass the test, please add it above!
+    print("SKIP")
+    raise SystemExit
+
+
+_IDX_MINUTE = const(5)
+_IDX_SECOND = const(6)
+
+_SLEEP_SECS = const(2)
+
+rtc = RTC()
+
+
+def test_sleep(sleep_fn, label):
+    attempts = 0
+    while True:
+        attempts += 1
+        rtc0 = rtc.datetime()
+        t0 = time.ticks_ms()
+        sleep_fn()
+        rtc1 = rtc.datetime()
+        t1 = time.ticks_ms()
+        if attempts < 3 and rtc0[_IDX_SECOND] - rtc1[_IDX_SECOND] == _SLEEP_SECS + 1:
+            # allow the possibility that occasionally the sleep runs a few milliseconds long and
+            # the RTC ticks over an additional second in that small window.
+            continue
+        if rtc0[_IDX_MINUTE] == rtc1[_IDX_MINUTE]:
+            # To avoid having to make datetime calculations, re-run the sleep until it starts
+            # and ends in the same minute!
+            break
+
+    sec0 = rtc0[_IDX_SECOND]
+    sec1 = rtc1[_IDX_SECOND]
+    ticks_diff = time.ticks_diff(t1, t0)
+
+    if sec1 - sec0 == _SLEEP_SECS and abs(_SLEEP_SECS * 1000 - ticks_diff) < 100:
+        print(label, "OK")
+    else:
+        print(label, "Bad sleep time")
+        print("t0", t0)
+        print("t1", t1)
+        print("ticks_diff", ticks_diff)
+        print("rtc0", rtc0)
+        print("rtc1", rtc1)
+
+
+def force_lightsleep(target_ms):
+    # lightsleep for at least target_ms, not only until the next interrupt
+    t_end = time.ticks_add(time.ticks_ms(), target_ms)
+    remaining = time.ticks_diff(t_end, time.ticks_ms())
+    while remaining > 0:
+        lightsleep(remaining)
+        remaining = time.ticks_diff(t_end, time.ticks_ms())
+
+
+test_sleep(lambda: time.sleep(_SLEEP_SECS), "time.sleep")
+test_sleep(lambda: time.sleep_ms(_SLEEP_SECS * 1000), "time.sleep_ms")
+test_sleep(lambda: force_lightsleep(_SLEEP_SECS * 1000), "forced machine.lightsleep")

--- a/tests/extmod_hardware/machine_rtc_sleep.py.exp
+++ b/tests/extmod_hardware/machine_rtc_sleep.py.exp
@@ -1,0 +1,3 @@
+time.sleep OK
+time.sleep_ms OK
+forced machine.lightsleep OK


### PR DESCRIPTION
### Summary

Closes #16519. This is a regression since v1.23 (exact commit unknown) - the RTC is frozen during lightsleep.

*This work was funded through GitHub Sponsors.*

### Testing

* Initial testing used the test case attached to the issue (thanks @madozu for this excellent reproducer).
* A new unit test `extmod_hardware/machine_rtc_sleep.py` is added in this PR that fails on RPI_PICO_W and RPI_PICO2_W without this fix, and passes with this fix.

#### New test & other ports

I've added the test under `extmod_hardware` because in theory the behaviour of `machine.RTC` and `machine.lightsleep` are hardware agnostic.

In my quick testing, none of the other boards I tested could pass it:

* esp32 port: Neither ESP32-S3 or ESP32-C6 wake after the timeout period without an external event. This is probably a bug, will try and investigate.
* mimxrt port: `machine.lightsleep()` raises `NotImplementedError`. The method should probably be removed.
* stm32: Boards with built-in USB (like pyboard) disconnect the USB port in lightsleep, so the test can't complete. Also tested a NUCLEO G4 board and found that it only intermittently woke from light sleep...

To avoid adding a known broken test on other ports I've added a check that currently skips unless the port is rp2, but there's a comment encouraging other ports to be added if/when they work.

### Trade-offs and Alternatives

* At some point it'd be nice to move to the [pico-sdk low_power module](https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#group_pico_low_power) to manage sleep, and I have a WIP branch for this. However, the "sleep for time" APIs in this module do not match the documented `machine.lightsleep()` behaviour - in "non-exclusive" mode the low_power APIs will wake to process interrupts but continue to go back to sleep until the timeout expires. By comparison, `machine.lightsleep()` is documented to return immediately after the next interrupt arrives. Arguably the pico-sdk low_power behaviour is more useful and more likely to be what someone expects, but I think it'd have to be something we change in MicroPython 2.0.

### Generative AI

I did not use generative AI tools when creating this PR.
